### PR TITLE
fix: Show correct trending tag values at the end of the chart lines

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -1433,7 +1433,7 @@
         errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/colors.xml"
-            line="101"
+            line="105"
             column="12"/>
     </issue>
 
@@ -1444,7 +1444,7 @@
         errorLine2="           ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/colors.xml"
-            line="102"
+            line="106"
             column="12"/>
     </issue>
 
@@ -2027,7 +2027,7 @@
         errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/styles.xml"
-            line="127"
+            line="129"
             column="12"/>
     </issue>
 
@@ -2038,7 +2038,7 @@
         errorLine2="           ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/styles.xml"
-            line="165"
+            line="173"
             column="12"/>
     </issue>
 
@@ -4791,55 +4791,11 @@
     <issue
         id="SelectableText"
         message="Consider making the text value selectable by specifying `android:textIsSelectable=&quot;true&quot;`"
-        errorLine1="    &lt;TextView"
-        errorLine2="     ~~~~~~~~">
-        <location
-            file="src/main/res/layout-land/item_trending_cell.xml"
-            line="33"
-            column="6"/>
-    </issue>
-
-    <issue
-        id="SelectableText"
-        message="Consider making the text value selectable by specifying `android:textIsSelectable=&quot;true&quot;`"
-        errorLine1="    &lt;TextView"
-        errorLine2="     ~~~~~~~~">
-        <location
-            file="src/main/res/layout/item_trending_cell.xml"
-            line="33"
-            column="6"/>
-    </issue>
-
-    <issue
-        id="SelectableText"
-        message="Consider making the text value selectable by specifying `android:textIsSelectable=&quot;true&quot;`"
-        errorLine1="    &lt;TextView"
-        errorLine2="     ~~~~~~~~">
-        <location
-            file="src/main/res/layout-land/item_trending_cell.xml"
-            line="50"
-            column="6"/>
-    </issue>
-
-    <issue
-        id="SelectableText"
-        message="Consider making the text value selectable by specifying `android:textIsSelectable=&quot;true&quot;`"
-        errorLine1="    &lt;TextView"
-        errorLine2="     ~~~~~~~~">
-        <location
-            file="src/main/res/layout/item_trending_cell.xml"
-            line="50"
-            column="6"/>
-    </issue>
-
-    <issue
-        id="SelectableText"
-        message="Consider making the text value selectable by specifying `android:textIsSelectable=&quot;true&quot;`"
         errorLine1="        &lt;TextView"
         errorLine2="         ~~~~~~~~">
         <location
             file="src/main/res/layout-land/item_trending_cell.xml"
-            line="79"
+            line="41"
             column="10"/>
     </issue>
 
@@ -4850,7 +4806,7 @@
         errorLine2="         ~~~~~~~~">
         <location
             file="src/main/res/layout/item_trending_cell.xml"
-            line="79"
+            line="41"
             column="10"/>
     </issue>
 
@@ -4861,7 +4817,7 @@
         errorLine2="         ~~~~~~~~">
         <location
             file="src/main/res/layout-land/item_trending_cell.xml"
-            line="94"
+            line="56"
             column="10"/>
     </issue>
 
@@ -4872,7 +4828,7 @@
         errorLine2="         ~~~~~~~~">
         <location
             file="src/main/res/layout/item_trending_cell.xml"
-            line="94"
+            line="56"
             column="10"/>
     </issue>
 
@@ -4883,7 +4839,7 @@
         errorLine2="         ~~~~~~~~">
         <location
             file="src/main/res/layout-land/item_trending_cell.xml"
-            line="125"
+            line="87"
             column="10"/>
     </issue>
 
@@ -4894,7 +4850,7 @@
         errorLine2="         ~~~~~~~~">
         <location
             file="src/main/res/layout/item_trending_cell.xml"
-            line="126"
+            line="88"
             column="10"/>
     </issue>
 
@@ -4983,50 +4939,6 @@
         <location
             file="src/main/res/layout/item_status.xml"
             line="237"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="SmallSp"
