### PR TITLE
fix: Apply setClickableText correctly, prevent spurious underlines

### DIFF
--- a/app/src/main/java/app/pachli/util/LinkHelper.kt
+++ b/app/src/main/java/app/pachli/util/LinkHelper.kt
@@ -68,7 +68,7 @@ fun setClickableText(view: TextView, content: CharSequence, mentions: List<Menti
     val spannableContent = markupHiddenUrls(view.context, content)
 
     view.text = spannableContent.apply {
-        getSpans(0, content.length, URLSpan::class.java).forEach {
+        getSpans(0, spannableContent.length, URLSpan::class.java).forEach {
             setClickableText(it, this, mentions, tags, listener)
         }
     }


### PR DESCRIPTION
The previous code was operating on the wrong text, resulting in normal URL spans (which have an underline) being applied, instead of the correct spans (which don't).

Fix this by using the correct length.