### PR TITLE
fix: Show media when resuming ViewMediaFragment

### DIFF
--- a/app/src/main/java/app/pachli/fragment/ViewImageFragment.kt
+++ b/app/src/main/java/app/pachli/fragment/ViewImageFragment.kt
@@ -72,9 +72,7 @@ class ViewImageFragment : ViewMediaFragment() {
     }
 
     override fun setupMediaView(
-        url: String,
         previewUrl: String?,
-        description: String?,
         showingDescription: Boolean,
     ) {
         binding.photoView.transitionName = url
@@ -96,20 +94,15 @@ class ViewImageFragment : ViewMediaFragment() {
         super.onViewCreated(view, savedInstanceState)
 
         val arguments = this.requireArguments()
-        val attachment = BundleCompat.getParcelable(arguments, ARG_ATTACHMENT, Attachment::class.java)
+        attachment = BundleCompat.getParcelable(arguments, ARG_ATTACHMENT, Attachment::class.java)
         this.shouldStartTransition = arguments.getBoolean(ARG_START_POSTPONED_TRANSITION)
-        val url: String?
-        var description: String? = null
 
-        if (attachment != null) {
-            url = attachment.url
-            description = attachment.description
-        } else {
-            url = arguments.getString(ARG_SINGLE_IMAGE_URL)
-            if (url == null) {
-                throw IllegalArgumentException("attachment or image url has to be set")
-            }
-        }
+        BundleCompat.getParcelable(arguments, ARG_ATTACHMENT, Attachment::class.java)?.let {
+            url = it.url
+            description = it.description
+        } ?: arguments.getString(ARG_SINGLE_IMAGE_URL)?.let {
+            url = it
+        } ?: throw IllegalArgumentException("attachment or image url has to be set")
 
         val singleTapDetector = GestureDetectorCompat(
             requireContext(),
@@ -219,8 +212,11 @@ class ViewImageFragment : ViewMediaFragment() {
                 }
             },
         )
+    }
 
-        finalizeViewSetup(url, attachment?.previewUrl, description)
+    override fun onResume() {
+        super.onResume()
+        finalizeViewSetup(attachment?.previewUrl)
     }
 
     override fun onToolbarVisibilityChange(visible: Boolean) {

--- a/app/src/main/java/app/pachli/fragment/ViewMediaFragment.kt
+++ b/app/src/main/java/app/pachli/fragment/ViewMediaFragment.kt
@@ -27,9 +27,7 @@ abstract class ViewMediaFragment : Fragment() {
     private var toolbarVisibilityDisposable: Function0<Boolean>? = null
 
     abstract fun setupMediaView(
-        url: String,
         previewUrl: String?,
-        description: String?,
         showingDescription: Boolean,
     )
 
@@ -37,6 +35,15 @@ abstract class ViewMediaFragment : Fragment() {
 
     protected var showingDescription = false
     protected var isDescriptionVisible = false
+
+    /** URL of the media to show */
+    protected lateinit var url: String
+
+    /** The attachment to show. Null if [newSingleImageInstance] was used */
+    protected var attachment: Attachment? = null
+
+    /** Media description */
+    protected var description: String? = null
 
     companion object {
         @JvmStatic
@@ -81,12 +88,12 @@ abstract class ViewMediaFragment : Fragment() {
 
     abstract fun onTransitionEnd()
 
-    protected fun finalizeViewSetup(url: String, previewUrl: String?, description: String?) {
+    protected fun finalizeViewSetup(previewUrl: String?) {
         val mediaActivity = activity as ViewMediaActivity
 
         showingDescription = !TextUtils.isEmpty(description)
         isDescriptionVisible = showingDescription
-        setupMediaView(url, previewUrl, description, showingDescription && mediaActivity.isToolbarVisible)
+        setupMediaView(previewUrl, showingDescription && mediaActivity.isToolbarVisible)
 
         toolbarVisibilityDisposable = (activity as ViewMediaActivity)
             .addToolbarVisibilityListener { isVisible ->

--- a/app/src/main/java/app/pachli/fragment/ViewVideoFragment.kt
+++ b/app/src/main/java/app/pachli/fragment/ViewVideoFragment.kt
@@ -128,7 +128,9 @@ class ViewVideoFragment : ViewMediaFragment() {
         val attachment = arguments?.getParcelable<Attachment>(ARG_ATTACHMENT)
             ?: throw IllegalArgumentException("attachment has to be set")
 
-        val url = attachment.url
+        url = attachment.url
+        description = attachment.description
+
         isAudio = attachment.type == Attachment.Type.AUDIO
 
         /**
@@ -244,8 +246,6 @@ class ViewVideoFragment : ViewMediaFragment() {
         savedSeekPosition = savedInstanceState?.getLong(SEEK_POSITION) ?: 0
 
         mediaAttachment = attachment
-
-        finalizeViewSetup(url, attachment.previewUrl, attachment.description)
     }
 
     override fun onStart() {
@@ -258,6 +258,8 @@ class ViewVideoFragment : ViewMediaFragment() {
 
     override fun onResume() {
         super.onResume()
+
+        finalizeViewSetup(attachment?.previewUrl)
 
         if (Build.VERSION.SDK_INT <= 23 || player == null) {
             initializePlayer()
@@ -349,9 +351,7 @@ class ViewVideoFragment : ViewMediaFragment() {
 
     @SuppressLint("ClickableViewAccessibility")
     override fun setupMediaView(
-        url: String,
         previewUrl: String?,
-        description: String?,
         showingDescription: Boolean,
     ) {
         binding.mediaDescription.text = description


### PR DESCRIPTION
Previous code finalised the view setup in `onViewCreated`, so if you opened some media, switched away from the app, and switched back you'd get a blank screen.

Fix this by doing the finalisation in `onResume()`, so the media is displayed correctly when returning to the fragment.

Fixes #161