### PR TITLE
refactor: Use ksp instead of kapt for Hilt

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,6 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.google.ksp)
     alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.kotlin.kapt)
     alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.aboutlibraries)
     alias(libs.plugins.hilt)
@@ -174,7 +173,7 @@ dependencies {
     implementation libs.bundles.autodispose
 
     implementation libs.hilt.android
-    kapt libs.hilt.compiler
+    ksp libs.hilt.compiler
 
     implementation libs.sparkbutton
 
@@ -205,7 +204,7 @@ dependencies {
     testImplementation libs.turbine
     testImplementation libs.androidx.test.core.ktx
     testImplementation libs.hilt.android.testing
-    kaptTest libs.hilt.compiler
+    kspTest libs.hilt.compiler
 
     androidTestImplementation libs.espresso.core
     androidTestImplementation libs.androidx.room.testing

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.google.ksp) apply false
     alias(libs.plugins.kotlin.android) apply false
-    alias(libs.plugins.kotlin.kapt) apply false
     alias(libs.plugins.kotlin.parcelize) apply false
     alias(libs.plugins.ktlint) apply false
     alias(libs.plugins.aboutlibraries) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -63,7 +63,6 @@ android-application = { id = "com.android.application", version.ref = "agp" }
 google-ksp = "com.google.devtools.ksp:1.9.10-1.0.13"
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
-kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 ktlint = "org.jlleitschuh.gradle.ktlint:11.6.1"
 


### PR DESCRIPTION
This removes all use of kapt from the project.