### PR TITLE
docs: Add a privacy policy

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,16 @@
+# Pachli Privacy Policy
+
+Pachli does not collect any personal information from the user.
+
+Data from connected accounts is cached locally on the device when it is required for functionality and performance. This data cannot be accessed by other applications (on non-rooted devices). It can be deleted by logging out of your account in the application, clearing the application's local storage, or uninstalling the application.
+
+The application requires the following permissions for the following reasons:
+
+- `INTERNET`: Connect to your server of choice, fetch and post content
+- `ACCESS_NETWORK_STATE`: Defer work when the network is unavailable, and retry work when the network becomes available
+- `POST_NOTIFICATIONS`: Show notifications from your server
+- `READ_MEDIA_IMAGES` / `VIDEO` / `AUDIO`, and `READ_EXTERNAL_STORAGE`: Select media on your device if you attach it to a post
+- `WRITE_EXTERNAL_STORAGE`: Save media to your device if you download it from a post
+- `FOREGROUND_SERVICE`: Improve reliability when sending posts
+
+If you have any questions about this privacy policy please contact team@pachli.app

--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -102,7 +102,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/AndroidManifest.xml"
-            line="14"
+            line="17"
             column="9"/>
     </issue>
 
@@ -113,7 +113,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/AndroidManifest.xml"
-            line="21"
+            line="24"
             column="9"/>
     </issue>
 
@@ -806,7 +806,7 @@
         errorLine2="                              ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/AndroidManifest.xml"
-            line="21"
+            line="24"
             column="31"/>
     </issue>
 
@@ -817,7 +817,7 @@
         errorLine2="                              ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/AndroidManifest.xml"
-            line="21"
+            line="24"
             column="31"/>
     </issue>
 
@@ -828,7 +828,7 @@
         errorLine2="                              ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/AndroidManifest.xml"
-            line="21"
+            line="24"
             column="31"/>
     </issue>
 
@@ -839,7 +839,7 @@
         errorLine2="                              ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/AndroidManifest.xml"
-            line="21"
+            line="24"
             column="31"/>
     </issue>
 
@@ -850,7 +850,7 @@
         errorLine2="                              ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/AndroidManifest.xml"
-            line="21"
+            line="24"
             column="31"/>
     </issue>
 
@@ -861,7 +861,7 @@
         errorLine2="                              ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/AndroidManifest.xml"
-            line="21"
+            line="24"
             column="31"/>
     </issue>
 
@@ -872,7 +872,7 @@
         errorLine2="                              ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/AndroidManifest.xml"
-            line="21"
+            line="24"
             column="31"/>
     </issue>
 
@@ -883,7 +883,7 @@
         errorLine2="                              ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/AndroidManifest.xml"
-            line="21"
+            line="24"
             column="31"/>
     </issue>
 
@@ -894,7 +894,7 @@
         errorLine2="                              ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/AndroidManifest.xml"
-            line="21"
+            line="24"
             column="31"/>
     </issue>
 
@@ -905,7 +905,7 @@
         errorLine2="                             ~~~~~">
         <location
             file="src/main/AndroidManifest.xml"
-            line="15"
+            line="18"
             column="30"/>
     </issue>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,10 +3,13 @@
     xmlns:tools="http://schemas.android.com/tools" >
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28"/>
-    <uses-permission android:name="android.permission.VIBRATE" /> <!-- For notifications -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <application


### PR DESCRIPTION
While drafting the policy I noticed that the `READ_MEDIA_*` permissions could be added (for newer devices), the `ACCESS_NETWORK_STATE` permission was missing, and `VIBRATE` was unnecessary.