### PR TITLE
fix: Fix crash on entering MainActivity on some tablets

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -19,7 +19,7 @@
         errorLine2="                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="982"
+            line="986"
             column="42"/>
     </issue>
 
@@ -30,7 +30,7 @@
         errorLine2="                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="1017"
+            line="1021"
             column="42"/>
     </issue>
 
@@ -120,17 +120,6 @@
     <issue
         id="UseAppTint"
         message="Must use `app:tint` instead of `android:tint`"
-        errorLine1="            android:tint=&quot;?android:attr/textColorTertiary&quot;"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/layout/activity_compose.xml"
-            line="314"
-            column="13"/>
-    </issue>
-
-    <issue
-        id="UseAppTint"
-        message="Must use `app:tint` instead of `android:tint`"
         errorLine1="        android:tint=&quot;?colorPrimary&quot;"
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
@@ -146,7 +135,7 @@
         errorLine2="                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="542"
+            line="546"
             column="32"/>
     </issue>
 
@@ -762,7 +751,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="332"
+            line="334"
             column="5"/>
     </issue>
 
@@ -773,7 +762,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="389"
+            line="391"
             column="5"/>
     </issue>
 
@@ -784,7 +773,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="561"
+            line="563"
             column="5"/>
     </issue>
 
@@ -795,7 +784,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="774"
+            line="776"
             column="5"/>
     </issue>
 
