### PR TITLE
fix: Fix toolbar flickering when scrolling lists

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -1366,17 +1366,6 @@
         errorLine1="    android:background=&quot;?android:attr/colorBackground&quot;>"
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="src/main/res/layout/fragment_timeline.xml"
-            line="6"
-            column="5"/>
-    </issue>
-
-    <issue
-        id="Overdraw"
-        message="Possible overdraw: Root element paints background `?android:attr/colorBackground` with a theme that also paints a background (inferred theme is `@style/Theme.Pachli`)"
-        errorLine1="    android:background=&quot;?android:attr/colorBackground&quot;>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
             file="src/main/res/layout/fragment_timeline_notifications.xml"
             line="23"
             column="5"/>
@@ -3853,7 +3842,7 @@
         errorLine2="                                 ~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/components/timeline/TimelineFragment.kt"
-            line="174"
+            line="177"
             column="34"/>
     </issue>
 

--- a/app/src/main/java/app/pachli/StatusListActivity.kt
+++ b/app/src/main/java/app/pachli/StatusListActivity.kt
@@ -32,8 +32,10 @@ import app.pachli.components.timeline.TimelineKind
 import app.pachli.databinding.ActivityStatuslistBinding
 import app.pachli.entity.Filter
 import app.pachli.entity.FilterV1
+import app.pachli.interfaces.AppBarLayoutHost
 import app.pachli.util.viewBinding
 import at.connyduck.calladapter.networkresult.fold
+import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.snackbar.Snackbar
 import dagger.android.DispatchingAndroidInjector
 import dagger.android.HasAndroidInjector
@@ -45,7 +47,7 @@ import javax.inject.Inject
  * Show a list of statuses of a particular type; containing a particular hashtag,
  * the user's favourites, bookmarks, etc.
  */
