### PR TITLE
fix: Restore the user's reading position under all circumstances

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -3688,7 +3688,7 @@
         errorLine2="                                              ~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/components/timeline/TimelineFragment.kt"
-            line="185"
+            line="180"
             column="47"/>
     </issue>
 

--- a/app/src/main/java/app/pachli/components/timeline/CachedTimelineRepository.kt
+++ b/app/src/main/java/app/pachli/components/timeline/CachedTimelineRepository.kt
@@ -85,7 +85,7 @@ class CachedTimelineRepository @Inject constructor(
         Log.d(TAG, "initialKey: $initialKey is row: $row")
 
         return Pager(
-            config = PagingConfig(pageSize = pageSize),
+            config = PagingConfig(pageSize = pageSize, jumpThreshold = PAGE_SIZE * 3, enablePlaceholders = true),
             initialKey = row,
             remoteMediator = CachedTimelineRemoteMediator(
                 initialKey,

--- a/app/src/main/java/app/pachli/db/AppDatabase.kt
+++ b/app/src/main/java/app/pachli/db/AppDatabase.kt
@@ -24,6 +24,7 @@ import androidx.room.RoomDatabase
 import androidx.room.migration.AutoMigrationSpec
 import app.pachli.components.conversation.ConversationEntity
 
+@Suppress("ClassName")
 @Database(
     entities = [
         DraftEntity::class,


### PR DESCRIPTION
The previous code did not always work when the user returned to the app after a lengthy absence (e.g., overnight).

Instead of restoring by scrolling in `TimelineFragment`, restore by working with the platform.

Determine the initial page to fetch by looking half a page ahead of the saved saved status ID, and fetch that status and the page immediately prior. This seems to match the view's expectations about what will be immediately available.

Set `jumpThreshold` and `enablePlaceholders` in the `PagingConfig` so the paging system will jump to the saved status.

Remove the restoration code in `TimelineFragment`.

Fixes #53