### PR TITLE
fix: Prevent crashes with bugs in Friendica and Pleroma servers

### DIFF
--- a/core/network/src/main/kotlin/app/pachli/core/network/model/Card.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/Card.kt
@@ -26,15 +26,24 @@ data class Card(
     override val title: String,
     override val description: String,
     @Json(name = "type") override val kind: PreviewCardKind,
-    @Json(name = "author_name") override val authorName: String,
-    @Json(name = "author_url") override val authorUrl: String,
+    // Missing from Pleroma, https://git.pleroma.social/pleroma/pleroma/-/issues/3238
+    @Json(name = "author_name") override val authorName: String = "",
+    // Missing from Pleroma, https://git.pleroma.social/pleroma/pleroma/-/issues/3238
+    @Json(name = "author_url") override val authorUrl: String = "",
     @Json(name = "provider_name") override val providerName: String,
     @Json(name = "provider_url") override val providerUrl: String,
-    override val html: String,
-    override val width: Int,
-    override val height: Int,
+    // Missing from Friendica, https://github.com/friendica/friendica/issues/13887
+    // Missing from Pleroma, https://git.pleroma.social/pleroma/pleroma/-/issues/3238
+    override val html: String = "",
+    // Missing from Pleroma, https://git.pleroma.social/pleroma/pleroma/-/issues/3238
+    override val width: Int = 0,
+    // Missing from Pleroma, https://git.pleroma.social/pleroma/pleroma/-/issues/3238
+    override val height: Int = 0,
     override val image: String? = null,
-    @Json(name = "embed_url") override val embedUrl: String,
+    // Missing from Friendica, https://github.com/friendica/friendica/issues/13887
+    // Missing from Pleroma, https://git.pleroma.social/pleroma/pleroma/-/issues/3238
+    @Json(name = "embed_url") override val embedUrl: String = "",
+    // Missing from Pleroma, https://git.pleroma.social/pleroma/pleroma/-/issues/3238
     override val blurhash: String? = null,
 ) : PreviewCard {
 

--- a/core/network/src/main/kotlin/app/pachli/core/network/model/TrendsLink.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/TrendsLink.kt
@@ -42,7 +42,7 @@ interface PreviewCard {
     val title: String
     val description: String
     val kind: PreviewCardKind
-    val authorName: String? // Not supposed to be null, per API, but seen null in the wild
+    val authorName: String
     val authorUrl: String
     val providerName: String
     val providerUrl: String
@@ -68,7 +68,7 @@ data class TrendsLink(
     override val title: String,
     override val description: String,
     @Json(name = "type") override val kind: PreviewCardKind,
-    @Json(name = "author_name") override val authorName: String,
+    @Json(name = "author_name") override val authorName: String = "",
     @Json(name = "author_url") override val authorUrl: String,
     @Json(name = "provider_name") override val providerName: String,
     @Json(name = "provider_url") override val providerUrl: String,


### PR DESCRIPTION
Neither server type implements the Mastodon API correctly, see

- https://github.com/friendica/friendica/issues/13887
- https://git.pleroma.social/pleroma/pleroma/-/issues/3238

Prevent crashes when parsing their broken JSON by providing default values for properties they omit.

Fixes #433