### PR TITLE
fix: Correctly show if an account is a bot or not

### DIFF
--- a/app/src/main/java/app/pachli/components/account/AccountActivity.kt
+++ b/app/src/main/java/app/pachli/components/account/AccountActivity.kt
@@ -772,7 +772,7 @@ class AccountActivity :
             }
         }
 
-        if (loadedAccount?.bot == false) {
+        if (loadedAccount?.bot == true) {
             val badgeView = getBadge(
                 MaterialColors.getColor(
                     binding.accountBadgeContainer,


### PR DESCRIPTION
e35fa1db inadvertently contained some left over debug code that treats non-bot accounts as bots (for displaying the bot badge) and vice versa.

Fixes #321