### PR TITLE
fix: Show display name in timelines, not the username

### DIFF
--- a/core/network/src/main/kotlin/app/pachli/core/network/model/TimelineAccount.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/TimelineAccount.kt
@@ -29,7 +29,7 @@ data class TimelineAccount(
     @SerializedName("acct") val username: String,
     // should never be null per Api definition, but some servers break the contract
     @Deprecated("prefer the `name` property, which is not-null and not-empty")
-    val displayName: String?,
+    @SerializedName("display_name") val displayName: String?,
     val url: String,
     val avatar: String,
     val note: String,


### PR DESCRIPTION
Commit 993b7469 inadvertently broke this by removing the @SerializedName annotation, so the user's display name was always null and the UI fell back to showing the username.

Fixes #371