### PR TITLE
fix: Fix toolbar flickering in additional activities

### DIFF
--- a/app/src/main/java/app/pachli/components/accountlist/AccountListActivity.kt
+++ b/app/src/main/java/app/pachli/components/accountlist/AccountListActivity.kt
@@ -22,14 +22,22 @@ import androidx.fragment.app.commit
 import app.pachli.BottomSheetActivity
 import app.pachli.R
 import app.pachli.databinding.ActivityAccountListBinding
+import app.pachli.interfaces.AppBarLayoutHost
+import app.pachli.util.viewBinding
+import com.google.android.material.appbar.AppBarLayout
 import dagger.android.DispatchingAndroidInjector
 import dagger.android.HasAndroidInjector
 import javax.inject.Inject
 
-class AccountListActivity : BottomSheetActivity(), HasAndroidInjector {
+class AccountListActivity : BottomSheetActivity(), AppBarLayoutHost, HasAndroidInjector {
 
     @Inject
     lateinit var dispatchingAndroidInjector: DispatchingAndroidInjector<Any>
+
+    private val binding: ActivityAccountListBinding by viewBinding(ActivityAccountListBinding::inflate)
+
+    override val appBarLayout: AppBarLayout
+        get() = binding.includedToolbar.appbar
 
     enum class Type {
         FOLLOWS,
@@ -43,7 +51,6 @@ class AccountListActivity : BottomSheetActivity(), HasAndroidInjector {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val binding = ActivityAccountListBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
         val type = intent.getSerializableExtra(EXTRA_TYPE) as Type

--- a/app/src/main/java/app/pachli/components/accountlist/AccountListFragment.kt
+++ b/app/src/main/java/app/pachli/components/accountlist/AccountListFragment.kt
@@ -45,6 +45,7 @@ import app.pachli.di.Injectable
 import app.pachli.entity.Relationship
 import app.pachli.entity.TimelineAccount
 import app.pachli.interfaces.AccountActionListener
+import app.pachli.interfaces.AppBarLayoutHost
 import app.pachli.interfaces.LinkListener
 import app.pachli.network.MastodonApi
 import app.pachli.settings.PrefKeys
@@ -101,6 +102,7 @@ class AccountListFragment :
         binding.recyclerView.addItemDecoration(
             MaterialDividerItemDecoration(requireContext(), MaterialDividerItemDecoration.VERTICAL),
         )
+        (requireActivity() as? AppBarLayoutHost)?.appBarLayout?.setLiftOnScrollTargetView(binding.recyclerView)
 
         binding.swipeRefreshLayout.setOnRefreshListener { fetchAccounts() }
         binding.swipeRefreshLayout.setColorSchemeColors(MaterialColors.getColor(binding.root, androidx.appcompat.R.attr.colorPrimary))

--- a/app/src/main/java/app/pachli/components/filters/FiltersActivity.kt
+++ b/app/src/main/java/app/pachli/components/filters/FiltersActivity.kt
@@ -42,6 +42,7 @@ class FiltersActivity : BaseActivity(), FiltersListener {
 
         binding.swipeRefreshLayout.setOnRefreshListener { loadFilters() }
         binding.swipeRefreshLayout.setColorSchemeColors(MaterialColors.getColor(binding.root, androidx.appcompat.R.attr.colorPrimary))
+        binding.includedToolbar.appbar.setLiftOnScrollTargetView(binding.filtersList)
 
         setTitle(R.string.pref_title_timeline_filters)
     }

--- a/app/src/main/java/app/pachli/components/followedtags/FollowedTagsActivity.kt
+++ b/app/src/main/java/app/pachli/components/followedtags/FollowedTagsActivity.kt
@@ -75,6 +75,8 @@ class FollowedTagsActivity :
                 }
             }
         }
+
+        binding.includedToolbar.appbar.setLiftOnScrollTargetView(binding.followedTagsView)
     }
 
     private fun setupRecyclerView(adapter: FollowedTagsAdapter) {

--- a/app/src/main/java/app/pachli/components/scheduled/ScheduledStatusActivity.kt
+++ b/app/src/main/java/app/pachli/components/scheduled/ScheduledStatusActivity.kt
@@ -89,6 +89,7 @@ class ScheduledStatusActivity :
             MaterialDividerItemDecoration(this, MaterialDividerItemDecoration.VERTICAL),
         )
         binding.scheduledTootList.adapter = adapter
+        binding.includedToolbar.appbar.setLiftOnScrollTargetView(binding.scheduledTootList)
 
         lifecycleScope.launch {
             viewModel.data.collectLatest { pagingData ->


### PR DESCRIPTION
Testing showed additional activities with toolbar flicking issues. Fix as before, using `setLiftOnScrollTargetView` to specify the scrolling view the toolbar should lift above.