### PR TITLE
fix: Use correct colour on "mute account" dialog

### DIFF
--- a/app/src/main/res/layout/dialog_mute_account.xml
+++ b/app/src/main/res/layout/dialog_mute_account.xml
@@ -18,7 +18,6 @@
     <CheckBox android:id="@+id/checkbox"
               android:layout_height="wrap_content"
               android:layout_width="wrap_content"
-              android:textColor="?attr/colorOnTertiary"
               app:buttonTint="@color/compound_button_color"
               android:text="@string/dialog_mute_hide_notifications"/>
 


### PR DESCRIPTION
The previous code used "?attr/colorOnTertiary", which is the wrong colour for the default background. Remove the override, so the correct styled colour is used.