### PR TITLE
fix: Show translated content when viewing a thread

### DIFF
--- a/app/src/main/java/app/pachli/components/timeline/CachedTimelineRepository.kt
+++ b/app/src/main/java/app/pachli/components/timeline/CachedTimelineRepository.kt
@@ -156,6 +156,13 @@ class CachedTimelineRepository @Inject constructor(
         return timelineDao.getStatusViewData(activeAccount!!.id, statusId)
     }
 
+    /**
+     * @return Map between statusIDs and any translations for them cached in the repository.
+     */
+    suspend fun getStatusTranslations(statusIds: List<String>): Map<String, TranslatedStatusEntity> {
+        return translatedStatusDao.getTranslations(activeAccount!!.id, statusIds)
+    }
+
     /** Remove all statuses authored/boosted by the given account, for the active account */
     suspend fun removeAllByAccountId(accountId: String) = externalScope.launch {
         timelineDao.removeAllByUser(activeAccount!!.id, accountId)

--- a/app/src/main/java/app/pachli/components/viewthread/ViewThreadViewModel.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/ViewThreadViewModel.kt
@@ -195,8 +195,8 @@ class ViewThreadViewModel @Inject constructor(
             contextResult.fold({ statusContext ->
                 val ids = statusContext.ancestors.map { it.id } + statusContext.descendants.map { it.id }
                 val cachedViewData = repository.getStatusViewData(ids)
-                val ancestors = statusContext.ancestors.map {
-                        status ->
+                val cachedTranslations = repository.getStatusTranslations(ids)
+                val ancestors = statusContext.ancestors.map { status ->
                     val svd = cachedViewData[status.id]
                     StatusViewData.from(
                         status,
@@ -205,6 +205,7 @@ class ViewThreadViewModel @Inject constructor(
                         isCollapsed = svd?.contentCollapsed ?: true,
                         isDetailed = false,
                         translationState = svd?.translationState ?: TranslationState.SHOW_ORIGINAL,
+                        translation = cachedTranslations[status.id],
                     )
                 }.filterByFilterAction()
                 val descendants = statusContext.descendants.map {
@@ -217,6 +218,7 @@ class ViewThreadViewModel @Inject constructor(
                         isCollapsed = svd?.contentCollapsed ?: true,
                         isDetailed = false,
                         translationState = svd?.translationState ?: TranslationState.SHOW_ORIGINAL,
+                        translation = cachedTranslations[status.id],
                     )
                 }.filterByFilterAction()
                 val statuses = ancestors + detailedStatus + descendants

--- a/app/src/main/java/app/pachli/viewdata/StatusViewData.kt
+++ b/app/src/main/java/app/pachli/viewdata/StatusViewData.kt
@@ -18,6 +18,7 @@ package app.pachli.viewdata
 import android.os.Build
 import android.text.Spanned
 import android.text.SpannedString
+import app.pachli.BuildConfig
 import app.pachli.core.database.model.ConversationAccountEntity
 import app.pachli.core.database.model.ConversationStatusEntity
 import app.pachli.core.database.model.TimelineStatusWithAccount
@@ -191,16 +192,29 @@ data class StatusViewData(
             filterAction: Filter.Action = Filter.Action.NONE,
             translationState: TranslationState = TranslationState.SHOW_ORIGINAL,
             translation: TranslatedStatusEntity? = null,
-        ) = StatusViewData(
-            status = status,
-            isShowingContent = isShowingContent,
-            isCollapsed = isCollapsed,
-            isExpanded = isExpanded,
-            isDetailed = isDetailed,
-            filterAction = filterAction,
-            translationState = translationState,
-            translation = translation,
-        )
+        ): StatusViewData {
+            if (BuildConfig.DEBUG) {
+                // TODO: Ensure that invalid state is not representable.
+                // Currently the translation is encoded in both `translationState` and
+                // `translation`. If they get out of sync then this will fire. It would be
+                // better to encode the translation in a single type (enum, sealed class?)
+                // that can only represent valid states, so this can't happen.
+                if (translationState == TranslationState.SHOW_TRANSLATION && translation == null) {
+                    throw IllegalStateException("trying to show a null translation")
+                }
+            }
+
+            return StatusViewData(
+                status = status,
+                isShowingContent = isShowingContent,
+                isCollapsed = isCollapsed,
+                isExpanded = isExpanded,
+                isDetailed = isDetailed,
+                filterAction = filterAction,
+                translationState = translationState,
+                translation = translation,
+            )
+        }
 
         fun from(conversationStatusEntity: ConversationStatusEntity) = StatusViewData(
             status = Status(

--- a/app/src/test/java/app/pachli/components/viewthread/ViewThreadViewModelTest.kt
+++ b/app/src/test/java/app/pachli/components/viewthread/ViewThreadViewModelTest.kt
@@ -165,6 +165,7 @@ class ViewThreadViewModelTest {
 
         val cachedTimelineRepository: CachedTimelineRepository = mock {
             onBlocking { getStatusViewData(any()) } doReturn emptyMap()
+            onBlocking { getStatusTranslations(any()) } doReturn emptyMap()
         }
 
         val serverCapabilitiesRepository = ServerCapabilitiesRepository(

--- a/core/database/src/main/kotlin/app/pachli/core/database/dao/TranslatedStatusDao.kt
+++ b/core/database/src/main/kotlin/app/pachli/core/database/dao/TranslatedStatusDao.kt
@@ -18,6 +18,8 @@
 package app.pachli.core.database.dao
 
 import androidx.room.Dao
+import androidx.room.MapColumn
+import androidx.room.Query
 import androidx.room.Upsert
 import app.pachli.core.database.model.TranslatedStatusEntity
 
@@ -25,4 +27,16 @@ import app.pachli.core.database.model.TranslatedStatusEntity
 interface TranslatedStatusDao {
     @Upsert
     suspend fun upsert(translatedStatusEntity: TranslatedStatusEntity)
+
+    /**
+     * @return map from statusIDs to known translations for those IDs
+     */
+    @Query(
+        """SELECT *
+            FROM TranslatedStatusEntity
+            WHERE timelineUserId = :accountId
+            AND serverId IN (:serverIds)""",
+    )
+    suspend fun getTranslations(accountId: Long, serverIds: List<String>):
+        Map<@MapColumn(columnName = "serverId") String, TranslatedStatusEntity>
 }

--- a/core/database/src/main/kotlin/app/pachli/core/database/model/TranslatedStatusEntity.kt
+++ b/core/database/src/main/kotlin/app/pachli/core/database/model/TranslatedStatusEntity.kt
@@ -46,7 +46,7 @@ data class TranslatedStatusEntity(
 
     /**
      * The translated spoiler text of the status (text), if it exists, equivalent to
-     * [Status.spoilerText]
+     * [app.pachli.core.network.model.Status.spoilerText]
      */
     // Not documented, see https://github.com/mastodon/documentation/issues/1248
     val spoilerText: String,


### PR DESCRIPTION
If a status was part of a thread, and it was not the "detailed" status, and it had been translated, then the view data was marked as "show the translation". But the translation was not loaded, so the status content appeared as empty.

Fix that by loading the translated content of all statuses in the thead and ensure that the translated content is rendered.

Throw an `IllegalStateException` in debug builds to catch any future occurrences of this.

Fixes #281