### PR TITLE
fix: Prevent colour related crash on API level ~ 26

### DIFF
--- a/app/src/main/res/layout/item_status_edit.xml
+++ b/app/src/main/res/layout/item_status_edit.xml
@@ -46,7 +46,7 @@
         android:layout_width="0dp"
         android:layout_height="1dp"
         android:layout_marginTop="4dp"
-        android:background="?android:textColorPrimary"
+        android:background="?colorOutline"
         android:importantForAccessibility="no"
         app:layout_constraintEnd_toEndOf="@+id/status_edit_content_warning_description"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
Viewing edited statuses could crash on API levels around 26 with a ResourceNotFoundException. Using `?colorOutline` for the divider colour instead of `?android:textColorPrimary` fixes this, and is also a better colour to use.