### PR TITLE
chore: Update .gitignore for gradle-profiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,8 @@
 build
 /captures
 .externalNativeBuild
+gradle-user-home
+profile-out
+profile-out-*
 app/release
 app-release.apk


### PR DESCRIPTION
Ignore directories created by `gradle-profiler`.