### PR TITLE
feat: Warn the user about an Android animation bug

### DIFF
--- a/app/src/main/java/app/pachli/MainActivity.kt
+++ b/app/src/main/java/app/pachli/MainActivity.kt
@@ -788,7 +788,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
                 arrayOf(
                     "Clear home timeline cache",
                     "Remove first 40 statuses",
-                    "Reset janky animation warning flag"
+                    "Reset janky animation warning flag",
                 ),
             ) { _, which ->
                 Timber.d("Developer tools: $which")

--- a/app/src/main/java/app/pachli/PachliApplication.kt
+++ b/app/src/main/java/app/pachli/PachliApplication.kt
@@ -18,6 +18,7 @@
 package app.pachli
 
 import android.app.Application
+import androidx.core.content.edit
 import androidx.work.Constraints
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.PeriodicWorkRequestBuilder
@@ -119,6 +120,14 @@ class PachliApplication : Application() {
     private fun upgradeSharedPreferences(oldVersion: Int, newVersion: Int) {
         Timber.d("Upgrading shared preferences: $oldVersion -> $newVersion")
         val editor = sharedPreferencesRepository.edit()
+
+        if (oldVersion != NEW_INSTALL_SCHEMA_VERSION) {
+            // Upgrading rather than a new install. Possibly show the janky animation warning,
+            // see https://github.com/material-components/material-components-android/issues/3644
+            if (!sharedPreferencesRepository.contains(PrefKeys.SHOW_JANKY_ANIMATION_WARNING)) {
+                sharedPreferencesRepository.edit { putBoolean(PrefKeys.SHOW_JANKY_ANIMATION_WARNING, true) }
+            }
+        }
 
         // General usage is:
         //

--- a/app/src/main/java/app/pachli/settings/SettingsConstants.kt
+++ b/app/src/main/java/app/pachli/settings/SettingsConstants.kt
@@ -112,6 +112,9 @@ object PrefKeys {
     const val UPDATE_NOTIFICATION_VERSIONCODE = "updateNotificationVersioncode"
     const val UPDATE_NOTIFICATION_LAST_NOTIFICATION_MS = "updateNotificationLastNotificationMs"
 
+    /* Flag to show the "janky animation" warning dialog */
+    const val SHOW_JANKY_ANIMATION_WARNING = "showJankyAnimationWarning"
+
     /** Keys that are no longer used (e.g., the preference has been removed */
     object Deprecated {
         // Empty at this time

--- a/app/src/main/java/app/pachli/usecase/DeveloperToolsUseCase.kt
+++ b/app/src/main/java/app/pachli/usecase/DeveloperToolsUseCase.kt
@@ -17,8 +17,11 @@
 
 package app.pachli.usecase
 
+import androidx.core.content.edit
 import app.pachli.db.TimelineDao
 import app.pachli.di.TransactionProvider
+import app.pachli.settings.PrefKeys
+import app.pachli.util.SharedPreferencesRepository
 import javax.inject.Inject
 
 /**
@@ -28,6 +31,7 @@ import javax.inject.Inject
 class DeveloperToolsUseCase @Inject constructor(
     private val transactionProvider: TransactionProvider,
     private val timelineDao: TimelineDao,
+    private val sharedPreferencesRepository: SharedPreferencesRepository,
 ) {
     /**
      * Clear the home timeline cache.
@@ -44,5 +48,10 @@ class DeveloperToolsUseCase @Inject constructor(
             val ids = timelineDao.getMostRecentNStatusIds(accountId, 40)
             timelineDao.deleteRange(accountId, ids.last(), ids.first())
         }
+    }
+
+    /** Reset the SHOW_JANKY_ANIMATION_WARNING flag */
+    fun resetJankyAnimationWarningFlag() = sharedPreferencesRepository.edit {
+        putBoolean(PrefKeys.SHOW_JANKY_ANIMATION_WARNING, true)
     }
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -709,4 +709,6 @@
     <string name="reaction_name_and_count">%1$s %2$d</string>
     <string name="announcement_date">%1$s %2$s</string>
     <string name="announcement_date_updated">(Aktualisiert: %1$s)</string>
+    <string name="janky_animation_title">Möglicherweise müssen Sie Ihr Gerät neu starten</string>
+    <string name="janky_animation_msg">Diese Version von Pachli kann auf einigen Geräten einen Android-Bug auslösen und fehlerhafte Animationen anzeigen.\n\nZum Beispiel, wenn Sie auf einen Beitrag tippen, um ein Thema anzuzeigen.\n\nWenn Sie dies sehen, müssen Sie Ihr Gerät neu starten.\n\nSie müssen dies nur einmal tun.\n\nDies ist ein Android-Fehler, für den Pachli nichts kann.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -844,4 +844,7 @@
 
     <string name="translating">Translating…</string>
     <string name="translation_provider_fmt">%1$s</string>
+
+    <string name="janky_animation_title">You may need to restart your device</string>
+    <string name="janky_animation_msg">This version of Pachli may trigger an Android bug on some devices, and show broken animations.\n\nFor example, when tapping a post to view a thread.\n\nIf you see this you will need to restart your device.\n\nYou only need to do this once.\n\nThis is Android bug, there is nothing Pachli can do.</string>
 </resources>


### PR DESCRIPTION
Upgrading to this version of Pachli may trigger an Android bug where cached animation specifications are not cleared, resulting in incorrect animations (e.g., when navigating between activities).

This is an Android bug triggered by the Android Material library, https://github.com/material-components/material-components-android/issues/3644.

Show the user a dialog (once) when launching after an upgrade, so they know to restart their device if necessary.