### PR TITLE
refactor: Log with Timber

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -197,6 +197,7 @@ dependencies {
     implementation libs.bundles.xmldiff
 
     implementation libs.bundles.aboutlibraries
+    implementation libs.timber
 
     testImplementation libs.androidx.test.junit
     testImplementation libs.robolectric

--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -2929,7 +2929,7 @@
         errorLine2="                     ~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/components/login/LoginActivity.kt"
-            line="155"
+            line="156"
             column="22"/>
     </issue>
 
@@ -3094,7 +3094,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="557"
+            line="556"
             column="17"/>
     </issue>
 
@@ -3105,7 +3105,7 @@
         errorLine2="                    ~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="560"
+            line="559"
             column="21"/>
     </issue>
 
@@ -3116,7 +3116,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="565"
+            line="564"
             column="17"/>
     </issue>
 
@@ -3127,7 +3127,7 @@
         errorLine2="                    ~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="569"
+            line="568"
             column="21"/>
     </issue>
 
@@ -3138,7 +3138,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="574"
+            line="573"
             column="17"/>
     </issue>
 
@@ -3149,7 +3149,7 @@
         errorLine2="                    ~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="577"
+            line="576"
             column="21"/>
     </issue>
 
@@ -3160,7 +3160,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="582"
+            line="581"
             column="17"/>
     </issue>
 
@@ -3171,7 +3171,7 @@
         errorLine2="                    ~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="585"
+            line="584"
             column="21"/>
     </issue>
 
@@ -3182,7 +3182,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="590"
+            line="589"
             column="17"/>
     </issue>
 
@@ -3193,7 +3193,7 @@
         errorLine2="                    ~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="593"
+            line="592"
             column="21"/>
     </issue>
 
@@ -3204,7 +3204,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="597"
+            line="596"
             column="17"/>
     </issue>
 
@@ -3215,7 +3215,7 @@
         errorLine2="                    ~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="600"
+            line="599"
             column="21"/>
     </issue>
 
@@ -3226,7 +3226,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="605"
+            line="604"
             column="17"/>
     </issue>
 
@@ -3237,7 +3237,7 @@
         errorLine2="                    ~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="608"
+            line="607"
             column="21"/>
     </issue>
 
@@ -3248,7 +3248,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="612"
+            line="611"
             column="17"/>
     </issue>
 
@@ -3259,7 +3259,7 @@
         errorLine2="                    ~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="616"
+            line="615"
             column="21"/>
     </issue>
 
@@ -3270,7 +3270,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="625"
+            line="624"
             column="17"/>
     </issue>
 
@@ -3281,7 +3281,7 @@
         errorLine2="                    ~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="628"
+            line="627"
             column="21"/>
     </issue>
 
@@ -3292,7 +3292,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="633"
+            line="632"
             column="17"/>
     </issue>
 
@@ -3303,7 +3303,7 @@
         errorLine2="                    ~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="636"
+            line="635"
             column="21"/>
     </issue>
 
@@ -3314,7 +3314,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="641"
+            line="640"
             column="17"/>
     </issue>
 
@@ -3325,7 +3325,7 @@
         errorLine2="                    ~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="644"
+            line="643"
             column="21"/>
     </issue>
 
@@ -3336,7 +3336,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="649"
+            line="648"
             column="17"/>
     </issue>
 
@@ -3347,7 +3347,7 @@
         errorLine2="                    ~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="652"
+            line="651"
             column="21"/>
     </issue>
 
@@ -3358,7 +3358,7 @@
         errorLine2="                    ~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="659"
+            line="658"
             column="21"/>
     </issue>
 
@@ -3369,7 +3369,7 @@
         errorLine2="                        ~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="662"
+            line="661"
             column="25"/>
     </issue>
 
@@ -3380,7 +3380,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="671"
+            line="670"
             column="17"/>
     </issue>
 
@@ -3391,7 +3391,7 @@
         errorLine2="                    ~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="674"
+            line="673"
             column="21"/>
     </issue>
 
@@ -3402,7 +3402,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="687"
+            line="686"
             column="17"/>
     </issue>
 
@@ -3413,7 +3413,7 @@
         errorLine2="                    ~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="691"
+            line="690"
             column="21"/>
     </issue>
 
@@ -3424,7 +3424,7 @@
         errorLine2="                ~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="812"
+            line="811"
             column="17"/>
     </issue>
 
@@ -3435,7 +3435,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="814"
+            line="813"
             column="17"/>
     </issue>
 
@@ -3446,7 +3446,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="825"
+            line="824"
             column="17"/>
     </issue>
 

--- a/app/src/main/java/app/pachli/BaseActivity.java
+++ b/app/src/main/java/app/pachli/BaseActivity.java
@@ -29,7 +29,6 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.MenuItem;
 import android.view.View;
 
@@ -66,6 +65,7 @@ import dagger.hilt.InstallIn;
 import dagger.hilt.android.AndroidEntryPoint;
 import dagger.hilt.android.EntryPointAccessors;
 import dagger.hilt.components.SingletonComponent;
+import timber.log.Timber;
 
 @AndroidEntryPoint
 public abstract class BaseActivity extends AppCompatActivity {
@@ -96,7 +96,7 @@ public abstract class BaseActivity extends AppCompatActivity {
         super.setTheme(themeId);
         if (BuildConfig.DEBUG) {
             String name = getResources().getResourceEntryName(themeId);
-            Log.d(TAG, "Setting theme: " + name);
+            Timber.d("Setting theme: %s", name);
         }
     }
 
@@ -108,7 +108,7 @@ public abstract class BaseActivity extends AppCompatActivity {
          * runtime, just individual activities. So, each activity has to set its theme before any
          * views are created. */
         String theme = sharedPreferencesRepository.getString(APP_THEME, ThemeUtils.APP_THEME_DEFAULT);
-        Log.d("activeTheme", theme);
+        Timber.d("activeTheme: %s", theme);
         if (theme.equals(THEME_BLACK)) {
             setTheme(R.style.Theme_Pachli_Black);
         }

--- a/app/src/main/java/app/pachli/EditProfileActivity.kt
+++ b/app/src/main/java/app/pachli/EditProfileActivity.kt
@@ -22,7 +22,6 @@ import android.graphics.Bitmap
 import android.graphics.Color
 import android.net.Uri
 import android.os.Bundle
-import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
@@ -59,6 +58,7 @@ import com.mikepenz.iconics.utils.colorInt
 import com.mikepenz.iconics.utils.sizeDp
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 @AndroidEntryPoint
 class EditProfileActivity : BaseActivity() {
@@ -315,7 +315,7 @@ class EditProfileActivity : BaseActivity() {
     }
 
     private fun onPickFailure(throwable: Throwable?) {
-        Log.w("EditProfileActivity", "failed to pick media", throwable)
+        Timber.w("failed to pick media", throwable)
         Snackbar.make(binding.avatarButton, R.string.error_media_upload_sending, Snackbar.LENGTH_LONG).show()
     }
 

--- a/app/src/main/java/app/pachli/MainActivity.kt
+++ b/app/src/main/java/app/pachli/MainActivity.kt
@@ -34,7 +34,6 @@ import android.os.Build
 import android.os.Build.VERSION_CODES.TIRAMISU
 import android.os.Bundle
 import android.text.TextUtils
-import android.util.Log
 import android.view.KeyEvent
 import android.view.Menu
 import android.view.MenuInflater
@@ -141,6 +140,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import de.c1710.filemojicompat_ui.helpers.EMOJI_PREFERENCE
 import io.reactivex.rxjava3.schedulers.Schedulers
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -392,8 +392,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
         super.onResume()
         val currentEmojiPack = sharedPreferencesRepository.getString(EMOJI_PREFERENCE, "")
         if (currentEmojiPack != selectedEmojiPack) {
-            Log.d(
-                TAG,
+            Timber.d(
                 "onResume: EmojiPack has been changed from %s to %s"
                     .format(selectedEmojiPack, currentEmojiPack),
             )
@@ -709,10 +708,10 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
                     "Remove first 40 statuses",
                 ),
             ) { _, which ->
-                Log.d(TAG, "Developer tools: $which")
+                Timber.d("Developer tools: $which")
                 when (which) {
                     0 -> {
-                        Log.d(TAG, "Clearing home timeline cache")
+                        Timber.d("Clearing home timeline cache")
                         lifecycleScope.launch {
                             accountManager.activeAccount?.let {
                                 developerToolsUseCase.clearHomeTimelineCache(it.id)
@@ -720,7 +719,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
                         }
                     }
                     1 -> {
-                        Log.d(TAG, "Removing most recent 40 statuses")
+                        Timber.d("Removing most recent 40 statuses")
                         lifecycleScope.launch {
                             accountManager.activeAccount?.let {
                                 developerToolsUseCase.deleteFirstKStatuses(it.id, 40)
@@ -921,7 +920,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
                 onFetchUserInfoSuccess(userInfo)
             },
             { throwable ->
-                Log.e(TAG, "Failed to fetch user info. " + throwable.message)
+                Timber.e("Failed to fetch user info. " + throwable.message)
             },
         )
     }
@@ -1054,7 +1053,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
                         updateAnnouncementsBadge()
                     },
                     { throwable ->
-                        Log.w(TAG, "Failed to fetch announcements.", throwable)
+                        Timber.w("Failed to fetch announcements.", throwable)
                     },
                 )
         }
@@ -1098,7 +1097,6 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
     override fun getActionButton() = binding.composeButton
 
     companion object {
-        private const val TAG = "MainActivity" // logging tag
         private const val DRAWER_ITEM_ADD_ACCOUNT: Long = -13
         private const val DRAWER_ITEM_ANNOUNCEMENTS: Long = 14
         private const val REDIRECT_URL = "redirectUrl"

--- a/app/src/main/java/app/pachli/PachliApplication.kt
+++ b/app/src/main/java/app/pachli/PachliApplication.kt
@@ -18,7 +18,6 @@
 package app.pachli
 
 import android.app.Application
-import android.util.Log
 import androidx.work.Constraints
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.PeriodicWorkRequestBuilder
@@ -41,6 +40,7 @@ import de.c1710.filemojicompat_ui.helpers.EmojiPackHelper
 import de.c1710.filemojicompat_ui.helpers.EmojiPreference
 import io.reactivex.rxjava3.plugins.RxJavaPlugins
 import org.conscrypt.Conscrypt
+import timber.log.Timber
 import java.security.Security
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -73,6 +73,8 @@ class PachliApplication : Application() {
 
         AutoDisposePlugins.setHideProxies(false) // a small performance optimization
 
+        if (BuildConfig.DEBUG) Timber.plant(Timber.DebugTree())
+
         // Migrate shared preference keys and defaults from version to version.
         val oldVersion = sharedPreferencesRepository.getInt(PrefKeys.SCHEMA_VERSION, NEW_INSTALL_SCHEMA_VERSION)
         if (oldVersion != SCHEMA_VERSION) {
@@ -91,7 +93,7 @@ class PachliApplication : Application() {
         localeManager.setLocale()
 
         RxJavaPlugins.setErrorHandler {
-            Log.w("RxJava", "undeliverable exception", it)
+            Timber.tag("RxJava").w(it, "undeliverable exception")
         }
 
         NotificationHelper.createWorkerNotificationChannel(this)
@@ -115,7 +117,7 @@ class PachliApplication : Application() {
     }
 
     private fun upgradeSharedPreferences(oldVersion: Int, newVersion: Int) {
-        Log.d(TAG, "Upgrading shared preferences: $oldVersion -> $newVersion")
+        Timber.d("Upgrading shared preferences: $oldVersion -> $newVersion")
         val editor = sharedPreferencesRepository.edit()
 
         // General usage is:
@@ -129,6 +131,5 @@ class PachliApplication : Application() {
     }
 
     companion object {
-        private const val TAG = "PachliApplication"
     }
 }

--- a/app/src/main/java/app/pachli/PachliApplication.kt
+++ b/app/src/main/java/app/pachli/PachliApplication.kt
@@ -129,7 +129,4 @@ class PachliApplication : Application() {
         editor.putInt(PrefKeys.SCHEMA_VERSION, newVersion)
         editor.apply()
     }
-
-    companion object {
-    }
 }

--- a/app/src/main/java/app/pachli/StatusListActivity.kt
+++ b/app/src/main/java/app/pachli/StatusListActivity.kt
@@ -20,7 +20,6 @@ package app.pachli
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
 import androidx.fragment.app.commit
@@ -40,6 +39,7 @@ import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import retrofit2.HttpException
+import timber.log.Timber
 import javax.inject.Inject
 
 /**
@@ -72,7 +72,7 @@ class StatusListActivity : BottomSheetActivity(), AppBarLayoutHost {
     private var mutedFilter: Filter? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        Log.d("StatusListActivity", "onCreate")
+        Timber.d("onCreate")
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
 
@@ -125,7 +125,7 @@ class StatusListActivity : BottomSheetActivity(), AppBarLayoutHost {
                         updateMuteTagMenuItems()
                     },
                     {
-                        Log.w(TAG, "Failed to query tag #$tag", it)
+                        Timber.w("Failed to query tag #$tag", it)
                     },
                 )
             }
@@ -145,7 +145,7 @@ class StatusListActivity : BottomSheetActivity(), AppBarLayoutHost {
                     },
                     {
                         Snackbar.make(binding.root, getString(R.string.error_following_hashtag_format, tag), Snackbar.LENGTH_SHORT).show()
-                        Log.e(TAG, "Failed to follow #$tag", it)
+                        Timber.e("Failed to follow #$tag", it)
                     },
                 )
             }
@@ -165,7 +165,7 @@ class StatusListActivity : BottomSheetActivity(), AppBarLayoutHost {
                     },
                     {
                         Snackbar.make(binding.root, getString(R.string.error_unfollowing_hashtag_format, tag), Snackbar.LENGTH_SHORT).show()
-                        Log.e(TAG, "Failed to unfollow #$tag", it)
+                        Timber.e("Failed to unfollow #$tag", it)
                     },
                 )
             }
@@ -204,11 +204,11 @@ class StatusListActivity : BottomSheetActivity(), AppBarLayoutHost {
                                 updateTagMuteState(mutedFilterV1 != null)
                             },
                             { throwable ->
-                                Log.e(TAG, "Error getting filters: $throwable")
+                                Timber.e("Error getting filters: $throwable")
                             },
                         )
                     } else {
-                        Log.e(TAG, "Error getting filters: $throwable")
+                        Timber.e("Error getting filters: $throwable")
                     }
                 },
             )
@@ -245,7 +245,7 @@ class StatusListActivity : BottomSheetActivity(), AppBarLayoutHost {
                         Snackbar.make(binding.root, getString(R.string.confirmation_hashtag_muted, hashtag), Snackbar.LENGTH_SHORT).show()
                     } else {
                         Snackbar.make(binding.root, getString(R.string.error_muting_hashtag_format, hashtag), Snackbar.LENGTH_SHORT).show()
-                        Log.e(TAG, "Failed to mute $tagWithHash")
+                        Timber.e("Failed to mute $tagWithHash")
                     }
                 },
                 { throwable ->
@@ -265,12 +265,12 @@ class StatusListActivity : BottomSheetActivity(), AppBarLayoutHost {
                             },
                             { throwable ->
                                 Snackbar.make(binding.root, getString(R.string.error_muting_hashtag_format, hashtag), Snackbar.LENGTH_SHORT).show()
-                                Log.e(TAG, "Failed to mute $tagWithHash", throwable)
+                                Timber.e("Failed to mute $tagWithHash", throwable)
                             },
                         )
                     } else {
                         Snackbar.make(binding.root, getString(R.string.error_muting_hashtag_format, hashtag), Snackbar.LENGTH_SHORT).show()
-                        Log.e(TAG, "Failed to mute $tagWithHash", throwable)
+                        Timber.e("Failed to mute $tagWithHash", throwable)
                     }
                 },
             )
@@ -324,7 +324,7 @@ class StatusListActivity : BottomSheetActivity(), AppBarLayoutHost {
                 },
                 { throwable ->
                     Snackbar.make(binding.root, getString(R.string.error_unmuting_hashtag_format, hashtag), Snackbar.LENGTH_SHORT).show()
-                    Log.e(TAG, "Failed to unmute $tagWithHash", throwable)
+                    Timber.e("Failed to unmute $tagWithHash", throwable)
                 },
             )
         }
@@ -334,7 +334,6 @@ class StatusListActivity : BottomSheetActivity(), AppBarLayoutHost {
 
     companion object {
         private const val EXTRA_KIND = "kind"
-        private const val TAG = "StatusListActivity"
 
         fun newFavouritesIntent(context: Context) =
             Intent(context, StatusListActivity::class.java).apply {

--- a/app/src/main/java/app/pachli/TabPreferenceActivity.kt
+++ b/app/src/main/java/app/pachli/TabPreferenceActivity.kt
@@ -20,7 +20,6 @@ package app.pachli
 import android.content.Intent
 import android.graphics.Color
 import android.os.Bundle
-import android.util.Log
 import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
@@ -64,6 +63,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import java.util.regex.Pattern
 import javax.inject.Inject
 
@@ -332,7 +332,7 @@ class TabPreferenceActivity : BaseActivity(), ItemInteractionListener {
                 },
                 { throwable ->
                     dialog.hide()
-                    Log.e("TabPreferenceActivity", "failed to load lists", throwable)
+                    Timber.w(throwable, "failed to load lists")
                     Snackbar.make(binding.root, R.string.error_list_load, Snackbar.LENGTH_LONG).show()
                 },
             )

--- a/app/src/main/java/app/pachli/ViewMediaActivity.kt
+++ b/app/src/main/java/app/pachli/ViewMediaActivity.kt
@@ -33,7 +33,6 @@ import android.os.Build
 import android.os.Bundle
 import android.os.Environment
 import android.transition.Transition
-import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
@@ -65,6 +64,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.core.Single
 import io.reactivex.rxjava3.schedulers.Schedulers
+import timber.log.Timber
 import java.io.File
 import java.io.FileNotFoundException
 import java.io.FileOutputStream
@@ -255,7 +255,7 @@ class ViewMediaActivity : BaseActivity(), ViewImageFragment.PhotoActionsListener
     private fun shareMedia() {
         val directory = applicationContext.getExternalFilesDir("Pachli")
         if (directory == null || !(directory.exists())) {
-            Log.e(TAG, "Error obtaining directory to save temporary media.")
+            Timber.e("Error obtaining directory to save temporary media.")
             return
         }
 
@@ -269,7 +269,7 @@ class ViewMediaActivity : BaseActivity(), ViewImageFragment.PhotoActionsListener
                 Attachment.Type.VIDEO,
                 Attachment.Type.GIFV,
                 -> shareMediaFile(directory, attachment.url)
-                else -> Log.e(TAG, "Unknown media format for sharing.")
+                else -> Timber.e("Unknown media format for sharing.")
             }
         }
     }
@@ -299,9 +299,9 @@ class ViewMediaActivity : BaseActivity(), ViewImageFragment.PhotoActionsListener
                 stream.close()
                 return@fromCallable true
             } catch (fnfe: FileNotFoundException) {
-                Log.e(TAG, "Error writing temporary media.")
+                Timber.e("Error writing temporary media.")
             } catch (ioe: IOException) {
-                Log.e(TAG, "Error writing temporary media.")
+                Timber.e("Error writing temporary media.")
             }
             return@fromCallable false
         }
@@ -313,7 +313,7 @@ class ViewMediaActivity : BaseActivity(), ViewImageFragment.PhotoActionsListener
             .autoDispose(AndroidLifecycleScopeProvider.from(this, Lifecycle.Event.ON_DESTROY))
             .subscribe(
                 { result ->
-                    Log.d(TAG, "Download image result: $result")
+                    Timber.d("Download image result: $result")
                     isCreating = false
                     invalidateOptionsMenu()
                     binding.progressBarShare.visibility = View.GONE
@@ -325,7 +325,7 @@ class ViewMediaActivity : BaseActivity(), ViewImageFragment.PhotoActionsListener
                     isCreating = false
                     invalidateOptionsMenu()
                     binding.progressBarShare.visibility = View.GONE
-                    Log.e(TAG, "Failed to download image", error)
+                    Timber.e("Failed to download image", error)
                 },
             )
     }
@@ -351,7 +351,6 @@ class ViewMediaActivity : BaseActivity(), ViewImageFragment.PhotoActionsListener
         private const val EXTRA_ATTACHMENTS = "attachments"
         private const val EXTRA_ATTACHMENT_INDEX = "index"
         private const val EXTRA_SINGLE_IMAGE_URL = "single_image"
-        private const val TAG = "ViewMediaActivity"
 
         @JvmStatic
         fun newIntent(context: Context?, attachments: List<AttachmentViewData>, index: Int): Intent {

--- a/app/src/main/java/app/pachli/adapter/StatusBaseViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/StatusBaseViewHolder.kt
@@ -869,8 +869,6 @@ abstract class StatusBaseViewHolder protected constructor(itemView: View) :
     }
 
     companion object {
-        private const val TAG = "StatusBaseViewHolder"
-
         @JvmStatic
         protected fun hasPreviewableAttachment(attachments: List<Attachment>): Boolean {
             for ((_, _, _, _, type) in attachments) {

--- a/app/src/main/java/app/pachli/components/account/AccountActivity.kt
+++ b/app/src/main/java/app/pachli/components/account/AccountActivity.kt
@@ -998,7 +998,6 @@ class AccountActivity :
     }
 
     companion object {
-
         private const val KEY_ACCOUNT_ID = "id"
         private val argbEvaluator = ArgbEvaluator()
 

--- a/app/src/main/java/app/pachli/components/account/AccountViewModel.kt
+++ b/app/src/main/java/app/pachli/components/account/AccountViewModel.kt
@@ -1,6 +1,5 @@
 package app.pachli.components.account
 
-import android.util.Log
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -24,6 +23,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -77,7 +77,7 @@ class AccountViewModel @Inject constructor(
                             isFromOwnDomain = getDomain(account.url) == activeAccount.domain
                         },
                         { t ->
-                            Log.w(TAG, "failed obtaining account", t)
+                            Timber.w("failed obtaining account", t)
                             accountData.postValue(Error(cause = t))
                             isDataLoading = false
                             isRefreshing.postValue(false)
@@ -98,7 +98,7 @@ class AccountViewModel @Inject constructor(
                             relationshipData.postValue(if (relationships.isNotEmpty()) Success(relationships[0]) else Error())
                         },
                         { t ->
-                            Log.w(TAG, "failed obtaining relationships", t)
+                            Timber.w("failed obtaining relationships", t)
                             relationshipData.postValue(Error(cause = t))
                         },
                     )
@@ -151,7 +151,7 @@ class AccountViewModel @Inject constructor(
                     relationshipData.postValue(Success(relation.copy(blockingDomain = true)))
                 }
             }, { e ->
-                Log.e(TAG, "Error muting $instance", e)
+                Timber.e("Error muting $instance", e)
             },)
         }
     }
@@ -164,7 +164,7 @@ class AccountViewModel @Inject constructor(
                     relationshipData.postValue(Success(relation.copy(blockingDomain = false)))
                 }
             }, { e ->
-                Log.e(TAG, "Error unmuting $instance", e)
+                Timber.e("Error unmuting $instance", e)
             },)
         }
     }
@@ -265,7 +265,7 @@ class AccountViewModel @Inject constructor(
                 }
             },
             { t ->
-                Log.w(TAG, "failed loading relationship", t)
+                Timber.w("failed loading relationship", t)
                 relationshipData.postValue(Error(relation, cause = t))
             },
         )
@@ -284,7 +284,7 @@ class AccountViewModel @Inject constructor(
                         noteSaved.postValue(false)
                     },
                     { t ->
-                        Log.w(TAG, "Error updating note", t)
+                        Timber.w("Error updating note", t)
                     },
                 )
         }

--- a/app/src/main/java/app/pachli/components/account/media/AccountMediaFragment.kt
+++ b/app/src/main/java/app/pachli/components/account/media/AccountMediaFragment.kt
@@ -196,9 +196,6 @@ class AccountMediaFragment :
     }
 
     companion object {
-        @Suppress("unused")
-        private const val TAG = "AccountMediaFragment"
-
         fun newInstance(accountId: String): AccountMediaFragment {
             val fragment = AccountMediaFragment()
             val args = Bundle(1)

--- a/app/src/main/java/app/pachli/components/accountlist/AccountListFragment.kt
+++ b/app/src/main/java/app/pachli/components/accountlist/AccountListFragment.kt
@@ -17,7 +17,6 @@
 package app.pachli.components.accountlist
 
 import android.os.Bundle
-import android.util.Log
 import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
@@ -60,6 +59,7 @@ import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import retrofit2.Response
+import timber.log.Timber
 import java.io.IOException
 import javax.inject.Inject
 
@@ -208,7 +208,7 @@ class AccountListFragment :
         } else {
             "unmute"
         }
-        Log.e(TAG, "Failed to $verb account id $accountId")
+        Timber.e("Failed to $verb account id $accountId")
     }
 
     override fun onBlock(block: Boolean, id: String, position: Int) {
@@ -248,7 +248,7 @@ class AccountListFragment :
         } else {
             "unblock"
         }
-        Log.e(TAG, "Failed to $verb account accountId $accountId: $throwable")
+        Timber.e("Failed to $verb account accountId $accountId: $throwable")
     }
 
     override fun onRespondToFollowRequest(
@@ -271,7 +271,7 @@ class AccountListFragment :
                     } else {
                         "reject"
                     }
-                    Log.e(TAG, "Failed to $verb account id $accountId.", throwable)
+                    Timber.e("Failed to $verb account id $accountId.", throwable)
                 },
             )
         }
@@ -383,7 +383,7 @@ class AccountListFragment :
         lifecycleScope.launch {
             api.relationships(ids)
                 .fold(::onFetchRelationshipsSuccess) { throwable ->
-                    Log.e(TAG, "Fetch failure for relationships of accounts: $ids", throwable)
+                    Timber.e("Fetch failure for relationships of accounts: $ids", throwable)
                 }
         }
     }
@@ -398,7 +398,7 @@ class AccountListFragment :
     private fun onFetchAccountsFailure(throwable: Throwable) {
         fetching = false
         binding.swipeRefreshLayout.isRefreshing = false
-        Log.e(TAG, "Fetch failure", throwable)
+        Timber.e("Fetch failure", throwable)
 
         if (adapter.itemCount == 0) {
             binding.messageView.show()
@@ -410,7 +410,6 @@ class AccountListFragment :
     }
 
     companion object {
-        private const val TAG = "AccountList" // logging tag
         private const val ARG_TYPE = "type"
         private const val ARG_ID = "id"
 

--- a/app/src/main/java/app/pachli/components/announcements/AnnouncementsViewModel.kt
+++ b/app/src/main/java/app/pachli/components/announcements/AnnouncementsViewModel.kt
@@ -173,7 +173,4 @@ class AnnouncementsViewModel @Inject constructor(
                 )
         }
     }
-
-    companion object {
-    }
 }

--- a/app/src/main/java/app/pachli/components/announcements/AnnouncementsViewModel.kt
+++ b/app/src/main/java/app/pachli/components/announcements/AnnouncementsViewModel.kt
@@ -16,7 +16,6 @@
 
 package app.pachli.components.announcements
 
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -34,6 +33,7 @@ import app.pachli.util.Success
 import at.connyduck.calladapter.networkresult.fold
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -70,8 +70,7 @@ class AnnouncementsViewModel @Inject constructor(
                                             eventHub.dispatch(AnnouncementReadEvent(announcement.id))
                                         },
                                         { throwable ->
-                                            Log.d(
-                                                TAG,
+                                            Timber.d(
                                                 "Failed to mark announcement as read.",
                                                 throwable,
                                             )
@@ -130,7 +129,7 @@ class AnnouncementsViewModel @Inject constructor(
                         )
                     },
                     {
-                        Log.w(TAG, "Failed to add reaction to the announcement.", it)
+                        Timber.w("Failed to add reaction to the announcement.", it)
                     },
                 )
         }
@@ -169,13 +168,12 @@ class AnnouncementsViewModel @Inject constructor(
                         )
                     },
                     {
-                        Log.w(TAG, "Failed to remove reaction from the announcement.", it)
+                        Timber.w("Failed to remove reaction from the announcement.", it)
                     },
                 )
         }
     }
 
     companion object {
-        private const val TAG = "AnnouncementsViewModel"
     }
 }

--- a/app/src/main/java/app/pachli/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeActivity.kt
@@ -32,7 +32,6 @@ import android.os.Parcelable
 import android.provider.MediaStore
 import android.text.Spanned
 import android.text.style.URLSpan
-import android.util.Log
 import android.view.KeyEvent
 import android.view.MenuItem
 import android.view.View
@@ -118,6 +117,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
+import timber.log.Timber
 import java.io.File
 import java.io.IOException
 import java.text.DecimalFormat
@@ -190,9 +190,9 @@ class ComposeActivity :
                 }
             }
         } else if (result == CropImage.CancelledResult) {
-            Log.w("ComposeActivity", "Edit image cancelled by user")
+            Timber.w("Edit image cancelled by user")
         } else {
-            Log.w("ComposeActivity", "Edit image failed: " + result.error)
+            Timber.w("Edit image failed: " + result.error)
             displayTransientMessage(R.string.error_image_edit_failed)
         }
         viewModel.cropImageItemOld = null
@@ -1332,8 +1332,6 @@ class ComposeActivity :
     ) : Parcelable
 
     companion object {
-        @Suppress("unused")
-        private const val TAG = "ComposeActivity"
         private const val PERMISSIONS_REQUEST_READ_EXTERNAL_STORAGE = 1
 
         internal const val COMPOSE_OPTIONS_EXTRA = "COMPOSE_OPTIONS"

--- a/app/src/main/java/app/pachli/components/compose/ComposeViewModel.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeViewModel.kt
@@ -17,7 +17,6 @@
 package app.pachli.components.compose
 
 import android.net.Uri
-import android.util.Log
 import androidx.core.net.toUri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -52,6 +51,7 @@ import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -380,7 +380,7 @@ class ComposeViewModel @Inject constructor(
                     .fold({ accounts ->
                         accounts.map { AutocompleteResult.AccountResult(it) }
                     }, { e ->
-                        Log.e(TAG, "Autocomplete search for $token failed.", e)
+                        Timber.e("Autocomplete search for $token failed.", e)
                         emptyList()
                     },)
             }
@@ -389,7 +389,7 @@ class ComposeViewModel @Inject constructor(
                     .fold({ searchResult ->
                         searchResult.hashtags.map { AutocompleteResult.HashtagResult(it.name) }
                     }, { e ->
-                        Log.e(TAG, "Autocomplete search for $token failed.", e)
+                        Timber.e("Autocomplete search for $token failed.", e)
                         emptyList()
                     },)
             }
@@ -406,7 +406,7 @@ class ComposeViewModel @Inject constructor(
                 }
             }
             else -> {
-                Log.w(TAG, "Unexpected autocompletion token: $token")
+                Timber.w("Unexpected autocompletion token: $token")
                 return emptyList()
             }
         }

--- a/app/src/main/java/app/pachli/components/compose/MediaUploader.kt
+++ b/app/src/main/java/app/pachli/components/compose/MediaUploader.kt
@@ -23,7 +23,6 @@ import android.media.MediaMetadataRetriever
 import android.media.MediaMetadataRetriever.METADATA_KEY_MIMETYPE
 import android.net.Uri
 import android.os.Environment
-import android.util.Log
 import android.webkit.MimeTypeMap
 import androidx.core.content.FileProvider
 import androidx.core.net.toUri
@@ -56,6 +55,7 @@ import kotlinx.coroutines.flow.shareIn
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
 import retrofit2.HttpException
+import timber.log.Timber
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
@@ -170,7 +170,7 @@ class MediaUploader @Inject constructor(
 
                     contentResolver.openInputStream(inUri).use { input ->
                         if (input == null) {
-                            Log.w(TAG, "Media input is null")
+                            Timber.w("Media input is null")
                             uri = inUri
                             return@use
                         }
@@ -189,7 +189,7 @@ class MediaUploader @Inject constructor(
                 ContentResolver.SCHEME_FILE -> {
                     val path = uri.path
                     if (path == null) {
-                        Log.w(TAG, "empty uri path $uri")
+                        Timber.w("empty uri path $uri")
                         throw CouldNotOpenFileException()
                     }
                     val inputFile = File(path)
@@ -209,16 +209,16 @@ class MediaUploader @Inject constructor(
                     }
                 }
                 else -> {
-                    Log.w(TAG, "Unknown uri scheme $uri")
+                    Timber.w("Unknown uri scheme $uri")
                     throw CouldNotOpenFileException()
                 }
             }
         } catch (e: IOException) {
-            Log.w(TAG, e)
+            Timber.w(e)
             throw CouldNotOpenFileException()
         }
         if (mediaSize == MEDIA_SIZE_UNKNOWN) {
-            Log.w(TAG, "Could not determine file size of upload")
+            Timber.w("Could not determine file size of upload")
             throw MediaTypeException()
         }
 
@@ -244,7 +244,7 @@ class MediaUploader @Inject constructor(
                 }
             }
         } else {
-            Log.w(TAG, "Could not determine mime type of upload")
+            Timber.w("Could not determine mime type of upload")
             throw MediaTypeException()
         }
     }
@@ -338,6 +338,5 @@ class MediaUploader @Inject constructor(
     }
 
     private companion object {
-        private const val TAG = "MediaUploader"
     }
 }

--- a/app/src/main/java/app/pachli/components/compose/MediaUploader.kt
+++ b/app/src/main/java/app/pachli/components/compose/MediaUploader.kt
@@ -336,7 +336,4 @@ class MediaUploader @Inject constructor(
         return media.type == QueuedMedia.Type.IMAGE &&
             (media.mediaSize > instanceInfo.imageSizeLimit || getImageSquarePixels(context.contentResolver, media.uri) > instanceInfo.imageMatrixLimit)
     }
-
-    private companion object {
-    }
 }

--- a/app/src/main/java/app/pachli/components/conversation/ConversationsViewModel.kt
+++ b/app/src/main/java/app/pachli/components/conversation/ConversationsViewModel.kt
@@ -16,7 +16,6 @@
 
 package app.pachli.components.conversation
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.ExperimentalPagingApi
@@ -34,6 +33,7 @@ import at.connyduck.calladapter.networkresult.fold
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -79,7 +79,7 @@ class ConversationsViewModel @Inject constructor(
 
                 saveConversationToDb(newConversation)
             }, { e ->
-                Log.w(TAG, "failed to favourite status", e)
+                Timber.w("failed to favourite status", e)
             },)
         }
     }
@@ -94,7 +94,7 @@ class ConversationsViewModel @Inject constructor(
 
                 saveConversationToDb(newConversation)
             }, { e ->
-                Log.w(TAG, "failed to bookmark status", e)
+                Timber.w("failed to bookmark status", e)
             },)
         }
     }
@@ -110,7 +110,7 @@ class ConversationsViewModel @Inject constructor(
 
                     saveConversationToDb(newConversation)
                 }, { e ->
-                    Log.w(TAG, "failed to vote in poll", e)
+                    Timber.w("failed to vote in poll", e)
                 },)
         }
     }
@@ -155,7 +155,7 @@ class ConversationsViewModel @Inject constructor(
                     accountId = accountManager.activeAccount!!.id,
                 )
             } catch (e: Exception) {
-                Log.w(TAG, "failed to delete conversation", e)
+                Timber.w("failed to delete conversation", e)
             }
         }
     }
@@ -175,7 +175,7 @@ class ConversationsViewModel @Inject constructor(
 
                 conversationsDao.insert(newConversation)
             } catch (e: Exception) {
-                Log.w(TAG, "failed to mute conversation", e)
+                Timber.w("failed to mute conversation", e)
             }
         }
     }
@@ -185,6 +185,5 @@ class ConversationsViewModel @Inject constructor(
     }
 
     companion object {
-        private const val TAG = "ConversationsViewModel"
     }
 }

--- a/app/src/main/java/app/pachli/components/conversation/ConversationsViewModel.kt
+++ b/app/src/main/java/app/pachli/components/conversation/ConversationsViewModel.kt
@@ -183,7 +183,4 @@ class ConversationsViewModel @Inject constructor(
     private suspend fun saveConversationToDb(conversation: ConversationEntity) {
         conversationsDao.insert(conversation)
     }
-
-    companion object {
-    }
 }

--- a/app/src/main/java/app/pachli/components/drafts/DraftHelper.kt
+++ b/app/src/main/java/app/pachli/components/drafts/DraftHelper.kt
@@ -18,7 +18,6 @@ package app.pachli.components.drafts
 
 import android.content.Context
 import android.net.Uri
-import android.util.Log
 import android.webkit.MimeTypeMap
 import androidx.core.content.FileProvider
 import androidx.core.net.toUri
@@ -37,6 +36,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okio.buffer
 import okio.sink
+import timber.log.Timber
 import java.io.File
 import java.io.IOException
 import java.text.SimpleDateFormat
@@ -70,7 +70,7 @@ class DraftHelper @Inject constructor(
         val externalFilesDir = context.getExternalFilesDir("Pachli")
 
         if (externalFilesDir == null || !(externalFilesDir.exists())) {
-            Log.e("DraftHelper", "Error obtaining directory to save media.")
+            Timber.e("Error obtaining directory to save media.")
             throw Exception()
         }
 
@@ -130,7 +130,7 @@ class DraftHelper @Inject constructor(
         )
 
         draftDao.insertOrReplace(draft)
-        Log.d("DraftHelper", "saved draft to db")
+        Timber.d("saved draft to db")
     }
 
     suspend fun deleteDraftAndAttachments(draftId: Int) {
@@ -153,7 +153,7 @@ class DraftHelper @Inject constructor(
     suspend fun deleteAttachments(draft: DraftEntity) = withContext(Dispatchers.IO) {
         draft.attachments.forEach { attachment ->
             if (context.contentResolver.delete(attachment.uri, null, null) == 0) {
-                Log.e("DraftHelper", "Did not delete file ${attachment.uriString}")
+                Timber.e("Did not delete file ${attachment.uriString}")
             }
         }
     }
@@ -193,7 +193,7 @@ class DraftHelper @Inject constructor(
                     }
                 }
             } catch (ex: IOException) {
-                Log.w("DraftHelper", "failed to save media", ex)
+                Timber.w("failed to save media", ex)
                 return null
             }
         } else {

--- a/app/src/main/java/app/pachli/components/drafts/DraftsActivity.kt
+++ b/app/src/main/java/app/pachli/components/drafts/DraftsActivity.kt
@@ -19,7 +19,6 @@ package app.pachli.components.drafts
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import android.widget.LinearLayout
 import android.widget.Toast
 import androidx.activity.viewModels
@@ -41,6 +40,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import retrofit2.HttpException
+import timber.log.Timber
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -130,7 +130,7 @@ class DraftsActivity : BaseActivity(), DraftActionListener {
                     { throwable ->
                         bottomSheet.state = BottomSheetBehavior.STATE_HIDDEN
 
-                        Log.w(TAG, "failed loading reply information", throwable)
+                        Timber.w("failed loading reply information", throwable)
 
                         if (throwable is HttpException && throwable.code() == 404) {
                             // the original status to which a reply was drafted has been deleted

--- a/app/src/main/java/app/pachli/components/followedtags/FollowedTagsActivity.kt
+++ b/app/src/main/java/app/pachli/components/followedtags/FollowedTagsActivity.kt
@@ -3,7 +3,6 @@ package app.pachli.components.followedtags
 import android.app.Dialog
 import android.content.DialogInterface
 import android.os.Bundle
-import android.util.Log
 import android.widget.AutoCompleteTextView
 import androidx.activity.viewModels
 import androidx.appcompat.app.AlertDialog
@@ -30,6 +29,7 @@ import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -104,7 +104,7 @@ class FollowedTagsActivity :
                     binding.followedTagsMessageView.show()
                     val errorState = loadState.refresh as LoadState.Error
                     binding.followedTagsMessageView.setup(errorState.error) { retry() }
-                    Log.w(TAG, "error loading followed hashtags", errorState.error)
+                    Timber.w("error loading followed hashtags", errorState.error)
                 } else {
                     binding.followedTagsView.show()
                     binding.followedTagsMessageView.hide()

--- a/app/src/main/java/app/pachli/components/followedtags/FollowedTagsViewModel.kt
+++ b/app/src/main/java/app/pachli/components/followedtags/FollowedTagsViewModel.kt
@@ -1,6 +1,5 @@
 package app.pachli.components.followedtags
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.ExperimentalPagingApi
@@ -13,6 +12,7 @@ import app.pachli.entity.HashTag
 import app.pachli.network.MastodonApi
 import at.connyduck.calladapter.networkresult.fold
 import dagger.hilt.android.lifecycle.HiltViewModel
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -41,12 +41,11 @@ class FollowedTagsViewModel @Inject constructor(
             .fold({ searchResult ->
                 searchResult.hashtags.map { ComposeAutoCompleteAdapter.AutocompleteResult.HashtagResult(it.name) }
             }, { e ->
-                Log.e(TAG, "Autocomplete search for $token failed.", e)
+                Timber.e("Autocomplete search for $token failed.", e)
                 emptyList()
             },)
     }
 
     companion object {
-        private const val TAG = "FollowedTagsViewModel"
     }
 }

--- a/app/src/main/java/app/pachli/components/followedtags/FollowedTagsViewModel.kt
+++ b/app/src/main/java/app/pachli/components/followedtags/FollowedTagsViewModel.kt
@@ -45,7 +45,4 @@ class FollowedTagsViewModel @Inject constructor(
                 emptyList()
             },)
     }
-
-    companion object {
-    }
 }

--- a/app/src/main/java/app/pachli/components/instanceinfo/InstanceInfoRepository.kt
+++ b/app/src/main/java/app/pachli/components/instanceinfo/InstanceInfoRepository.kt
@@ -16,7 +16,6 @@
 
 package app.pachli.components.instanceinfo
 
-import android.util.Log
 import app.pachli.db.AccountManager
 import app.pachli.db.EmojisEntity
 import app.pachli.db.InstanceDao
@@ -28,6 +27,7 @@ import at.connyduck.calladapter.networkresult.getOrElse
 import at.connyduck.calladapter.networkresult.onSuccess
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import timber.log.Timber
 import javax.inject.Inject
 
 class InstanceInfoRepository @Inject constructor(
@@ -46,7 +46,7 @@ class InstanceInfoRepository @Inject constructor(
         api.getCustomEmojis()
             .onSuccess { emojiList -> instanceDao.upsert(EmojisEntity(instanceName, emojiList)) }
             .getOrElse { throwable ->
-                Log.w(TAG, "failed to load custom emojis, falling back to cache", throwable)
+                Timber.w("failed to load custom emojis, falling back to cache", throwable)
                 instanceDao.getEmojiInfo(instanceName)?.emojiList.orEmpty()
             }
     }
@@ -81,7 +81,7 @@ class InstanceInfoRepository @Inject constructor(
                     instanceEntity
                 },
                 { throwable ->
-                    Log.w(TAG, "failed to instance, falling back to cache and default values", throwable)
+                    Timber.w("failed to instance, falling back to cache and default values", throwable)
                     try { instanceDao.getInstanceInfo(instanceName) } catch (_: Exception) { null }
                 },
             ).let { instanceInfo: InstanceInfoEntity? ->
@@ -105,8 +105,6 @@ class InstanceInfoRepository @Inject constructor(
     }
 
     companion object {
-        private const val TAG = "InstanceInfoRepo"
-
         const val DEFAULT_CHARACTER_LIMIT = 500
         private const val DEFAULT_MAX_OPTION_COUNT = 4
         private const val DEFAULT_MAX_OPTION_LENGTH = 50

--- a/app/src/main/java/app/pachli/components/instancemute/fragment/InstanceListFragment.kt
+++ b/app/src/main/java/app/pachli/components/instancemute/fragment/InstanceListFragment.kt
@@ -1,7 +1,6 @@
 package app.pachli.components.instancemute.fragment
 
 import android.os.Bundle
-import android.util.Log
 import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
@@ -22,6 +21,7 @@ import com.google.android.material.divider.MaterialDividerItemDecoration
 import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -70,7 +70,7 @@ class InstanceListFragment :
                 api.blockDomain(instance).fold({
                     adapter.addItem(instance)
                 }, { e ->
-                    Log.e(TAG, "Error muting domain $instance", e)
+                    Timber.e("Error muting domain $instance", e)
                 },)
             } else {
                 api.unblockDomain(instance).fold({
@@ -81,7 +81,7 @@ class InstanceListFragment :
                         }
                         .show()
                 }, { e ->
-                    Log.e(TAG, "Error unmuting domain $instance", e)
+                    Timber.e("Error unmuting domain $instance", e)
                 },)
             }
         }
@@ -136,7 +136,7 @@ class InstanceListFragment :
     private fun onFetchInstancesFailure(throwable: Throwable) {
         fetching = false
         binding.instanceProgressBar.hide()
-        Log.e(TAG, "Fetch failure", throwable)
+        Timber.e("Fetch failure", throwable)
 
         if (adapter.itemCount == 0) {
             binding.messageView.show()
@@ -148,6 +148,5 @@ class InstanceListFragment :
     }
 
     companion object {
-        private const val TAG = "InstanceList"
     }
 }

--- a/app/src/main/java/app/pachli/components/instancemute/fragment/InstanceListFragment.kt
+++ b/app/src/main/java/app/pachli/components/instancemute/fragment/InstanceListFragment.kt
@@ -146,7 +146,4 @@ class InstanceListFragment :
             }
         }
     }
-
-    companion object {
-    }
 }

--- a/app/src/main/java/app/pachli/components/login/LoginActivity.kt
+++ b/app/src/main/java/app/pachli/components/login/LoginActivity.kt
@@ -45,6 +45,7 @@ import com.bumptech.glide.Glide
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import okhttp3.HttpUrl
+import timber.log.Timber
 import javax.inject.Inject
 
 /** Main login page, the first thing that users see. Has prompt for instance and login button. */
@@ -196,7 +197,7 @@ class LoginActivity : BaseActivity() {
                     binding.domainTextInputLayout.error =
                         getString(R.string.error_failed_app_registration)
                     setLoading(false)
-                    Log.e(TAG, Log.getStackTraceString(e))
+                    Timber.e(Log.getStackTraceString(e))
                     return@launch
                 },
             )
@@ -265,7 +266,7 @@ class LoginActivity : BaseActivity() {
             getString(R.string.error_authorization_unknown)
         } else {
             // Use error returned by the server or fall back to the generic message
-            Log.e(TAG, "%s %s".format(getString(R.string.error_authorization_denied), error))
+            Timber.e("%s %s".format(getString(R.string.error_authorization_denied), error))
             error.ifBlank { getString(R.string.error_authorization_denied) }
         }
     }
@@ -293,7 +294,7 @@ class LoginActivity : BaseActivity() {
                 setLoading(false)
                 binding.domainTextInputLayout.error =
                     getString(R.string.error_retrieving_oauth_token)
-                Log.e(TAG, getString(R.string.error_retrieving_oauth_token), e)
+                Timber.e(getString(R.string.error_retrieving_oauth_token), e)
             },
         )
     }
@@ -326,7 +327,7 @@ class LoginActivity : BaseActivity() {
             setLoading(false)
             binding.domainTextInputLayout.error =
                 getString(R.string.error_loading_account_details)
-            Log.e(TAG, getString(R.string.error_loading_account_details), e)
+            Timber.e(getString(R.string.error_loading_account_details), e)
         },)
     }
 
@@ -350,7 +351,6 @@ class LoginActivity : BaseActivity() {
     }
 
     companion object {
-        private const val TAG = "LoginActivity" // logging tag
         private const val OAUTH_SCOPES = "read write follow push"
         private const val LOGIN_MODE = "LOGIN_MODE"
         private const val DOMAIN = "domain"

--- a/app/src/main/java/app/pachli/components/login/LoginWebViewActivity.kt
+++ b/app/src/main/java/app/pachli/components/login/LoginWebViewActivity.kt
@@ -24,7 +24,6 @@ import android.graphics.Color
 import android.net.Uri
 import android.os.Bundle
 import android.os.Parcelable
-import android.util.Log
 import android.webkit.CookieManager
 import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
@@ -47,6 +46,7 @@ import app.pachli.util.visible
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
+import timber.log.Timber
 
 /** Contract for starting [LoginWebViewActivity]. */
 class OauthLogin : ActivityResultContract<LoginData, LoginResult>() {
@@ -148,7 +148,7 @@ class LoginWebViewActivity : BaseActivity() {
                 request: WebResourceRequest,
                 error: WebResourceError,
             ) {
-                Log.d("LoginWeb", "Failed to load ${data.url}: $error")
+                Timber.d("Failed to load ${data.url}: $error")
                 sendResult(LoginResult.Err(getString(R.string.error_could_not_load_login_page)))
             }
 

--- a/app/src/main/java/app/pachli/components/login/LoginWebViewViewModel.kt
+++ b/app/src/main/java/app/pachli/components/login/LoginWebViewViewModel.kt
@@ -16,7 +16,6 @@
 
 package app.pachli.components.login
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import app.pachli.network.MastodonApi
@@ -24,6 +23,7 @@ import at.connyduck.calladapter.networkresult.fold
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -42,7 +42,7 @@ class LoginWebViewViewModel @Inject constructor(
                 api.getInstance(domain).fold({ instance ->
                     instanceRules.value = instance.rules?.map { rule -> rule.text }.orEmpty()
                 }, { throwable ->
-                    Log.w("LoginWebViewViewModel", "failed to load instance info", throwable)
+                    Timber.w("failed to load instance info", throwable)
                 },)
             }
         }

--- a/app/src/main/java/app/pachli/components/notifications/NotificationFetcher.kt
+++ b/app/src/main/java/app/pachli/components/notifications/NotificationFetcher.kt
@@ -19,7 +19,6 @@ package app.pachli.components.notifications
 
 import android.app.NotificationManager
 import android.content.Context
-import android.util.Log
 import androidx.annotation.WorkerThread
 import app.pachli.components.notifications.NotificationHelper.filterNotification
 import app.pachli.db.AccountEntity
@@ -31,6 +30,7 @@ import app.pachli.network.MastodonApi
 import app.pachli.util.isLessThan
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.delay
+import timber.log.Timber
 import javax.inject.Inject
 import kotlin.math.min
 import kotlin.time.Duration.Companion.milliseconds
@@ -111,7 +111,7 @@ class NotificationFetcher @Inject constructor(
 
                     accountManager.saveAccount(account)
                 } catch (e: Exception) {
-                    Log.e(TAG, "Error while fetching notifications", e)
+                    Timber.e("Error while fetching notifications", e)
                 }
             }
         }
