### PR TITLE
fix: Prevent crash by keeping network.model.** classes

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -38,7 +38,7 @@
 # Pachli specific options
 
 # keep members of our model classes, they are used in json de/serialization
--keepclassmembers class app.pachli.core.network.model.* { *; }
+-keepclassmembers class app.pachli.core.network.model.** { *; }
 
 -keep public enum app.pachli.core.network.model.*$** {
     **[] $VALUES;


### PR DESCRIPTION
Previous rule didn't consider a deeper package hierarchy, so the new NodeInfo classes were being removed by ProGuard.