### PR TITLE
ci: Fetch all revisions to calculate correct versionCode

### DIFF
--- a/.github/workflows/upload-orange-release-google-play.yml
+++ b/.github/workflows/upload-orange-release-google-play.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+            fetch-depth: 0
 
       - uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
Previous configuration only fetched the most recent revision. Since the `orangeRelease` `versionCode` is calculated from the number of previous revisions this always set the `versionCode` to 1.

Fetch all revisions to avoid this.