### PR TITLE
ci: Start creating the build / sign / upload-to-Google-Play pipeline

### DIFF
--- a/.github/workflows/upload-blue-release-google-play.yml
+++ b/.github/workflows/upload-blue-release-google-play.yml
@@ -1,0 +1,69 @@
+name: Upload blueRelease to Google Play
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Gradle Wrapper Validation
+        uses: gradle/wrapper-validation-action@v1
+
+      - name: Copy CI gradle.properties
+        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
+
+      - name: Gradle Build Action
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
+
+      - name: Build APK
+        run: ./gradlew assembleBlueRelease --stacktrace
+
+      - name: Build AAB
+        run: ./gradlew :app:bundleBlueRelease --stacktrace
+
+      - uses: r0adkll/sign-android-release@v1.0.4
+        name: Sign app APK
+        id: sign_app_apk
+        with:
+          releaseDirectory: app/build/outputs/apk/blue/release
+          signingKeyBase64: ${{ secrets.SIGNING_KEY }}
+          alias: ${{ secrets.SIGNING_KEY_ALIAS }}
+          keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
+          keyPassword: ${{ secrets.KEY_PASSWORD }}
+        env:
+          BUILD_TOOLS_VERSION: "34.0.0"
+
+      - uses: r0adkll/sign-android-release@v1.0.4
+        name: Sign app AAB
+        id: sign_app_aab
+        with:
+          releaseDirectory: app/build/outputs/bundle/blueRelease
+          signingKeyBase64: ${{ secrets.SIGNING_KEY }}
+          alias: ${{ secrets.SIGNING_KEY_ALIAS }}
+          keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
+          keyPassword: ${{ secrets.KEY_PASSWORD }}
+        env:
+          BUILD_TOOLS_VERSION: "34.0.0"
+
+      - name: Upload APK Release Asset
+        id: upload-release-asset-apk
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: ${{steps.sign_app_apk.outputs.signedReleaseFile}}
+          asset_name: app-release.apk
+          asset_content_type: application/zip

--- a/.github/workflows/upload-blue-release-google-play.yml
+++ b/.github/workflows/upload-blue-release-google-play.yml
@@ -59,11 +59,7 @@ jobs:
 
       - name: Upload APK Release Asset
         id: upload-release-asset-apk
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/upload-artifact@v3
         with:
-          upload_url: ${{ steps.get_release.outputs.upload_url }}
-          asset_path: ${{steps.sign_app_apk.outputs.signedReleaseFile}}
-          asset_name: app-release.apk
-          asset_content_type: application/zip
+          name: app-release.apk
+          path: ${{steps.sign_app_apk.outputs.signedReleaseFile}}


### PR DESCRIPTION
This action should build the APK and AAB, sign them, and store the APK as an asset.

Uploading to the correct Google Play release track will come later.