### PR TITLE
fix: Prevent memory leak when updating shortcuts

### DIFF
--- a/app/src/main/java/app/pachli/MainActivity.kt
+++ b/app/src/main/java/app/pachli/MainActivity.kt
@@ -1025,7 +1025,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
         }
 
         updateProfiles()
-        updateShortcut(this, accountManager.activeAccount!!)
+        updateShortcut(applicationContext, accountManager.activeAccount!!)
     }
 
     @SuppressLint("CheckResult")


### PR DESCRIPTION
Shortcuts were being updated using `MainActivity.this` as the `Context` and leaking in `ShortcutManagerCompat`. Use the application context to fix this.