### PR TITLE
chore: Migrate from gradle-build-action to setup-gradle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,10 @@ jobs:
       - name: Copy CI gradle.properties
         run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
-      - name: Gradle Build Action
-        uses: gradle/gradle-build-action@v2
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
         with:
-          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: ktlint
         run: ./gradlew clean ktlintCheck

--- a/.github/workflows/ktlint.yml
+++ b/.github/workflows/ktlint.yml
@@ -22,9 +22,10 @@ jobs:
 
       - uses: gradle/wrapper-validation-action@v1
 
-      - uses: gradle/gradle-build-action@v2
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
         with:
-          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - run: chmod +x ./gradlew
 

--- a/.github/workflows/populate-gradle-build-cache.yml
+++ b/.github/workflows/populate-gradle-build-cache.yml
@@ -30,9 +30,10 @@ jobs:
       - name: Copy CI gradle.properties
         run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
-      - uses: gradle/gradle-build-action@v2
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
         with:
-          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Run app:buildOrangeDebug
         run: ./gradlew app:build${{ matrix.color }}${{ matrix.store }}Debug

--- a/.github/workflows/upload-blue-release-google-play.yml
+++ b/.github/workflows/upload-blue-release-google-play.yml
@@ -22,10 +22,10 @@ jobs:
       - name: Copy CI gradle.properties
         run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
-      - name: Gradle Build Action
-        uses: gradle/gradle-build-action@v2
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
         with:
-          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Build GitHub APK
         run: ./gradlew assembleBlueGithubRelease --stacktrace

--- a/.github/workflows/upload-orange-release-google-play.yml
+++ b/.github/workflows/upload-orange-release-google-play.yml
@@ -24,10 +24,10 @@ jobs:
       - name: Copy CI gradle.properties
         run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
-      - name: Gradle Build Action
-        uses: gradle/gradle-build-action@v2
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
         with:
-          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Test
         run: ./gradlew app:testOrangeGoogleReleaseUnitTest --stacktrace


### PR DESCRIPTION
gradle-build-action is deprecated, setup-gradle replaces it. Enable the new support for the configuration cache.