### PR TITLE
fix: Allow HIDE_TOP_TOOLBAR preference text to wrap

### DIFF
--- a/app/src/main/java/app/pachli/components/preference/PreferencesFragment.kt
+++ b/app/src/main/java/app/pachli/components/preference/PreferencesFragment.kt
@@ -142,6 +142,7 @@ class PreferencesFragment : PreferenceFragmentCompat() {
                     setDefaultValue(false)
                     key = PrefKeys.HIDE_TOP_TOOLBAR
                     setTitle(R.string.pref_title_hide_top_toolbar)
+                    isSingleLineTitle = false
                 }
 
                 switchPreference {


### PR DESCRIPTION
Previously it was constrained to a single line, and would clip on narrow devices.

Fixes #436