### PR TITLE
fix: Enable/disable vote button when the user can/can't vote

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -861,7 +861,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/adapter/PollAdapter.kt"
-            line="62"
+            line="67"
             column="9"/>
     </issue>
 
@@ -872,7 +872,18 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/adapter/PollAdapter.kt"
-            line="62"
+            line="67"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="NotifyDataSetChanged"
+        message="It will always be more efficient to use more specific change events if you can. Rely on `notifyDataSetChanged` as a last resort."
+        errorLine1="        notifyDataSetChanged()"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/app/pachli/adapter/PollAdapter.kt"
+            line="67"
             column="9"/>
     </issue>
 

--- a/app/src/main/java/app/pachli/adapter/PollAdapter.kt
+++ b/app/src/main/java/app/pachli/adapter/PollAdapter.kt
@@ -39,8 +39,6 @@ class PollAdapter : RecyclerView.Adapter<BindingHolder<ItemPollBinding>>() {
     private var resultClickListener: View.OnClickListener? = null
     private var animateEmojis = false
     private var enabled = true
-    /** Listener to call when the user clicks on a poll option */
-    private var optionClickListener: View.OnClickListener? = null
 
     /** Listener to call when the user clicks on a poll option */
     private var optionClickListener: View.OnClickListener? = null

--- a/app/src/main/java/app/pachli/adapter/PollAdapter.kt
+++ b/app/src/main/java/app/pachli/adapter/PollAdapter.kt
@@ -39,6 +39,8 @@ class PollAdapter : RecyclerView.Adapter<BindingHolder<ItemPollBinding>>() {
     private var resultClickListener: View.OnClickListener? = null
     private var animateEmojis = false
     private var enabled = true
+    /** Listener to call when the user clicks on a poll option */
+    private var optionClickListener: View.OnClickListener? = null
 
     @JvmOverloads
     fun setup(
@@ -50,6 +52,7 @@ class PollAdapter : RecyclerView.Adapter<BindingHolder<ItemPollBinding>>() {
         resultClickListener: View.OnClickListener?,
         animateEmojis: Boolean,
         enabled: Boolean = true,
+        optionClickListener: View.OnClickListener? = null,
     ) {
         this.pollOptions = options
         this.voteCount = voteCount
@@ -59,6 +62,7 @@ class PollAdapter : RecyclerView.Adapter<BindingHolder<ItemPollBinding>>() {
         this.resultClickListener = resultClickListener
         this.animateEmojis = animateEmojis
         this.enabled = enabled
+        this.optionClickListener = optionClickListener
         notifyDataSetChanged()
     }
 
@@ -120,6 +124,7 @@ class PollAdapter : RecyclerView.Adapter<BindingHolder<ItemPollBinding>>() {
                         pollOption.selected = index == holder.bindingAdapterPosition
                         notifyItemChanged(index)
                     }
+                    optionClickListener?.onClick(radioButton)
                 }
             }
             MULTIPLE -> {
@@ -127,6 +132,7 @@ class PollAdapter : RecyclerView.Adapter<BindingHolder<ItemPollBinding>>() {
                 checkBox.isChecked = option.selected
                 checkBox.setOnCheckedChangeListener { _, isChecked ->
                     pollOptions[holder.bindingAdapterPosition].selected = isChecked
+                    optionClickListener?.onClick(checkBox)
                 }
             }
         }

--- a/app/src/main/java/app/pachli/adapter/PollAdapter.kt
+++ b/app/src/main/java/app/pachli/adapter/PollAdapter.kt
@@ -42,6 +42,9 @@ class PollAdapter : RecyclerView.Adapter<BindingHolder<ItemPollBinding>>() {
     /** Listener to call when the user clicks on a poll option */
     private var optionClickListener: View.OnClickListener? = null
 
+    /** Listener to call when the user clicks on a poll option */
+    private var optionClickListener: View.OnClickListener? = null
+
     @JvmOverloads
     fun setup(
         options: List<PollOptionViewData>,

--- a/app/src/main/java/app/pachli/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/app/pachli/adapter/StatusBaseViewHolder.java
@@ -1039,6 +1039,10 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
             pollButton.setVisibility(View.GONE);
         } else {
             // voting possible
+            View.OnClickListener optionClickListener = v -> {
+                pollButton.setEnabled(!pollAdapter.getSelected().isEmpty());
+            };
+
             pollAdapter.setup(
                     poll.getOptions(),
                     poll.getVotesCount(),
@@ -1046,10 +1050,13 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
                     emojis,
                     poll.getMultiple() ? PollAdapter.MULTIPLE : PollAdapter.SINGLE,
                     null,
-                    statusDisplayOptions.animateEmojis()
+                    statusDisplayOptions.animateEmojis(),
+                    true,
+                    optionClickListener
             );
 
             pollButton.setVisibility(View.VISIBLE);
+            pollButton.setEnabled(false);
 
             pollButton.setOnClickListener(v -> {
                 int position = getBindingAdapterPosition();


### PR DESCRIPTION
Previously the voting button was always enabled, even if the user hadn't made a choice.

Disable the button by default, and listen for clicks on the options. Enable the button whenever one or more options are selected.

Fixes #90