### PR TITLE
fix: Restore the user's reading position in more circumstances

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -2324,7 +2324,7 @@
         errorLine2="                ~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/components/accountlist/AccountListFragment.kt"
-            line="138"
+            line="140"
             column="17"/>
     </issue>
 
@@ -2665,7 +2665,7 @@
         errorLine2="                        ~~~~~~~">
         <location
             file="src/main/java/app/pachli/components/followedtags/FollowedTagsActivity.kt"
-            line="94"
+            line="96"
             column="25"/>
     </issue>
 
@@ -2676,7 +2676,7 @@
         errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/components/followedtags/FollowedTagsActivity.kt"
-            line="202"
+            line="204"
             column="21"/>
     </issue>
 
@@ -3809,7 +3809,7 @@
         errorLine2="                                              ~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/components/timeline/TimelineFragment.kt"
-            line="178"
+            line="177"
             column="47"/>
     </issue>
 

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/TimelineViewModel.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/TimelineViewModel.kt
@@ -445,6 +445,7 @@ abstract class TimelineViewModel(
                         Log.d(TAG, "Saving Home timeline position at: ${action.visibleId}")
                         activeAccount.lastVisibleHomeTimelineStatusId = action.visibleId
                         accountManager.saveAccount(activeAccount)
+                        readingPositionId = action.visibleId
                     }
             }
         }


### PR DESCRIPTION
The previous code only attempted to restore the user's reading position once, after any initial refresh.

Adjust this so the position is restored after any refresh (which may have been triggered from a menu instead of a swipe), and use `scrollToPositionWithOffset` to ensure it's visible.