### PR TITLE
fix: Use the correct contrast colour on hashtag tab chips

### DIFF
--- a/app/src/main/res/layout/item_tab_preference.xml
+++ b/app/src/main/res/layout/item_tab_preference.xml
@@ -70,7 +70,8 @@
             android:checkable="false"
             android:text="@string/add_hashtag_title"
             app:chipIcon="@drawable/ic_plus_24dp"
-            app:chipSurfaceColor="?colorPrimary" />
+            app:chipSurfaceColor="?colorPrimary"
+            android:textColor="?colorOnPrimary" />
 
     </com.google.android.material.chip.ChipGroup>
 


### PR DESCRIPTION
The chips for adding a new hashtag to a tab specified the background colour without setting the text colour, resulting in the colour being too low-contrast against the background.

Use `?colorOnPrimary` to get the correct colour.