### PR TITLE
fix: Show media when opening a thread, based on user preferences

### DIFF
--- a/app/src/main/java/app/pachli/components/viewthread/ViewThreadViewModel.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/ViewThreadViewModel.kt
@@ -124,7 +124,7 @@ class ViewThreadViewModel @Inject constructor(
                     StatusViewData.from(
                         status = status.actionableStatus,
                         isExpanded = timelineStatusWithAccount.viewData?.expanded ?: alwaysOpenSpoiler,
-                        isShowingContent = timelineStatusWithAccount.viewData?.contentShowing ?: alwaysShowSensitiveMedia,
+                        isShowingContent = timelineStatusWithAccount.viewData?.contentShowing ?: (alwaysShowSensitiveMedia || !status.actionableStatus.sensitive),
                         isCollapsed = timelineStatusWithAccount.viewData?.contentCollapsed ?: true,
                         isDetailed = true,
                     )
@@ -133,7 +133,7 @@ class ViewThreadViewModel @Inject constructor(
                         timelineStatusWithAccount,
                         gson,
                         isExpanded = alwaysOpenSpoiler,
-                        isShowingContent = alwaysShowSensitiveMedia,
+                        isShowingContent = (alwaysShowSensitiveMedia || !status.actionableStatus.sensitive),
                         isDetailed = true,
                     )
                 }


### PR DESCRIPTION
A previous change dropped the check to see if media was marked as sensitive, and so all media was hidden when viewing a thread. Reinstate the check so only sensitive media is hidden (if the user preferences are set that way).