### PR TITLE
fix: Keep network model classes, preventing crash on startup

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -41,6 +41,7 @@
 
 # keep members of our model classes, they are used in json de/serialization
 -keepclassmembers class app.pachli.entity.* { *; }
+-keepclassmembers class app.pachli.network.model.* { *; }
 
 -keep public enum app.pachli.entity.*$** {
     **[] $VALUES;


### PR DESCRIPTION
Without this the model classes are not retained, which causes a `ClassCastException` when parsing the new models for the instance v1 and instance v2 API calls.

Fixes #250