### PR TITLE
fix: Add foregroundServiceType/onTimeout() to prevent crash

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -200,6 +200,7 @@
         </service>
 
         <service android:name=".service.SendStatusService"
+            android:foregroundServiceType="shortService"
             android:exported="false" />
 
         <provider


### PR DESCRIPTION
Android 14 (SDK 34) requires a `foregroundServiceType` and `onTimeout()` implementation for foreground services, otherwise creating the service will crash.

Do this. If `SendStatusService` does timeout then any pending statuses are marked as failed, saved to drafts, and the user is informed.

Fixes #162