### PR TITLE
fix: Refer to "SDK level" rather than "SDK version"

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -406,7 +406,7 @@
     <string name="about_title_activity">About</string>
     <string name="about_pachli_version">Pachli %s</string>
     <string name="about_device_info_title">Your device</string>
-    <string name="about_device_info">%s %s\nAndroid version: %s\nSDK version: %d</string>
+    <string name="about_device_info">%s %s\nAndroid version: %s\nSDK level: %d</string>
     <string name="about_account_info_title">Your account</string>
     <string name="about_account_info">\@%s\@%s\nVersion: %s</string>
     <string name="about_powered_by_pachli">Powered by Pachli</string>


### PR DESCRIPTION
"level" is the term used throughout Android documentation.

Originally submitted by https://github.com/chaoscalm