### PR TITLE
fix: Ensure update-related data classes are retained

### DIFF
--- a/app/src/fdroid/kotlin/app/pachli/updatecheck/FdroidService.kt
+++ b/app/src/fdroid/kotlin/app/pachli/updatecheck/FdroidService.kt
@@ -17,15 +17,18 @@
 
 package app.pachli.updatecheck
 
+import androidx.annotation.Keep
 import at.connyduck.calladapter.networkresult.NetworkResult
 import retrofit2.http.GET
 import retrofit2.http.Path
 
+@Keep
 data class FdroidPackageVersion(
     val versionName: String,
     val versionCode: Int
 )
 
+@Keep
 data class FdroidPackage(
     val packageName: String,
     val suggestedVersionCode: Int,

--- a/app/src/github/kotlin/app/pachli/updatecheck/GithubService.kt
+++ b/app/src/github/kotlin/app/pachli/updatecheck/GithubService.kt
@@ -17,11 +17,13 @@
 
 package app.pachli.updatecheck
 
+import androidx.annotation.Keep
 import at.connyduck.calladapter.networkresult.NetworkResult
 import com.google.gson.annotations.SerializedName
 import retrofit2.http.GET
 import retrofit2.http.Path
 
+@Keep
 data class GitHubReleaseAsset(
     /** File name for the asset, e.g., "113.apk" */
     val name: String,
@@ -30,6 +32,7 @@ data class GitHubReleaseAsset(
     @SerializedName("content_type") val contentType: String
 )
 
+@Keep
 data class GitHubRelease(
     /** URL for the release's web page */
     @SerializedName("html_url") val htmlUrl: String,


### PR DESCRIPTION
Prevents a crash if Proguard optimises them away in release builds.