-        message="Avoid using sizes smaller than `11sp`: `8sp`"
-        errorLine1="        android:textSize=&quot;8sp&quot;"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/layout-land/item_trending_cell.xml"
-            line="42"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="SmallSp"
-        message="Avoid using sizes smaller than `11sp`: `8sp`"
-        errorLine1="        android:textSize=&quot;8sp&quot;"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/layout/item_trending_cell.xml"
-            line="42"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="SmallSp"
-        message="Avoid using sizes smaller than `11sp`: `8sp`"
-        errorLine1="        android:textSize=&quot;8sp&quot;"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/layout-land/item_trending_cell.xml"
-            line="59"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="SmallSp"
-        message="Avoid using sizes smaller than `11sp`: `8sp`"
-        errorLine1="        android:textSize=&quot;8sp&quot;"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/layout/item_trending_cell.xml"
-            line="59"
             column="9"/>
     </issue>
 
@@ -5181,50 +5093,6 @@
         <location
             file="src/main/res/layout/item_status_notification.xml"
             line="22"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="RtlSymmetry"
-        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
-        errorLine1="        android:paddingStart=&quot;6dp&quot;"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/layout-land/item_trending_cell.xml"
-            line="38"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="RtlSymmetry"
-        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
-        errorLine1="        android:paddingStart=&quot;6dp&quot;"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/layout/item_trending_cell.xml"
-            line="38"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="RtlSymmetry"
-        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
-        errorLine1="        android:paddingStart=&quot;6dp&quot;"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/layout-land/item_trending_cell.xml"
-            line="55"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="RtlSymmetry"
-        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
-        errorLine1="        android:paddingStart=&quot;6dp&quot;"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/layout/item_trending_cell.xml"
-            line="55"
             column="9"/>
     </issue>
 

