### PR TITLE
ci: Make secrets available in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,16 @@
 name: CI
 
+# Run on pull_request_target to access secrets.GRADLE_ENCRYPTION_KEY,
+# and ensure permissions are marked read-only
+
 on:
   push:
     tags:
       - '*'
-  pull_request:
+  pull_request_target:
   workflow_dispatch:
+
+permissions: read-all
 
 jobs:
   build:


### PR DESCRIPTION
Previous code used `pull_request:` which meant
`secrets.GRADLE_ENCRYPTION_KEY` was not available, so the configuration cache was not restored.

Use `pull_request_target` to give the workflow access to `secrets`, and explicitly downscope the permissions of `GITHUB_TOKEN` to read only.