### PR TITLE
change: Provide a vendor property in LintRegistry

### DIFF
--- a/checks/src/main/java/app/pachli/lint/checks/LintRegistry.kt
+++ b/checks/src/main/java/app/pachli/lint/checks/LintRegistry.kt
@@ -1,6 +1,7 @@
 package app.pachli.lint.checks
 
 import com.android.tools.lint.client.api.IssueRegistry
+import com.android.tools.lint.client.api.Vendor
 import com.android.tools.lint.detector.api.CURRENT_API
 import com.android.tools.lint.detector.api.Issue
 
@@ -14,4 +15,11 @@ class LintRegistry : IssueRegistry() {
 
     override val api: Int
         get() = CURRENT_API
+
+    override val vendor = Vendor(
+        vendorName = "Pachli",
+        identifier = "app.pachli.lint:pachli-lint",
+        feedbackUrl = "https://github.com/pachli/pachli-android/issues",
+        contact = "https://github.com/pachli/pachli-android",
+    )
 }

--- a/checks/src/main/resources/META-INF/services/com.android.tools.lint.client.api.IssueRegistry
+++ b/checks/src/main/resources/META-INF/services/com.android.tools.lint.client.api.IssueRegistry
@@ -1,0 +1,18 @@
+#
+# Copyright 2024 Pachli Association
+#
+# This file is a part of Pachli.
+#
+# This program is free software; you can redistribute it and/or modify it under the terms of the
+# GNU General Public License as published by the Free Software Foundation; either version 3 of the
+# License, or (at your option) any later version.
+#
+# Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+# the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with Pachli; if not,
+# see <http://www.gnu.org/licenses>.
+#
+
+app.pachli.lint.checks.LintRegistry


### PR DESCRIPTION
Resolves a build-time warning:

```
app.pachli.lint.checks.LintRegistry ... does not specify a vendor;
see IssueRegistry#vendor
```