--- a/app/src/main/java/app/pachli/components/trending/TrendingTagViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/trending/TrendingTagViewHolder.kt
@@ -41,9 +41,6 @@ class TrendingTagViewHolder(
         val totalAccounts = tagViewData.accounts.sum()
         binding.totalAccounts.text = formatNumber(totalAccounts, 1000)
 
-        binding.currentUsage.text = tagViewData.usage.last().toString()
-        binding.currentAccounts.text = tagViewData.usage.last().toString()
-
         itemView.setOnClickListener {
             onViewTag(tagViewData.name)
         }

--- a/app/src/main/res/layout-land/item_trending_cell.xml
+++ b/app/src/main/res/layout-land/item_trending_cell.xml
@@ -21,48 +21,10 @@
         android:importantForAccessibility="no"
         app:graphColor="?android:colorBackground"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/current_usage"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:lineWidth="2sp"
-        app:metaColor="@color/tusky_blue_light"
-        app:primaryLineColor="@color/tusky_blue"
-        app:proportionalTrending="true"
-        app:secondaryLineColor="@color/tusky_red" />
-
-    <TextView
-        android:id="@+id/current_usage"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:importantForAccessibility="no"
-        android:paddingStart="6dp"
-        android:textAlignment="textEnd"
-        android:textAppearance="@style/TextAppearance.AppCompat.Small"
-        android:textColor="@color/tusky_blue"
-        android:textSize="8sp"
-        android:textStyle="normal"
-        app:layout_constrainedWidth="true"
-        app:layout_constraintBottom_toTopOf="@id/current_accounts"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@id/graph"
-        tools:text="12 345" />
-
-    <TextView
-        android:id="@+id/current_accounts"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:importantForAccessibility="no"
-        android:paddingStart="6dp"
-        android:textAlignment="textEnd"
-        android:textAppearance="@style/TextAppearance.AppCompat.Small"
-        android:textColor="@color/tusky_red"
-        android:textSize="8sp"
-        android:textStyle="normal"
-        app:layout_constrainedWidth="true"
-        app:layout_constraintBottom_toBottomOf="@id/graph"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@id/graph"
-        tools:text="12 345" />
+        app:proportionalTrending="true" />
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/legend_container"
@@ -99,7 +61,7 @@
             android:importantForAccessibility="no"
             android:textAlignment="textEnd"
             android:textAppearance="?android:attr/textAppearanceListItemSmall"
-            android:textColor="@color/tusky_blue"
+            android:textColor="@color/pachli_blue"
             android:textStyle="normal|bold"
             app:layout_constrainedWidth="false"
             app:layout_constraintEnd_toStartOf="@id/barrier2"
@@ -129,7 +91,7 @@
             android:importantForAccessibility="no"
             android:textAlignment="textEnd"
             android:textAppearance="?android:attr/textAppearanceListItemSmall"
-            android:textColor="@color/tusky_red"
+            android:textColor="@color/pachli_orange"
             android:textStyle="normal|bold"
             app:layout_constrainedWidth="false"
             app:layout_constraintEnd_toStartOf="@id/barrier2"
@@ -158,5 +120,4 @@
             app:constraint_referenced_ids="total_usage,total_accounts"
             tools:layout_editor_absoluteY="8dp" />
     </androidx.constraintlayout.widget.ConstraintLayout>
-
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_trending_cell.xml
+++ b/app/src/main/res/layout/item_trending_cell.xml
@@ -21,48 +21,10 @@
         android:importantForAccessibility="no"
         app:graphColor="?android:colorBackground"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/current_usage"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:lineWidth="2sp"
-        app:metaColor="@color/tusky_blue_light"
-        app:primaryLineColor="@color/tusky_blue"
-        app:proportionalTrending="true"
-        app:secondaryLineColor="@color/tusky_red" />
-
-    <TextView
-        android:id="@+id/current_usage"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:importantForAccessibility="no"
-        android:paddingStart="6dp"
-        android:textAlignment="textEnd"
-        android:textAppearance="@style/TextAppearance.AppCompat.Small"
-        android:textColor="@color/tusky_blue"
-        android:textSize="8sp"
-        android:textStyle="normal"
-        app:layout_constrainedWidth="true"
-        app:layout_constraintBottom_toTopOf="@id/current_accounts"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@id/graph"
-        tools:text="12 345" />
-
-    <TextView
-        android:id="@+id/current_accounts"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:importantForAccessibility="no"
-        android:paddingStart="6dp"
-        android:textAlignment="textEnd"
-        android:textAppearance="@style/TextAppearance.AppCompat.Small"
-        android:textColor="@color/tusky_red"
-        android:textSize="8sp"
-        android:textStyle="normal"
-        app:layout_constrainedWidth="true"
-        app:layout_constraintBottom_toBottomOf="@id/graph"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@id/graph"
-        tools:text="12 345" />
+        app:proportionalTrending="true" />
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/legend_container"
@@ -99,7 +61,7 @@
             android:importantForAccessibility="no"
             android:textAlignment="textEnd"
             android:textAppearance="?android:attr/textAppearanceListItemSmall"
-            android:textColor="@color/tusky_blue"
+            android:textColor="@color/pachli_blue"
             android:textStyle="normal|bold"
             app:layout_constrainedWidth="false"
             app:layout_constraintEnd_toStartOf="@id/usageLabel"
@@ -132,7 +94,7 @@
             android:importantForAccessibility="no"
             android:textAlignment="textEnd"
             android:textAppearance="?android:attr/textAppearanceListItemSmall"
-            android:textColor="@color/tusky_red"
+            android:textColor="@color/pachli_orange"
             android:textStyle="normal|bold"
             app:layout_constrainedWidth="false"
             app:layout_constraintEnd_toStartOf="@+id/accountsLabel"

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -13,15 +13,6 @@
         <attr name="description" format="string|reference" />
     </declare-styleable>
 
-    <declare-styleable name="GraphView">
-        <attr name="primaryLineColor" format="reference|color" />
-        <attr name="secondaryLineColor" format="reference|color" />
-        <attr name="lineWidth" format="dimension" />
-        <attr name="graphColor" format="reference|color" />
-        <attr name="metaColor" format="reference|color" />
-        <attr name="proportionalTrending" format="boolean" />
-    </declare-styleable>
-
     <declare-styleable name="SliderPreference">
         <attr name="android:value" format="string|reference" />
         <attr name="android:valueFrom" format="string|reference" />

--- a/app/src/main/res/values/attrs_graphview.xml
+++ b/app/src/main/res/values/attrs_graphview.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2024 Pachli Association
+  ~
+  ~ This file is a part of Pachli.
+  ~
+  ~ This program is free software; you can redistribute it and/or modify it under the terms of the
+  ~ GNU General Public License as published by the Free Software Foundation; either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+  ~ the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+  ~ Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License along with Pachli; if not,
+  ~ see <http://www.gnu.org/licenses>.
+  -->
+
+<resources>
+    <!-- Style to use for GraphView in the theme. -->
+    <attr name="graphViewStyle" format="reference"/>
+
+    <declare-styleable name="GraphView">
+        <attr name="primaryLineColor" format="reference|color" />
+        <attr name="secondaryLineColor" format="reference|color" />
+        <attr name="lineWidth" format="dimension" />
+        <attr name="labelTextSize" format="dimension" />
+        <attr name="graphColor" format="reference|color" />
+        <attr name="metaColor" format="reference|color" />
+        <attr name="proportionalTrending" format="boolean" />
+    </declare-styleable>
+</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -72,6 +72,11 @@
     <color name="tusky_green_light">#25d069</color>
     <color name="tusky_red">#DF1553</color>
 
+    <color name="pachli_blue">#006382</color>
+    <color name="pachli_orange">#F37B2F</color>
+    <color name="pachli_dark_gray">#30383A</color>
+    <color name="pachli_light_gray">#D4D2C6</color>
+
     <color name="white">#fff</color>
     <color name="black">#000</color>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -65,17 +65,16 @@
     <!-- end of material base colors -->
 
     <color name="tusky_blue">#2b90d9</color>
-    <color name="tusky_blue_light">#56a7e1</color>
     <color name="tusky_orange">#ca8f04</color>
     <color name="tusky_orange_light">#fab207</color>
     <color name="tusky_green">#19a341</color>
     <color name="tusky_green_light">#25d069</color>
-    <color name="tusky_red">#DF1553</color>
 
     <color name="pachli_blue">#006382</color>
     <color name="pachli_orange">#F37B2F</color>
-    <color name="pachli_dark_gray">#30383A</color>
-    <color name="pachli_light_gray">#D4D2C6</color>
+    <!-- Commented out for the time being as unused, but kept here as reference -->
+<!--    <color name="pachli_dark_gray">#30383A</color>-->
+<!--    <color name="pachli_light_gray">#D4D2C6</color>-->
 
     <color name="white">#fff</color>
     <color name="black">#000</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -80,6 +80,8 @@
 
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:windowLightStatusBar">?attr/isLightTheme</item>
+
+        <item name="graphViewStyle">@style/Pachli.Widget.GraphView</item>
     </style>
 
     <style name="AppTheme" parent="Theme.Pachli" />
@@ -157,6 +159,12 @@
 
     <style name="Pachli.Widget.Material3.TabLayout" parent="Widget.Material3.TabLayout">
         <item name="android:background">@color/black</item>
+    </style>
+
+    <style name="Pachli.Widget.GraphView" parent="">
+        <item name="primaryLineColor">@color/pachli_blue</item>
+        <item name="secondaryLineColor">@color/pachli_orange</item>
+        <item name="lineWidth">2sp</item>
     </style>
 
     <style name="Theme.Pachli.Black" parent="Base.Theme.Black" />


### PR DESCRIPTION
The previous code incorrectly showed the trending tag usage data twice next to the end of the trending tag lines, instead of one entry for the usage data and one entry for the account data.

Fix that.

As part of this fix change how the data is displayed. Instead of using two distinct `TextView`, fixed to the bottom end of the chart, draw the text directly on the chart. The text is accurately position so that it is next to the end of the relevant line. If both lines overlap the label positions are adjusted appropriately.

The chart now uses Pachli blue and orange for the line colours.

While doing this I discovered that the mechanism used to fall back to particular chart colours if none were specified was incorrect, so fix that too.