### PR TITLE
build: Use `updateLintBaseline` task

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -65,7 +65,7 @@ android {
 
     lint {
         lintConfig file("lint.xml")
-        // Regenerate by running `./gradlew app:newLintBaseline`
+        // Regenerate by running `./gradlew updateLintBaselineOrangeDebug`
         baseline = file("lint-baseline.xml")
     }
 
@@ -216,19 +216,4 @@ dependencies {
     androidTestImplementation libs.androidx.test.junit
     androidTestImplementation libs.hilt.android.testing
     androidTestImplementation libs.androidx.test.core.ktx
-}
-
-tasks.register("newLintBaseline") {
-    description 'Deletes and then recreates the lint baseline'
-
-    // This task should always run, irrespective of caching
-    notCompatibleWithConfigurationCache("Is always out of date")
-    outputs.upToDateWhen { false }
-
-    doLast {
-        delete android.lint.baseline.path
-    }
-
-    // Regenerate the lint baseline
-    it.finalizedBy tasks.named("lintBlueDebug")
 }

--- a/docs/contributing/code.md
+++ b/docs/contributing/code.md
@@ -302,10 +302,10 @@ A number of pre-existing lint errors and warnings have been grandfathered in to 
 
 These are being removed over time, please do not add to them.
 
-If your PR fixes some of the existing lint issues, or moves code so that the baseline file is no longer valid you can you regenerate it with the `newLintBaseline` task.
+If your PR fixes some of the existing lint issues, or moves code so that the baseline file is no longer valid you can you regenerate it with the `updateLintBaselineOrangeDebug` task.
 
 ```shell
-./gradlew newLintBaseline
+./gradlew updateLintBaselineOrangeDebug
 ```
 
 #### Screenshots


### PR DESCRIPTION
There's a well-hidden `updateLintBaseline` task that does what the custom `newLintBaseline` task does. Prefer the `update...` task to reduce the amount of custom machinery in this build.