### PR TITLE
feat: Put option to hide self-boosts in preference (#39)

### DIFF
--- a/app/src/main/java/app/pachli/components/preference/TabFilterPreferencesFragment.kt
+++ b/app/src/main/java/app/pachli/components/preference/TabFilterPreferencesFragment.kt
@@ -37,6 +37,14 @@ class TabFilterPreferencesFragment : PreferenceFragmentCompat() {
                 }
 
                 switchPreference {
+                    setTitle(R.string.pref_title_show_self_boosts)
+                    setSummary(R.string.pref_title_show_self_boosts_description)
+                    key = PrefKeys.TAB_FILTER_HOME_SELF_BOOSTS
+                    setDefaultValue(true)
+                    isIconSpaceReserved = false
+                }
+
+                switchPreference {
                     setTitle(R.string.pref_title_show_replies)
                     key = PrefKeys.TAB_FILTER_HOME_REPLIES
                     setDefaultValue(true)

--- a/app/src/main/java/app/pachli/components/preference/TabFilterPreferencesFragment.kt
+++ b/app/src/main/java/app/pachli/components/preference/TabFilterPreferencesFragment.kt
@@ -39,7 +39,7 @@ class TabFilterPreferencesFragment : PreferenceFragmentCompat() {
                 switchPreference {
                     setTitle(R.string.pref_title_show_self_boosts)
                     setSummary(R.string.pref_title_show_self_boosts_description)
-                    key = PrefKeys.TAB_FILTER_HOME_SELF_BOOSTS
+                    key = PrefKeys.TAB_SHOW_HOME_SELF_BOOSTS
                     setDefaultValue(true)
                     isIconSpaceReserved = false
                 }

--- a/app/src/main/java/app/pachli/components/preference/TabFilterPreferencesFragment.kt
+++ b/app/src/main/java/app/pachli/components/preference/TabFilterPreferencesFragment.kt
@@ -42,7 +42,7 @@ class TabFilterPreferencesFragment : PreferenceFragmentCompat() {
                     key = PrefKeys.TAB_SHOW_HOME_SELF_BOOSTS
                     setDefaultValue(true)
                     isIconSpaceReserved = false
-                }
+                }.apply { dependency = PrefKeys.TAB_FILTER_HOME_BOOSTS }
 
                 switchPreference {
                     setTitle(R.string.pref_title_show_replies)

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/TimelineViewModel.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/TimelineViewModel.kt
@@ -497,7 +497,7 @@ abstract class TimelineViewModel(
             (status.inReplyToId != null && filterRemoveReplies) ||
             (status.reblog != null && filterRemoveReblogs) ||
             // To determine if the boost is boosting your own toot
-            ((status.reblog != null && status.account.username == statusViewData.username) && filterRemoveSelfReblogs)
+            ((status.account.id == status.reblog?.account?.id) && filterRemoveSelfReblogs)
         ) {
             return Filter.Action.HIDE
         } else {

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/TimelineViewModel.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/TimelineViewModel.kt
@@ -399,7 +399,7 @@ abstract class TimelineViewModel(
             filterRemoveReblogs =
                 !sharedPreferencesRepository.getBoolean(PrefKeys.TAB_FILTER_HOME_BOOSTS, true)
             filterRemoveSelfReblogs =
-                !sharedPreferencesRepository.getBoolean(PrefKeys.TAB_FILTER_HOME_SELF_BOOSTS, true)
+                !sharedPreferencesRepository.getBoolean(PrefKeys.TAB_SHOW_HOME_SELF_BOOSTS, true)
         }
 
         // Save the visible status ID (if it's the home timeline)
@@ -565,8 +565,8 @@ abstract class TimelineViewModel(
                     reloadKeepingReadingPosition()
                 }
             }
-            PrefKeys.TAB_FILTER_HOME_SELF_BOOSTS -> {
-                val filter = sharedPreferencesRepository.getBoolean(PrefKeys.TAB_FILTER_HOME_SELF_BOOSTS, true)
+            PrefKeys.TAB_SHOW_HOME_SELF_BOOSTS -> {
+                val filter = sharedPreferencesRepository.getBoolean(PrefKeys.TAB_SHOW_HOME_SELF_BOOSTS, true)
                 val oldRemoveSelfReblogs = filterRemoveSelfReblogs
                 filterRemoveSelfReblogs = timelineKind is TimelineKind.Home && !filter
                 if (oldRemoveSelfReblogs != filterRemoveSelfReblogs) {

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/TimelineViewModel.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/TimelineViewModel.kt
@@ -301,6 +301,7 @@ abstract class TimelineViewModel(
 
     private var filterRemoveReplies = false
     private var filterRemoveReblogs = false
+    private var filterRemoveSelfReblogs = false
 
     protected val activeAccount = accountManager.activeAccount!!
 
@@ -397,6 +398,8 @@ abstract class TimelineViewModel(
                 !sharedPreferencesRepository.getBoolean(PrefKeys.TAB_FILTER_HOME_REPLIES, true)
             filterRemoveReblogs =
                 !sharedPreferencesRepository.getBoolean(PrefKeys.TAB_FILTER_HOME_BOOSTS, true)
+            filterRemoveSelfReblogs =
+                !sharedPreferencesRepository.getBoolean(PrefKeys.TAB_FILTER_HOME_SELF_BOOSTS, true)
         }
 
         // Save the visible status ID (if it's the home timeline)
@@ -492,7 +495,9 @@ abstract class TimelineViewModel(
         val status = statusViewData.status
         return if (
             (status.inReplyToId != null && filterRemoveReplies) ||
-            (status.reblog != null && filterRemoveReblogs)
+            (status.reblog != null && filterRemoveReblogs) ||
+            // To determine if the boost is boosting your own toot
+            ((status.reblog != null && status.account.username == statusViewData.username) && filterRemoveSelfReblogs)
         ) {
             return Filter.Action.HIDE
         } else {
@@ -557,6 +562,14 @@ abstract class TimelineViewModel(
                 val oldRemoveReblogs = filterRemoveReblogs
                 filterRemoveReblogs = timelineKind is TimelineKind.Home && !filter
                 if (oldRemoveReblogs != filterRemoveReblogs) {
+                    reloadKeepingReadingPosition()
+                }
+            }
+            PrefKeys.TAB_FILTER_HOME_SELF_BOOSTS -> {
+                val filter = sharedPreferencesRepository.getBoolean(PrefKeys.TAB_FILTER_HOME_SELF_BOOSTS, true)
+                val oldRemoveSelfReblogs = filterRemoveSelfReblogs
+                filterRemoveSelfReblogs = timelineKind is TimelineKind.Home && !filter
+                if (oldRemoveSelfReblogs != filterRemoveSelfReblogs) {
                     reloadKeepingReadingPosition()
                 }
             }

--- a/app/src/main/java/app/pachli/settings/SettingsConstants.kt
+++ b/app/src/main/java/app/pachli/settings/SettingsConstants.kt
@@ -103,6 +103,7 @@ object PrefKeys {
 
     const val TAB_FILTER_HOME_REPLIES = "tabFilterHomeReplies_v2" // This was changed once to reset an unintentionally set default.
     const val TAB_FILTER_HOME_BOOSTS = "tabFilterHomeBoosts"
+    const val TAB_FILTER_HOME_SELF_BOOSTS = "tabFilterHomeSelfBoosts"
 
     /** UI text scaling factor, stored as float, 100 = 100% = no scaling */
     const val UI_TEXT_SCALE_RATIO = "uiTextScaleRatio"

--- a/app/src/main/java/app/pachli/settings/SettingsConstants.kt
+++ b/app/src/main/java/app/pachli/settings/SettingsConstants.kt
@@ -103,7 +103,7 @@ object PrefKeys {
 
     const val TAB_FILTER_HOME_REPLIES = "tabFilterHomeReplies_v2" // This was changed once to reset an unintentionally set default.
     const val TAB_FILTER_HOME_BOOSTS = "tabFilterHomeBoosts"
-    const val TAB_FILTER_HOME_SELF_BOOSTS = "tabFilterHomeSelfBoosts"
+    const val TAB_SHOW_HOME_SELF_BOOSTS = "tabShowHomeSelfBoosts"
 
     /** UI text scaling factor, stored as float, 100 = 100% = no scaling */
     const val UI_TEXT_SCALE_RATIO = "uiTextScaleRatio"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -144,6 +144,8 @@
     <string name="action_share_account_username">Share username of account</string>
     <string name="action_hide_reblogs">Hide boosts</string>
     <string name="action_show_reblogs">Show boosts</string>
+    <string name="pref_title_show_self_boosts">Show self-boosts</string>
+    <string name="pref_title_show_self_boosts_description">Someone boosting their own post</string>
     <string name="action_report">Report</string>
     <string name="action_edit">Edit</string>
     <string name="action_delete">Delete</string>


### PR DESCRIPTION
# Overview
Some Mastodon posters have a annoying habit of boosting their own posts some time after they've posted them. 
Some people got fed up , TL became disorganized due to this.

No need to see the same toot over and over again.

# Changes Made
- Add an additional option to the "Filters > Tabs" preference to show these self-boosts (default: on)

# Screenshot
***screen of "Filters > Tabs" preference***
before | after
:--: | :--:
| ![image](https://github.com/pachli/pachli-android/assets/62137820/e34e4620-3852-4f46-9663-bf1046f35e5f) |![image](https://github.com/pachli/pachli-android/assets/62137820/6d462fce-b746-4aeb-8c29-c7c5f157efb9)

***screen of Home Timeline***
***switch-on(self-boosts are displayed)*** | ***swith-off(self-boosts are not displayed)***
:--: | :--:
| ![image](https://github.com/pachli/pachli-android/assets/62137820/765fb73a-462a-4cae-a1d3-5817a10ec07d) |![image](https://github.com/pachli/pachli-android/assets/62137820/cacd5c40-dbbf-490c-a65c-b503d2936af2)

# Concern
With the current implementation, when "Show boosts" is OFF, boosts are not displayed whether "Show self-boosts" is ON or OFF. Is this behavior OK?

# Related issue
Fixes #39