@@ -143,18 +143,18 @@ class NotificationFetcher @Inject constructor(
         // - The Mastodon marker API (if the server supports it)
         // - account.notificationMarkerId
         // - account.lastNotificationId
-        Log.d(TAG, "getting notification marker for ${account.fullName}")
+        Timber.d("getting notification marker for ${account.fullName}")
         val remoteMarkerId = fetchMarker(authHeader, account)?.lastReadId ?: "0"
         val localMarkerId = account.notificationMarkerId
         val markerId = if (remoteMarkerId.isLessThan(localMarkerId)) localMarkerId else remoteMarkerId
         val readingPosition = account.lastNotificationId
 
         var minId: String? = if (readingPosition.isLessThan(markerId)) markerId else readingPosition
-        Log.d(TAG, "  remoteMarkerId: $remoteMarkerId")
-        Log.d(TAG, "  localMarkerId: $localMarkerId")
-        Log.d(TAG, "  readingPosition: $readingPosition")
+        Timber.d("  remoteMarkerId: $remoteMarkerId")
+        Timber.d("  localMarkerId: $localMarkerId")
+        Timber.d("  readingPosition: $readingPosition")
 
-        Log.d(TAG, "getting Notifications for ${account.fullName}, min_id: $minId")
+        Timber.d("getting Notifications for ${account.fullName}, min_id: $minId")
 
         // Fetch all outstanding notifications
         val notifications = buildList {
@@ -182,7 +182,7 @@ class NotificationFetcher @Inject constructor(
         // Save the newest notification ID in the marker.
         notifications.firstOrNull()?.let {
             val newMarkerId = notifications.first().id
-            Log.d(TAG, "updating notification marker for ${account.fullName} to: $newMarkerId")
+            Timber.d("updating notification marker for ${account.fullName} to: $newMarkerId")
             mastodonApi.updateMarkersWithAuth(
                 auth = authHeader,
                 domain = account.domain,
@@ -203,17 +203,15 @@ class NotificationFetcher @Inject constructor(
                 listOf("notifications"),
             )
             val notificationMarker = allMarkers["notifications"]
-            Log.d(TAG, "Fetched marker for ${account.fullName}: $notificationMarker")
+            Timber.d("Fetched marker for ${account.fullName}: $notificationMarker")
             notificationMarker
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to fetch marker", e)
+            Timber.e("Failed to fetch marker", e)
             null
         }
     }
 
     companion object {
-        private const val TAG = "NotificationFetcher"
-
         // There's a system limit on the maximum number of notifications an app
         // can show, NotificationManagerService.MAX_PACKAGE_NOTIFICATIONS. Unfortunately
         // that's not available to client code or via the NotificationManager API.

--- a/app/src/main/java/app/pachli/components/notifications/NotificationHelper.java
+++ b/app/src/main/java/app/pachli/components/notifications/NotificationHelper.java
@@ -34,7 +34,6 @@ import android.os.Bundle;
 import android.provider.Settings;
 import android.service.notification.StatusBarNotification;
 import android.text.TextUtils;
-import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -78,6 +77,7 @@ import app.pachli.receiver.SendStatusBroadcastReceiver;
 import app.pachli.util.StringUtils;
 import app.pachli.viewdata.PollViewDataKt;
 import app.pachli.worker.NotificationWorker;
+import timber.log.Timber;
 
 public class NotificationHelper {
 
@@ -197,7 +197,7 @@ public class NotificationHelper {
 
             accountAvatar = target.get();
         } catch (ExecutionException | InterruptedException e) {
-            Log.d(TAG, "error loading account avatar", e);
+            Timber.w(e, "error loading account avatar");
             accountAvatar = BitmapFactory.decodeResource(context.getResources(), R.drawable.avatar_default);
         }
 
@@ -299,7 +299,7 @@ public class NotificationHelper {
             // This works here because the channelId and the groupKey are the same.
             List<StatusBarNotification> members = channelGroups.get(channelId);
             if (members == null) { // can't happen, but just in case...
-                Log.e(TAG, "members == null for channel ID " + channelId);
+                Timber.e("members == null for channel ID %s", channelId);
                 continue;
             }
             members.add(sn);
@@ -600,12 +600,12 @@ public class NotificationHelper {
             if (notificationManager.areNotificationsEnabled()) {
                 for (NotificationChannel channel : notificationManager.getNotificationChannels()) {
                     if (channel != null && channel.getImportance() > NotificationManager.IMPORTANCE_NONE) {
-                        Log.d(TAG, "NotificationsEnabled");
+                        Timber.d("NotificationsEnabled");
                         return true;
                     }
                 }
             }
-            Log.d(TAG, "NotificationsDisabled");
+            Timber.d("NotificationsDisabled");
 
             return false;
 
@@ -641,12 +641,12 @@ public class NotificationHelper {
 
         workManager.enqueue(workRequest);
 
-        Log.d(TAG, "enabled notification checks with "+ PeriodicWorkRequest.MIN_PERIODIC_INTERVAL_MILLIS + "ms interval");
+        Timber.d("enabled notification checks with "+ PeriodicWorkRequest.MIN_PERIODIC_INTERVAL_MILLIS + "ms interval");
     }
 
     public static void disablePullNotifications(@NonNull Context context) {
         WorkManager.getInstance(context).cancelAllWorkByTag(NOTIFICATION_PULL_TAG);
-        Log.d(TAG, "disabled notification checks");
+        Timber.d("disabled notification checks");
     }
 
     public static void clearNotificationsForAccount(@NonNull Context context, @NonNull AccountEntity account) {

--- a/app/src/main/java/app/pachli/components/notifications/NotificationsFragment.kt
+++ b/app/src/main/java/app/pachli/components/notifications/NotificationsFragment.kt
@@ -20,7 +20,6 @@ package app.pachli.components.notifications
 import android.app.Dialog
 import android.content.DialogInterface
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuInflater
@@ -82,6 +81,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 @AndroidEntryPoint
 class NotificationsFragment :
@@ -207,7 +207,7 @@ class NotificationsFragment :
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 launch {
                     viewModel.pagingData.collectLatest { pagingData ->
-                        Log.d(TAG, "Submitting data to adapter")
+                        Timber.d("Submitting data to adapter")
                         adapter.submitData(pagingData)
                     }
                 }
@@ -224,7 +224,7 @@ class NotificationsFragment :
                 // - With a "Retry" option if the error included a UiAction to retry.
                 launch {
                     viewModel.uiError.collect { error ->
-                        Log.d(TAG, error.toString())
+                        Timber.d(error.toString())
                         val message = getString(
                             error.message,
                             error.throwable.localizedMessage
@@ -657,7 +657,6 @@ class NotificationsFragment :
     }
 
     companion object {
-        private const val TAG = "NotificationsFragment"
         fun newInstance() = NotificationsFragment()
 
         private val notificationDiffCallback: DiffUtil.ItemCallback<NotificationViewData> =

--- a/app/src/main/java/app/pachli/components/notifications/NotificationsPagingAdapter.kt
+++ b/app/src/main/java/app/pachli/components/notifications/NotificationsPagingAdapter.kt
@@ -225,7 +225,5 @@ class NotificationsPagingAdapter(
     }
 
     companion object {
-        @Suppress("unused")
-        private const val TAG = "NotificationsPagingAdapter"
     }
 }

--- a/app/src/main/java/app/pachli/components/notifications/NotificationsPagingAdapter.kt
+++ b/app/src/main/java/app/pachli/components/notifications/NotificationsPagingAdapter.kt
@@ -223,7 +223,4 @@ class NotificationsPagingAdapter(
             binding.text1.text = viewData.statusViewData?.content
         }
     }
-
-    companion object {
-    }
 }

--- a/app/src/main/java/app/pachli/components/notifications/NotificationsPagingSource.kt
+++ b/app/src/main/java/app/pachli/components/notifications/NotificationsPagingSource.kt
@@ -205,7 +205,4 @@ class NotificationsPagingSource @Inject constructor(
             return id
         }
     }
-
-    companion object {
-    }
 }

--- a/app/src/main/java/app/pachli/components/notifications/NotificationsPagingSource.kt
+++ b/app/src/main/java/app/pachli/components/notifications/NotificationsPagingSource.kt
@@ -17,7 +17,6 @@
 
 package app.pachli.components.notifications
 
-import android.util.Log
 import androidx.paging.PagingSource
 import androidx.paging.PagingSource.LoadResult
 import androidx.paging.PagingState
@@ -30,6 +29,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import okhttp3.Headers
 import retrofit2.Response
+import timber.log.Timber
 import javax.inject.Inject
 
 private val INVALID = LoadResult.Invalid<String, Notification>()
@@ -41,7 +41,7 @@ class NotificationsPagingSource @Inject constructor(
     private val notificationFilter: Set<Notification.Type>,
 ) : PagingSource<String, Notification>() {
     override suspend fun load(params: LoadParams<String>): LoadResult<String, Notification> {
-        Log.d(TAG, "load() with ${params.javaClass.simpleName} for key: ${params.key}")
+        Timber.d("load() with ${params.javaClass.simpleName} for key: ${params.key}")
 
         try {
             val response = when (params) {
@@ -86,7 +86,7 @@ class NotificationsPagingSource @Inject constructor(
             // is a lot of spurious animation, especially during the initial load, as multiple pages
             // are loaded and the paging source is repeatedly invalidated.
             if (invalid) {
-                Log.d(TAG, "Invalidated, returning LoadResult.Invalid")
+                Timber.d("Invalidated, returning LoadResult.Invalid")
                 return INVALID
             }
 
@@ -201,12 +201,11 @@ class NotificationsPagingSource @Inject constructor(
     override fun getRefreshKey(state: PagingState<String, Notification>): String? {
         return state.anchorPosition?.let { anchorPosition ->
             val id = state.closestItemToPosition(anchorPosition)?.id
-            Log.d(TAG, "  getRefreshKey returning $id")
+            Timber.d("  getRefreshKey returning $id")
             return id
         }
     }
 
     companion object {
-        private const val TAG = "NotificationsPagingSource"
     }
 }

--- a/app/src/main/java/app/pachli/components/notifications/NotificationsRepository.kt
+++ b/app/src/main/java/app/pachli/components/notifications/NotificationsRepository.kt
@@ -17,7 +17,6 @@
 
 package app.pachli.components.notifications
 
-import android.util.Log
 import androidx.paging.InvalidatingPagingSourceFactory
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
@@ -32,6 +31,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
 import okhttp3.ResponseBody
 import retrofit2.Response
+import timber.log.Timber
 import javax.inject.Inject
 
 class NotificationsRepository @Inject constructor(
@@ -50,7 +50,7 @@ class NotificationsRepository @Inject constructor(
         pageSize: Int = PAGE_SIZE,
         initialKey: String? = null,
     ): Flow<PagingData<Notification>> {
-        Log.d(TAG, "getNotificationsStream(), filtering: $filter")
+        Timber.d("getNotificationsStream(), filtering: $filter")
 
         factory = InvalidatingPagingSourceFactory {
             NotificationsPagingSource(mastodonApi, gson, filter)
@@ -74,7 +74,6 @@ class NotificationsRepository @Inject constructor(
     }.await()
 
     companion object {
-        private const val TAG = "NotificationsRepository"
         private const val PAGE_SIZE = 30
     }
 }

--- a/app/src/main/java/app/pachli/components/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/app/pachli/components/notifications/NotificationsViewModel.kt
@@ -17,7 +17,6 @@
 
 package app.pachli.components.notifications
 
-import android.util.Log
 import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -72,6 +71,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import retrofit2.HttpException
+import timber.log.Timber
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -357,7 +357,7 @@ class NotificationsViewModel @Inject constructor(
             .distinctUntilChanged()
             // Save each change back to the active account
             .onEach { action ->
-                Log.d(TAG, "notificationFilter: $action")
+                Timber.d("notificationFilter: $action")
                 account.notificationsFilter = serialize(action.filter)
                 accountManager.saveAccount(account)
             }
@@ -388,7 +388,7 @@ class NotificationsViewModel @Inject constructor(
                 .filterIsInstance<InfallibleUiAction.SaveVisibleId>()
                 .distinctUntilChanged()
                 .collectLatest { action ->
-                    Log.d(TAG, "Saving visible ID: ${action.visibleId}, active account = ${account.id}")
+                    Timber.d("Saving visible ID: ${action.visibleId}, active account = ${account.id}")
                     account.lastNotificationId = action.visibleId
                     accountManager.saveAccount(account)
                 }
@@ -514,7 +514,7 @@ class NotificationsViewModel @Inject constructor(
         filters: Set<Notification.Type>,
         initialKey: String? = null,
     ): Flow<PagingData<NotificationViewData>> {
-        Log.d(TAG, "getNotifications: $initialKey")
+        Timber.d("getNotifications: $initialKey")
         return repository.getNotificationsStream(filter = filters, initialKey = initialKey)
             .map { pagingData ->
                 pagingData.map { notification ->
@@ -552,7 +552,7 @@ class NotificationsViewModel @Inject constructor(
             "0" -> null
             else -> id
         }
-        Log.d(TAG, "Restoring at $initialKey")
+        Timber.d("Restoring at $initialKey")
         return initialKey
     }
 
@@ -569,7 +569,6 @@ class NotificationsViewModel @Inject constructor(
     )
 
     companion object {
-        private const val TAG = "NotificationsViewModel"
         private val THROTTLE_TIMEOUT = 500.milliseconds
     }
 }

--- a/app/src/main/java/app/pachli/components/notifications/PushNotificationHelper.kt
+++ b/app/src/main/java/app/pachli/components/notifications/PushNotificationHelper.kt
@@ -21,7 +21,6 @@ package app.pachli.components.notifications
 import android.app.NotificationManager
 import android.content.Context
 import android.os.Build
-import android.util.Log
 import android.view.View
 import androidx.appcompat.app.AlertDialog
 import app.pachli.R
@@ -38,8 +37,7 @@ import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.unifiedpush.android.connector.UnifiedPush
-
-private const val TAG = "PushNotificationHelper"
+import timber.log.Timber
 
 private const val KEY_MIGRATION_NOTICE_DISMISSED = "migration_notice_dismissed"
 
@@ -190,10 +188,10 @@ suspend fun registerUnifiedPushEndpoint(
         auth,
         buildSubscriptionData(context, account),
     ).onFailure { throwable ->
-        Log.w(TAG, "Error setting push endpoint for account ${account.id}", throwable)
+        Timber.w("Error setting push endpoint for account ${account.id}", throwable)
         disableUnifiedPushNotificationsForAccount(context, account)
     }.onSuccess {
-        Log.d(TAG, "UnifiedPush registration succeeded for account ${account.id}")
+        Timber.d("UnifiedPush registration succeeded for account ${account.id}")
 
         account.pushPubKey = keyPair.pubkey
         account.pushPrivKey = keyPair.privKey
@@ -212,7 +210,7 @@ suspend fun updateUnifiedPushSubscription(context: Context, api: MastodonApi, ac
             account.domain,
             buildSubscriptionData(context, account),
         ).onSuccess {
-            Log.d(TAG, "UnifiedPush subscription updated for account ${account.id}")
+            Timber.d("UnifiedPush subscription updated for account ${account.id}")
 
             account.pushServerKey = it.serverKey
             accountManager.saveAccount(account)
@@ -224,10 +222,10 @@ suspend fun unregisterUnifiedPushEndpoint(api: MastodonApi, accountManager: Acco
     withContext(Dispatchers.IO) {
         api.unsubscribePushNotifications("Bearer ${account.accessToken}", account.domain)
             .onFailure { throwable ->
-                Log.w(TAG, "Error unregistering push endpoint for account " + account.id, throwable)
+                Timber.w("Error unregistering push endpoint for account " + account.id, throwable)
             }
             .onSuccess {
-                Log.d(TAG, "UnifiedPush unregistration succeeded for account " + account.id)
+                Timber.d("UnifiedPush unregistration succeeded for account " + account.id)
                 // Clear the URL in database
                 account.unifiedPushUrl = ""
                 account.pushServerKey = ""

--- a/app/src/main/java/app/pachli/components/preference/AccountPreferencesFragment.kt
+++ b/app/src/main/java/app/pachli/components/preference/AccountPreferencesFragment.kt
@@ -19,7 +19,6 @@ package app.pachli.components.preference
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
-import android.util.Log
 import androidx.annotation.DrawableRes
 import androidx.preference.PreferenceFragmentCompat
 import app.pachli.BaseActivity
@@ -56,6 +55,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
+import timber.log.Timber
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -304,13 +304,13 @@ class AccountPreferencesFragment : PreferenceFragmentCompat() {
                                 accountManager.saveAccount(it)
                             }
                         } else {
-                            Log.e("AccountPreferences", "failed updating settings on server")
+                            Timber.e("failed updating settings on server")
                             showErrorSnackbar(visibility, sensitive)
                         }
                     }
 
                     override fun onFailure(call: Call<Account>, t: Throwable) {
-                        Log.e("AccountPreferences", "failed updating settings on server", t)
+                        Timber.e("failed updating settings on server", t)
                         showErrorSnackbar(visibility, sensitive)
                     }
                 },

--- a/app/src/main/java/app/pachli/components/preference/PreferencesActivity.kt
+++ b/app/src/main/java/app/pachli/components/preference/PreferencesActivity.kt
@@ -19,7 +19,6 @@ package app.pachli.components.preference
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import androidx.activity.OnBackPressedCallback
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
@@ -39,6 +38,7 @@ import app.pachli.util.setAppNightMode
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -99,7 +99,7 @@ class PreferencesActivity :
                 when (key) {
                     APP_THEME -> {
                         val theme = sharedPreferencesRepository.getNonNullString(APP_THEME, APP_THEME_DEFAULT)
-                        Log.d("activeTheme", theme)
+                        Timber.d("activeTheme: %s", theme)
                         setAppNightMode(theme)
 
                         restartActivitiesOnBackPressedCallback.isEnabled = true
@@ -164,8 +164,6 @@ class PreferencesActivity :
     }
 
     companion object {
-        @Suppress("unused")
-        private const val TAG = "PreferencesActivity"
         const val GENERAL_PREFERENCES = 0
         const val ACCOUNT_PREFERENCES = 1
         const val NOTIFICATION_PREFERENCES = 2

--- a/app/src/main/java/app/pachli/components/report/adapter/StatusesPagingSource.kt
+++ b/app/src/main/java/app/pachli/components/report/adapter/StatusesPagingSource.kt
@@ -16,7 +16,6 @@
 
 package app.pachli.components.report.adapter
 
-import android.util.Log
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import app.pachli.entity.Status
@@ -24,6 +23,7 @@ import app.pachli.network.MastodonApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.withContext
+import timber.log.Timber
 
 class StatusesPagingSource(
     private val accountId: String,
@@ -69,7 +69,7 @@ class StatusesPagingSource(
                 nextKey = result.lastOrNull()?.id,
             )
         } catch (e: Exception) {
-            Log.w("StatusesPagingSource", "failed to load statuses", e)
+            Timber.w("failed to load statuses", e)
             return LoadResult.Error(e)
         }
     }

--- a/app/src/main/java/app/pachli/components/scheduled/ScheduledStatusViewModel.kt
+++ b/app/src/main/java/app/pachli/components/scheduled/ScheduledStatusViewModel.kt
@@ -16,7 +16,6 @@
 
 package app.pachli.components.scheduled
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.Pager
@@ -28,6 +27,7 @@ import app.pachli.network.MastodonApi
 import at.connyduck.calladapter.networkresult.fold
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -51,7 +51,7 @@ class ScheduledStatusViewModel @Inject constructor(
                     pagingSourceFactory.remove(status)
                 },
                 { throwable ->
-                    Log.w("ScheduledTootViewModel", "Error deleting scheduled status", throwable)
+                    Timber.w("Error deleting scheduled status", throwable)
                 },
             )
         }

--- a/app/src/main/java/app/pachli/components/search/SearchViewModel.kt
+++ b/app/src/main/java/app/pachli/components/search/SearchViewModel.kt
@@ -16,7 +16,6 @@
 
 package app.pachli.components.search
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.Pager
@@ -37,6 +36,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -126,7 +126,7 @@ class SearchViewModel @Inject constructor(
                     ),
                 )
             }, { t ->
-                Log.d(TAG, "Failed to reblog status ${statusViewData.id}", t)
+                Timber.d("Failed to reblog status ${statusViewData.id}", t)
             },)
         }
     }
@@ -144,7 +144,7 @@ class SearchViewModel @Inject constructor(
         updateStatus(statusViewData.status.copy(poll = votedPoll))
         viewModelScope.launch {
             timelineCases.voteInPoll(statusViewData.id, votedPoll.id, choices)
-                .onFailure { t -> Log.d(TAG, "Failed to vote in poll: ${statusViewData.id}", t) }
+                .onFailure { t -> Timber.d("Failed to vote in poll: ${statusViewData.id}", t) }
         }
     }
 
@@ -209,7 +209,6 @@ class SearchViewModel @Inject constructor(
     }
 
     companion object {
-        private const val TAG = "SearchViewModel"
         private const val DEFAULT_LOAD_SIZE = 20
     }
 }

--- a/app/src/main/java/app/pachli/components/search/adapter/SearchAccountsAdapter.kt
+++ b/app/src/main/java/app/pachli/components/search/adapter/SearchAccountsAdapter.kt
@@ -47,7 +47,6 @@ class SearchAccountsAdapter(private val linkListener: LinkListener, private val 
     }
 
     companion object {
-
         val ACCOUNT_COMPARATOR = object : DiffUtil.ItemCallback<TimelineAccount>() {
             override fun areContentsTheSame(oldItem: TimelineAccount, newItem: TimelineAccount): Boolean =
                 oldItem == newItem

--- a/app/src/main/java/app/pachli/components/search/adapter/SearchHashtagsAdapter.kt
+++ b/app/src/main/java/app/pachli/components/search/adapter/SearchHashtagsAdapter.kt
@@ -41,7 +41,6 @@ class SearchHashtagsAdapter(private val linkListener: LinkListener) :
     }
 
     companion object {
-
         val HASHTAG_COMPARATOR = object : DiffUtil.ItemCallback<HashTag>() {
             override fun areContentsTheSame(oldItem: HashTag, newItem: HashTag): Boolean =
                 oldItem.name == newItem.name

--- a/app/src/main/java/app/pachli/components/search/adapter/SearchStatusesAdapter.kt
+++ b/app/src/main/java/app/pachli/components/search/adapter/SearchStatusesAdapter.kt
@@ -44,7 +44,6 @@ class SearchStatusesAdapter(
     }
 
     companion object {
-
         val STATUS_COMPARATOR = object : DiffUtil.ItemCallback<StatusViewData>() {
             override fun areContentsTheSame(oldItem: StatusViewData, newItem: StatusViewData): Boolean =
                 oldItem == newItem

--- a/app/src/main/java/app/pachli/components/search/fragments/SearchStatusesFragment.kt
+++ b/app/src/main/java/app/pachli/components/search/fragments/SearchStatusesFragment.kt
@@ -26,7 +26,6 @@ import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.os.Environment
-import android.util.Log
 import android.view.View
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
@@ -61,6 +60,7 @@ import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -476,7 +476,7 @@ class SearchStatusesFragment : SearchFragment<StatusViewData>(), StatusActionLis
                                 startActivity(intent)
                             },
                             { error ->
-                                Log.w("SearchStatusesFragment", "error deleting status", error)
+                                Timber.w("error deleting status", error)
                                 Toast.makeText(context, R.string.error_generic, Toast.LENGTH_SHORT).show()
                             },
                         )

--- a/app/src/main/java/app/pachli/components/timeline/CachedTimelineRepository.kt
+++ b/app/src/main/java/app/pachli/components/timeline/CachedTimelineRepository.kt
@@ -17,7 +17,6 @@
 
 package app.pachli.components.timeline
 
-import android.util.Log
 import androidx.paging.ExperimentalPagingApi
 import androidx.paging.InvalidatingPagingSourceFactory
 import androidx.paging.Pager
@@ -38,6 +37,7 @@ import com.google.gson.Gson
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 // TODO: This is very similar to NetworkTimelineRepository. They could be merged (and the use
@@ -68,7 +68,7 @@ class CachedTimelineRepository @Inject constructor(
         pageSize: Int = PAGE_SIZE,
         initialKey: String? = null,
     ): Flow<PagingData<TimelineStatusWithAccount>> {
-        Log.d(TAG, "getStatusStream(): key: $initialKey")
+        Timber.d("getStatusStream(): key: $initialKey")
 
         factory = InvalidatingPagingSourceFactory {
             activeAccount?.let { timelineDao.getStatuses(it.id) } ?: EmptyPagingSource()
@@ -86,7 +86,7 @@ class CachedTimelineRepository @Inject constructor(
             }
         }
 
-        Log.d(TAG, "initialKey: $initialKey is row: $row")
+        Timber.d("initialKey: $initialKey is row: $row")
 
         return Pager(
             config = PagingConfig(pageSize = pageSize, jumpThreshold = PAGE_SIZE * 3, enablePlaceholders = true),
@@ -163,7 +163,6 @@ class CachedTimelineRepository @Inject constructor(
     }
 
     companion object {
-        private const val TAG = "CachedTimelineRepository"
         private const val PAGE_SIZE = 30
     }
 }

--- a/app/src/main/java/app/pachli/components/timeline/FiltersRepository.kt
+++ b/app/src/main/java/app/pachli/components/timeline/FiltersRepository.kt
@@ -58,7 +58,4 @@ class FiltersRepository @Inject constructor(
             }
         },
     )
-
-    companion object {
-    }
 }

--- a/app/src/main/java/app/pachli/components/timeline/FiltersRepository.kt
+++ b/app/src/main/java/app/pachli/components/timeline/FiltersRepository.kt
@@ -60,7 +60,5 @@ class FiltersRepository @Inject constructor(
     )
 
     companion object {
-        @Suppress("unused")
-        private const val TAG = "FiltersRepository"
     }
 }

--- a/app/src/main/java/app/pachli/components/timeline/NetworkTimelineRepository.kt
+++ b/app/src/main/java/app/pachli/components/timeline/NetworkTimelineRepository.kt
@@ -17,7 +17,6 @@
 
 package app.pachli.components.timeline
 
-import android.util.Log
 import androidx.paging.ExperimentalPagingApi
 import androidx.paging.InvalidatingPagingSourceFactory
 import androidx.paging.Pager
@@ -33,6 +32,7 @@ import app.pachli.network.MastodonApi
 import app.pachli.util.getDomain
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
+import timber.log.Timber
 import javax.inject.Inject
 
 // Things that make this more difficult than it should be:
@@ -84,7 +84,7 @@ class NetworkTimelineRepository @Inject constructor(
         pageSize: Int = PAGE_SIZE,
         initialKey: String? = null,
     ): Flow<PagingData<Status>> {
-        Log.d(TAG, "getStatusStream(): key: $initialKey")
+        Timber.d("getStatusStream(): key: $initialKey")
 
         factory = InvalidatingPagingSourceFactory {
             NetworkTimelinePagingSource(pageCache)
@@ -174,7 +174,6 @@ class NetworkTimelineRepository @Inject constructor(
     }
 
     companion object {
-        private const val TAG = "NetworkTimelineRepository"
         private const val PAGE_SIZE = 30
     }
 }

--- a/app/src/main/java/app/pachli/components/timeline/TimelineFragment.kt
+++ b/app/src/main/java/app/pachli/components/timeline/TimelineFragment.kt
@@ -18,7 +18,6 @@
 package app.pachli.components.timeline
 
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuInflater
@@ -90,6 +89,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import kotlin.time.Duration.Companion.seconds
 
 @AndroidEntryPoint
@@ -230,7 +230,7 @@ class TimelineFragment :
                 // TODO: Very similar to same code in NotificationsFragment
                 launch {
                     viewModel.uiError.collect { error ->
-                        Log.d(TAG, error.toString())
+                        Timber.d(error.toString())
                         val message = getString(
                             error.message,
                             error.throwable.localizedMessage
@@ -519,7 +519,7 @@ class TimelineFragment :
             ?.let { adapter.snapshot().getOrNull(it)?.id }
 
         id?.let {
-            Log.d(TAG, "Saving ID: $it")
+            Timber.d("Saving ID: $it")
             viewModel.accept(InfallibleUiAction.SaveVisibleId(visibleId = it))
         }
     }
@@ -731,7 +731,7 @@ class TimelineFragment :
 
         val wasEnabled = talkBackWasEnabled
         talkBackWasEnabled = a11yManager?.isEnabled == true
-        Log.d(TAG, "talkback was enabled: $wasEnabled, now $talkBackWasEnabled")
+        Timber.d("talkback was enabled: $wasEnabled, now $talkBackWasEnabled")
         if (talkBackWasEnabled && !wasEnabled) {
             adapter.notifyItemRangeChanged(0, adapter.itemCount)
         }
@@ -760,7 +760,6 @@ class TimelineFragment :
     }
 
     companion object {
-        private const val TAG = "TimelineFragment" // logging tag
         private const val KIND_ARG = "kind"
         private const val ARG_ENABLE_SWIPE_TO_REFRESH = "enableSwipeToRefresh"
 

--- a/app/src/main/java/app/pachli/components/timeline/TimelinePagingAdapter.kt
+++ b/app/src/main/java/app/pachli/components/timeline/TimelinePagingAdapter.kt
@@ -86,8 +86,6 @@ class TimelinePagingAdapter(
     }
 
     companion object {
-        @Suppress("unused")
-        private const val TAG = "TimelinePagingAdapter"
         private const val VIEW_TYPE_STATUS = 0
         private const val VIEW_TYPE_STATUS_FILTERED = 1
         private const val VIEW_TYPE_PLACEHOLDER = -1

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/CachedTimelineRemoteMediator.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/CachedTimelineRemoteMediator.kt
@@ -17,7 +17,6 @@
 
 package app.pachli.components.timeline.viewmodel
 
-import android.util.Log
 import androidx.annotation.VisibleForTesting
 import androidx.paging.ExperimentalPagingApi
 import androidx.paging.InvalidatingPagingSourceFactory
@@ -43,6 +42,7 @@ import kotlinx.coroutines.coroutineScope
 import okhttp3.Headers
 import retrofit2.HttpException
 import retrofit2.Response
+import timber.log.Timber
 import java.io.IOException
 
 @OptIn(ExperimentalPagingApi::class)
@@ -66,7 +66,7 @@ class CachedTimelineRemoteMediator(
             return MediatorResult.Success(endOfPaginationReached = true)
         }
 
-        Log.d(TAG, "load(), LoadType = $loadType")
+        Timber.d("load(), LoadType = $loadType")
 
         return try {
             val response = when (loadType) {
@@ -75,7 +75,7 @@ class CachedTimelineRemoteMediator(
                         state.closestItemToPosition(maxOf(0, it - (state.config.pageSize / 2)))
                     }?.status?.serverId
                     val statusId = closestItem ?: initialKey
-                    Log.d(TAG, "Loading from item: $statusId")
+                    Timber.d("Loading from item: $statusId")
                     getInitialPage(statusId, state.config.pageSize)
                 }
                 LoadType.APPEND -> {
@@ -84,7 +84,7 @@ class CachedTimelineRemoteMediator(
                         TIMELINE_ID,
                         RemoteKeyKind.NEXT,
                     ) ?: return MediatorResult.Success(endOfPaginationReached = true)
-                    Log.d(TAG, "Loading from remoteKey: $rke")
+                    Timber.d("Loading from remoteKey: $rke")
                     api.homeTimeline(maxId = rke.key, limit = state.config.pageSize)
                 }
                 LoadType.PREPEND -> {
@@ -93,7 +93,7 @@ class CachedTimelineRemoteMediator(
                         TIMELINE_ID,
                         RemoteKeyKind.PREV,
                     ) ?: return MediatorResult.Success(endOfPaginationReached = true)
-                    Log.d(TAG, "Loading from remoteKey: $rke")
+                    Timber.d("Loading from remoteKey: $rke")
                     api.homeTimeline(minId = rke.key, limit = state.config.pageSize)
                 }
             }
@@ -103,7 +103,7 @@ class CachedTimelineRemoteMediator(
                 return MediatorResult.Error(HttpException(response))
             }
 
-            Log.d(TAG, "${statuses.size} - # statuses loaded")
+            Timber.d("${statuses.size} - # statuses loaded")
 
             // This request succeeded with no new data, and pagination ends (unless this is a
             // REFRESH, which must always set endOfPaginationReached to false).
@@ -112,7 +112,7 @@ class CachedTimelineRemoteMediator(
                 return MediatorResult.Success(endOfPaginationReached = loadType != LoadType.REFRESH)
             }
 
-            Log.d(TAG, "  ${statuses.first().id}..${statuses.last().id}")
+            Timber.d("  ${statuses.first().id}..${statuses.last().id}")
 
             val links = Links.from(response.headers()["link"])
 
@@ -271,8 +271,6 @@ class CachedTimelineRemoteMediator(
     }
 
     companion object {
-        private const val TAG = "CachedTimelineRemoteMediator"
-
         @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
         const val TIMELINE_ID = "HOME"
     }

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/CachedTimelineViewModel.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/CachedTimelineViewModel.kt
@@ -17,7 +17,6 @@
 
 package app.pachli.components.timeline.viewmodel
 
-import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
@@ -45,6 +44,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 /**
@@ -86,7 +86,7 @@ class CachedTimelineViewModel @Inject constructor(
     private fun getStatuses(
         initialKey: String? = null,
     ): Flow<PagingData<StatusViewData>> {
-        Log.d(TAG, "getStatuses: kind: $timelineKind, initialKey: $initialKey")
+        Timber.d("getStatuses: kind: $timelineKind, initialKey: $initialKey")
         return repository.getStatusStream(kind = timelineKind, initialKey = initialKey)
             .map { pagingData ->
                 pagingData
@@ -181,6 +181,5 @@ class CachedTimelineViewModel @Inject constructor(
     }
 
     companion object {
-        private const val TAG = "CachedTimelineViewModel"
     }
 }

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/CachedTimelineViewModel.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/CachedTimelineViewModel.kt
@@ -179,7 +179,4 @@ class CachedTimelineViewModel @Inject constructor(
     override suspend fun invalidate() {
         repository.invalidate()
     }
-
-    companion object {
-    }
 }

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelinePagingSource.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelinePagingSource.kt
@@ -17,11 +17,11 @@
 
 package app.pachli.components.timeline.viewmodel
 
-import android.util.Log
 import androidx.paging.PagingSource
 import androidx.paging.PagingSource.LoadResult
 import androidx.paging.PagingState
 import app.pachli.entity.Status
+import timber.log.Timber
 import javax.inject.Inject
 
 private val INVALID = LoadResult.Invalid<String, Status>()
@@ -32,7 +32,7 @@ class NetworkTimelinePagingSource @Inject constructor(
 ) : PagingSource<String, Status>() {
 
     override suspend fun load(params: LoadParams<String>): LoadResult<String, Status> {
-        Log.d(TAG, "- load(), type = ${params.javaClass.simpleName}, key = ${params.key}")
+        Timber.d("- load(), type = ${params.javaClass.simpleName}, key = ${params.key}")
         pageCache.debug()
 
         val page = synchronized(pageCache) {
@@ -103,17 +103,17 @@ class NetworkTimelinePagingSource @Inject constructor(
         }
 
         if (page == null) {
-            Log.d(TAG, "  Returning empty page")
+            Timber.d("  Returning empty page")
         } else {
-            Log.d(TAG, "  Returning full page:")
-            Log.d(TAG, "     $page")
+            Timber.d("  Returning full page:")
+            Timber.d("     $page")
         }
 
         // Bail if this paging source has already been invalidated. If you do not do this there
         // is a lot of spurious animation, especially during the initial load, as multiple pages
         // are loaded and the paging source is repeatedly invalidated.
         if (invalid) {
-            Log.d(TAG, "Invalidated, returning LoadResult.Invalid")
+            Timber.d("Invalidated, returning LoadResult.Invalid")
             return INVALID
         }
 
@@ -150,11 +150,10 @@ class NetworkTimelinePagingSource @Inject constructor(
             it.getOrNull(it.size / 2)?.id
         }
 
-        Log.d(TAG, "- getRefreshKey(), state.anchorPosition = ${state.anchorPosition}, return $refreshKey")
+        Timber.d("- getRefreshKey(), state.anchorPosition = ${state.anchorPosition}, return $refreshKey")
         return refreshKey
     }
 
     companion object {
-        private const val TAG = "NetworkTimelinePagingSource"
     }
 }

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelinePagingSource.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelinePagingSource.kt
@@ -153,7 +153,4 @@ class NetworkTimelinePagingSource @Inject constructor(
         Timber.d("- getRefreshKey(), state.anchorPosition = ${state.anchorPosition}, return $refreshKey")
         return refreshKey
     }
-
-    companion object {
-    }
 }

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelineRemoteMediator.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelineRemoteMediator.kt
@@ -187,7 +187,4 @@ class NetworkTimelineRemoteMediator(
             )
         }
     }
-
-    companion object {
-    }
 }

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelineRemoteMediator.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelineRemoteMediator.kt
@@ -17,7 +17,6 @@
 
 package app.pachli.components.timeline.viewmodel
 
-import android.util.Log
 import androidx.paging.ExperimentalPagingApi
 import androidx.paging.InvalidatingPagingSourceFactory
 import androidx.paging.LoadType
@@ -31,6 +30,7 @@ import app.pachli.network.MastodonApi
 import kotlinx.coroutines.CoroutineScope
 import retrofit2.HttpException
 import retrofit2.Response
+import timber.log.Timber
 import java.io.IOException
 
 /** Remote mediator for accessing timelines that are not backed by the database. */
@@ -100,7 +100,7 @@ class NetworkTimelineRemoteMediator(
                 }
             }
 
-            Log.d(TAG, "- load(), type = $loadType, key = $key")
+            Timber.d("- load(), type = $loadType, key = $key")
 
             val response = fetchStatusPageByKind(loadType, key, state.config.initialLoadSize)
             val page = Page.tryFrom(response).getOrElse { return MediatorResult.Error(it) }
@@ -113,13 +113,10 @@ class NetworkTimelineRemoteMediator(
                     }
 
                     pageCache.upsert(page)
-                    Log.d(
-                        TAG,
-                        "  Page $loadType complete for $timelineKind, now got ${pageCache.size} pages",
-                    )
+                    Timber.d("  Page $loadType complete for $timelineKind, now got ${pageCache.size} pages")
                     pageCache.debug()
                 }
-                Log.d(TAG, "  Invalidating paging source")
+                Timber.d("  Invalidating paging source")
                 factory.invalidate()
             }
 
@@ -192,6 +189,5 @@ class NetworkTimelineRemoteMediator(
     }
 
     companion object {
-        private const val TAG = "NetworkTimelineRemoteMediator"
     }
 }

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelineViewModel.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelineViewModel.kt
@@ -206,7 +206,4 @@ class NetworkTimelineViewModel @Inject constructor(
     override suspend fun invalidate() {
         repository.invalidate()
     }
-
-    companion object {
-    }
 }

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelineViewModel.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelineViewModel.kt
@@ -17,7 +17,6 @@
 
 package app.pachli.components.timeline.viewmodel
 
-import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
@@ -44,6 +43,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 /**
@@ -84,7 +84,7 @@ class NetworkTimelineViewModel @Inject constructor(
     private fun getStatuses(
         initialKey: String? = null,
     ): Flow<PagingData<StatusViewData>> {
-        Log.d(TAG, "getStatuses: kind: $timelineKind, initialKey: $initialKey")
+        Timber.d("getStatuses: kind: $timelineKind, initialKey: $initialKey")
         return repository.getStatusStream(viewModelScope, kind = timelineKind, initialKey = initialKey)
             .map { pagingData ->
                 pagingData.map {
@@ -122,8 +122,8 @@ class NetworkTimelineViewModel @Inject constructor(
     }
 
     override fun changeContentCollapsed(isCollapsed: Boolean, status: StatusViewData) {
-        Log.d(TAG, "changeContentCollapsed: $isCollapsed")
-        Log.d(TAG, "  " + status.content)
+        Timber.d("changeContentCollapsed: $isCollapsed")
+        Timber.d("  " + status.content)
         modifiedViewData[status.id] = status.copy(
             isCollapsed = isCollapsed,
         )
@@ -208,6 +208,5 @@ class NetworkTimelineViewModel @Inject constructor(
     }
 
     companion object {
-        private const val TAG = "NetworkTimelineViewModel"
     }
 }

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/PageCache.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/PageCache.kt
@@ -17,13 +17,13 @@
 
 package app.pachli.components.timeline.viewmodel
 
-import android.util.Log
 import app.pachli.BuildConfig
 import app.pachli.entity.Status
 import app.pachli.network.Links
 import app.pachli.util.isLessThan
 import retrofit2.HttpException
 import retrofit2.Response
+import timber.log.Timber
 import java.util.TreeMap
 import kotlin.Result.Companion.failure
 import kotlin.Result.Companion.success
@@ -92,8 +92,6 @@ data class Page(
     }
 
     companion object {
-        private const val TAG = "Page"
-
         fun tryFrom(response: Response<List<Status>>): Result<Page> {
             val statuses = response.body()
             if (!response.isSuccessful || statuses == null) {
@@ -101,8 +99,8 @@ data class Page(
             }
 
             val links = Links.from(response.headers()["link"])
-            Log.d(TAG, "  link: " + response.headers()["link"])
-            Log.d(TAG, "  ${statuses.size} - # statuses loaded")
+            Timber.d("  link: " + response.headers()["link"])
+            Timber.d("  ${statuses.size} - # statuses loaded")
 
             return success(
                 Page(
@@ -136,8 +134,8 @@ class PageCache : TreeMap<String, Page>(compareBy({ it.length }, { it })) {
     fun upsert(page: Page) {
         val key = page.data.last().id
 
-        Log.d(TAG, "Inserting new page:")
-        Log.d(TAG, "  $page")
+        Timber.d("Inserting new page:")
+        Timber.d("  $page")
 
         this[key] = page
 
@@ -158,18 +156,17 @@ class PageCache : TreeMap<String, Page>(compareBy({ it.length }, { it })) {
      */
     fun debug() {
         if (BuildConfig.DEBUG) { // Makes it easier for Proguard to optimise this out
-            Log.d(TAG, "Page cache state:")
+            Timber.d("Page cache state:")
             if (this.isEmpty()) {
-                Log.d(TAG, "  ** empty **")
+                Timber.d("  ** empty **")
             } else {
                 this.onEachIndexed { index, entry ->
-                    Log.d(TAG, "  $index: ${entry.value}")
+                    Timber.d("  $index: ${entry.value}")
                 }
             }
         }
     }
 
     companion object {
-        private const val TAG = "PageCache"
     }
 }

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/PageCache.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/PageCache.kt
@@ -166,7 +166,4 @@ class PageCache : TreeMap<String, Page>(compareBy({ it.length }, { it })) {
             }
         }
     }
-
-    companion object {
-    }
 }

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/TimelineViewModel.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/TimelineViewModel.kt
@@ -17,7 +17,6 @@
 
 package app.pachli.components.timeline.viewmodel
 
-import android.util.Log
 import androidx.annotation.CallSuper
 import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
@@ -75,6 +74,7 @@ import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import kotlin.time.Duration.Companion.milliseconds
 
 data class UiState(
@@ -318,7 +318,7 @@ abstract class TimelineViewModel(
     init {
         viewModelScope.launch {
             updateFiltersFromPreferences().collectLatest {
-                Log.d(TAG, "Filters updated")
+                Timber.d("Filters updated")
             }
         }
 
@@ -406,7 +406,7 @@ abstract class TimelineViewModel(
                     .filterIsInstance<InfallibleUiAction.SaveVisibleId>()
                     .distinctUntilChanged()
                     .collectLatest { action ->
-                        Log.d(TAG, "Saving Home timeline position at: ${action.visibleId}")
+                        Timber.d("Saving Home timeline position at: ${action.visibleId}")
                         activeAccount.lastVisibleHomeTimelineStatusId = action.visibleId
                         accountManager.saveAccount(activeAccount)
                         readingPositionId = action.visibleId
@@ -516,7 +516,7 @@ abstract class TimelineViewModel(
     /** Gets the current filters from the repository. */
     private fun getFilters() {
         viewModelScope.launch {
-            Log.d(TAG, "getFilters()")
+            Timber.d("getFilters()")
             try {
                 val filterKind = Filter.Kind.from(timelineKind)
                 filterModel = when (val filters = filtersRepository.getFilters()) {
@@ -524,7 +524,7 @@ abstract class TimelineViewModel(
                     is FilterKind.V2 -> FilterModel(filterKind)
                 }
             } catch (throwable: Throwable) {
-                Log.d(TAG, "updateFilter(): Error fetching filters: ${throwable.message}")
+                Timber.d("updateFilter(): Error fetching filters: ${throwable.message}")
                 _uiErrorChannel.send(UiError.GetFilters(throwable))
             }
         }
@@ -600,7 +600,6 @@ abstract class TimelineViewModel(
     }
 
     companion object {
-        private const val TAG = "TimelineViewModel"
         private val THROTTLE_TIMEOUT = 500.milliseconds
 
         /** Tag for the timelineKind in `savedStateHandle` */

--- a/app/src/main/java/app/pachli/components/trending/TrendingLinksFragment.kt
+++ b/app/src/main/java/app/pachli/components/trending/TrendingLinksFragment.kt
@@ -19,7 +19,6 @@ package app.pachli.components.trending
 
 import android.content.res.Configuration
 import android.os.Bundle
-import android.util.Log
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
@@ -57,6 +56,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import retrofit2.HttpException
+import timber.log.Timber
 
 @AndroidEntryPoint
 class TrendingLinksFragment :
@@ -220,7 +220,7 @@ class TrendingLinksFragment :
 
         val wasEnabled = talkBackWasEnabled
         talkBackWasEnabled = a11yManager?.isEnabled == true
-        Log.d(TAG, "talkback was enabled: $wasEnabled, now $talkBackWasEnabled")
+        Timber.d("talkback was enabled: $wasEnabled, now $talkBackWasEnabled")
         if (talkBackWasEnabled && !wasEnabled) {
             adapter.notifyItemRangeChanged(0, adapter.itemCount)
         }
@@ -229,8 +229,6 @@ class TrendingLinksFragment :
     }
 
     companion object {
-        private const val TAG = "TrendingLinksFragment"
-
         fun newInstance() = TrendingLinksFragment()
     }
 }

--- a/app/src/main/java/app/pachli/components/trending/TrendingTagsFragment.kt
+++ b/app/src/main/java/app/pachli/components/trending/TrendingTagsFragment.kt
@@ -20,7 +20,6 @@ package app.pachli.components.trending
 import android.annotation.SuppressLint
 import android.content.res.Configuration
 import android.os.Bundle
-import android.util.Log
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
@@ -59,6 +58,7 @@ import com.mikepenz.iconics.utils.sizeDp
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 @AndroidEntryPoint
 class TrendingTagsFragment :
@@ -181,7 +181,7 @@ class TrendingTagsFragment :
     }
 
     private fun processViewState(uiState: TrendingTagsViewModel.TrendingTagsUiState) {
-        Log.d(TAG, uiState.loadingState.name)
+        Timber.d(uiState.loadingState.name)
         when (uiState.loadingState) {
             TrendingTagsViewModel.LoadingState.INITIAL -> clearLoadingState()
             TrendingTagsViewModel.LoadingState.LOADING -> applyLoadingState()
@@ -265,7 +265,7 @@ class TrendingTagsFragment :
 
         val wasEnabled = talkBackWasEnabled
         talkBackWasEnabled = a11yManager?.isEnabled == true
-        Log.d(TAG, "talkback was enabled: $wasEnabled, now $talkBackWasEnabled")
+        Timber.d("talkback was enabled: $wasEnabled, now $talkBackWasEnabled")
         if (talkBackWasEnabled && !wasEnabled) {
             adapter.notifyItemRangeChanged(0, adapter.itemCount)
         }
@@ -290,8 +290,6 @@ class TrendingTagsFragment :
     }
 
     companion object {
-        private const val TAG = "TrendingTagsFragment"
-
         fun newInstance() = TrendingTagsFragment()
     }
 }

--- a/app/src/main/java/app/pachli/components/trending/viewmodel/TrendingLinksViewModel.kt
+++ b/app/src/main/java/app/pachli/components/trending/viewmodel/TrendingLinksViewModel.kt
@@ -87,8 +87,6 @@ class TrendingLinksViewModel @Inject constructor(
     }
 
     companion object {
-        @Suppress("unused")
-        private const val TAG = "TrendingLinksViewModel"
         private val THROTTLE_TIMEOUT = 500.milliseconds
     }
 }

--- a/app/src/main/java/app/pachli/components/trending/viewmodel/TrendingTagsViewModel.kt
+++ b/app/src/main/java/app/pachli/components/trending/viewmodel/TrendingTagsViewModel.kt
@@ -124,7 +124,4 @@ class TrendingTagsViewModel @Inject constructor(
 
         return map { TrendingViewData.Tag.from(it, maxTrendingValue) }
     }
-
-    companion object {
-    }
 }

--- a/app/src/main/java/app/pachli/components/trending/viewmodel/TrendingTagsViewModel.kt
+++ b/app/src/main/java/app/pachli/components/trending/viewmodel/TrendingTagsViewModel.kt
@@ -16,7 +16,6 @@
 
 package app.pachli.components.trending.viewmodel
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import app.pachli.appstore.EventHub
@@ -34,6 +33,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import java.io.IOException
 import javax.inject.Inject
 
@@ -107,7 +107,7 @@ class TrendingTagsViewModel @Inject constructor(
                 }
             },
             { error ->
-                Log.w(TAG, "failed loading trending tags", error)
+                Timber.w("failed loading trending tags", error)
                 if (error is IOException) {
                     _uiState.value = TrendingTagsUiState(emptyList(), LoadingState.ERROR_NETWORK)
                 } else {
@@ -126,6 +126,5 @@ class TrendingTagsViewModel @Inject constructor(
     }
 
     companion object {
-        private const val TAG = "TrendingViewModel"
     }
 }

--- a/app/src/main/java/app/pachli/components/viewthread/ThreadAdapter.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/ThreadAdapter.kt
@@ -70,8 +70,6 @@ class ThreadAdapter(
     }
 
     companion object {
-        @Suppress("unused")
-        private const val TAG = "ThreadAdapter"
         private const val VIEW_TYPE_STATUS = 0
         private const val VIEW_TYPE_STATUS_DETAILED = 1
         private const val VIEW_TYPE_STATUS_FILTERED = 2

--- a/app/src/main/java/app/pachli/components/viewthread/ViewThreadActivity.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/ViewThreadActivity.kt
@@ -51,7 +51,6 @@ class ViewThreadActivity : BottomSheetActivity() {
     }
 
     companion object {
-
         fun startIntent(context: Context, id: String, url: String): Intent {
             val intent = Intent(context, ViewThreadActivity::class.java)
             intent.putExtra(ID_EXTRA, id)

--- a/app/src/main/java/app/pachli/components/viewthread/ViewThreadFragment.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/ViewThreadFragment.kt
@@ -17,7 +17,6 @@
 package app.pachli.components.viewthread
 
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuInflater
@@ -56,6 +55,7 @@ import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 @AndroidEntryPoint
 class ViewThreadFragment :
@@ -166,7 +166,7 @@ class ViewThreadFragment :
                         binding.statusView.hide()
                     }
                     is ThreadUiState.Error -> {
-                        Log.w(TAG, "failed to load status", uiState.throwable)
+                        Timber.w("failed to load status", uiState.throwable)
                         initialProgressBar.cancel()
                         threadProgressBar.cancel()
 
@@ -214,7 +214,7 @@ class ViewThreadFragment :
 
         lifecycleScope.launch {
             viewModel.errors.collect { throwable ->
-                Log.w(TAG, "failed to load status context", throwable)
+                Timber.w("failed to load status context", throwable)
                 Snackbar.make(binding.root, R.string.error_generic, Snackbar.LENGTH_SHORT)
                     .setAction(R.string.action_retry) {
                         viewModel.retry(thisThreadsStatusId)
@@ -408,8 +408,6 @@ class ViewThreadFragment :
     }
 
     companion object {
-        private const val TAG = "ViewThreadFragment"
-
         private const val ID_EXTRA = "id"
         private const val URL_EXTRA = "url"
 

--- a/app/src/main/java/app/pachli/components/viewthread/ViewThreadViewModel.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/ViewThreadViewModel.kt
@@ -566,9 +566,6 @@ class ViewThreadViewModel @Inject constructor(
             status.copy(filtered = null)
         }
     }
-
-    companion object {
-    }
 }
 
 sealed interface ThreadUiState {

--- a/app/src/main/java/app/pachli/components/viewthread/ViewThreadViewModel.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/ViewThreadViewModel.kt
@@ -16,7 +16,6 @@
 
 package app.pachli.components.viewthread
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import app.pachli.appstore.BlockEvent
@@ -56,6 +55,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -123,12 +123,12 @@ class ViewThreadViewModel @Inject constructor(
         _uiState.value = ThreadUiState.Loading
 
         viewModelScope.launch {
-            Log.d(TAG, "Finding status with: $id")
+            Timber.d("Finding status with: $id")
             val contextCall = async { api.statusContext(id) }
             val timelineStatusWithAccount = timelineDao.getStatus(id)
 
             var detailedStatus = if (timelineStatusWithAccount != null) {
-                Log.d(TAG, "Loaded status from local timeline")
+                Timber.d("Loaded status from local timeline")
                 val status = timelineStatusWithAccount.toStatus(gson)
 
                 // Return the correct status, depending on which one matched. If you do not do
@@ -153,7 +153,7 @@ class ViewThreadViewModel @Inject constructor(
                     )
                 }
             } else {
-                Log.d(TAG, "Loaded status from network")
+                Timber.d("Loaded status from network")
                 val result = api.status(id).getOrElse { exception ->
                     _uiState.value = ThreadUiState.Error(exception)
                     return@launch
@@ -252,7 +252,7 @@ class ViewThreadViewModel @Inject constructor(
             timelineCases.reblog(status.actionableId, reblog).getOrThrow()
         } catch (t: Exception) {
             ifExpected(t) {
-                Log.d(TAG, "Failed to reblog status " + status.actionableId, t)
+                Timber.d("Failed to reblog status " + status.actionableId, t)
             }
         }
     }
@@ -262,7 +262,7 @@ class ViewThreadViewModel @Inject constructor(
             timelineCases.favourite(status.actionableId, favorite).getOrThrow()
         } catch (t: Exception) {
             ifExpected(t) {
-                Log.d(TAG, "Failed to favourite status " + status.actionableId, t)
+                Timber.d("Failed to favourite status " + status.actionableId, t)
             }
         }
     }
@@ -272,14 +272,14 @@ class ViewThreadViewModel @Inject constructor(
             timelineCases.bookmark(status.actionableId, bookmark).getOrThrow()
         } catch (t: Exception) {
             ifExpected(t) {
-                Log.d(TAG, "Failed to bookmark status " + status.actionableId, t)
+                Timber.d("Failed to bookmark status " + status.actionableId, t)
             }
         }
     }
 
     fun voteInPoll(choices: List<Int>, status: StatusViewData): Job = viewModelScope.launch {
         val poll = status.status.actionableStatus.poll ?: run {
-            Log.w(TAG, "No poll on status ${status.id}")
+            Timber.w("No poll on status ${status.id}")
             return@launch
         }
 
@@ -292,7 +292,7 @@ class ViewThreadViewModel @Inject constructor(
             timelineCases.voteInPoll(status.actionableId, poll.id, choices).getOrThrow()
         } catch (t: Exception) {
             ifExpected(t) {
-                Log.d(TAG, "Failed to vote in poll: " + status.actionableId, t)
+                Timber.d("Failed to vote in poll: " + status.actionableId, t)
             }
         }
     }
@@ -568,7 +568,6 @@ class ViewThreadViewModel @Inject constructor(
     }
 
     companion object {
-        private const val TAG = "ViewThreadViewModel"
     }
 }
 

--- a/app/src/main/java/app/pachli/components/viewthread/edits/ViewEditsFragment.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/edits/ViewEditsFragment.kt
@@ -17,7 +17,6 @@
 package app.pachli.components.viewthread.edits
 
 import android.os.Bundle
-import android.util.Log
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
@@ -52,6 +51,7 @@ import com.mikepenz.iconics.utils.colorInt
 import com.mikepenz.iconics.utils.sizeDp
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -102,7 +102,7 @@ class ViewEditsFragment :
                     }
                     EditsUiState.Refreshing -> {}
                     is EditsUiState.Error -> {
-                        Log.w(TAG, "failed to load edits", uiState.throwable)
+                        Timber.w("failed to load edits", uiState.throwable)
 
                         binding.swipeRefreshLayout.isRefreshing = false
                         binding.recyclerView.hide()
@@ -199,8 +199,6 @@ class ViewEditsFragment :
         get() = (activity as? BottomSheetActivity)
 
     companion object {
-        private const val TAG = "ViewEditsFragment"
-
         private const val STATUS_ID_EXTRA = "id"
 
         fun newInstance(statusId: String): ViewEditsFragment {

--- a/app/src/main/java/app/pachli/db/AccountManager.kt
+++ b/app/src/main/java/app/pachli/db/AccountManager.kt
@@ -17,7 +17,6 @@
 package app.pachli.db
 
 import android.content.Context
-import android.util.Log
 import app.pachli.di.ApplicationScope
 import app.pachli.entity.Account
 import app.pachli.entity.Status
@@ -27,6 +26,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -35,8 +35,6 @@ import javax.inject.Singleton
  * This class caches the account database and handles all account related operations
  * @author ConnyDuck
  */
-
-private const val TAG = "AccountManager"
 
 @Singleton
 class AccountManager @Inject constructor(
@@ -84,7 +82,7 @@ class AccountManager @Inject constructor(
     ) {
         activeAccount?.let {
             it.isActive = false
-            Log.d(TAG, "addAccount: saving account with id " + it.id)
+            Timber.d("addAccount: saving account with id " + it.id)
 
             accountDao.insertOrReplace(it)
         }
@@ -126,7 +124,7 @@ class AccountManager @Inject constructor(
      */
     fun saveAccount(account: AccountEntity) {
         if (account.id != 0L) {
-            Log.d(TAG, "saveAccount: saving account with id " + account.id)
+            Timber.d("saveAccount: saving account with id " + account.id)
             accountDao.insertOrReplace(account)
         }
     }
@@ -147,7 +145,7 @@ class AccountManager @Inject constructor(
             if (accounts.size > 0) {
                 accounts[0].isActive = true
                 activeAccount = accounts[0]
-                Log.d(TAG, "logActiveAccountOut: saving account with id " + accounts[0].id)
+                Timber.d("logActiveAccountOut: saving account with id " + accounts[0].id)
                 accountDao.insertOrReplace(accounts[0])
             } else {
                 activeAccount = null
@@ -173,7 +171,7 @@ class AccountManager @Inject constructor(
             it.emojis = account.emojis.orEmpty()
             it.locked = account.locked
 
-            Log.d(TAG, "updateActiveAccount: saving account with id " + it.id)
+            Timber.d("updateActiveAccount: saving account with id " + it.id)
             accountDao.insertOrReplace(it)
         }
     }
@@ -188,7 +186,7 @@ class AccountManager @Inject constructor(
         } ?: return // invalid accountId passed, do nothing
 
         activeAccount?.let {
-            Log.d(TAG, "setActiveAccount: saving account with id " + it.id)
+            Timber.d("setActiveAccount: saving account with id " + it.id)
             it.isActive = false
             saveAccount(it)
         }

--- a/app/src/main/java/app/pachli/db/DraftsAlert.kt
+++ b/app/src/main/java/app/pachli/db/DraftsAlert.kt
@@ -18,7 +18,6 @@ package app.pachli.db
 
 import android.content.Context
 import android.content.DialogInterface
-import android.util.Log
 import androidx.appcompat.app.AlertDialog
 import androidx.lifecycle.LifecycleCoroutineScope
 import androidx.lifecycle.LifecycleOwner
@@ -26,6 +25,7 @@ import androidx.lifecycle.lifecycleScope
 import app.pachli.R
 import app.pachli.components.drafts.DraftsActivity
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -34,8 +34,6 @@ import javax.inject.Singleton
  * It must be separately registered in each lifetime in which it is to appear,
  * and it only appears if the post failure belongs to the current user.
  */
-
-private const val TAG = "DraftsAlert"
 
 @Singleton
 class DraftsAlert @Inject constructor(private val draftDao: DraftDao) {
@@ -56,7 +54,7 @@ class DraftsAlert @Inject constructor(private val draftDao: DraftDao) {
             // at init, at next onResume, or immediately if the context is resumed already.
             if (showAlert) {
                 draftsNeedUserAlert.observe(context) { count ->
-                    Log.d(TAG, "User id $activeAccountId changed: Notification-worthy draft count $count")
+                    Timber.d("User id $activeAccountId changed: Notification-worthy draft count $count")
                     if (count > 0) {
                         AlertDialog.Builder(context)
                             .setTitle(R.string.action_post_failed)
@@ -77,12 +75,12 @@ class DraftsAlert @Inject constructor(private val draftDao: DraftDao) {
                 }
             } else {
                 draftsNeedUserAlert.observe(context) {
-                    Log.d(TAG, "User id $activeAccountId: Clean out notification-worthy drafts")
+                    Timber.d("User id $activeAccountId: Clean out notification-worthy drafts")
                     clearDraftsAlert(coroutineScope, activeAccountId)
                 }
             }
         } ?: run {
-            Log.w(TAG, "Attempted to observe drafts, but there is no active account")
+            Timber.w("Attempted to observe drafts, but there is no active account")
         }
     }
 

--- a/app/src/main/java/app/pachli/di/NetworkModule.kt
+++ b/app/src/main/java/app/pachli/di/NetworkModule.kt
@@ -18,7 +18,6 @@ package app.pachli.di
 
 import android.content.Context
 import android.os.Build
-import android.util.Log
 import app.pachli.BuildConfig
 import app.pachli.db.AccountManager
 import app.pachli.json.Rfc3339DateJsonAdapter
@@ -46,6 +45,7 @@ import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.create
+import timber.log.Timber
 import java.net.IDN
 import java.net.InetSocketAddress
 import java.net.Proxy
@@ -56,7 +56,6 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 @Module
 object NetworkModule {
-    private const val TAG = "NetworkModule"
 
     @Provides
     @Singleton
@@ -98,7 +97,7 @@ object NetworkModule {
             ProxyConfiguration.create(httpServer, httpPort)?.also { conf ->
                 val address = InetSocketAddress.createUnresolved(IDN.toASCII(conf.hostname), conf.port)
                 builder.proxy(Proxy(Proxy.Type.HTTP, address))
-            } ?: Log.w(TAG, "Invalid proxy configuration: ($httpServer, $httpPort)")
+            } ?: Timber.w("Invalid proxy configuration: ($httpServer, $httpPort)")
         }
 
         return builder

--- a/app/src/main/java/app/pachli/entity/Status.kt
+++ b/app/src/main/java/app/pachli/entity/Status.kt
@@ -92,7 +92,6 @@ data class Status(
         }
 
         companion object {
-
             @JvmStatic
             fun byNum(num: Int): Visibility {
                 return when (num) {

--- a/app/src/main/java/app/pachli/fragment/SFragment.kt
+++ b/app/src/main/java/app/pachli/fragment/SFragment.kt
@@ -26,7 +26,6 @@ import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.os.Environment
-import android.util.Log
 import android.view.MenuItem
 import android.view.View
 import android.widget.Toast
@@ -60,6 +59,7 @@ import at.connyduck.calladapter.networkresult.fold
 import at.connyduck.calladapter.networkresult.onFailure
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 /* Note from Andrew on Jan. 22, 2017: This class is a design problem for me, so I left it with an
@@ -353,7 +353,7 @@ abstract class SFragment : Fragment() {
                 lifecycleScope.launch {
                     val result = timelineCases.delete(id).exceptionOrNull()
                     if (result != null) {
-                        Log.w("SFragment", "error deleting status", result)
+                        Timber.w("error deleting status", result)
                         Toast.makeText(context, R.string.error_generic, Toast.LENGTH_SHORT).show()
                     }
                     // XXX: Removes the item even if there was an error. This is probably not
@@ -399,7 +399,7 @@ abstract class SFragment : Fragment() {
                             startActivity(startIntent(requireContext(), composeOptions))
                         },
                         { error: Throwable? ->
-                            Log.w("SFragment", "error deleting status", error)
+                            Timber.w(error, "error deleting status")
                             Toast.makeText(context, R.string.error_generic, Toast.LENGTH_SHORT)
                                 .show()
                         },
@@ -491,8 +491,6 @@ abstract class SFragment : Fragment() {
     }
 
     companion object {
-        @Suppress("unused")
-        private const val TAG = "SFragment"
         private fun accountIsInMentions(account: AccountEntity?, mentions: List<Status.Mention>): Boolean {
             return mentions.any { mention ->
                 account?.username == mention.username && account.domain == Uri.parse(mention.url)?.host

--- a/app/src/main/java/app/pachli/fragment/ViewVideoFragment.kt
+++ b/app/src/main/java/app/pachli/fragment/ViewVideoFragment.kt
@@ -319,7 +319,7 @@ class ViewVideoFragment : ViewMediaFragment() {
         ExoPlayer.Builder(requireContext())
             .setMediaSourceFactory(mediaSourceFactory)
             .build().apply {
-                if (BuildConfig.DEBUG) addAnalyticsListener(EventLogger("$TAG:ExoPlayer"))
+                if (BuildConfig.DEBUG) addAnalyticsListener(EventLogger("${javaClass.simpleName}:ExoPlayer"))
                 setMediaItem(MediaItem.fromUri(mediaAttachment.url))
                 addListener(mediaPlayerListener)
                 repeatMode = Player.REPEAT_MODE_ONE
@@ -427,7 +427,6 @@ class ViewVideoFragment : ViewMediaFragment() {
     override fun onTransitionEnd() { }
 
     companion object {
-        private const val TAG = "ViewVideoFragment"
         private const val CONTROLS_TIMEOUT_MS = 2000 // Consistent with YouTube player
         private const val SEEK_POSITION = "seekPosition"
     }

--- a/app/src/main/java/app/pachli/json/Rfc3339DateJsonAdapter.kt
+++ b/app/src/main/java/app/pachli/json/Rfc3339DateJsonAdapter.kt
@@ -16,12 +16,12 @@
  */
 package app.pachli.json
 
-import android.util.Log
 import com.google.gson.JsonParseException
 import com.google.gson.TypeAdapter
 import com.google.gson.stream.JsonReader
 import com.google.gson.stream.JsonToken
 import com.google.gson.stream.JsonWriter
+import timber.log.Timber
 import java.io.IOException
 import java.util.Date
 
@@ -47,7 +47,7 @@ class Rfc3339DateJsonAdapter : TypeAdapter<Date?>() {
                 try {
                     reader.nextString().parseIsoDate()
                 } catch (jpe: JsonParseException) {
-                    Log.w("Rfc3339DateJsonAdapter", jpe)
+                    Timber.w(jpe)
                     null
                 }
             }

--- a/app/src/main/java/app/pachli/network/InstanceSwitchAuthInterceptor.kt
+++ b/app/src/main/java/app/pachli/network/InstanceSwitchAuthInterceptor.kt
@@ -16,7 +16,6 @@
 
 package app.pachli.network
 
-import android.util.Log
 import app.pachli.db.AccountManager
 import okhttp3.HttpUrl
 import okhttp3.Interceptor
@@ -25,6 +24,7 @@ import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
+import timber.log.Timber
 import java.io.IOException
 
 class InstanceSwitchAuthInterceptor(private val accountManager: AccountManager) : Interceptor {
@@ -58,7 +58,7 @@ class InstanceSwitchAuthInterceptor(private val accountManager: AccountManager) 
             val newRequest: Request = builder.build()
 
             if (MastodonApi.PLACEHOLDER_DOMAIN == newRequest.url.host) {
-                Log.w("ISAInterceptor", "no user logged in or no domain header specified - can't make request to " + newRequest.url)
+                Timber.w("no user logged in or no domain header specified - can't make request to " + newRequest.url)
                 return Response.Builder()
                     .code(400)
                     .message("Bad Request")

--- a/app/src/main/java/app/pachli/receiver/SendStatusBroadcastReceiver.kt
+++ b/app/src/main/java/app/pachli/receiver/SendStatusBroadcastReceiver.kt
@@ -21,7 +21,6 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager.PERMISSION_GRANTED
-import android.util.Log
 import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
@@ -34,9 +33,8 @@ import app.pachli.service.SendStatusService
 import app.pachli.service.StatusToSend
 import app.pachli.util.randomAlphanumericString
 import dagger.hilt.android.AndroidEntryPoint
+import timber.log.Timber
 import javax.inject.Inject
-
-private const val TAG = "SendStatusBR"
 
 @AndroidEntryPoint
 class SendStatusBroadcastReceiver : BroadcastReceiver() {
@@ -62,7 +60,7 @@ class SendStatusBroadcastReceiver : BroadcastReceiver() {
             val message = getReplyMessage(intent)
 
             if (account == null) {
-                Log.w(TAG, "Account \"$senderId\" not found in database. Aborting quick reply!")
+                Timber.w("Account \"$senderId\" not found in database. Aborting quick reply!")
 
                 if (ActivityCompat.checkSelfPermission(context, POST_NOTIFICATIONS) != PERMISSION_GRANTED) {
                     return

--- a/app/src/main/java/app/pachli/service/SendStatusService.kt
+++ b/app/src/main/java/app/pachli/service/SendStatusService.kt
@@ -12,7 +12,6 @@ import android.content.Intent
 import android.os.Build
 import android.os.IBinder
 import android.os.Parcelable
-import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.annotation.StringRes
 import androidx.core.app.NotificationCompat
@@ -47,6 +46,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.parcelize.Parcelize
 import retrofit2.HttpException
+import timber.log.Timber
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -144,7 +144,7 @@ class SendStatusService : Service() {
                     when (val uploadState = mediaUploader.getMediaUploadState(mediaItem.localId)) {
                         is UploadEvent.FinishedEvent -> mediaItem.copy(id = uploadState.mediaId, processed = uploadState.processed)
                         is UploadEvent.ErrorEvent -> {
-                            Log.w(TAG, "failed uploading media", uploadState.error)
+                            Timber.w("failed uploading media", uploadState.error)
                             failSending(statusId)
                             stopSelfWhenDone()
                             return@launch
@@ -176,7 +176,7 @@ class SendStatusService : Service() {
                     mediaCheckRetries++
                 }
             } catch (e: Exception) {
-                Log.w(TAG, "failed getting media status", e)
+                Timber.w("failed getting media status", e)
                 retrySending(statusId)
                 return@launch
             }
@@ -189,7 +189,7 @@ class SendStatusService : Service() {
                         mastodonApi.updateMedia(mediaItem.id!!, mediaItem.description, mediaItem.focus?.toMastodonApiString())
                             .fold({
                             }, { throwable ->
-                                Log.w(TAG, "failed to update media on status send", throwable)
+                                Timber.w("failed to update media on status send", throwable)
                                 failOrRetry(throwable, statusId)
 
                                 return@launch
@@ -257,7 +257,7 @@ class SendStatusService : Service() {
 
                 notificationManager.cancel(statusId)
             }, { throwable ->
-                Log.w(TAG, "failed sending status", throwable)
+                Timber.w("failed sending status", throwable)
                 failOrRetry(throwable, statusId)
             },)
             stopSelfWhenDone()
@@ -415,8 +415,6 @@ class SendStatusService : Service() {
     }
 
     companion object {
-        private const val TAG = "SendStatusService"
-
         private const val KEY_STATUS = "status"
         private const val KEY_CANCEL = "cancel_id"
         private const val CHANNEL_ID = "send_toots"

--- a/app/src/main/java/app/pachli/usecase/TimelineCases.kt
+++ b/app/src/main/java/app/pachli/usecase/TimelineCases.kt
@@ -16,7 +16,6 @@
 
 package app.pachli.usecase
 
-import android.util.Log
 import app.pachli.appstore.BlockEvent
 import app.pachli.appstore.BookmarkEvent
 import app.pachli.appstore.EventHub
@@ -37,6 +36,7 @@ import at.connyduck.calladapter.networkresult.NetworkResult
 import at.connyduck.calladapter.networkresult.fold
 import at.connyduck.calladapter.networkresult.onFailure
 import at.connyduck.calladapter.networkresult.onSuccess
+import timber.log.Timber
 import javax.inject.Inject
 
 class TimelineCases @Inject constructor(
@@ -89,7 +89,7 @@ class TimelineCases @Inject constructor(
             mastodonApi.muteAccount(statusId, notifications, duration)
             eventHub.dispatch(MuteEvent(statusId))
         } catch (t: Throwable) {
-            Log.w(TAG, "Failed to mute account", t)
+            Timber.w("Failed to mute account", t)
         }
     }
 
@@ -98,14 +98,14 @@ class TimelineCases @Inject constructor(
             mastodonApi.blockAccount(statusId)
             eventHub.dispatch(BlockEvent(statusId))
         } catch (t: Throwable) {
-            Log.w(TAG, "Failed to block account", t)
+            Timber.w("Failed to block account", t)
         }
     }
 
     suspend fun delete(statusId: String): NetworkResult<DeletedStatus> {
         return mastodonApi.deleteStatus(statusId)
             .onSuccess { eventHub.dispatch(StatusDeletedEvent(statusId)) }
-            .onFailure { Log.w(TAG, "Failed to delete status", it) }
+            .onFailure { Timber.w("Failed to delete status", it) }
     }
 
     suspend fun pin(statusId: String, pin: Boolean): NetworkResult<Status> {
@@ -117,7 +117,7 @@ class TimelineCases @Inject constructor(
             eventHub.dispatch(PinEvent(statusId, pin))
             NetworkResult.success(status)
         }, { e ->
-            Log.w(TAG, "Failed to change pin state", e)
+            Timber.w("Failed to change pin state", e)
             NetworkResult.failure(TimelineError(e.getServerErrorMessage()))
         },)
     }
@@ -141,7 +141,6 @@ class TimelineCases @Inject constructor(
     }
 
     companion object {
-        private const val TAG = "TimelineCases"
     }
 }
 

--- a/app/src/main/java/app/pachli/usecase/TimelineCases.kt
+++ b/app/src/main/java/app/pachli/usecase/TimelineCases.kt
@@ -139,9 +139,6 @@ class TimelineCases @Inject constructor(
     suspend fun rejectFollowRequest(accountId: String): NetworkResult<Relationship> {
         return mastodonApi.rejectFollowRequest(accountId)
     }
-
-    companion object {
-    }
 }
 
 class TimelineError(message: String?) : RuntimeException(message)

--- a/app/src/main/java/app/pachli/util/AbsoluteTimeFormatter.kt
+++ b/app/src/main/java/app/pachli/util/AbsoluteTimeFormatter.kt
@@ -40,7 +40,6 @@ class AbsoluteTimeFormatter @JvmOverloads constructor(private val tz: TimeZone =
     }
 
     companion object {
-
         private fun isSameDate(dateOne: Date, dateTwo: Date, tz: TimeZone): Boolean {
             val calendarOne = Calendar.getInstance(tz).apply { time = dateOne }
             val calendarTwo = Calendar.getInstance(tz).apply { time = dateTwo }

--- a/app/src/main/java/app/pachli/util/CombinedLoadStatesExtensions.kt
+++ b/app/src/main/java/app/pachli/util/CombinedLoadStatesExtensions.kt
@@ -17,7 +17,6 @@
 
 package app.pachli.util
 
-import android.util.Log
 import androidx.paging.CombinedLoadStates
 import androidx.paging.LoadState
 import app.pachli.BuildConfig
@@ -27,6 +26,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.scan
+import timber.log.Timber
 
 /**
  * Each [CombinedLoadStates] state does not contain enough information to understand the actual
@@ -168,8 +168,8 @@ fun Flow<CombinedLoadStates>.asRefreshState(): Flow<UserRefreshState> {
         if (BuildConfig.DEBUG) {
             previousLoadState?.let {
                 val loadStateDiff = loadState.diff(previousLoadState)
-                Log.d("UserRefreshState", "Current state: $refresh $prepend")
-                if (loadStateDiff.isNotEmpty()) Log.d("RefreshState", loadStateDiff)
+                Timber.d("Current state: $refresh $prepend")
+                if (loadStateDiff.isNotEmpty()) Timber.d(loadStateDiff)
             }
             previousLoadState = loadState
         }

--- a/app/src/main/java/app/pachli/util/CompositeWithOpaqueBackground.kt
+++ b/app/src/main/java/app/pachli/util/CompositeWithOpaqueBackground.kt
@@ -124,8 +124,6 @@ class CompositeWithOpaqueBackground(val view: View) : BitmapTransformation() {
     }
 
     companion object {
-        @Suppress("unused")
-        private const val TAG = "CompositeWithOpaqueBackground"
         private val ID = CompositeWithOpaqueBackground::class.qualifiedName!!
         private val ID_BYTES = ID.toByteArray(Charset.forName("UTF-8"))
 

--- a/app/src/main/java/app/pachli/util/LinkHelper.kt
+++ b/app/src/main/java/app/pachli/util/LinkHelper.kt
@@ -28,7 +28,6 @@ import android.text.Spanned
 import android.text.method.LinkMovementMethod
 import android.text.style.ClickableSpan
 import android.text.style.URLSpan
-import android.util.Log
 import android.view.MotionEvent
 import android.view.MotionEvent.ACTION_UP
 import android.view.View
@@ -50,6 +49,7 @@ import com.mikepenz.iconics.IconicsSize
 import com.mikepenz.iconics.typeface.library.googlematerial.GoogleMaterial
 import com.mikepenz.iconics.utils.color
 import com.mikepenz.iconics.utils.size
+import timber.log.Timber
 import java.lang.ref.WeakReference
 import java.net.URI
 import java.net.URISyntaxException
@@ -270,7 +270,7 @@ private fun openLinkInBrowser(uri: Uri?, context: Context) {
     try {
         context.startActivity(intent)
     } catch (e: ActivityNotFoundException) {
-        Log.w(TAG, "Activity was not found for intent, $intent")
+        Timber.w("Activity was not found for intent, $intent")
     }
 }
 
@@ -298,7 +298,7 @@ fun openLinkInCustomTab(uri: Uri, context: Context) {
     try {
         customTabsIntent.launchUrl(context, uri)
     } catch (e: ActivityNotFoundException) {
-        Log.w(TAG, "Activity was not found for intent $customTabsIntent")
+        Timber.w("Activity was not found for intent $customTabsIntent")
         openLinkInBrowser(uri, context)
     }
 }
@@ -349,8 +349,6 @@ fun looksLikeMastodonUrl(urlString: String): Boolean {
             it.matches("^/o/[a-f0-9]+$".toRegex())
     }
 }
-
-private const val TAG = "LinkHelper"
 
 /**
  * [LinkMovementMethod] that doesn't add a leading/trailing clickable area.

--- a/app/src/main/java/app/pachli/util/LocaleUtils.kt
+++ b/app/src/main/java/app/pachli/util/LocaleUtils.kt
@@ -16,10 +16,10 @@
 
 package app.pachli.util
 
-import android.util.Log
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.os.LocaleListCompat
 import app.pachli.db.AccountEntity
+import timber.log.Timber
 import java.util.Locale
 
 private const val TAG: String = "LocaleUtils"
@@ -48,7 +48,7 @@ private fun ensureLanguagesAreFirst(locales: MutableList<Locale>, languages: Lis
                 // - Your per-account posting language is set to one android doesn't know (e.g. toki pona)
                 // - Replying to a post in a language android doesn't know
                 locales.add(0, Locale(language))
-                Log.w(TAG, "Attempting to use unknown language tag '$language'")
+                Timber.w("Attempting to use unknown language tag '$language'")
                 continue
             }
         }

--- a/app/src/main/java/app/pachli/util/MediaUtils.kt
+++ b/app/src/main/java/app/pachli/util/MediaUtils.kt
@@ -23,8 +23,8 @@ import android.graphics.BitmapFactory
 import android.graphics.Matrix
 import android.net.Uri
 import android.provider.OpenableColumns
-import android.util.Log
 import androidx.exifinterface.media.ExifInterface
+import timber.log.Timber
 import java.io.File
 import java.io.FileNotFoundException
 import java.io.IOException
@@ -36,7 +36,7 @@ import java.util.Locale
 /**
  * Helper methods for obtaining and resizing media files
  */
-private const val TAG = "MediaUtils"
+
 private const val MEDIA_TEMP_PREFIX = "Pachli_Share_Media"
 const val MEDIA_SIZE_UNKNOWN = -1L
 
@@ -148,7 +148,7 @@ fun getImageOrientation(uri: Uri, contentResolver: ContentResolver): Int {
     val inputStream = try {
         contentResolver.openInputStream(uri)
     } catch (e: FileNotFoundException) {
-        Log.w(TAG, e)
+        Timber.w(e)
         return ExifInterface.ORIENTATION_UNDEFINED
     }
     inputStream ?: return ExifInterface.ORIENTATION_UNDEFINED
@@ -157,7 +157,7 @@ fun getImageOrientation(uri: Uri, contentResolver: ContentResolver): Int {
         val exifInterface = try {
             ExifInterface(it)
         } catch (e: IOException) {
-            Log.w(TAG, e)
+            Timber.w(e)
             return@use ExifInterface.ORIENTATION_UNDEFINED
         }
 
@@ -189,7 +189,7 @@ fun deleteStaleCachedMedia(mediaDirectory: File?) {
         try {
             file.delete()
         } catch (se: SecurityException) {
-            Log.e(TAG, "Error removing stale cached media")
+            Timber.e("Error removing stale cached media")
         }
     }
 }

--- a/app/src/main/java/app/pachli/util/SharedPreferencesRepository.kt
+++ b/app/src/main/java/app/pachli/util/SharedPreferencesRepository.kt
@@ -18,11 +18,11 @@
 package app.pachli.util
 
 import android.content.SharedPreferences
-import android.util.Log
 import app.pachli.di.ApplicationScope
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -51,7 +51,7 @@ class SharedPreferencesRepository @Inject constructor(
         }
 
     init {
-        Log.d("SharedPreferencesRepository", "Being created")
+        Timber.d("Being created")
         sharedPreferences.registerOnSharedPreferenceChangeListener(listener)
     }
 }

--- a/app/src/main/java/app/pachli/util/StatusDisplayOptionsRepository.kt
+++ b/app/src/main/java/app/pachli/util/StatusDisplayOptionsRepository.kt
@@ -170,7 +170,4 @@ class StatusDisplayOptionsRepository @Inject constructor(
             openSpoiler = account?.alwaysOpenSpoiler ?: default.openSpoiler,
         )
     }
-
-    companion object {
-    }
 }

--- a/app/src/main/java/app/pachli/util/StatusDisplayOptionsRepository.kt
+++ b/app/src/main/java/app/pachli/util/StatusDisplayOptionsRepository.kt
@@ -17,7 +17,6 @@
 
 package app.pachli.util
 
-import android.util.Log
 import androidx.annotation.VisibleForTesting
 import androidx.annotation.VisibleForTesting.Companion.PRIVATE
 import app.pachli.db.AccountEntity
@@ -31,6 +30,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -73,12 +73,12 @@ class StatusDisplayOptionsRepository @Inject constructor(
     )
 
     init {
-        Log.d(TAG, "Created StatusDisplayOptionsRepository")
+        Timber.d("Created StatusDisplayOptionsRepository")
 
         // Update whenever preferences change
         externalScope.launch {
             sharedPreferencesRepository.changes.filter { prefKeys.contains(it) }.collect { key ->
-                Log.d(TAG, "Updating because shared preference changed")
+                Timber.d("Updating because shared preference changed")
                 _flow.update { prev ->
                     when (key) {
                         PrefKeys.ANIMATE_GIF_AVATARS -> prev.copy(
@@ -128,14 +128,14 @@ class StatusDisplayOptionsRepository @Inject constructor(
 
         externalScope.launch {
             accountManager.activeAccountFlow.collect {
-                Log.d(TAG, "Updating because active account changed")
+                Timber.d("Updating because active account changed")
                 _flow.emit(initialStatusDisplayOptions(it))
             }
         }
 
         externalScope.launch {
             accountPreferenceDataStore.changes.collect { (key, value) ->
-                Log.d(TAG, "Updating because account preference changed")
+                Timber.d("Updating because account preference changed")
                 _flow.update { prev ->
                     when (key) {
                         PrefKeys.MEDIA_PREVIEW_ENABLED -> prev.copy(mediaPreviewEnabled = value)
@@ -172,6 +172,5 @@ class StatusDisplayOptionsRepository @Inject constructor(
     }
 
     companion object {
-        private const val TAG = "StatusDisplayOptionsRepository"
     }
 }

--- a/app/src/main/java/app/pachli/util/ViewExtensions.kt
+++ b/app/src/main/java/app/pachli/util/ViewExtensions.kt
@@ -16,11 +16,11 @@
 
 package app.pachli.util
 
-import android.util.Log
 import android.view.View
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager2.widget.ViewPager2
+import timber.log.Timber
 
 fun View.show() {
     this.visibility = View.VISIBLE
@@ -64,7 +64,7 @@ fun ViewPager2.reduceSwipeSensitivity() {
         val scaleFactor = 2
         touchSlopField.set(recyclerView, touchSlop * scaleFactor)
     } catch (e: Exception) {
-        Log.w("reduceSwipeSensitivity", e)
+        Timber.tag("reduceSwipeSensitibity").w(e)
     }
 }
 

--- a/app/src/main/java/app/pachli/view/ClickableSpanTextView.kt
+++ b/app/src/main/java/app/pachli/view/ClickableSpanTextView.kt
@@ -29,7 +29,6 @@ import android.text.Spanned
 import android.text.style.ClickableSpan
 import android.text.style.URLSpan
 import android.util.AttributeSet
-import android.util.Log
 import android.view.MotionEvent
 import android.view.MotionEvent.ACTION_CANCEL
 import android.view.MotionEvent.ACTION_DOWN
@@ -39,6 +38,7 @@ import androidx.appcompat.widget.AppCompatTextView
 import androidx.core.view.doOnLayout
 import app.pachli.BuildConfig
 import app.pachli.R
+import timber.log.Timber
 import java.lang.Float.max
 import java.lang.Float.min
 import kotlin.math.abs
@@ -216,7 +216,7 @@ class ClickableSpanTextView @JvmOverloads constructor(
                 for (entry in spanRects) {
                     if (!entry.key.contains(x, y)) continue
                     clickedSpan = entry.value
-                    Log.v(TAG, "span click: ${(clickedSpan as URLSpan).url}")
+                    Timber.v("span click: ${(clickedSpan as URLSpan).url}")
                     return super.onTouchEvent(event)
                 }
 
@@ -231,13 +231,13 @@ class ClickableSpanTextView @JvmOverloads constructor(
                         activeEntry = entry
                         continue
                     }
-                    Log.v(TAG, "Overlap: ${(entry.value as URLSpan).url} ${(activeEntry.value as URLSpan).url}")
+                    Timber.v("Overlap: ${(entry.value as URLSpan).url} ${(activeEntry.value as URLSpan).url}")
                     if (isClickOnFirst(entry.key, activeEntry.key, x, y)) {
                         activeEntry = entry
                     }
                 }
                 clickedSpan = activeEntry?.value
-                clickedSpan?.let { Log.v(TAG, "padding click: ${(clickedSpan as URLSpan).url}") }
+                clickedSpan?.let { Timber.v("padding click: ${(clickedSpan as URLSpan).url}") }
                 return super.onTouchEvent(event)
             }
             ACTION_UP -> {
@@ -335,15 +335,15 @@ class ClickableSpanTextView @JvmOverloads constructor(
      * @return true if the click was closer to the first rectangle than the second
      */
     private fun isClickOnFirst(first: RectF, second: RectF, x: Float, y: Float): Boolean {
-        Log.v(TAG, "first: $first second: $second click: $x $y")
+        Timber.v("first: $first second: $second click: $x $y")
         val (firstDiff, secondDiff) = if (first.top == second.top) {
-            Log.v(TAG, "left/right overlap")
+            Timber.v("left/right overlap")
             Pair(abs(first.centerX() - x), abs(second.centerX() - x))
         } else {
-            Log.v(TAG, "top/bottom overlap")
+            Timber.v("top/bottom overlap")
             Pair(abs(first.centerY() - y), abs(second.centerY() - y))
         }
-        Log.d(TAG, "firstDiff: $firstDiff secondDiff: $secondDiff")
+        Timber.d("firstDiff: $firstDiff secondDiff: $secondDiff")
         return firstDiff < secondDiff
     }
 

--- a/app/src/main/java/app/pachli/view/SliderPreference.kt
+++ b/app/src/main/java/app/pachli/view/SliderPreference.kt
@@ -195,8 +195,6 @@ class SliderPreference @JvmOverloads constructor(
     }
 
     companion object {
-        @Suppress("unused")
-        private const val TAG = "SliderPreference"
         private const val defaultValueFrom = 0F
         private const val defaultValueTo = 1F
         private const val defaultValue = 0.5F

--- a/app/src/main/java/app/pachli/viewmodel/AccountsInListViewModel.kt
+++ b/app/src/main/java/app/pachli/viewmodel/AccountsInListViewModel.kt
@@ -16,7 +16,6 @@
 
 package app.pachli.viewmodel
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import app.pachli.entity.TimelineAccount
@@ -30,6 +29,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 data class State(val accounts: Either<Throwable, List<TimelineAccount>>, val searchResult: List<TimelineAccount>?)
@@ -66,8 +66,7 @@ class AccountsInListViewModel @Inject constructor(private val api: MastodonApi) 
                         }
                     },
                     {
-                        Log.i(
-                            javaClass.simpleName,
+                        Timber.i(
                             "Failed to add account to list: ${account.username}",
                         )
                     },
@@ -89,8 +88,7 @@ class AccountsInListViewModel @Inject constructor(private val api: MastodonApi) 
                         }
                     },
                     {
-                        Log.i(
-                            javaClass.simpleName,
+                        Timber.i(
                             "Failed to remove account from list: $accountId",
                         )
                     },

--- a/app/src/main/java/app/pachli/worker/PruneCacheWorker.kt
+++ b/app/src/main/java/app/pachli/worker/PruneCacheWorker.kt
@@ -19,7 +19,6 @@ package app.pachli.worker
 
 import android.app.Notification
 import android.content.Context
-import android.util.Log
 import androidx.work.CoroutineWorker
 import androidx.work.ForegroundInfo
 import androidx.work.ListenableWorker
@@ -29,6 +28,7 @@ import app.pachli.components.notifications.NotificationHelper
 import app.pachli.components.notifications.NotificationHelper.NOTIFICATION_ID_PRUNE_CACHE
 import app.pachli.db.AccountManager
 import app.pachli.db.TimelineDao
+import timber.log.Timber
 import javax.inject.Inject
 
 /** Prune the database cache of old statuses. */
@@ -42,7 +42,7 @@ class PruneCacheWorker(
 
     override suspend fun doWork(): Result {
         for (account in accountManager.accounts) {
-            Log.d(TAG, "Pruning database using account ID: ${account.id}")
+            Timber.d("Pruning database using account ID: ${account.id}")
             timelineDao.cleanup(account.id, MAX_STATUSES_IN_CACHE)
         }
         return Result.success()
@@ -51,7 +51,6 @@ class PruneCacheWorker(
     override suspend fun getForegroundInfo() = ForegroundInfo(NOTIFICATION_ID_PRUNE_CACHE, notification)
 
     companion object {
-        private const val TAG = "PruneCacheWorker"
         private const val MAX_STATUSES_IN_CACHE = 1000
         const val PERIODIC_WORK_TAG = "PruneCacheWorker_periodic"
     }

--- a/app/src/main/java/app/pachli/worker/WorkerFactory.kt
+++ b/app/src/main/java/app/pachli/worker/WorkerFactory.kt
@@ -64,7 +64,4 @@ class WorkerFactory @Inject constructor(
         }
         return null
     }
-
-    companion object {
-    }
 }

--- a/app/src/main/java/app/pachli/worker/WorkerFactory.kt
+++ b/app/src/main/java/app/pachli/worker/WorkerFactory.kt
@@ -18,10 +18,10 @@
 package app.pachli.worker
 
 import android.content.Context
-import android.util.Log
 import androidx.work.ListenableWorker
 import androidx.work.WorkerFactory
 import androidx.work.WorkerParameters
+import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Provider
 import javax.inject.Singleton
@@ -56,7 +56,7 @@ class WorkerFactory @Inject constructor(
             // Class might be missing if it was renamed / moved to a different package, as
             // periodic work requests from before the rename might still exist. Catch and
             // return null, which should stop future requests.
-            Log.d(TAG, "Invalid class: $workerClassName", e)
+            Timber.d("Invalid class: $workerClassName", e)
             null
         }
         workerFactories[key]?.let {
@@ -66,6 +66,5 @@ class WorkerFactory @Inject constructor(
     }
 
     companion object {
-        private const val TAG = "WorkerFactory"
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,6 +51,7 @@ rxandroid3 = "3.0.2"
 rxjava3 = "3.1.7"
 rxkotlin3 = "3.0.1"
 sparkbutton = "4.1.0"
+timber = "5.0.1"
 touchimageview = "3.6"
 truth = "1.1.5"
 turbine = "1.0.0"
@@ -145,6 +146,7 @@ rxjava3-android = { module = "io.reactivex.rxjava3:rxandroid", version.ref = "rx
 rxjava3-core = { module = "io.reactivex.rxjava3:rxjava", version.ref = "rxjava3" }
 rxjava3-kotlin = { module = "io.reactivex.rxjava3:rxkotlin", version.ref = "rxkotlin3" }
 sparkbutton = { module = "com.github.connyduck:sparkbutton", version.ref = "sparkbutton" }
+timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
 touchimageview = { module = "com.github.MikeOrtiz:TouchImageView", version.ref = "touchimageview" }
 truth = { module = "com.google.truth:truth", version.ref = "truth" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }


### PR DESCRIPTION
Use Timber instead of `android.util.Log`. Removes the need for `TAG`
statics in companion objects, slightly simplifying the code. Opens the
door for some production logging in the future.