### PR TITLE
ci: Use correct versionCode for orange.* versions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -136,7 +136,7 @@ android {
         variant.outputs.configureEach {
             // Set the "orange" release versionCode to the number of commits on the
             // branch, to ensure the versionCode updates on every release.
-            if (variant.buildType.name == "release" && variant.flavorName == "orange") {
+            if (variant.buildType.name == "release" && variant.flavorName.startsWith("orange")) {
                 versionCodeOverride = gitRevCount
             }
             outputFileName = "Pachli_${variant.versionName}_${variant.versionCode}_${gitSha}_" +


### PR DESCRIPTION
Now that the flavour includes the store name it's not sufficient to check for "orange" as the flavour, as that no longer matches. Now it must start with "orange" to trigger using the git commit count as the version code.