@@ -1362,7 +1351,7 @@
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/black` with a theme that also paints a background (inferred theme is `@style/DefaultTheme`)"
+        message="Possible overdraw: Root element paints background `@color/black` with a theme that also paints a background (inferred theme is `@style/Theme.Pachli`)"
         errorLine1="    android:background=&quot;@color/black&quot;"
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
@@ -1373,7 +1362,7 @@
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `?android:attr/colorBackground` with a theme that also paints a background (inferred theme is `@style/DefaultTheme`)"
+        message="Possible overdraw: Root element paints background `?android:attr/colorBackground` with a theme that also paints a background (inferred theme is `@style/Theme.Pachli`)"
         errorLine1="    android:background=&quot;?android:attr/colorBackground&quot;>"
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
@@ -1384,7 +1373,7 @@
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `?android:attr/colorBackground` with a theme that also paints a background (inferred theme is `@style/DefaultTheme`)"
+        message="Possible overdraw: Root element paints background `?android:attr/colorBackground` with a theme that also paints a background (inferred theme is `@style/Theme.Pachli`)"
         errorLine1="    android:background=&quot;?android:attr/colorBackground&quot;>"
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
@@ -1395,7 +1384,7 @@
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `?attr/selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/DefaultTheme`)"
+        message="Possible overdraw: Root element paints background `?attr/selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/Theme.Pachli`)"
         errorLine1="    android:background=&quot;?attr/selectableItemBackground&quot;"
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
@@ -1406,7 +1395,7 @@
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `?attr/selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/DefaultTheme`)"
+        message="Possible overdraw: Root element paints background `?attr/selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/Theme.Pachli`)"
         errorLine1="    android:background=&quot;?attr/selectableItemBackground&quot;"
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
@@ -1417,7 +1406,7 @@
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `?attr/selectableItemBackgroundBorderless` with a theme that also paints a background (inferred theme is `@style/DefaultTheme`)"
+        message="Possible overdraw: Root element paints background `?attr/selectableItemBackgroundBorderless` with a theme that also paints a background (inferred theme is `@style/Theme.Pachli`)"
         errorLine1="    android:background=&quot;?attr/selectableItemBackgroundBorderless&quot;"
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
@@ -1428,7 +1417,7 @@
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `?attr/selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/DefaultTheme`)"
+        message="Possible overdraw: Root element paints background `?attr/selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/Theme.Pachli`)"
         errorLine1="    android:background=&quot;?attr/selectableItemBackground&quot;"
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
@@ -1439,7 +1428,7 @@
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `?attr/selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/DefaultTheme`)"
+        message="Possible overdraw: Root element paints background `?attr/selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/Theme.Pachli`)"
         errorLine1="    android:background=&quot;?attr/selectableItemBackground&quot;"
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
@@ -1565,7 +1554,7 @@
         errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/colors.xml"
-            line="106"
+            line="103"
             column="12"/>
     </issue>
 
@@ -1576,7 +1565,7 @@
         errorLine2="           ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/colors.xml"
-            line="107"
+            line="104"
             column="12"/>
     </issue>
 
@@ -1862,7 +1851,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="265"
+            line="267"
             column="13"/>
     </issue>
 
@@ -1873,7 +1862,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="266"
+            line="268"
             column="13"/>
     </issue>
 
@@ -1884,7 +1873,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="291"
+            line="293"
             column="13"/>
     </issue>
 
@@ -1895,7 +1884,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="322"
+            line="324"
             column="13"/>
     </issue>
 
@@ -1906,7 +1895,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="402"
+            line="404"
             column="13"/>
     </issue>
 
@@ -1917,7 +1906,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="458"
+            line="460"
             column="13"/>
     </issue>
 
@@ -1928,7 +1917,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="509"
+            line="511"
             column="13"/>
     </issue>
 
@@ -1939,7 +1928,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="513"
+            line="515"
             column="13"/>
     </issue>
 
@@ -1950,7 +1939,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="514"
+            line="516"
             column="13"/>
     </issue>
 
@@ -1961,7 +1950,7 @@
         errorLine2="            ~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="515"
+            line="517"
             column="13"/>
     </issue>
 
@@ -1972,7 +1961,7 @@
         errorLine2="            ~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="516"
+            line="518"
             column="13"/>
     </issue>
 
@@ -1983,7 +1972,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="517"
+            line="519"
             column="13"/>
     </issue>
 
@@ -1994,7 +1983,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="518"
+            line="520"
             column="13"/>
     </issue>
 
@@ -2005,7 +1994,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="519"
+            line="521"
             column="13"/>
     </issue>
 
@@ -2016,7 +2005,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="520"
+            line="522"
             column="13"/>
     </issue>
 
@@ -2027,7 +2016,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="522"
+            line="524"
             column="13"/>
     </issue>
 
@@ -2038,7 +2027,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="600"
+            line="602"
             column="13"/>
     </issue>
 
@@ -2049,7 +2038,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="601"
+            line="603"
             column="13"/>
     </issue>
 
@@ -2060,7 +2049,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="616"
+            line="618"
             column="13"/>
     </issue>
 
@@ -2071,7 +2060,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="618"
+            line="620"
             column="13"/>
     </issue>
 
@@ -2082,7 +2071,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="619"
+            line="621"
             column="13"/>
     </issue>
 
@@ -2093,7 +2082,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="622"
+            line="624"
             column="13"/>
     </issue>
 
@@ -2104,7 +2093,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="667"
+            line="669"
             column="13"/>
     </issue>
 
@@ -2115,7 +2104,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="715"
+            line="717"
             column="13"/>
     </issue>
 
@@ -2126,7 +2115,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="721"
+            line="723"
             column="13"/>
     </issue>
 
@@ -2137,7 +2126,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="762"
+            line="764"
             column="13"/>
     </issue>
 
@@ -2148,7 +2137,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="796"
+            line="798"
             column="13"/>
     </issue>
 
@@ -2159,7 +2148,7 @@
         errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/styles.xml"
-            line="137"
+            line="129"
             column="12"/>
     </issue>
 
@@ -2170,7 +2159,7 @@
         errorLine2="           ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/styles.xml"
-            line="180"
+            line="158"
             column="12"/>
     </issue>
 
@@ -2533,7 +2522,7 @@
         errorLine2="                    ~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/components/compose/ComposeActivity.kt"
-            line="543"
+            line="544"
             column="21"/>
     </issue>
 
@@ -2544,7 +2533,7 @@
         errorLine2="                ~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/components/compose/ComposeActivity.kt"
-            line="552"
+            line="553"
             column="17"/>
     </issue>
 
@@ -2555,7 +2544,7 @@
         errorLine2="                ~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/components/compose/ComposeActivity.kt"
-            line="552"
+            line="553"
             column="17"/>
     </issue>
 
@@ -3193,7 +3182,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="561"
+            line="565"
             column="17"/>
     </issue>
 
@@ -3204,7 +3193,7 @@
         errorLine2="                    ~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="564"
+            line="568"
             column="21"/>
     </issue>
 
@@ -3213,31 +3202,9 @@
         message="Access to `private` method `primaryDrawerItem` of class `MainActivityKt` requires synthetic accessor"
         errorLine1="                primaryDrawerItem {"
         errorLine2="                ~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/java/app/pachli/MainActivity.kt"
-            line="569"
-            column="17"/>
-    </issue>
-
-    <issue
-        id="SyntheticAccessor"
-        message="Access to `private` method `setOnClick` of class `MainActivityKt` requires synthetic accessor"
-        errorLine1="                    onClick = {"
-        errorLine2="                    ~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
             line="573"
-            column="21"/>
-    </issue>
-
-    <issue
-        id="SyntheticAccessor"
-        message="Access to `private` method `primaryDrawerItem` of class `MainActivityKt` requires synthetic accessor"
-        errorLine1="                primaryDrawerItem {"
-        errorLine2="                ~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/java/app/pachli/MainActivity.kt"
-            line="578"
             column="17"/>
     </issue>
 
@@ -3248,7 +3215,7 @@
         errorLine2="                    ~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="581"
+            line="577"
             column="21"/>
     </issue>
 
@@ -3259,7 +3226,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="586"
+            line="582"
             column="17"/>
     </issue>
 
@@ -3270,7 +3237,7 @@
         errorLine2="                    ~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="589"
+            line="585"
             column="21"/>
     </issue>
 
@@ -3281,7 +3248,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="594"
+            line="590"
             column="17"/>
     </issue>
 
@@ -3292,7 +3259,7 @@
         errorLine2="                    ~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="597"
+            line="593"
             column="21"/>
     </issue>
 
@@ -3301,20 +3268,20 @@
         message="Access to `private` method `primaryDrawerItem` of class `MainActivityKt` requires synthetic accessor"
         errorLine1="                primaryDrawerItem {"
         errorLine2="                ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/app/pachli/MainActivity.kt"
+            line="598"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `setOnClick` of class `MainActivityKt` requires synthetic accessor"
+        errorLine1="                    onClick = {"
+        errorLine2="                    ~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
             line="601"
-            column="17"/>
-    </issue>
-
-    <issue
-        id="SyntheticAccessor"
-        message="Access to `private` method `setOnClick` of class `MainActivityKt` requires synthetic accessor"
-        errorLine1="                    onClick = {"
-        errorLine2="                    ~~~~~~~">
-        <location
-            file="src/main/java/app/pachli/MainActivity.kt"
-            line="604"
             column="21"/>
     </issue>
 
@@ -3325,7 +3292,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="609"
+            line="605"
             column="17"/>
     </issue>
 
@@ -3336,7 +3303,7 @@
         errorLine2="                    ~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="612"
+            line="608"
             column="21"/>
     </issue>
 
@@ -3345,31 +3312,31 @@
         message="Access to `private` method `primaryDrawerItem` of class `MainActivityKt` requires synthetic accessor"
         errorLine1="                primaryDrawerItem {"
         errorLine2="                ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/app/pachli/MainActivity.kt"
+            line="613"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `setOnClick` of class `MainActivityKt` requires synthetic accessor"
+        errorLine1="                    onClick = {"
+        errorLine2="                    ~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
             line="616"
-            column="17"/>
+            column="21"/>
     </issue>
 
     <issue
         id="SyntheticAccessor"
-        message="Access to `private` method `setOnClick` of class `MainActivityKt` requires synthetic accessor"
-        errorLine1="                    onClick = {"
-        errorLine2="                    ~~~~~~~">
+        message="Access to `private` method `primaryDrawerItem` of class `MainActivityKt` requires synthetic accessor"
+        errorLine1="                primaryDrawerItem {"
+        errorLine2="                ~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
             line="620"
-            column="21"/>
-    </issue>
-
-    <issue
-        id="SyntheticAccessor"
-        message="Access to `private` method `secondaryDrawerItem` of class `MainActivityKt` requires synthetic accessor"
-        errorLine1="                secondaryDrawerItem {"
-        errorLine2="                ~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/java/app/pachli/MainActivity.kt"
-            line="629"
             column="17"/>
     </issue>
 
@@ -3380,7 +3347,7 @@
         errorLine2="                    ~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="632"
+            line="624"
             column="21"/>
     </issue>
 
@@ -3391,7 +3358,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="637"
+            line="633"
             column="17"/>
     </issue>
 
@@ -3402,7 +3369,7 @@
         errorLine2="                    ~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="640"
+            line="636"
             column="21"/>
     </issue>
 
@@ -3413,7 +3380,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="645"
+            line="641"
             column="17"/>
     </issue>
 
@@ -3424,7 +3391,7 @@
         errorLine2="                    ~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="648"
+            line="644"
             column="21"/>
     </issue>
 
@@ -3435,7 +3402,29 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="653"
+            line="649"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `setOnClick` of class `MainActivityKt` requires synthetic accessor"
+        errorLine1="                    onClick = {"
+        errorLine2="                    ~~~~~~~">
+        <location
+            file="src/main/java/app/pachli/MainActivity.kt"
+            line="652"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` method `secondaryDrawerItem` of class `MainActivityKt` requires synthetic accessor"
+        errorLine1="                secondaryDrawerItem {"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/app/pachli/MainActivity.kt"
+            line="657"
             column="17"/>
     </issue>
 
