### PR TITLE
fix: Show thread indicators and other dividers using Material colours

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -1521,7 +1521,7 @@
         errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/colors.xml"
-            line="103"
+            line="101"
             column="12"/>
     </issue>
 
@@ -1532,7 +1532,7 @@
         errorLine2="           ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/colors.xml"
-            line="104"
+            line="102"
             column="12"/>
     </issue>
 
@@ -2115,7 +2115,7 @@
         errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/styles.xml"
-            line="129"
+            line="127"
             column="12"/>
     </issue>
 
@@ -2126,7 +2126,7 @@
         errorLine2="           ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/styles.xml"
-            line="158"
+            line="154"
             column="12"/>
     </issue>
 
@@ -4938,7 +4938,7 @@
         errorLine2="     ~~~~~~~~">
         <location
             file="src/main/res/layout/item_status_detailed.xml"
-            line="299"
+            line="297"
             column="6"/>
     </issue>
 
@@ -4949,7 +4949,7 @@
         errorLine2="     ~~~~~~~~">
         <location
             file="src/main/res/layout/item_status_detailed.xml"
-            line="313"
+            line="311"
             column="6"/>
     </issue>
 

--- a/app/src/main/java/app/pachli/util/LinkHelper.kt
+++ b/app/src/main/java/app/pachli/util/LinkHelper.kt
@@ -251,7 +251,7 @@ private fun openLinkInBrowser(uri: Uri?, context: Context) {
 fun openLinkInCustomTab(uri: Uri, context: Context) {
     val toolbarColor = MaterialColors.getColor(context, com.google.android.material.R.attr.colorSurface, Color.BLACK)
     val navigationbarColor = MaterialColors.getColor(context, android.R.attr.navigationBarColor, Color.BLACK)
-    val navigationbarDividerColor = MaterialColors.getColor(context, R.attr.dividerColor, Color.BLACK)
+    val navigationbarDividerColor = MaterialColors.getColor(context, com.google.android.material.R.attr.dividerColor, Color.BLACK)
     val colorSchemeParams = CustomTabColorSchemeParams.Builder()
         .setToolbarColor(toolbarColor)
         .setNavigationBarColor(navigationbarColor)

--- a/app/src/main/java/app/pachli/view/GraphView.kt
+++ b/app/src/main/java/app/pachli/view/GraphView.kt
@@ -156,7 +156,7 @@ class GraphView @JvmOverloads constructor(
             metaColor = context.getColor(
                 a.getResourceId(
                     R.styleable.GraphView_metaColor,
-                    R.color.dividerColor,
+                    com.google.android.material.R.attr.dividerColor,
                 ),
             )
 

--- a/app/src/main/res/drawable/conversation_thread_line.xml
+++ b/app/src/main/res/drawable/conversation_thread_line.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <size android:width="4dp" />
-    <solid android:color="?attr/dividerColor" />
+    <solid android:color="?colorOutlineVariant" />
 </shape>

--- a/app/src/main/res/drawable/status_divider.xml
+++ b/app/src/main/res/drawable/status_divider.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle">
-    <size android:height="1dp" />
-    <solid android:color="?attr/dividerColor" />
-</shape>

--- a/app/src/main/res/layout/item_status_detailed.xml
+++ b/app/src/main/res/layout/item_status_detailed.xml
@@ -282,15 +282,13 @@
         app:layout_constraintTop_toBottomOf="@id/status_poll_description"
         tools:text="21 Dec 2018 18:45" />
 
-    <View
+    <com.google.android.material.divider.MaterialDivider
         android:id="@+id/status_info_divider"
         android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:layout_below="@id/status_meta_info"
+        android:layout_height="wrap_content"
         android:layout_marginStart="14dp"
         android:layout_marginTop="6dp"
         android:layout_marginEnd="14dp"
-        android:background="?android:attr/listDivider"
         android:importantForAccessibility="no"
         android:paddingStart="16dp"
         android:paddingEnd="16dp"
@@ -333,14 +331,13 @@
         app:barrierDirection="bottom"
         app:constraint_referenced_ids="status_reblogs,status_favourites" />
 
-    <View
+    <com.google.android.material.divider.MaterialDivider
         android:id="@+id/status_buttons_divider"
         android:layout_width="match_parent"
-        android:layout_height="1dp"
+        android:layout_height="wrap_content"
         android:layout_marginStart="14dp"
         android:layout_marginTop="6dp"
         android:layout_marginEnd="14dp"
-        android:background="?android:attr/listDivider"
         android:importantForAccessibility="no"
         android:paddingStart="16dp"
         android:paddingEnd="16dp"

--- a/app/src/main/res/values-night/theme_colors.xml
+++ b/app/src/main/res/values-night/theme_colors.xml
@@ -2,8 +2,6 @@
 <resources>
     <color name="textColorDisabled">@color/tusky_grey_40</color>
 
-    <color name="dividerColor">@color/tusky_grey_30</color>
-
     <color name="favoriteButtonActiveColor">@color/tusky_orange</color>
 
     <!-- colors used to show inserted/deleted text -->

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -36,7 +36,6 @@
     <attr name="textColorDisabled" format="reference|color" />
     <attr name="iconColor" format="reference|color" />
     <attr name="windowBackgroundColor" format="reference|color" />
-    <attr name="dividerColor" format="reference|color" />
 
     <attr name="status_text_small" format="dimension" />
     <attr name="status_text_medium" format="dimension" />

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -81,10 +81,8 @@
     <color name="tusky_grey_05">#070b14</color>
     <color name="tusky_grey_10">#16191f</color>
     <color name="tusky_grey_20">#282c37</color>
-    <color name="tusky_grey_30">#444b5d</color>
     <color name="tusky_grey_40">#596378</color>
     <color name="tusky_grey_70">#9baec8</color>
-    <color name="tusky_grey_80">#b9c8d8</color>
 
     <color name="transparent_tusky_blue">#8c2b90d9</color>
     <color name="transparent_black">#8f000000</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -71,8 +71,6 @@
         <item name="status_text_medium">16sp</item>
         <item name="status_text_large">18sp</item>
 
-        <item name="android:listDivider">@drawable/status_divider</item>
-
         <item name="alertDialogTheme">@style/AppDialog</item>
         <item name="snackbarButtonStyle">@style/AppButton.TextButton</item>
 
@@ -148,8 +146,6 @@
 
         <!-- TODO: Remove this, use colorControlNormal everywhere instead of iconColor -->
         <item name="iconColor">?attr/colorControlNormal</item>
-
-        <item name="dividerColor">@color/tusky_grey_20</item>
     </style>
 
     <style name="Theme.Pachli.Black" parent="Base.Theme.Black" />

--- a/app/src/main/res/values/theme_colors.xml
+++ b/app/src/main/res/values/theme_colors.xml
@@ -2,8 +2,6 @@
 <resources>
     <color name="textColorDisabled">@color/tusky_grey_70</color>
 
-    <color name="dividerColor">@color/tusky_grey_80</color>
-
     <color name="favoriteButtonActiveColor">@color/tusky_orange_light</color>
 
     <color name="botBadgeForeground">@color/tusky_grey_20</color>


### PR DESCRIPTION
Use the Material colour for `conversation_thread_line` (which is `colorOutlineVariant`) instead of a custom attribute.

Elsewhere, use the Material attribute directly (in code), or replace the custom divider with a `MaterialDivider`.

This makes some colour definitions unused, so remove them.

Fixes #148