### PR TITLE
ci: Run ktlint workflow on forks, with write permissions

### DIFF
--- a/.github/workflows/ktlint.yml
+++ b/.github/workflows/ktlint.yml
@@ -1,9 +1,8 @@
 name: reviewdog-suggester
-on: pull_request
+on: pull_request_target
 
 permissions:
   contents: read
-  issues: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
Previously the permissions were only applied to branches from this repository, not forks. Use `pull_request_target` so the `GITHUB_TOKEN` will have the correct permissions when this workflow is run from a PR created from a clone.

Remove the `issues` permission, it didn't seem necessary.