### PR TITLE
change: Mark markdown-plugin as a distinct project

### DIFF
--- a/plugins/markdown2resource/settings.gradle
+++ b/plugins/markdown2resource/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = "markdown2resource-plugin"


### PR DESCRIPTION
Create a settings.gradle file so it is treated as a separate project.