### PR TITLE
fix: Create hashtag filters with the `#` character

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -229,6 +229,8 @@
     <string name="confirmation_unblocked">User unblocked</string>
     <string name="confirmation_unmuted">User unmuted</string>
     <string name="confirmation_domain_unmuted">%s unhidden</string>
+    <string name="confirmation_hashtag_muted">#%s hidden</string>
+    <string name="confirmation_hashtag_unmuted">#%s unhidden</string>
     <string name="confirmation_hashtag_unfollowed">#%s unfollowed</string>
 
     <string name="post_sent">Sent!</string>


### PR DESCRIPTION
Previous code created hashtag filters without the `#`, so muting the tag `#something` would filter all posts that contained `something`, with or without the `#`.

Fix this when creating filters, and only remove filters (when unmuting) if the title and contents match.

Show a snackbar when hashtags are successfully muted/unmuted, so the user is aware something happened.