### PR TITLE
refactor: Ensure `statusDisplayOptions` are created consistently

### DIFF
--- a/app/src/main/java/app/pachli/components/conversation/ConversationsFragment.kt
+++ b/app/src/main/java/app/pachli/components/conversation/ConversationsFragment.kt
@@ -48,7 +48,6 @@ import app.pachli.interfaces.ActionButtonActivity
 import app.pachli.interfaces.ReselectableFragment
 import app.pachli.interfaces.StatusActionListener
 import app.pachli.settings.PrefKeys
-import app.pachli.util.CardViewMode
 import app.pachli.util.StatusDisplayOptions
 import app.pachli.util.hide
 import app.pachli.util.show
@@ -99,20 +98,9 @@ class ConversationsFragment :
 
         val preferences = PreferenceManager.getDefaultSharedPreferences(view.context)
 
-        val statusDisplayOptions = StatusDisplayOptions(
-            animateAvatars = preferences.getBoolean(PrefKeys.ANIMATE_GIF_AVATARS, false),
-            mediaPreviewEnabled = accountManager.activeAccount?.mediaPreviewEnabled ?: true,
-            useAbsoluteTime = preferences.getBoolean(PrefKeys.ABSOLUTE_TIME_VIEW, false),
-            showBotOverlay = preferences.getBoolean(PrefKeys.SHOW_BOT_OVERLAY, true),
-            useBlurhash = preferences.getBoolean(PrefKeys.USE_BLURHASH, true),
-            cardViewMode = CardViewMode.NONE,
-            confirmReblogs = preferences.getBoolean(PrefKeys.CONFIRM_REBLOGS, true),
-            confirmFavourites = preferences.getBoolean(PrefKeys.CONFIRM_FAVOURITES, false),
-            hideStats = preferences.getBoolean(PrefKeys.WELLBEING_HIDE_STATS_POSTS, false),
-            animateEmojis = preferences.getBoolean(PrefKeys.ANIMATE_CUSTOM_EMOJIS, false),
-            showStatsInline = preferences.getBoolean(PrefKeys.SHOW_STATS_INLINE, false),
-            showSensitiveMedia = accountManager.activeAccount!!.alwaysShowSensitiveMedia,
-            openSpoiler = accountManager.activeAccount!!.alwaysOpenSpoiler,
+        val statusDisplayOptions = StatusDisplayOptions.from(
+            preferences,
+            accountManager.activeAccount!!,
         )
 
         adapter = ConversationAdapter(statusDisplayOptions, this)

--- a/app/src/main/java/app/pachli/components/report/fragments/ReportStatusesFragment.kt
+++ b/app/src/main/java/app/pachli/components/report/fragments/ReportStatusesFragment.kt
@@ -46,8 +46,6 @@ import app.pachli.di.Injectable
 import app.pachli.di.ViewModelFactory
 import app.pachli.entity.Attachment
 import app.pachli.entity.Status
-import app.pachli.settings.PrefKeys
-import app.pachli.util.CardViewMode
 import app.pachli.util.StatusDisplayOptions
 import app.pachli.util.viewBinding
 import app.pachli.util.visible
@@ -146,20 +144,9 @@ class ReportStatusesFragment :
 
     private fun initStatusesView() {
         val preferences = PreferenceManager.getDefaultSharedPreferences(requireContext())
-        val statusDisplayOptions = StatusDisplayOptions(
-            animateAvatars = false,
-            mediaPreviewEnabled = accountManager.activeAccount?.mediaPreviewEnabled ?: true,
-            useAbsoluteTime = preferences.getBoolean(PrefKeys.ABSOLUTE_TIME_VIEW, false),
-            showBotOverlay = false,
-            useBlurhash = preferences.getBoolean(PrefKeys.USE_BLURHASH, true),
-            cardViewMode = CardViewMode.NONE,
-            confirmReblogs = preferences.getBoolean(PrefKeys.CONFIRM_REBLOGS, true),
-            confirmFavourites = preferences.getBoolean(PrefKeys.CONFIRM_FAVOURITES, false),
-            hideStats = preferences.getBoolean(PrefKeys.WELLBEING_HIDE_STATS_POSTS, false),
-            animateEmojis = preferences.getBoolean(PrefKeys.ANIMATE_CUSTOM_EMOJIS, false),
-            showStatsInline = preferences.getBoolean(PrefKeys.SHOW_STATS_INLINE, false),
-            showSensitiveMedia = accountManager.activeAccount!!.alwaysShowSensitiveMedia,
-            openSpoiler = accountManager.activeAccount!!.alwaysOpenSpoiler,
+        val statusDisplayOptions = StatusDisplayOptions.from(
+            preferences,
+            accountManager.activeAccount!!,
         )
 
         adapter = StatusesAdapter(statusDisplayOptions, viewModel.statusViewState, this)

--- a/app/src/main/java/app/pachli/components/search/fragments/SearchStatusesFragment.kt
+++ b/app/src/main/java/app/pachli/components/search/fragments/SearchStatusesFragment.kt
@@ -51,8 +51,6 @@ import app.pachli.entity.Status
 import app.pachli.entity.Status.Mention
 import app.pachli.interfaces.AccountSelectionListener
 import app.pachli.interfaces.StatusActionListener
-import app.pachli.settings.PrefKeys
-import app.pachli.util.CardViewMode
 import app.pachli.util.StatusDisplayOptions
 import app.pachli.util.openLink
 import app.pachli.view.showMuteAccountDialog
@@ -77,20 +75,9 @@ class SearchStatusesFragment : SearchFragment<StatusViewData>(), StatusActionLis
 
     override fun createAdapter(): PagingDataAdapter<StatusViewData, *> {
         val preferences = PreferenceManager.getDefaultSharedPreferences(binding.searchRecyclerView.context)
-        val statusDisplayOptions = StatusDisplayOptions(
-            animateAvatars = preferences.getBoolean(PrefKeys.ANIMATE_GIF_AVATARS, false),
-            mediaPreviewEnabled = viewModel.mediaPreviewEnabled,
-            useAbsoluteTime = preferences.getBoolean(PrefKeys.ABSOLUTE_TIME_VIEW, false),
-            showBotOverlay = preferences.getBoolean(PrefKeys.SHOW_BOT_OVERLAY, true),
-            useBlurhash = preferences.getBoolean(PrefKeys.USE_BLURHASH, true),
-            cardViewMode = CardViewMode.NONE,
-            confirmReblogs = preferences.getBoolean(PrefKeys.CONFIRM_REBLOGS, true),
-            confirmFavourites = preferences.getBoolean(PrefKeys.CONFIRM_FAVOURITES, false),
-            hideStats = preferences.getBoolean(PrefKeys.WELLBEING_HIDE_STATS_POSTS, false),
-            animateEmojis = preferences.getBoolean(PrefKeys.ANIMATE_CUSTOM_EMOJIS, false),
-            showStatsInline = preferences.getBoolean(PrefKeys.SHOW_STATS_INLINE, false),
-            showSensitiveMedia = accountManager.activeAccount!!.alwaysShowSensitiveMedia,
-            openSpoiler = accountManager.activeAccount!!.alwaysOpenSpoiler,
+        val statusDisplayOptions = StatusDisplayOptions.from(
+            preferences,
+            accountManager.activeAccount!!,
         )
 
         binding.searchRecyclerView.addItemDecoration(

--- a/app/src/main/java/app/pachli/components/viewthread/ViewThreadFragment.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/ViewThreadFragment.kt
@@ -43,8 +43,6 @@ import app.pachli.di.Injectable
 import app.pachli.di.ViewModelFactory
 import app.pachli.fragment.SFragment
 import app.pachli.interfaces.StatusActionListener
-import app.pachli.settings.PrefKeys
-import app.pachli.util.CardViewMode
 import app.pachli.util.ListStatusAccessibilityDelegate
 import app.pachli.util.StatusDisplayOptions
 import app.pachli.util.hide
@@ -97,24 +95,9 @@ class ViewThreadFragment :
         thisThreadsStatusId = requireArguments().getString(ID_EXTRA)!!
         val preferences = PreferenceManager.getDefaultSharedPreferences(requireContext())
 
-        val statusDisplayOptions = StatusDisplayOptions(
-            animateAvatars = preferences.getBoolean(PrefKeys.ANIMATE_GIF_AVATARS, false),
-            mediaPreviewEnabled = accountManager.activeAccount!!.mediaPreviewEnabled,
-            useAbsoluteTime = preferences.getBoolean(PrefKeys.ABSOLUTE_TIME_VIEW, false),
-            showBotOverlay = preferences.getBoolean(PrefKeys.SHOW_BOT_OVERLAY, true),
-            useBlurhash = preferences.getBoolean(PrefKeys.USE_BLURHASH, true),
-            cardViewMode = if (preferences.getBoolean(PrefKeys.SHOW_CARDS_IN_TIMELINES, false)) {
-                CardViewMode.INDENTED
-            } else {
-                CardViewMode.NONE
-            },
-            confirmReblogs = preferences.getBoolean(PrefKeys.CONFIRM_REBLOGS, true),
-            confirmFavourites = preferences.getBoolean(PrefKeys.CONFIRM_FAVOURITES, false),
-            hideStats = preferences.getBoolean(PrefKeys.WELLBEING_HIDE_STATS_POSTS, false),
-            animateEmojis = preferences.getBoolean(PrefKeys.ANIMATE_CUSTOM_EMOJIS, false),
-            showStatsInline = preferences.getBoolean(PrefKeys.SHOW_STATS_INLINE, false),
-            showSensitiveMedia = accountManager.activeAccount!!.alwaysShowSensitiveMedia,
-            openSpoiler = accountManager.activeAccount!!.alwaysOpenSpoiler,
+        val statusDisplayOptions = StatusDisplayOptions.from(
+            preferences,
+            accountManager.activeAccount!!,
         )
         adapter = ThreadAdapter(statusDisplayOptions, this)
     }


### PR DESCRIPTION
Previous code created `statusDisplayOptions` in full each time, risking the creation of inconsistent states / defaults.

Refactor to use `StatusDisplayOptions.from()` so the user's settings (and defaults) are always respected.