### PR TITLE
fix: Use correct colours for preference switches

### DIFF
--- a/app/src/main/java/app/pachli/settings/SettingsDSL.kt
+++ b/app/src/main/java/app/pachli/settings/SettingsDSL.kt
@@ -12,7 +12,7 @@ import androidx.preference.Preference
 import androidx.preference.PreferenceCategory
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.PreferenceScreen
-import androidx.preference.SwitchPreference
+import androidx.preference.SwitchPreferenceCompat
 import app.pachli.view.SliderPreference
 import de.c1710.filemojicompat_ui.views.picker.preference.EmojiPickerPreference
 
@@ -53,9 +53,9 @@ inline fun PreferenceParent.sliderPreference(
 }
 
 inline fun PreferenceParent.switchPreference(
-    builder: SwitchPreference.() -> Unit,
-): SwitchPreference {
-    val pref = SwitchPreference(context)
+    builder: SwitchPreferenceCompat.() -> Unit,
+): SwitchPreferenceCompat {
+    val pref = SwitchPreferenceCompat(context)
     builder(pref)
     addPref(pref)
     return pref


### PR DESCRIPTION
The previous code used SwitchPreference to generate the switches, which didn't apply the Material colours. This made it difficult to distinguish between the on/off states, as the non-Material colours for those states are very similar.

Fix by using SwitchPreferenceCompat which uses the correct Material colours.