### PR TITLE
ci: Move reviewdog permissions block

### DIFF
--- a/.github/workflows/ktlint.yml
+++ b/.github/workflows/ktlint.yml
@@ -1,5 +1,11 @@
 name: reviewdog-suggester
 on: pull_request
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   ktlint:
     timeout-minutes: 5
@@ -28,8 +34,3 @@ jobs:
       - uses: reviewdog/action-suggester@v1
         with:
           tool_name: ktlintFormat
-
-permissions:
-  contents: read
-  issues: write
-  pull-requests: write


### PR DESCRIPTION
The permission declaration appears to be sensitive to the position in the file. Move it to the start to ensure it takes effect.