### PR TITLE
fix: Use the correct name for filters affecting threads

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -457,7 +457,7 @@
     <string name="replying_to">Replying to @%s</string>
 
     <string name="pref_title_public_filter_keywords">Public timelines</string>
-    <string name="pref_title_thread_filter_keywords">Conversations</string>
+    <string name="pref_title_thread_filter_keywords">Threads</string>
     <string name="pref_title_account_filter_keywords">Profiles</string>
     <string name="filter_addition_title">Add filter</string>
     <string name="filter_edit_title">Edit filter</string>


### PR DESCRIPTION
Previous code called filters that affect threads "Conversations". Correct this to "Threads", to distinguish from "Direct Messages" which can also be known as "conversations" (in the API in particular).