### PR TITLE
feat: Display compose button when viewing favorites list

### DIFF
--- a/app/src/main/java/app/pachli/StatusListActivity.kt
+++ b/app/src/main/java/app/pachli/StatusListActivity.kt
@@ -121,6 +121,12 @@ class StatusListActivity : BottomSheetActivity(), AppBarLayoutHost, ActionButton
                     ),
                 )
             }
+            is TimelineKind.Favourites -> {
+                ComposeActivity.startIntent(
+                    this,
+                    ComposeActivity.ComposeOptions(),
+                )
+            }
             else -> null
         }
 


### PR DESCRIPTION
# Overview
Display the "compose" FAB when viewing a favourite list. 
Tapping the button will open the `ComposeActivity` for creating new toot.

# Screenshots
Before | After
:--: | :--:
|![image](https://github.com/pachli/pachli-android/assets/62137820/40d4446a-4c35-407d-8537-19224ba9e6a6)|![image](https://github.com/pachli/pachli-android/assets/62137820/093b1355-2ce6-4d0e-8f81-77b5a7eb5a53)

# Related issue
Fixes #229