@@ -3446,7 +3435,7 @@
         errorLine2="                    ~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="656"
+            line="660"
             column="21"/>
     </issue>
 
@@ -3457,7 +3446,7 @@
         errorLine2="                    ~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="663"
+            line="667"
             column="21"/>
     </issue>
 
@@ -3468,7 +3457,7 @@
         errorLine2="                        ~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="666"
+            line="670"
             column="25"/>
     </issue>
 
@@ -3479,7 +3468,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="675"
+            line="679"
             column="17"/>
     </issue>
 
@@ -3490,7 +3479,7 @@
         errorLine2="                    ~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="678"
+            line="682"
             column="21"/>
     </issue>
 
@@ -3501,7 +3490,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="691"
+            line="695"
             column="17"/>
     </issue>
 
@@ -3512,7 +3501,7 @@
         errorLine2="                    ~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="695"
+            line="699"
             column="21"/>
     </issue>
 
@@ -3523,7 +3512,7 @@
         errorLine2="                ~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="815"
+            line="819"
             column="17"/>
     </issue>
 
@@ -3534,7 +3523,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="817"
+            line="821"
             column="17"/>
     </issue>
 
@@ -3545,7 +3534,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="828"
+            line="832"
             column="17"/>
     </issue>
 
@@ -4212,7 +4201,7 @@
         errorLine2="         ~~~~~~~~">
         <location
             file="src/main/res/layout/activity_compose.xml"
-            line="367"
+            line="365"
             column="10"/>
     </issue>
 
@@ -4872,7 +4861,7 @@
         errorLine2="             ~~~~~~~~">
         <location
             file="src/main/res/layout/item_status.xml"
-            line="193"
+            line="192"
             column="14"/>
     </issue>
 
@@ -4883,7 +4872,7 @@
         errorLine2="             ~~~~~~~~">
         <location
             file="src/main/res/layout/item_status.xml"
-            line="203"
+            line="202"
             column="14"/>
     </issue>
 
@@ -4894,7 +4883,7 @@
         errorLine2="             ~~~~~~~~">
         <location
             file="src/main/res/layout/item_status.xml"
-            line="213"
+            line="212"
             column="14"/>
     </issue>
 
@@ -4971,7 +4960,7 @@
         errorLine2="             ~~~~~~~~">
         <location
             file="src/main/res/layout/item_status_detailed.xml"
-            line="174"
+            line="173"
             column="14"/>
     </issue>
 
@@ -4982,7 +4971,7 @@
         errorLine2="             ~~~~~~~~">
         <location
             file="src/main/res/layout/item_status_detailed.xml"
-            line="185"
+            line="184"
             column="14"/>
     </issue>
 
@@ -4993,7 +4982,7 @@
         errorLine2="             ~~~~~~~~">
         <location
             file="src/main/res/layout/item_status_detailed.xml"
-            line="196"
+            line="195"
             column="14"/>
     </issue>
 
@@ -5004,7 +4993,7 @@
         errorLine2="     ~~~~~~~~">
         <location
             file="src/main/res/layout/item_status_detailed.xml"
-            line="256"
+            line="255"
             column="6"/>
     </issue>
 
@@ -5015,7 +5004,7 @@
         errorLine2="     ~~~~~~~~">
         <location
             file="src/main/res/layout/item_status_detailed.xml"
-            line="269"
+            line="268"
             column="6"/>
     </issue>
 
@@ -5026,7 +5015,7 @@
         errorLine2="     ~~~~~~~~">
         <location
             file="src/main/res/layout/item_status_detailed.xml"
-            line="300"
+            line="299"
             column="6"/>
     </issue>
 
@@ -5037,7 +5026,7 @@
         errorLine2="     ~~~~~~~~">
         <location
             file="src/main/res/layout/item_status_detailed.xml"
-            line="314"
+            line="313"
             column="6"/>
     </issue>
 
@@ -5741,7 +5730,7 @@
         errorLine2="           ~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/BaseActivity.java"
-            line="70"
+            line="71"
             column="12"/>
     </issue>
 
@@ -5752,7 +5741,7 @@
         errorLine2="                                                  ~~~~~~">
         <location
             file="src/main/java/app/pachli/BaseActivity.java"
-            line="177"
+            line="187"
             column="51"/>
     </issue>
 
@@ -5763,7 +5752,7 @@
         errorLine2="                                         ~~~~~~~~">
         <location
             file="src/main/java/app/pachli/BaseActivity.java"
-            line="183"
+            line="193"
             column="42"/>
     </issue>
 
@@ -5774,7 +5763,7 @@
         errorLine2="                                   ~~~~">
         <location
             file="src/main/java/app/pachli/BaseActivity.java"
-            line="211"
+            line="221"
             column="36"/>
     </issue>
 
@@ -5785,7 +5774,7 @@
         errorLine2="                                                                                                        ~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/BaseActivity.java"
-            line="211"
+            line="221"
             column="105"/>
     </issue>
 
@@ -5796,7 +5785,7 @@
         errorLine2="                                         ~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/BaseActivity.java"
-            line="219"
+            line="229"
             column="42"/>
     </issue>
 
@@ -5807,7 +5796,7 @@
         errorLine2="                                                                                              ~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/BaseActivity.java"
-            line="219"
+            line="229"
             column="95"/>
     </issue>
 
@@ -5818,7 +5807,7 @@
         errorLine2="                                   ~~~~~~~~">
         <location
             file="src/main/java/app/pachli/BaseActivity.java"
-            line="286"
+            line="296"
             column="36"/>
     </issue>
 
@@ -5829,7 +5818,7 @@
         errorLine2="                                                         ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/BaseActivity.java"
-            line="286"
+            line="296"
             column="58"/>
     </issue>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:theme="@style/DefaultTheme"
+        android:theme="@style/Theme.Pachli"
         android:usesCleartextTraffic="false"
         android:localeConfig="@xml/locales_config">
 
@@ -117,7 +117,7 @@
             android:configChanges="orientation|screenSize" />
         <activity
             android:name=".ViewMediaActivity"
-            android:theme="@style/BaseTheme"
+            android:theme="@style/Theme.Pachli"
             android:configChanges="orientation|screenSize|keyboardHidden|screenLayout|smallestScreenSize" />
         <activity
             android:name=".components.account.AccountActivity"

