### PR TITLE
fix: Prevent a crash if trending tags, links, or statuses are added to tabs

### DIFF
--- a/core/database/src/main/kotlin/app/pachli/core/database/model/TabData.kt
+++ b/core/database/src/main/kotlin/app/pachli/core/database/model/TabData.kt
@@ -28,9 +28,9 @@ enum class TabKind(val repr: String) {
     LOCAL("Local"),
     FEDERATED("Federated"),
     DIRECT("Direct"),
-    TRENDING_TAGS("TrendingTags"),
-    TRENDING_LINKS("TrendingLinks"),
-    TRENDING_STATUSES("TrendingStatuses"),
+    TRENDING_TAGS("Trending_Tags"),
+    TRENDING_LINKS("Trending_Links"),
+    TRENDING_STATUSES("Trending_Statuses"),
     HASHTAG("Hashtag"),
     LIST("List"),
     BOOKMARKS("Bookmarks")


### PR DESCRIPTION
The previous code was serialising the `TabKind` enum without the `_`, so
when it was converted back to the enum name (which has a `_`) it failed
and immediately crashed.

Fixes #306