### PR TITLE
ci: Enable Gradle configuration cache on CI

### DIFF
--- a/.github/ci-gradle.properties
+++ b/.github/ci-gradle.properties
@@ -19,6 +19,7 @@
 org.gradle.daemon=false
 org.gradle.parallel=true
 org.gradle.workers.max=2
+org.gradle.configuration-cache=true
 
 kotlin.incremental=false
 kotlin.compiler.execution.strategy=in-process


### PR DESCRIPTION
Gradle configuration currently takes ~ 25s per invocation on CI, this should hopefully reduce that significantly.