--- a/app/src/main/java/app/pachli/BaseActivity.java
+++ b/app/src/main/java/app/pachli/BaseActivity.java
@@ -18,6 +18,7 @@
 package app.pachli;
 
 import static app.pachli.settings.PrefKeys.APP_THEME;
+import static app.pachli.util.ThemeUtils.THEME_BLACK;
 
 import android.app.ActivityManager;
 import android.content.Context;
@@ -73,6 +74,15 @@ public abstract class BaseActivity extends AppCompatActivity implements Injectab
     private HashMap<Integer, PermissionRequester> requesters;
 
     @Override
+    public void setTheme(int themeId) {
+        super.setTheme(themeId);
+        if (BuildConfig.DEBUG) {
+            String name = getResources().getResourceEntryName(themeId);
+            Log.d(TAG, "Setting theme: " + name);
+        }
+    }
+
+    @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
@@ -83,8 +93,8 @@ public abstract class BaseActivity extends AppCompatActivity implements Injectab
          * views are created. */
         String theme = preferences.getString(APP_THEME, ThemeUtils.APP_THEME_DEFAULT);
         Log.d("activeTheme", theme);
-        if (theme.equals("black")) {
-            setTheme(R.style.AppBlackTheme);
+        if (theme.equals(THEME_BLACK)) {
+            setTheme(R.style.Theme_Pachli_Black);
         }
 
         /* set the taskdescription programmatically, the theme would turn it blue */

--- a/app/src/main/java/app/pachli/MainActivity.kt
+++ b/app/src/main/java/app/pachli/MainActivity.kt
@@ -509,13 +509,17 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidInje
         header.currentProfileName.maxLines = 1
         header.currentProfileName.ellipsize = TextUtils.TruncateAt.END
 
-        header.accountHeaderBackground.setColorFilter(getColor(R.color.headerBackgroundFilter))
+        // Account header background and text colours are not styleable, so set them here
         header.accountHeaderBackground.setBackgroundColor(
             MaterialColors.getColor(
                 header,
-                R.attr.colorBackgroundAccent,
+                com.google.android.material.R.attr.colorSecondaryContainer,
             ),
         )
+        val headerTextColor = MaterialColors.getColor(header, com.google.android.material.R.attr.colorOnSecondaryContainer)
+        header.currentProfileName.setTextColor(headerTextColor)
+        header.currentProfileEmail.setTextColor(headerTextColor)
+
         val animateAvatars = preferences.getBoolean("animateGifAvatars", false)
 
         DrawerImageLoader.init(

--- a/app/src/main/java/app/pachli/adapter/PollAdapter.kt
+++ b/app/src/main/java/app/pachli/adapter/PollAdapter.kt
@@ -19,7 +19,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
-import app.pachli.R
 import app.pachli.databinding.ItemPollBinding
 import app.pachli.entity.Emoji
 import app.pachli.util.BindingHolder
@@ -28,6 +27,7 @@ import app.pachli.util.visible
 import app.pachli.viewdata.PollOptionViewData
 import app.pachli.viewdata.buildDescription
 import app.pachli.viewdata.calculatePercent
+import com.google.android.material.color.MaterialColors
 
 class PollAdapter : RecyclerView.Adapter<BindingHolder<ItemPollBinding>>() {
 
@@ -95,14 +95,19 @@ class PollAdapter : RecyclerView.Adapter<BindingHolder<ItemPollBinding>>() {
                     .emojify(emojis, resultTextView, animateEmojis)
 
                 val level = percent * 100
-                val optionColor = if (option.voted) {
-                    R.color.colorBackgroundHighlight
+                val optionColor: Int
+                val textColor: Int
+                if (option.voted) {
+                    optionColor = MaterialColors.getColor(resultTextView, com.google.android.material.R.attr.colorPrimary)
+                    textColor = MaterialColors.getColor(resultTextView, com.google.android.material.R.attr.colorOnPrimary)
                 } else {
-                    R.color.colorBackgroundAccent
+                    optionColor = MaterialColors.getColor(resultTextView, com.google.android.material.R.attr.colorSecondary)
+                    textColor = MaterialColors.getColor(resultTextView, com.google.android.material.R.attr.colorOnSecondary)
                 }
 
                 resultTextView.background.level = level
-                resultTextView.background.setTint(resultTextView.context.getColor(optionColor))
+                resultTextView.background.setTint(optionColor)
+                resultTextView.setTextColor(textColor)
                 resultTextView.setOnClickListener(resultClickListener)
             }
             SINGLE -> {

--- a/app/src/main/java/app/pachli/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/app/pachli/adapter/StatusBaseViewHolder.java
@@ -186,7 +186,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
         this.avatarRadius36dp = itemView.getContext().getResources().getDimensionPixelSize(R.dimen.avatar_radius_36dp);
         this.avatarRadius24dp = itemView.getContext().getResources().getDimensionPixelSize(R.dimen.avatar_radius_24dp);
 
-        mediaPreviewUnloaded = new ColorDrawable(MaterialColors.getColor(itemView, R.attr.colorBackgroundAccent));
+        mediaPreviewUnloaded = new ColorDrawable(MaterialColors.getColor(itemView, android.R.attr.textColorLink));
 
         TouchDelegateHelper.expandTouchSizeToFillRow((ViewGroup) itemView, CollectionsKt.listOfNotNull(replyButton, reblogButton, favouriteButton, bookmarkButton, moreButton));
     }

--- a/app/src/main/java/app/pachli/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeActivity.kt
@@ -92,6 +92,7 @@ import app.pachli.settings.PrefKeys.APP_THEME
 import app.pachli.util.APP_THEME_DEFAULT
 import app.pachli.util.MentionSpan
 import app.pachli.util.PickMediaFiles
+import app.pachli.util.THEME_BLACK
 import app.pachli.util.getInitialLanguages
 import app.pachli.util.getLocaleList
 import app.pachli.util.getMediaSize
@@ -210,7 +211,7 @@ class ComposeActivity :
         activeAccount = accountManager.activeAccount ?: return
 
         val theme = preferences.getString(APP_THEME, APP_THEME_DEFAULT)
-        if (theme == "black") {
+        if (theme == THEME_BLACK) {
             setTheme(R.style.AppDialogActivityBlackTheme)
         }
         setContentView(binding.root)

--- a/app/src/main/java/app/pachli/components/viewthread/edits/ViewEditsAdapter.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/edits/ViewEditsAdapter.kt
@@ -178,7 +178,7 @@ class ViewEditsAdapter(
                 val placeholder: Drawable = if (blurhash != null && useBlurhash) {
                     decodeBlurHash(context, blurhash)
                 } else {
-                    ColorDrawable(MaterialColors.getColor(imageView, R.attr.colorBackgroundAccent))
+                    ColorDrawable(MaterialColors.getColor(imageView, android.R.attr.colorBackground))
                 }
 
                 if (attachment.previewUrl.isNullOrEmpty()) {

--- a/app/src/main/java/app/pachli/util/StatusViewHelper.kt
+++ b/app/src/main/java/app/pachli/util/StatusViewHelper.kt
@@ -16,7 +16,6 @@
 package app.pachli.util
 
 import android.content.Context
-import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.text.InputFilter
 import android.text.TextUtils
@@ -86,7 +85,7 @@ class StatusViewHelper(private val itemView: View) {
             return
         }
 
-        val mediaPreviewUnloaded = ColorDrawable(MaterialColors.getColor(context, R.attr.colorBackgroundAccent, Color.BLACK))
+        val mediaPreviewUnloaded = ColorDrawable(MaterialColors.getColor(itemView, android.R.attr.colorBackground))
 
         val n = min(attachments.size, Status.MAX_MEDIA_ATTACHMENTS)
 
@@ -313,6 +312,8 @@ class StatusViewHelper(private val itemView: View) {
     private fun setupPollResult(poll: PollViewData, emojis: List<Emoji>, pollResults: List<TextView>, animateEmojis: Boolean) {
         val options = poll.options
 
+        // TODO: This is very similar to code in PollAdapter.onBindViewHolder, investigate how it
+        // can best be reused.
         for (i in 0 until Status.MAX_POLL_OPTIONS) {
             if (i < options.size) {
                 val percent = calculatePercent(options[i].votesCount, poll.votersCount, poll.votesCount)
@@ -322,14 +323,20 @@ class StatusViewHelper(private val itemView: View) {
                 pollResults[i].visibility = View.VISIBLE
 
                 val level = percent * 100
-                val optionColor = if (options[i].voted) {
-                    R.color.colorBackgroundHighlight
+
+                val optionColor: Int
+                val textColor: Int
+                if (options[i].voted) {
+                    optionColor = MaterialColors.getColor(pollResults[i], com.google.android.material.R.attr.colorPrimary)
+                    textColor = MaterialColors.getColor(pollResults[i], com.google.android.material.R.attr.colorOnPrimary)
                 } else {
-                    R.color.colorBackgroundAccent
+                    optionColor = MaterialColors.getColor(pollResults[i], com.google.android.material.R.attr.colorSecondary)
+                    textColor = MaterialColors.getColor(pollResults[i], com.google.android.material.R.attr.colorOnSecondary)
                 }
 
                 pollResults[i].background.level = level
-                pollResults[i].background.setTint(pollResults[i].context.getColor(optionColor))
+                pollResults[i].background.setTint(optionColor)
+                pollResults[i].setTextColor(textColor)
             } else {
                 pollResults[i].visibility = View.GONE
             }

--- a/app/src/main/res/drawable/card_frame.xml
+++ b/app/src/main/res/drawable/card_frame.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
     <corners android:radius="6dp" />
-    <stroke android:color="?attr/colorBackgroundAccent" android:width="1dp" />
+    <stroke android:color="?colorOutline" android:width="1dp" />
 </shape>

--- a/app/src/main/res/drawable/card_image_placeholder.xml
+++ b/app/src/main/res/drawable/card_image_placeholder.xml
@@ -3,8 +3,10 @@
     android:width="48dp"
     android:height="48dp"
     android:viewportWidth="24"
-    android:viewportHeight="24">
+    android:viewportHeight="24"
+    android:tint="?android:textColorLink"
+    >
     <path
-        android:fillColor="?android:attr/textColorTertiary"
+        android:fillColor="#fff"
         android:pathData="M6,2A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2H6M6,4H13V9H18V20H6V4M8,12V14H16V12H8M8,16V18H13V16H8Z" />
 </vector>

--- a/app/src/main/res/drawable/help_message_background.xml
+++ b/app/src/main/res/drawable/help_message_background.xml
@@ -7,8 +7,7 @@
         android:top="1dp">
 
         <shape android:shape="rectangle">
-            <solid android:color="?attr/colorBackgroundAccent"/>
-            <stroke android:width="1dp" android:color="?attr/dividerColor"/>
+            <stroke android:width="1dp" android:color="?colorOutline"/>
         </shape>
     </item>
 </layer-list>

--- a/app/src/main/res/drawable/poll_option_shape.xml
+++ b/app/src/main/res/drawable/poll_option_shape.xml
@@ -3,5 +3,5 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <corners android:radius="6dp"/>
-    <solid android:color="?attr/colorBackgroundAccent" />
+    <solid android:color="?colorSecondary" />
 </shape>

--- a/app/src/main/res/layout-sw640dp/fragment_timeline.xml
+++ b/app/src/main/res/layout-sw640dp/fragment_timeline.xml
@@ -1,25 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="?attr/windowBackgroundColor">
+    android:layout_height="match_parent">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="640dp"
         android:layout_height="match_parent"
         android:layout_gravity="center_horizontal"
         android:background="?android:attr/colorBackground">
-
-        <ProgressBar
-            android:id="@+id/progressBar"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
 
         <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
             android:id="@+id/swipeRefreshLayout"
@@ -40,16 +29,18 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:layout_marginBottom="?attr/actionBarSize"
-                    android:src="@android:color/transparent"
-                    android:visibility="gone"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintLeft_toLeftOf="parent"
-                    app:layout_constraintRight_toRightOf="parent"
-                    app:layout_constraintTop_toTopOf="parent"
-                    tools:src="@drawable/errorphant_error"
-                    tools:visibility="visible" />
+                    android:visibility="gone" />
             </FrameLayout>
         </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+
+        <ProgressBar
+            android:id="@+id/progressBar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
         <androidx.core.widget.ContentLoadingProgressBar
             android:id="@+id/topProgressBar"
@@ -62,7 +53,5 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
-
     </androidx.constraintlayout.widget.ConstraintLayout>
-
 </FrameLayout>

--- a/app/src/main/res/layout-sw640dp/fragment_timeline_notifications.xml
+++ b/app/src/main/res/layout-sw640dp/fragment_timeline_notifications.xml
@@ -20,62 +20,18 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="?attr/windowBackgroundColor">
+    android:layout_height="match_parent">
 
-    <androidx.coordinatorlayout.widget.CoordinatorLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="640dp"
         android:layout_height="match_parent"
         android:layout_gravity="center_horizontal"
         android:background="?android:attr/colorBackground">
 
-        <com.google.android.material.appbar.AppBarLayout
-            android:id="@+id/appBarOptions"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="?attr/colorSurface"
-            app:elevation="0dp">
-
-            <LinearLayout
-                android:id="@+id/topButtonsLayout"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal">
-
-                <Button
-                    android:id="@+id/buttonClear"
-                    style="@style/AppButton.TextButton"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="@string/notifications_clear"
-                    android:textSize="?attr/status_text_medium" />
-
-                <Button
-                    android:id="@+id/buttonFilter"
-                    style="@style/AppButton.TextButton"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="@string/notifications_apply_filter"
-                    android:textSize="?attr/status_text_medium" />
-
-            </LinearLayout>
-
-            <View
-                android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:layout_gravity="bottom"
-                android:background="?android:attr/listDivider"
-                app:layout_scrollFlags="scroll|enterAlways" />
-
-        </com.google.android.material.appbar.AppBarLayout>
-
         <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
             android:id="@+id/swipeRefreshLayout"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            app:layout_behavior="@string/appbar_scrolling_view_behavior">
+            android:layout_height="match_parent">
 
             <FrameLayout
                 android:layout_width="match_parent"
@@ -84,16 +40,14 @@
                 <androidx.recyclerview.widget.RecyclerView
                     android:id="@+id/recyclerView"
                     android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:background="?android:attr/colorBackground" />
+                    android:layout_height="match_parent" />
 
                 <app.pachli.view.BackgroundMessageView
                     android:id="@+id/statusView"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:layout_gravity="center"
-                    android:visibility="gone"
-                    tools:visibility="visible" />
+                    android:layout_marginBottom="?attr/actionBarSize"
+                    android:visibility="gone" />
             </FrameLayout>
         </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
@@ -101,7 +55,22 @@
             android:id="@+id/progressBar"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="center" />
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
-    </androidx.coordinatorlayout.widget.CoordinatorLayout>
+        <androidx.core.widget.ContentLoadingProgressBar
+            android:id="@+id/topProgressBar"
+            style="@style/Widget.AppCompat.ProgressBar.Horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:indeterminate="true"
+            android:visibility="gone"
+            app:layout_constraintBottom_toTopOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </FrameLayout>

--- a/app/src/main/res/layout/activity_compose.xml
+++ b/app/src/main/res/layout/activity_compose.xml
@@ -117,7 +117,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="2dp"
-                android:background="?attr/colorBackgroundAccent"
                 android:lineSpacingMultiplier="1.1"
                 android:paddingLeft="16dp"
                 android:paddingTop="4dp"
@@ -146,7 +145,6 @@
                     android:maxLines="1"
                     android:paddingLeft="16dp"
                     android:paddingRight="16dp"
-                    android:textColorHint="?android:attr/textColorTertiary"
                     android:textSize="?attr/status_text_medium" />
 
                 <View
@@ -311,7 +309,7 @@
             android:layout_marginEnd="4dp"
             android:contentDescription="@string/action_toggle_visibility"
             android:padding="4dp"
-            android:tint="?android:attr/textColorTertiary"
+            app:tint="?android:attr/textColorTertiary"
             app:tooltipText="@string/action_toggle_visibility"
             tools:src="@drawable/ic_public_24dp" />
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -23,10 +23,10 @@
             app:elevationOverlayEnabled="false">
 
             <androidx.appcompat.widget.Toolbar
+                style="@style/Pachli.Widget.Toolbar"
                 android:id="@+id/mainToolbar"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:minHeight="?attr/actionBarSizeWithSubtitle"
                 app:contentInsetStartWithNavigation="0dp"
                 app:layout_scrollFlags="scroll|enterAlways"
                 app:navigationContentDescription="@string/action_open_drawer" />

--- a/app/src/main/res/layout/item_poll.xml
+++ b/app/src/main/res/layout/item_poll.xml
@@ -18,7 +18,7 @@
         android:paddingEnd="6dp"
         android:paddingBottom="2dp"
         android:textAlignment="viewStart"
-        android:textColor="?android:attr/textColorPrimary"
+        android:textColor="?colorOnSecondary"
         android:textSize="?attr/status_text_medium"
         tools:text="40%" />
 

--- a/app/src/main/res/layout/item_status.xml
+++ b/app/src/main/res/layout/item_status.xml
@@ -176,7 +176,6 @@
             android:layout_width="match_parent"
             android:layout_height="300dp"
             android:layout_margin="1dp"
-            android:background="?attr/colorBackgroundAccent"
             android:importantForAccessibility="no"
             android:scaleType="center" />
 
@@ -216,6 +215,7 @@
                 android:layout_height="wrap_content"
                 android:ellipsize="end"
                 android:lines="1"
+                android:textColor="?android:attr/textColorLink"
                 android:textSize="?attr/status_text_medium" />
         </LinearLayout>
     </LinearLayout>

--- a/app/src/main/res/layout/item_status_detailed.xml
+++ b/app/src/main/res/layout/item_status_detailed.xml
@@ -157,7 +157,6 @@
             android:layout_width="match_parent"
             android:layout_height="300dp"
             android:layout_margin="1dp"
-            android:background="?attr/colorBackgroundAccent"
             android:importantForAccessibility="no"
             android:scaleType="center" />
 

--- a/app/src/main/res/layout/item_trending_link.xml
+++ b/app/src/main/res/layout/item_trending_link.xml
@@ -42,7 +42,6 @@
             android:layout_width="match_parent"
             android:layout_height="300dp"
             android:layout_margin="1dp"
-            android:background="?attr/colorBackgroundAccent"
             android:importantForAccessibility="no"
             android:scaleType="center" />
 
@@ -86,7 +85,7 @@
                 android:layout_height="wrap_content"
                 android:ellipsize="end"
                 android:lines="1"
-                android:textColor="?android:textColorTertiary"
+                android:textColor="?android:attr/textColorLink"
                 android:textSize="?attr/status_text_medium"
                 tools:ignore="SelectableText" />
         </LinearLayout>

--- a/app/src/main/res/values-large/styles.xml
+++ b/app/src/main/res/values-large/styles.xml
@@ -1,5 +1,5 @@
 <resources>
-    <style name="AppDialogActivityTheme" parent="@style/DefaultTheme">
+    <style name="AppDialogActivityTheme" parent="@style/Theme.Pachli">
         <item name="android:windowFrame">@null</item>
         <item name="android:windowBackground">@drawable/background_dialog_activity</item>
         <item name="android:windowIsFloating">true</item>
@@ -11,7 +11,7 @@
         <item name="android:windowMinWidthMinor">80%</item>
     </style>
 
-    <style name="AppDialogActivityBlackTheme" parent="@style/AppBlackTheme">
+    <style name="AppDialogActivityBlackTheme" parent="@style/Theme.Pachli.Black">
         <item name="android:windowFrame">@null</item>
         <item name="android:windowBackground">@drawable/background_dialog_activity</item>
         <item name="android:windowIsFloating">true</item>
@@ -22,5 +22,4 @@
         <item name="android:windowMinWidthMajor">80%</item>
         <item name="android:windowMinWidthMinor">80%</item>
     </style>
-
 </resources>

--- a/app/src/main/res/values-night/theme_colors.xml
+++ b/app/src/main/res/values-night/theme_colors.xml
@@ -2,13 +2,9 @@
 <resources>
     <color name="textColorDisabled">@color/tusky_grey_40</color>
 
-    <color name="colorBackgroundAccent">@color/tusky_grey_30</color>
-    <color name="colorBackgroundHighlight">@color/tusky_grey_50</color>
     <color name="dividerColor">@color/tusky_grey_30</color>
 
     <color name="favoriteButtonActiveColor">@color/tusky_orange</color>
-
-    <color name="headerBackgroundFilter">@color/header_background_filter_dark</color>
 
     <!-- colors used to show inserted/deleted text -->
     <color name="view_edits_background_insert">#00731B</color>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -16,7 +16,7 @@
   -->
 
 <resources>
-    <style name="AppTheme" parent="Theme.Material3.DayNight.NoActionBar">
+    <style name="Base.Theme.Pachli" parent="Theme.Material3.DayNight.NoActionBar">
         <item name="colorPrimary">@color/md_theme_dark_primary</item>
         <item name="colorOnPrimary">@color/md_theme_dark_onPrimary</item>
         <item name="colorPrimaryContainer">@color/md_theme_dark_primaryContainer</item>

--- a/app/src/main/res/values-v27/themes.xml
+++ b/app/src/main/res/values-v27/themes.xml
@@ -1,10 +1,8 @@
 <resources>
-
     <!--Black Application Theme Styles-->
-    <style name="AppBlackTheme" parent="BaseTheme.Black">
+    <style name="Theme.Pachli.Black" parent="Base.Theme.Black">
         <item name="android:windowLightNavigationBar">false</item>
         <item name="android:navigationBarColor">@color/black</item>
         <item name="android:navigationBarDividerColor">?attr/dividerColor</item>
     </style>
-
 </resources>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -33,8 +33,6 @@
     </declare-styleable>
 
     <!--Themed Attributes-->
-    <attr name="colorBackgroundAccent" format="reference|color" />
-    <attr name="colorBackgroundHighlight" format="reference|color" />
     <attr name="textColorDisabled" format="reference|color" />
     <attr name="iconColor" format="reference|color" />
     <attr name="windowBackgroundColor" format="reference|color" />

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -83,14 +83,11 @@
     <color name="tusky_grey_20">#282c37</color>
     <color name="tusky_grey_30">#444b5d</color>
     <color name="tusky_grey_40">#596378</color>
-    <color name="tusky_grey_50">#6e7b92</color>
     <color name="tusky_grey_70">#9baec8</color>
     <color name="tusky_grey_80">#b9c8d8</color>
 
     <color name="transparent_tusky_blue">#8c2b90d9</color>
     <color name="transparent_black">#8f000000</color>
-    <color name="header_background_filter_dark">#44000000</color>
-    <color name="header_background_filter_light">#66FFFFFF</color>
     <color name="transparent_statusbar_background">#44000000</color>
 
     <!-- colors used in the elephant friend drawables -->

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -49,7 +49,7 @@
     <style name="FontLuciole">
         <item name="android:fontFamily">@font/luciole</item>
         <!-- Luciole requires more vertical height than the other fonts -->
-        <item name="actionBarSizeWithSubtitle">62dp</item>
+        <item name="actionBarSize">66dp</item>
     </style>
 
     <style name="FontOpenDyslexic">
@@ -58,14 +58,12 @@
 
     <style name="SplashTheme" parent="Theme.SplashScreen">
         <item name="windowSplashScreenAnimatedIcon">@drawable/ic_splash</item>
-        <item name="postSplashScreenTheme">@style/DefaultTheme</item>
+        <item name="postSplashScreenTheme">@style/Theme.Pachli</item>
     </style>
 
-    <style name="DefaultTheme" parent="BaseTheme" />
+    <style name="AppDialogActivityTheme" parent="@style/Theme.Pachli" />
 
-    <style name="AppDialogActivityTheme" parent="@style/DefaultTheme" />
-
-    <style name="BaseTheme" parent="AppTheme">
+    <style name="Theme.Pachli" parent="Base.Theme.Pachli">
         <!-- Provide default text sizes. These are overwritten in BaseActivity, but
              if they are missing then the Android Studio layout preview crashes
              with java.lang.reflect.InvocationTargetException -->
@@ -73,16 +71,7 @@
         <item name="status_text_medium">16sp</item>
         <item name="status_text_large">18sp</item>
 
-        <!-- required by materialDrawer library -->
-        <item name="colorBackgroundAccent">@color/colorBackgroundAccent</item>
-
         <item name="android:listDivider">@drawable/status_divider</item>
-
-        <!-- required by materialDrawerLibrary, see definition of PachliDrawerStyle -->
-        <item name="dividerColor">@color/dividerColor</item>
-
-        <item name="materialDrawerStyle">@style/AppDrawerStyle</item>
-        <item name="materialDrawerHeaderStyle">@style/AppDrawerHeaderStyle</item>
 
         <item name="alertDialogTheme">@style/AppDialog</item>
         <item name="snackbarButtonStyle">@style/AppButton.TextButton</item>
@@ -91,21 +80,25 @@
 
         <item name="swipeRefreshLayoutProgressSpinnerBackgroundColor">?attr/colorSurface</item>
 
-        <item name="chipStyle">@style/Widget.MaterialComponents.Chip.Choice</item>
-
         <item name="preferenceTheme">@style/AppPreferenceTheme</item>
 
-        <item name="actionBarSizeWithSubtitle">?attr/actionBarSize</item>
+        <!-- Transparent system bars for edge-to-edge. -->
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:windowLightStatusBar">?attr/isLightTheme</item>
+    </style>
+
+    <style name="Pachli.Widget.Toolbar" parent="Widget.Material3.Toolbar">
+        <item name="android:minHeight">?attr/actionBarSize</item>
     </style>
 
     <style name="ViewMediaActivity.AppBarLayout" parent="ThemeOverlay.AppCompat">
         <item name="android:colorControlNormal">@color/white</item>
     </style>
 
-    <style name="AppDialog" parent="@style/ThemeOverlay.MaterialComponents.Dialog.Alert">
+    <style name="AppDialog" parent="@style/ThemeOverlay.Material3.Dialog.Alert">
         <item name="android:letterSpacing">0</item>
         <item name="dialogCornerRadius">8dp</item>
-<!--        <item name="android:colorBackground">@color/colorBackground</item>-->
     </style>
 
     <style name="AppDialogFragmentStyle" parent="@style/ThemeOverlay.MaterialComponents.Dialog">
@@ -126,7 +119,6 @@
     </style>
 
     <style name="AppButton.Outlined" parent="Widget.MaterialComponents.Button.OutlinedButton">
-        <item name="strokeColor">?attr/colorBackgroundAccent</item>
         <item name="android:letterSpacing">0</item>
     </style>
 
@@ -146,7 +138,7 @@
     </style>
 
     <!--Black Application Theme Styles-->
-    <style name="BaseTheme.Black" parent="BaseTheme">
+    <style name="Base.Theme.Black" parent="Theme.Pachli">
         <item name="colorPrimaryDark">@color/tusky_grey_05</item>
 
         <item name="android:colorBackground">@color/black</item>
@@ -156,25 +148,11 @@
 
         <!-- TODO: Remove this, use colorControlNormal everywhere instead of iconColor -->
         <item name="iconColor">?attr/colorControlNormal</item>
-        <item name="colorBackgroundHighlight">@color/tusky_grey_40</item>
-        <item name="colorBackgroundAccent">@color/tusky_grey_20</item>
 
         <item name="dividerColor">@color/tusky_grey_20</item>
     </style>
 
-    <style name="AppBlackTheme" parent="BaseTheme.Black" />
-
-    <style name="AppDrawerStyle" parent ="Widget.MaterialDrawerStyle">
-        <item name="materialDrawerBackground">?android:colorBackground</item>
-        <item name="materialDrawerPrimaryIcon">?colorOnBackground</item>
-        <item name="materialDrawerSecondaryIcon">?colorOnBackground</item>
-        <item name="materialDrawerDividerColor">?colorOnBackground</item>
-    </style>
-
-    <style name="AppDrawerHeaderStyle" parent ="Widget.MaterialDrawerHeaderStyle">
-        <item name="materialDrawerHeaderSelectionText">?android:textColorPrimary</item>
-        <item name="materialDrawerHeaderSelectionSubtext">?android:textColorPrimary</item>
-    </style>
+    <style name="Theme.Pachli.Black" parent="Base.Theme.Black" />
 
     <!-- customize the shape of the avatars in account selection list -->
     <style name="BezelImageView">

--- a/app/src/main/res/values/theme_colors.xml
+++ b/app/src/main/res/values/theme_colors.xml
@@ -2,13 +2,9 @@
 <resources>
     <color name="textColorDisabled">@color/tusky_grey_70</color>
 
-    <color name="colorBackgroundAccent">@color/tusky_grey_70</color>
-    <color name="colorBackgroundHighlight">@color/tusky_grey_50</color>
     <color name="dividerColor">@color/tusky_grey_80</color>
 
     <color name="favoriteButtonActiveColor">@color/tusky_orange_light</color>
-
-    <color name="headerBackgroundFilter">@color/header_background_filter_light</color>
 
     <color name="botBadgeForeground">@color/tusky_grey_20</color>
     <color name="botBadgeBackground">@color/white</color>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -16,7 +16,7 @@
   -->
 
 <resources>
-    <style name="AppTheme" parent="Theme.Material3.DayNight.NoActionBar">
+    <style name="Base.Theme.Pachli" parent="Theme.Material3.DayNight.NoActionBar">
         <item name="colorPrimary">@color/md_theme_light_primary</item>
         <item name="colorOnPrimary">@color/md_theme_light_onPrimary</item>
         <item name="colorPrimaryContainer">@color/md_theme_light_primaryContainer</item>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -159,7 +159,8 @@ androidx = ["androidx-core-ktx", "androidx-appcompat", "androidx-fragment-ktx", 
     "androidx-lifecycle-livedata-ktx", "androidx-lifecycle-common-java8", "androidx-lifecycle-reactivestreams-ktx",
     "androidx-constraintlayout", "androidx-paging-runtime-ktx", "androidx-viewpager2", "androidx-work-runtime-ktx",
     "androidx-core-splashscreen", "androidx-activity", "androidx-media3-exoplayer", "androidx-media3-exoplayer-dash",
-    "androidx-media3-exoplayer-hls", "androidx-media3-exoplayer-rtsp", "androidx-media3-datasource-okhttp", "androidx-media3-ui"]
+    "androidx-media3-exoplayer-hls", "androidx-media3-exoplayer-rtsp", "androidx-media3-datasource-okhttp", "androidx-media3-ui",
+    "android-material"]
 autodispose = ["autodispose-core", "autodispose-android-lifecycle"]
 dagger = ["dagger-core", "dagger-android-core", "dagger-android-support"]
 dagger-processors = ["dagger-compiler", "dagger-android-processor"]


### PR DESCRIPTION
First crash appeared to be caused by a failure to find the `attr/colorBackgroundAccent` colour from the theme.

It wasn't clear why the attribute could not be found, so to fix it was simpler to remove the color and attribute entirely, and replace it with something more appropriate from the Material 3 tokens.

- Preview cards are stroked with `colorOutline`
- Poll options use `colorPrimary` (user's vote) or `colorSecondary` (other choices) with appropriate text colours.
- Links in link preview cards use `android:attr/textColorLink`
- The placeholder icon in preview cards uses `?android/textColorLink`
- Remove it from `help_message_background`, and stroke with `?colorOutline`

Doing this I discovered several places where a colour was being specified unnecessarily, those have been removed.

To make it easier to understand the theme hierarchy that has been collapsed and renamed to follow Android conventions.

- AppTheme -> Base.Theme.Pachli
- BaseTheme -> Theme.Pachli
- DefaultTheme has been removed as unnecessary

This unearthed a second crash, where `attr/actionBarSizeWithSubtitle` was not found.

To fix that create an explicit style for toolbars that need it, and apply the style (`Pachli.Widget.Toolbar`).

This also surfaced a third problem, where the `fragment_timeline*` layouts had not been updated in `layout-sw640dp`, so those have been updated to reflect the same views/IDs as the default `fragment_timeline` layout.

These changes caused a small chain of "unused resource" lint errors, which have been fixed by removing the unused colours.

The Android Material libraries were also being implicitly depended on through other library imports instead of being explicit. So include them as an explicit dependency.

Fixes #18