### PR TITLE
feat: Show roles on profiles

### DIFF
--- a/app/src/main/java/app/pachli/components/account/AccountViewModel.kt
+++ b/app/src/main/java/app/pachli/components/account/AccountViewModel.kt
@@ -44,6 +44,9 @@ class AccountViewModel @Inject constructor(
     lateinit var accountId: String
     var isSelf = false
 
+    /** The domain of the viewed account **/
+    var domain = ""
+
     /** True if the viewed account has the same domain as the active account */
     var isFromOwnDomain = false
 
@@ -70,11 +73,12 @@ class AccountViewModel @Inject constructor(
                 mastodonApi.account(accountId)
                     .fold(
                         { account ->
+                            domain = getDomain(account.url)
                             accountData.postValue(Success(account))
                             isDataLoading = false
                             isRefreshing.postValue(false)
 
-                            isFromOwnDomain = getDomain(account.url) == activeAccount.domain
+                            isFromOwnDomain = domain == activeAccount.domain
                         },
                         { t ->
                             Timber.w("failed obtaining account", t)

--- a/app/src/main/res/drawable/profile_role_badge.xml
+++ b/app/src/main/res/drawable/profile_role_badge.xml
@@ -1,0 +1,22 @@
+<!--
+  ~ Copyright 2023 Pachli Association
+  ~
+  ~ This file is a part of Pachli.
+  ~
+  ~ This program is free software; you can redistribute it and/or modify it under the terms of the
+  ~ GNU General Public License as published by the Free Software Foundation; either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+  ~ the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+  ~ Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License along with Pachli; if not,
+  ~ see <http://www.gnu.org/licenses>.
+  -->
+
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M20,7h-5V4c0,-1.1 -0.9,-2 -2,-2h-2C9.9,2 9,2.9 9,4v3H4C2.9,7 2,7.9 2,9v11c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2V9C22,7.9 21.1,7 20,7zM9,12c0.83,0 1.5,0.67 1.5,1.5S9.83,15 9,15s-1.5,-0.67 -1.5,-1.5S8.17,12 9,12zM12,18H6v-0.75c0,-1 2,-1.5 3,-1.5s3,0.5 3,1.5V18zM13,9h-2V4h2V9zM18,16.5h-4V15h4V16.5zM18,13.5h-4V12h4V13.5z"/>
+</vector>

--- a/app/src/main/res/layout/activity_account.xml
+++ b/app/src/main/res/layout/activity_account.xml
@@ -150,42 +150,43 @@
                         app:srcCompat="@drawable/ic_reblog_private_24dp"
                         tools:visibility="visible" />
 
-                    <TextView
-                        android:id="@+id/accountFollowsYouTextView"
+                    <com.google.android.material.chip.Chip
+                        android:id="@+id/accountFollowsYouChip"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="6dp"
                         android:background="@drawable/profile_badge_background"
+                        android:clickable="false"
+                        android:focusable="false"
+                        android:minHeight="@dimen/profile_badge_min_height"
                         android:text="@string/follows_you"
                         android:textSize="?attr/status_text_small"
-                        android:textColor="?colorOnPrimaryContainer"
                         android:visibility="gone"
+                        app:chipBackgroundColor="#0000"
+                        app:chipMinHeight="@dimen/profile_badge_min_height"
+                        app:chipStrokeColor="?android:attr/textColorTertiary"
+                        app:chipStrokeWidth="@dimen/profile_badge_stroke_width"
+                        app:ensureMinTouchTargetSize="false"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toBottomOf="@id/accountUsernameTextView"
                         tools:visibility="visible" />
 
-                    <TextView
-                        android:id="@+id/accountBadgeTextView"
-                        android:layout_width="wrap_content"
+                    <com.google.android.material.chip.ChipGroup
+                        android:id="@+id/accountBadgeContainer"
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginStart="8dp"
                         android:layout_marginTop="6dp"
-                        android:background="@drawable/profile_badge_background"
-                        android:textColor="?colorOnPrimaryContainer"
-                        android:text="@string/profile_badge_bot_text"
-                        android:textSize="?attr/status_text_small"
-                        android:visibility="gone"
-                        app:layout_constraintStart_toEndOf="@id/accountFollowsYouTextView"
-                        app:layout_constraintTop_toBottomOf="@id/accountUsernameTextView"
-                        app:layout_goneMarginStart="0dp"
-                        tools:visibility="visible" />
+                        app:chipSpacingVertical="4dp"
+                        app:layout_constraintStart_toEndOf="@id/accountUsernameTextView"
+                        app:layout_constraintTop_toBottomOf="@id/accountFollowsYouChip"
+                        app:layout_goneMarginStart="0dp" />
 
                     <androidx.constraintlayout.widget.Barrier
                         android:id="@+id/labelBarrier"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         app:barrierDirection="bottom"
-                        app:constraint_referenced_ids="accountFollowsYouTextView,accountBadgeTextView" />
+                        app:constraint_referenced_ids="accountFollowsYouChip,accountBadgeContainer" />
 
                     <com.google.android.material.textfield.TextInputLayout
                         android:id="@+id/accountNoteTextInputLayout"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -43,6 +43,11 @@
     <dimen name="min_report_button_width">160dp</dimen>
     <dimen name="account_avatar_background_radius">14dp</dimen>
 
+    <dimen name="profile_badge_stroke_width">1dp</dimen>
+    <dimen name="profile_badge_min_height">24dp</dimen>
+    <dimen name="profile_badge_icon_size">16dp</dimen>
+    <dimen name="profile_badge_icon_start_padding">4dp</dimen>
+    <dimen name="profile_badge_icon_end_padding">0dp</dimen>
 
     <dimen name="card_radius">5dp</dimen>
 

--- a/core/network/src/main/kotlin/app/pachli/core/network/model/Account.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/Account.kt
@@ -38,7 +38,7 @@ data class Account(
     val emojis: List<Emoji>? = emptyList(), // nullable for backward compatibility
     val fields: List<Field>? = emptyList(), // nullable for backward compatibility
     val moved: Account? = null,
-
+    val roles: List<Role>? = emptyList()
 ) {
 
     val name: String
@@ -68,4 +68,14 @@ data class Field(
 data class StringField(
     val name: String,
     val value: String,
+)
+
+/** [Mastodon Entities: Role](https://docs.joinmastodon.org/entities/Role) */
+data class Role(
+    /** Displayable name of the role */
+    val name: String,
+    /** Colour to use for the role badge, may be the empty string */
+    val color: String,
+    /** True if the badge should be displayed on the account profile */
+    val highlighted: Boolean,
 )


### PR DESCRIPTION
Roles for the logged in user appeared in Mastodon 4.0.0 and can be displayed on the user's profile screen.

Show them as chips, adjusting the display of the existing "Follows you" and "Bot" indicators to make allowances for this.

Roles can have a custom colour assigned by the server admin. This is blended with the app colour so it is not too jarring in the display.

See also https://github.com/tuskyapp/Tusky/pull/4029