### PR TITLE
fix: Ensure system controls are visible on older devices

### DIFF
--- a/app/src/main/res/values-v29/themes.xml
+++ b/app/src/main/res/values-v29/themes.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Copyright 2023 Pachli Association
+  ~
+  ~ This file is a part of Pachli.
+  ~
+  ~ This program is free software; you can redistribute it and/or modify it under the terms of the
+  ~ GNU General Public License as published by the Free Software Foundation; either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+  ~ the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+  ~ Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License along with Pachli; if not,
+  ~ see <http://www.gnu.org/licenses>.
+  -->
+
+<resources>
+    <style name="Theme.Pachli" parent="Base.Theme.Pachli">
+        <!-- Transparent system bars for edge-to-edge. -->
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -80,9 +80,6 @@
 
         <item name="preferenceTheme">@style/AppPreferenceTheme</item>
 
-        <!-- Transparent system bars for edge-to-edge. -->
-        <item name="android:navigationBarColor">@android:color/transparent</item>
-        <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:windowLightStatusBar">?attr/isLightTheme</item>
     </style>
 


### PR DESCRIPTION
Previous code always set `navigationBarColor` and `statusBarColor` to `transparent` irrespective of the API level.

This only works on API 29 and above; if you do it on API levels lower than that the system navigation buttons (home, back, recents) are typically shown on a very similar colour to the background, making them very hard to see.

Fixes #221