### PR TITLE
fix: Update timeline when link preview setting changes

### DIFF
--- a/app/src/main/java/app/pachli/util/StatusDisplayOptionsRepository.kt
+++ b/app/src/main/java/app/pachli/util/StatusDisplayOptionsRepository.kt
@@ -66,6 +66,7 @@ class StatusDisplayOptionsRepository @Inject constructor(
         PrefKeys.CONFIRM_REBLOGS,
         PrefKeys.MEDIA_PREVIEW_ENABLED,
         PrefKeys.SHOW_BOT_OVERLAY,
+        PrefKeys.SHOW_CARDS_IN_TIMELINES,
         PrefKeys.USE_BLURHASH,
         PrefKeys.WELLBEING_HIDE_STATS_POSTS,
         PrefKeys.SHOW_STATS_INLINE,


### PR DESCRIPTION
The previous code didn't include SHOW_CARDS_IN_TIMELINES in the list of prefkeys that change `StatusDisplayOptions`, so changing the preference wouldn't update the timeline display; you had to close/restart the app.