### PR TITLE
fix: Restore image aspect ratio when drag ends

### DIFF
--- a/app/src/main/java/app/pachli/fragment/ViewImageFragment.kt
+++ b/app/src/main/java/app/pachli/fragment/ViewImageFragment.kt
@@ -193,7 +193,7 @@ class ViewImageFragment : ViewMediaFragment() {
                     if (abs(view.translationY) > 180) {
                         photoActionsListener.onDismiss()
                     } else {
-                        view.animate().translationY(0f).scaleX(1f).start()
+                        view.animate().translationY(0f).scaleX(1f).scaleY(1f).start()
                     }
                 }
             },


### PR DESCRIPTION
Previously, ending a drag on an image (that didn't result in dismissing the fragment) animates the image back in to position restoring the X axis scale factor.

The Y axis scale factor was not restored, potentially breaking the image's aspect ratio. Restore the Y axis scale factor to fix this (`ViewVideoFragment` already handles this correctly).

Fixes #202