-class StatusListActivity : BottomSheetActivity(), HasAndroidInjector {
+class StatusListActivity : BottomSheetActivity(), AppBarLayoutHost, HasAndroidInjector {
 
     @Inject
     lateinit var dispatchingAndroidInjector: DispatchingAndroidInjector<Any>
@@ -55,6 +57,9 @@ class StatusListActivity : BottomSheetActivity(), HasAndroidInjector {
 
     private val binding: ActivityStatuslistBinding by viewBinding(ActivityStatuslistBinding::inflate)
     private lateinit var timelineKind: TimelineKind
+
+    override val appBarLayout: AppBarLayout
+        get() = binding.includedToolbar.appbar
 
     /**
      * If showing statuses with a hashtag, the hashtag being used, without the

--- a/app/src/main/java/app/pachli/components/timeline/TimelineFragment.kt
+++ b/app/src/main/java/app/pachli/components/timeline/TimelineFragment.kt
@@ -57,6 +57,7 @@ import app.pachli.di.ViewModelFactory
 import app.pachli.entity.Status
 import app.pachli.fragment.SFragment
 import app.pachli.interfaces.ActionButtonActivity
+import app.pachli.interfaces.AppBarLayoutHost
 import app.pachli.interfaces.RefreshableFragment
 import app.pachli.interfaces.ReselectableFragment
 import app.pachli.interfaces.StatusActionListener
@@ -164,6 +165,8 @@ class TimelineFragment :
 
         setupSwipeRefreshLayout()
         setupRecyclerView()
+
+        (requireActivity() as? AppBarLayoutHost)?.appBarLayout?.setLiftOnScrollTargetView(binding.recyclerView)
 
         if (actionButtonPresent()) {
             binding.recyclerView.addOnScrollListener(

--- a/app/src/main/java/app/pachli/interfaces/AppBarLayoutHost.kt
+++ b/app/src/main/java/app/pachli/interfaces/AppBarLayoutHost.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.interfaces
+
+import com.google.android.material.appbar.AppBarLayout
+
+/**
+ * Access the host's [AppBarLayout].
+ *
+ * Activities that contain an [AppBarLayout] need to "lift" the app bar when content scrolls
+ * under the bar, otherwise the app bar background flickers.
+ *
+ * When the scrolling view and the app bar are in the same layout this is achieved with the
+ * `app:liftOnScrollTargetViewId` attribute. But when they are in different layouts the
+ * view that scrolls must call methods on the app bar to tell it when to "lift".
+ */
+interface AppBarLayoutHost {
+    val appBarLayout: AppBarLayout
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -17,12 +17,10 @@
             android:id="@+id/appBar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:elevation="@dimen/actionbar_elevation"
             app:liftOnScroll="true"
-            app:liftOnScrollTargetViewId="@id/viewPager"
-            app:elevationOverlayEnabled="false">
+            app:liftOnScrollTargetViewId="@id/viewPager">
 
-            <androidx.appcompat.widget.Toolbar
+            <com.google.android.material.appbar.MaterialToolbar
                 style="@style/Pachli.Widget.Toolbar"
                 android:id="@+id/mainToolbar"
                 android:layout_width="match_parent"
@@ -31,7 +29,7 @@
                 app:layout_scrollFlags="scroll|enterAlways"
                 app:navigationContentDescription="@string/action_open_drawer" />
 
-            <androidx.appcompat.widget.Toolbar
+            <com.google.android.material.appbar.MaterialToolbar
                 android:id="@+id/topNav"
                 android:layout_width="match_parent"
                 android:layout_height="48dp"
@@ -47,7 +45,7 @@
                     app:tabGravity="fill"
                     app:tabMaxWidth="0dp"
                     app:tabMode="scrollable" />
-            </androidx.appcompat.widget.Toolbar>
+            </com.google.android.material.appbar.MaterialToolbar>
 
         </com.google.android.material.appbar.AppBarLayout>
 
@@ -58,7 +56,7 @@
             android:layout_marginBottom="?attr/actionBarSize"
             app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
-        <androidx.appcompat.widget.Toolbar
+        <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/bottomNav"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -76,7 +74,7 @@
                 app:tabIndicatorGravity="top"
                 app:tabMaxWidth="0dp"
                 app:tabMode="scrollable" />
-        </androidx.appcompat.widget.Toolbar>
+        </com.google.android.material.appbar.MaterialToolbar>
 
         <com.google.android.material.floatingactionbutton.FloatingActionButton
             android:id="@+id/composeButton"

--- a/app/src/main/res/layout/activity_search.xml
+++ b/app/src/main/res/layout/activity_search.xml
@@ -9,14 +9,14 @@
     <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:elevation="@dimen/actionbar_elevation"
+        app:liftOnScroll="true"
+        app:liftOnScrollTargetViewId="@id/pages"
         app:layout_collapseMode="pin">
 
         <androidx.appcompat.widget.Toolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
-            android:elevation="@dimen/actionbar_elevation"
             app:contentInsetStartWithNavigation="0dp"
             app:layout_scrollFlags="scroll|snap|enterAlways"
             app:navigationIcon="?attr/homeAsUpIndicator" />

--- a/app/src/main/res/layout/activity_view_thread.xml
+++ b/app/src/main/res/layout/activity_view_thread.xml
@@ -11,11 +11,12 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:elevation="@dimen/actionbar_elevation"
+        app:liftOnScroll="true"
+        app:liftOnScrollTargetViewId="@id/fragment_container"
         app:elevationOverlayEnabled="false">
 
-        <androidx.appcompat.widget.Toolbar
+        <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"
-            style="@style/Widget.AppCompat.Toolbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:contentInsetStartWithNavigation="0dp"

--- a/app/src/main/res/layout/fragment_timeline.xml
+++ b/app/src/main/res/layout/fragment_timeline.xml
@@ -2,8 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="?android:attr/colorBackground">
+    android:layout_height="match_parent">
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/swipeRefreshLayout"

--- a/app/src/main/res/layout/toolbar_basic.xml
+++ b/app/src/main/res/layout/toolbar_basic.xml
@@ -5,10 +5,10 @@
     android:id="@+id/appbar"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:elevation="@dimen/actionbar_elevation"
+    app:liftOnScroll="true"
     app:layout_collapseMode="pin">
 
-    <androidx.appcompat.widget.Toolbar
+    <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize" />


### PR DESCRIPTION
Scrolling a thread, set of search results, or viewing a thread would cause the toolbar to flicker as items moved under it.

Fix this by configuring the toolbar to `liftOnScroll` in the relevant layouts.

It needs to be configured with the view (or ID of the view) that it will be scrolling. For views that are in the same layout this is done with the `liftOnScrollTargetViewId` attribute.

For views that are in different layouts (e.g. the toolbar is in the activity and the scrolling view is in a fragment) the app bar's `setLiftOnScrollTargetView` method must be called.

Do this in `TimelineFragment` if the hosting activity is a new interface `AppBarLayoutHost`. Implement this interface in `StatusListActivity`.

Update the relevant layouts to use `MaterialToolbar`.

Fixes #21