### PR TITLE
refactor: Use sealed interfaces for lighterweight code

### DIFF
--- a/app/src/main/java/app/pachli/components/compose/ComposeAutoCompleteAdapter.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeAutoCompleteAdapter.kt
@@ -143,12 +143,12 @@ class ComposeAutoCompleteAdapter(
         }
     }
 
-    sealed class AutocompleteResult {
-        class AccountResult(val account: TimelineAccount) : AutocompleteResult()
+    sealed interface AutocompleteResult {
+        class AccountResult(val account: TimelineAccount) : AutocompleteResult
 
-        class HashtagResult(val hashtag: String) : AutocompleteResult()
+        class HashtagResult(val hashtag: String) : AutocompleteResult
 
-        class EmojiResult(val emoji: Emoji) : AutocompleteResult()
+        class EmojiResult(val emoji: Emoji) : AutocompleteResult
     }
 
     interface AutocompletionProvider {

--- a/app/src/main/java/app/pachli/components/compose/MediaUploader.kt
+++ b/app/src/main/java/app/pachli/components/compose/MediaUploader.kt
@@ -65,12 +65,12 @@ import javax.inject.Singleton
 
 sealed interface FinalUploadEvent
 
-sealed class UploadEvent {
-    data class ProgressEvent(val percentage: Int) : UploadEvent()
+sealed interface UploadEvent {
+    data class ProgressEvent(val percentage: Int) : UploadEvent
     data class FinishedEvent(val mediaId: String, val processed: Boolean) :
-        UploadEvent(),
+        UploadEvent,
         FinalUploadEvent
-    data class ErrorEvent(val error: Throwable) : UploadEvent(), FinalUploadEvent
+    data class ErrorEvent(val error: Throwable) : UploadEvent, FinalUploadEvent
 }
 
 data class UploadData(

--- a/app/src/main/java/app/pachli/components/login/LoginWebViewActivity.kt
+++ b/app/src/main/java/app/pachli/components/login/LoginWebViewActivity.kt
@@ -89,15 +89,15 @@ data class LoginData(
     val oauthRedirectUrl: Uri,
 ) : Parcelable
 
-sealed class LoginResult : Parcelable {
+sealed interface LoginResult : Parcelable {
     @Parcelize
-    data class Ok(val code: String) : LoginResult()
+    data class Ok(val code: String) : LoginResult
 
     @Parcelize
-    data class Err(val errorMessage: String) : LoginResult()
+    data class Err(val errorMessage: String) : LoginResult
 
     @Parcelize
-    data object Cancel : LoginResult()
+    data object Cancel : LoginResult
 }
 
 /** Activity to do Oauth process using WebView. */

--- a/app/src/main/java/app/pachli/components/timeline/FiltersRepository.kt
+++ b/app/src/main/java/app/pachli/components/timeline/FiltersRepository.kt
@@ -26,12 +26,12 @@ import retrofit2.HttpException
 import javax.inject.Inject
 import javax.inject.Singleton
 
-sealed class FilterKind {
+sealed interface FilterKind {
     /** API v1 filter, filtering happens client side */
-    data class V1(val filters: List<FilterV1>) : FilterKind()
+    data class V1(val filters: List<FilterV1>) : FilterKind
 
     /** API v2 filter, filtering happens server side */
-    data class V2(val filters: List<Filter>) : FilterKind()
+    data class V2(val filters: List<Filter>) : FilterKind
 }
 
 /** Repository for filter information */

--- a/app/src/main/java/app/pachli/components/timeline/TimelineKind.kt
+++ b/app/src/main/java/app/pachli/components/timeline/TimelineKind.kt
@@ -22,26 +22,46 @@ import kotlinx.parcelize.Parcelize
 
 /** A timeline's type. Hold's data necessary to display that timeline. */
 @Parcelize
-sealed class TimelineKind : Parcelable {
-    data object Home : TimelineKind()
-    data object PublicFederated : TimelineKind()
-    data object PublicLocal : TimelineKind()
-    data class Tag(val tags: List<String>) : TimelineKind()
+sealed interface TimelineKind : Parcelable {
+    @Parcelize
+    data object Home : TimelineKind
+
+    @Parcelize
+    data object PublicFederated : TimelineKind
+
+    @Parcelize
+    data object PublicLocal : TimelineKind
+
+    @Parcelize
+    data class Tag(val tags: List<String>) : TimelineKind
 
     /** Any timeline showing statuses from a single user */
     @Parcelize
-    sealed class User(open val id: String) : TimelineKind() {
+    sealed interface User : TimelineKind {
+        val id: String
+
         /** Timeline showing just the user's statuses (no replies) */
-        data class Posts(override val id: String) : User(id)
+        @Parcelize
+        data class Posts(override val id: String) : User
 
         /** Timeline showing the user's pinned statuses */
-        data class Pinned(override val id: String) : User(id)
+        @Parcelize
+        data class Pinned(override val id: String) : User
 
         /** Timeline showing the user's top-level statuses and replies they have made */
-        data class Replies(override val id: String) : User(id)
+        @Parcelize
+        data class Replies(override val id: String) : User
     }
-    data object Favourites : TimelineKind()
-    data object Bookmarks : TimelineKind()
-    data class UserList(val id: String, val title: String) : TimelineKind()
-    data object TrendingStatuses : TimelineKind()
+
+    @Parcelize
+    data object Favourites : TimelineKind
+
+    @Parcelize
+    data object Bookmarks : TimelineKind
+
+    @Parcelize
+    data class UserList(val id: String, val title: String) : TimelineKind
+
+    @Parcelize
+    data object TrendingStatuses : TimelineKind
 }

--- a/app/src/main/java/app/pachli/components/trending/viewmodel/TrendingLinksViewModel.kt
+++ b/app/src/main/java/app/pachli/components/trending/viewmodel/TrendingLinksViewModel.kt
@@ -37,17 +37,17 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.milliseconds
 
-sealed class UiAction
+sealed interface UiAction
 
-sealed class InfallibleUiAction : UiAction() {
-    data object Reload : InfallibleUiAction()
+sealed interface InfallibleUiAction : UiAction {
+    data object Reload : InfallibleUiAction
 }
 
-sealed class LoadState {
-    data object Initial : LoadState()
-    data object Loading : LoadState()
-    data class Success(val data: List<TrendsLink>) : LoadState()
-    data class Error(val throwable: Throwable) : LoadState()
+sealed interface LoadState {
+    data object Initial : LoadState
+    data object Loading : LoadState
+    data class Success(val data: List<TrendsLink>) : LoadState
+    data class Error(val throwable: Throwable) : LoadState
 }
 
 @HiltViewModel

--- a/app/src/main/java/app/pachli/util/Resource.kt
+++ b/app/src/main/java/app/pachli/util/Resource.kt
@@ -1,13 +1,15 @@
 package app.pachli.util
 
-sealed class Resource<T>(open val data: T?)
+sealed interface Resource<T> {
+    val data: T?
+}
 
-class Loading<T> (override val data: T? = null) : Resource<T>(data)
+class Loading<T> (override val data: T? = null) : Resource<T>
 
-class Success<T> (override val data: T? = null) : Resource<T>(data)
+class Success<T> (override val data: T? = null) : Resource<T>
 
 class Error<T>(
     override val data: T? = null,
     val errorMessage: String? = null,
     val cause: Throwable? = null,
-) : Resource<T>(data)
+) : Resource<T>

--- a/app/src/main/java/app/pachli/viewdata/TrendingViewData.kt
+++ b/app/src/main/java/app/pachli/viewdata/TrendingViewData.kt
@@ -18,13 +18,13 @@ package app.pachli.viewdata
 import app.pachli.entity.TrendingTag
 import java.util.Date
 
-sealed class TrendingViewData {
-    abstract val id: String
+sealed interface TrendingViewData {
+    val id: String
 
     data class Header(
         val start: Date,
         val end: Date,
-    ) : TrendingViewData() {
+    ) : TrendingViewData {
         override val id: String
             get() = start.toString() + end.toString()
     }
@@ -34,7 +34,7 @@ sealed class TrendingViewData {
         val usage: List<Long>,
         val accounts: List<Long>,
         val maxTrendingValue: Long,
-    ) : TrendingViewData() {
+    ) : TrendingViewData {
         override val id: String
             get() = name
 


### PR DESCRIPTION
Using a sealed interface (instead of a sealed class) at the root of the hierarchy avoids the overhead of having to create and initialise the class (visible in the generated bytecode).

It also makes the instantiation code slightly less cumbersome because the code doesn't need to pass parameters to the root's constructor.