### PR TITLE
fix: Show correct account/timeline when composing from notifications

### DIFF
--- a/app/src/main/java/app/pachli/MainActivity.kt
+++ b/app/src/main/java/app/pachli/MainActivity.kt
@@ -557,7 +557,11 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
             }
         }
         startActivity(composeIntent)
-        finish()
+
+        // Recreate the activity to ensure it is using the correct active account
+        // (which may have changed while processing the compose intent) and so
+        // the user returns to the timeline when they finish ComposeActivity.
+        recreate()
     }
 
     private fun setupDrawer(

--- a/app/src/main/java/app/pachli/components/notifications/NotificationHelper.kt
+++ b/app/src/main/java/app/pachli/components/notifications/NotificationHelper.kt
@@ -431,9 +431,13 @@ private fun getStatusComposeIntent(
         language = language,
         kind = ComposeOptions.ComposeKind.NEW,
     )
-    val composeIntent =
-        MainActivityIntent.openCompose(context, composeOptions, account.id, body.id, account.id.toInt())
-    composeIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    val composeIntent = MainActivityIntent.openCompose(
+        context,
+        composeOptions,
+        account.id,
+        body.id,
+        account.id.toInt(),
+    )
     return PendingIntent.getActivity(
         context.applicationContext,
         notificationId,

--- a/app/src/main/java/app/pachli/service/PachliTileService.kt
+++ b/app/src/main/java/app/pachli/service/PachliTileService.kt
@@ -36,7 +36,6 @@ class PachliTileService : TileService() {
     @SuppressLint("StartActivityAndCollapseDeprecated")
     override fun onClick() {
         val intent = MainActivityIntent.openCompose(this, ComposeOptions())
-        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
             startActivityAndCollapse(getActivityPendingIntent(this, 0, intent))
         } else {

--- a/core/navigation/src/main/kotlin/app/pachli/core/navigation/Navigation.kt
+++ b/core/navigation/src/main/kotlin/app/pachli/core/navigation/Navigation.kt
@@ -268,7 +268,7 @@ class MainActivityIntent(context: Context) : Intent() {
         /**
          * Switches the active account to the provided accountId and then stays on MainActivity
          */
-        fun switchAccount(context: Context, pachliAccountId: Long) = MainActivityIntent(context).apply {
+        private fun switchAccount(context: Context, pachliAccountId: Long) = MainActivityIntent(context).apply {
             putExtra(EXTRA_PACHLI_ACCOUNT_ID, pachliAccountId)
         }
 
@@ -300,6 +300,7 @@ class MainActivityIntent(context: Context) : Intent() {
             putExtra(EXTRA_COMPOSE_OPTIONS, options)
             putExtra(EXTRA_NOTIFICATION_TAG, notificationTag)
             putExtra(EXTRA_NOTIFICATION_ID, notificationId)
+            flags = FLAG_ACTIVITY_NEW_TASK or FLAG_ACTIVITY_CLEAR_TASK
         }
 
         /**


### PR DESCRIPTION
The previous code didn't clear the task stack or recreate `MainActivity` when the active user was changed.

So if the user was logged in with account A and used "Compose" from a notification sent to account B, the active account was switched to B but the UI chrome wasn't. After exiting `ComposeActivity` they would be looking at the timeline for account B but with a toolbar that showed account A.

Fix this by clearing the task stack and explicitly recreating `MainActivity` when forwarding intents to `ComposeActivity`.