### PR TITLE
refactor: Use the correct package for TimelineKind

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -3644,7 +3644,7 @@
         errorLine2="                                              ~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/components/timeline/TimelineFragment.kt"
-            line="195"
+            line="196"
             column="47"/>
     </issue>
 

--- a/app/src/main/java/app/pachli/StatusListActivity.kt
+++ b/app/src/main/java/app/pachli/StatusListActivity.kt
@@ -28,9 +28,9 @@ import app.pachli.appstore.EventHub
 import app.pachli.appstore.FilterChangedEvent
 import app.pachli.components.compose.ComposeActivity
 import app.pachli.components.timeline.TimelineFragment
-import app.pachli.components.timeline.TimelineKind
 import app.pachli.core.network.model.Filter
 import app.pachli.core.network.model.FilterV1
+import app.pachli.core.network.model.TimelineKind
 import app.pachli.databinding.ActivityStatuslistBinding
 import app.pachli.interfaces.ActionButtonActivity
 import app.pachli.interfaces.AppBarLayoutHost

--- a/app/src/main/java/app/pachli/TabViewData.kt
+++ b/app/src/main/java/app/pachli/TabViewData.kt
@@ -24,11 +24,11 @@ import androidx.fragment.app.Fragment
 import app.pachli.components.conversation.ConversationsFragment
 import app.pachli.components.notifications.NotificationsFragment
 import app.pachli.components.timeline.TimelineFragment
-import app.pachli.components.timeline.TimelineKind
 import app.pachli.components.trending.TrendingLinksFragment
 import app.pachli.components.trending.TrendingTagsFragment
 import app.pachli.core.database.model.TabData
 import app.pachli.core.database.model.TabKind
