### PR TITLE
refactor: Remove rxjava3 from Mastodon API spec

### DIFF
--- a/app/src/main/java/app/pachli/components/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/app/pachli/components/notifications/NotificationsViewModel.kt
@@ -71,7 +71,6 @@ import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.rx3.await
 import retrofit2.HttpException
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.milliseconds
@@ -436,9 +435,9 @@ class NotificationsViewModel @Inject constructor(
                     try {
                         when (action) {
                             is NotificationAction.AcceptFollowRequest ->
-                                timelineCases.acceptFollowRequest(action.accountId).await()
+                                timelineCases.acceptFollowRequest(action.accountId)
                             is NotificationAction.RejectFollowRequest ->
-                                timelineCases.rejectFollowRequest(action.accountId).await()
+                                timelineCases.rejectFollowRequest(action.accountId)
                         }
                         uiSuccess.emit(NotificationActionSuccess.from(action))
                     } catch (e: Exception) {

--- a/app/src/main/java/app/pachli/components/scheduled/ScheduledStatusPagingSource.kt
+++ b/app/src/main/java/app/pachli/components/scheduled/ScheduledStatusPagingSource.kt
@@ -15,12 +15,11 @@
 
 package app.pachli.components.scheduled
 
-import android.util.Log
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import app.pachli.entity.ScheduledStatus
 import app.pachli.network.MastodonApi
-import kotlinx.coroutines.rx3.await
+import at.connyduck.calladapter.networkresult.getOrElse
 
 class ScheduledStatusPagingSourceFactory(
     private val mastodonApi: MastodonApi,
@@ -59,21 +58,12 @@ class ScheduledStatusPagingSource(
                 nextKey = scheduledStatusesCache.lastOrNull()?.id,
             )
         } else {
-            try {
-                val result = mastodonApi.scheduledStatuses(
-                    maxId = params.key,
-                    limit = params.loadSize,
-                ).await()
+            val result = mastodonApi.scheduledStatuses(
+                maxId = params.key,
+                limit = params.loadSize,
+            ).getOrElse { return LoadResult.Error(it) }
 
-                LoadResult.Page(
-                    data = result,
-                    prevKey = null,
-                    nextKey = result.lastOrNull()?.id,
-                )
-            } catch (e: Exception) {
-                Log.w("ScheduledStatuses", "Error loading scheduled statuses", e)
-                LoadResult.Error(e)
-            }
+            LoadResult.Page(data = result, prevKey = null, nextKey = result.lastOrNull()?.id)
         }
     }
 }

--- a/app/src/main/java/app/pachli/di/NetworkModule.kt
+++ b/app/src/main/java/app/pachli/di/NetworkModule.kt
@@ -40,7 +40,6 @@ import okhttp3.OkHttp
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
-import retrofit2.adapter.rxjava3.RxJava3CallAdapterFactory
 import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.create
 import java.net.IDN
@@ -115,7 +114,6 @@ class NetworkModule {
         return Retrofit.Builder().baseUrl("https://" + MastodonApi.PLACEHOLDER_DOMAIN)
             .client(httpClient)
             .addConverterFactory(GsonConverterFactory.create(gson))
-            .addCallAdapterFactory(RxJava3CallAdapterFactory.create())
             .addCallAdapterFactory(NetworkResultCallAdapterFactory.create())
             .build()
     }

--- a/app/src/main/java/app/pachli/usecase/TimelineCases.kt
+++ b/app/src/main/java/app/pachli/usecase/TimelineCases.kt
@@ -36,7 +36,6 @@ import at.connyduck.calladapter.networkresult.NetworkResult
 import at.connyduck.calladapter.networkresult.fold
 import at.connyduck.calladapter.networkresult.onFailure
 import at.connyduck.calladapter.networkresult.onSuccess
-import io.reactivex.rxjava3.core.Single
 import javax.inject.Inject
 
 class TimelineCases @Inject constructor(
@@ -132,11 +131,11 @@ class TimelineCases @Inject constructor(
         }
     }
 
-    fun acceptFollowRequest(accountId: String): Single<Relationship> {
+    suspend fun acceptFollowRequest(accountId: String): NetworkResult<Relationship> {
         return mastodonApi.authorizeFollowRequest(accountId)
     }
 
-    fun rejectFollowRequest(accountId: String): Single<Relationship> {
+    suspend fun rejectFollowRequest(accountId: String): NetworkResult<Relationship> {
         return mastodonApi.rejectFollowRequest(accountId)
     }
 

--- a/app/src/test/java/app/pachli/components/notifications/NotificationsViewModelTestNotificationAction.kt
+++ b/app/src/test/java/app/pachli/components/notifications/NotificationsViewModelTestNotificationAction.kt
@@ -19,8 +19,8 @@ package app.pachli.components.notifications
 
 import app.cash.turbine.test
 import app.pachli.entity.Relationship
+import at.connyduck.calladapter.networkresult.NetworkResult
 import com.google.common.truth.Truth.assertThat
-import io.reactivex.rxjava3.core.Single
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.mockito.kotlin.any
@@ -66,7 +66,7 @@ class NotificationsViewModelTestNotificationAction : NotificationsViewModelTestB
     fun `accepting follow request succeeds && emits UiSuccess`() = runTest {
         // Given
         timelineCases.stub {
-            onBlocking { acceptFollowRequest(any()) } doReturn Single.just(relationship)
+            onBlocking { acceptFollowRequest(any()) } doReturn NetworkResult.success(relationship)
         }
 
         viewModel.uiSuccess.test {
@@ -105,7 +105,7 @@ class NotificationsViewModelTestNotificationAction : NotificationsViewModelTestB
     @Test
     fun `rejecting follow request succeeds && emits UiSuccess`() = runTest {
         // Given
-        timelineCases.stub { onBlocking { rejectFollowRequest(any()) } doReturn Single.just(relationship) }
+        timelineCases.stub { onBlocking { rejectFollowRequest(any()) } doReturn NetworkResult.success(relationship) }
 
         viewModel.uiSuccess.test {
             // When

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -137,7 +137,6 @@ mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "
 networkresult-calladapter = { module = "at.connyduck:networkresult-calladapter", version.ref = "networkresult-calladapter" }
 okhttp-core = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 okhttp-logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
-retrofit-adapter-rxjava3 = { module = "com.squareup.retrofit2:adapter-rxjava3", version.ref = "retrofit" }
 retrofit-converter-gson = { module = "com.squareup.retrofit2:converter-gson", version.ref = "retrofit" }
 retrofit-core = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
@@ -169,7 +168,7 @@ glide = ["glide-core", "glide-okhttp3-integration", "glide-animation-plugin"]
 material-drawer = ["material-drawer-core", "material-drawer-iconics"]
 mockito = ["mockito-kotlin", "mockito-inline"]
 okhttp = ["okhttp-core", "okhttp-logging-interceptor"]
-retrofit = ["retrofit-core", "retrofit-converter-gson", "retrofit-adapter-rxjava3"]
+retrofit = ["retrofit-core", "retrofit-converter-gson"]
 room = ["androidx-room-ktx", "androidx-room-paging"]
 rxjava3 = ["rxjava3-core", "rxjava3-android", "rxjava3-kotlin"]
 xmldiff = ["diffx", "xmlwriter"]


### PR DESCRIPTION
Remove the rxjava3 `Single` type from the MastodonAPI definition, replacing with `Response` or `NetworkResult` as appropriate.

Update callsites and tests as appropriate.

This removes the need for `com.squareup.retrofit2:adapter-rxjava3`