### PR TITLE
feat: Increase the amount of information in link previews

### DIFF
--- a/app/src/main/res/layout/preview_card.xml
+++ b/app/src/main/res/layout/preview_card.xml
@@ -53,7 +53,7 @@
                 android:layout_marginBottom="4dp"
                 android:ellipsize="end"
                 android:fontFamily="sans-serif-medium"
-                android:lines="1"
+                android:maxLines="2"
                 android:textColor="?android:textColorSecondary"
                 android:textSize="?attr/status_text_medium"
                 tools:ignore="SelectableText" />
@@ -65,7 +65,7 @@
                 android:layout_marginBottom="4dp"
                 android:ellipsize="end"
                 android:lineSpacingMultiplier="1.1"
-                android:maxLines="2"
+                android:maxLines="3"
                 android:textColor="?android:textColorSecondary"
                 android:textSize="?attr/status_text_medium"
                 tools:ignore="SelectableText" />


### PR DESCRIPTION
Show up to two lines of the link's title and three lines of the link's description in link preview cards. This provides additional useful context to the user, especially when many links bury the important information at the end of the title.