+import app.pachli.core.network.model.TimelineKind
 
 /**
  * Wrap a [TabData] with additional information to display a tab with that data.

--- a/app/src/main/java/app/pachli/components/account/AccountPagerAdapter.kt
+++ b/app/src/main/java/app/pachli/components/account/AccountPagerAdapter.kt
@@ -20,7 +20,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import app.pachli.components.account.media.AccountMediaFragment
 import app.pachli.components.timeline.TimelineFragment
-import app.pachli.components.timeline.TimelineKind
+import app.pachli.core.network.model.TimelineKind
 import app.pachli.interfaces.RefreshableFragment
 import app.pachli.util.CustomFragmentStateAdapter
 

--- a/app/src/main/java/app/pachli/components/timeline/CachedTimelineRepository.kt
+++ b/app/src/main/java/app/pachli/components/timeline/CachedTimelineRepository.kt
@@ -33,6 +33,7 @@ import app.pachli.core.database.model.StatusViewDataEntity
 import app.pachli.core.database.model.TimelineStatusWithAccount
 import app.pachli.core.database.model.TranslatedStatusEntity
 import app.pachli.core.database.model.TranslationState
+import app.pachli.core.network.model.TimelineKind
 import app.pachli.core.network.model.Translation
 import app.pachli.core.network.retrofit.MastodonApi
 import app.pachli.util.EmptyPagingSource

--- a/app/src/main/java/app/pachli/components/timeline/NetworkTimelineRepository.kt
+++ b/app/src/main/java/app/pachli/components/timeline/NetworkTimelineRepository.kt
@@ -28,6 +28,7 @@ import app.pachli.components.timeline.viewmodel.NetworkTimelineRemoteMediator
 import app.pachli.components.timeline.viewmodel.PageCache
 import app.pachli.core.accounts.AccountManager
 import app.pachli.core.network.model.Status
+import app.pachli.core.network.model.TimelineKind
 import app.pachli.core.network.retrofit.MastodonApi
 import app.pachli.util.getDomain
 import kotlinx.coroutines.CoroutineScope

--- a/app/src/main/java/app/pachli/components/timeline/TimelineFragment.kt
+++ b/app/src/main/java/app/pachli/components/timeline/TimelineFragment.kt
@@ -53,6 +53,7 @@ import app.pachli.components.timeline.viewmodel.TimelineViewModel
 import app.pachli.components.timeline.viewmodel.UiSuccess
 import app.pachli.core.database.model.TranslationState
 import app.pachli.core.network.model.Status
+import app.pachli.core.network.model.TimelineKind
 import app.pachli.databinding.FragmentTimelineBinding
 import app.pachli.fragment.SFragment
 import app.pachli.interfaces.ActionButtonActivity

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelineRemoteMediator.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelineRemoteMediator.kt
@@ -23,9 +23,9 @@ import androidx.paging.LoadType
 import androidx.paging.PagingState
 import androidx.paging.RemoteMediator
 import app.pachli.BuildConfig
-import app.pachli.components.timeline.TimelineKind
 import app.pachli.core.accounts.AccountManager
 import app.pachli.core.network.model.Status
+import app.pachli.core.network.model.TimelineKind
 import app.pachli.core.network.retrofit.MastodonApi
 import kotlinx.coroutines.CoroutineScope
 import retrofit2.HttpException

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/TimelineViewModel.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/TimelineViewModel.kt
@@ -43,12 +43,12 @@ import app.pachli.appstore.StatusEditedEvent
 import app.pachli.appstore.UnfollowEvent
 import app.pachli.components.timeline.FilterKind
 import app.pachli.components.timeline.FiltersRepository
-import app.pachli.components.timeline.TimelineKind
 import app.pachli.components.timeline.util.ifExpected
 import app.pachli.core.accounts.AccountManager
 import app.pachli.core.network.model.Filter
 import app.pachli.core.network.model.Poll
 import app.pachli.core.network.model.Status
+import app.pachli.core.network.model.TimelineKind
 import app.pachli.core.preferences.PrefKeys
 import app.pachli.core.preferences.SharedPreferencesRepository
 import app.pachli.network.FilterModel

--- a/app/src/main/java/app/pachli/components/trending/TrendingActivity.kt
+++ b/app/src/main/java/app/pachli/components/trending/TrendingActivity.kt
@@ -32,7 +32,7 @@ import androidx.viewpager2.adapter.FragmentStateAdapter
 import app.pachli.BottomSheetActivity
 import app.pachli.R
 import app.pachli.components.timeline.TimelineFragment
-import app.pachli.components.timeline.TimelineKind
+import app.pachli.core.network.model.TimelineKind
 import app.pachli.databinding.ActivityTrendingBinding
 import app.pachli.interfaces.AppBarLayoutHost
 import app.pachli.util.reduceSwipeSensitivity

--- a/app/src/test/java/app/pachli/components/timeline/CachedTimelineViewModelTestBase.kt
+++ b/app/src/test/java/app/pachli/components/timeline/CachedTimelineViewModelTestBase.kt
@@ -25,6 +25,7 @@ import app.pachli.components.timeline.viewmodel.CachedTimelineViewModel
 import app.pachli.components.timeline.viewmodel.TimelineViewModel
 import app.pachli.core.accounts.AccountManager
 import app.pachli.core.network.model.Account
+import app.pachli.core.network.model.TimelineKind
 import app.pachli.core.network.retrofit.MastodonApi
 import app.pachli.core.preferences.SharedPreferencesRepository
 import app.pachli.core.testing.rules.MainCoroutineRule

--- a/app/src/test/java/app/pachli/components/timeline/CachedTimelineViewModelTestVisibleId.kt
+++ b/app/src/test/java/app/pachli/components/timeline/CachedTimelineViewModelTestVisibleId.kt
@@ -18,6 +18,7 @@
 package app.pachli.components.timeline
 
 import app.pachli.components.timeline.viewmodel.InfallibleUiAction
+import app.pachli.core.network.model.TimelineKind
 import com.google.common.truth.Truth.assertThat
 import dagger.hilt.android.testing.HiltAndroidTest
 import kotlinx.coroutines.test.runTest

--- a/app/src/test/java/app/pachli/components/timeline/NetworkTimelineRemoteMediatorTest.kt
+++ b/app/src/test/java/app/pachli/components/timeline/NetworkTimelineRemoteMediatorTest.kt
@@ -31,6 +31,7 @@ import app.pachli.components.timeline.viewmodel.PageCache
 import app.pachli.core.accounts.AccountManager
 import app.pachli.core.database.model.AccountEntity
 import app.pachli.core.network.model.Status
+import app.pachli.core.network.model.TimelineKind
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
 import okhttp3.Headers

--- a/app/src/test/java/app/pachli/components/timeline/NetworkTimelineViewModelTestBase.kt
+++ b/app/src/test/java/app/pachli/components/timeline/NetworkTimelineViewModelTestBase.kt
@@ -24,6 +24,7 @@ import app.pachli.components.timeline.viewmodel.NetworkTimelineViewModel
 import app.pachli.components.timeline.viewmodel.TimelineViewModel
 import app.pachli.core.accounts.AccountManager
 import app.pachli.core.network.model.Account
+import app.pachli.core.network.model.TimelineKind
 import app.pachli.core.network.retrofit.MastodonApi
 import app.pachli.core.preferences.SharedPreferencesRepository
 import app.pachli.core.testing.rules.MainCoroutineRule

--- a/app/src/test/java/app/pachli/components/timeline/NetworkTimelineViewModelTestVisibleId.kt
+++ b/app/src/test/java/app/pachli/components/timeline/NetworkTimelineViewModelTestVisibleId.kt
@@ -18,6 +18,7 @@
 package app.pachli.components.timeline
 
 import app.pachli.components.timeline.viewmodel.InfallibleUiAction
+import app.pachli.core.network.model.TimelineKind
 import com.google.common.truth.Truth.assertThat
 import dagger.hilt.android.testing.HiltAndroidTest
 import kotlinx.coroutines.test.runTest

--- a/core/network/src/main/kotlin/app/pachli/core/network/model/Filter.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/Filter.kt
@@ -1,7 +1,6 @@
 package app.pachli.core.network.model
 
 import android.os.Parcelable
-import app.pachli.components.timeline.TimelineKind
 import com.google.gson.annotations.SerializedName
 import kotlinx.parcelize.Parcelize
 import java.util.Date

--- a/core/network/src/main/kotlin/app/pachli/core/network/model/TimelineKind.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/TimelineKind.kt
@@ -15,7 +15,7 @@
  * see <http://www.gnu.org/licenses>.
  */
 
-package app.pachli.components.timeline
+package app.pachli.core.network.model
 
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize


### PR DESCRIPTION
The package wasn't renamed when it was moved, so was still `app.pachli.components.timeline`, instead of the new location, `app.pachli.core.network.model`.