### PR TITLE
fix: Remove filters from Firefish capabilities

### DIFF
--- a/core/network/src/main/kotlin/app/pachli/core/network/Server.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/Server.kt
@@ -271,9 +271,12 @@ data class Server(
                 // GoToSocial can't filter, https://github.com/superseriousbusiness/gotosocial/issues/1472
                 GOTOSOCIAL -> { }
 
+                // FireFish can't filter (conversation in the Firefish dev. chat )
+                FIREFISH -> { }
+
                 // Everything else. Assume server side filtering and no translation. This may be an
                 // incorrect assumption.
-                AKKOMA, FEDIBIRD, FIREFISH, FRIENDICA, GLITCH, HOMETOWN, ICESHRIMP, PIXELFED, PLEROMA, SHARKEY, UNKNOWN -> {
+                AKKOMA, FEDIBIRD, FRIENDICA, GLITCH, HOMETOWN, ICESHRIMP, PIXELFED, PLEROMA, SHARKEY, UNKNOWN -> {
                     c[ORG_JOINMASTODON_FILTERS_SERVER] = "1.0.0".toVersion()
                 }
             }

--- a/core/network/src/test/kotlin/app/pachli/core/network/ServerTest.kt
+++ b/core/network/src/test/kotlin/app/pachli/core/network/ServerTest.kt
@@ -230,7 +230,7 @@ class ServerTest(
                 ),
                 arrayOf(
                     Triple(
-                        "Firefish can filter",
+                        "Firefish can't filter",
                         NodeInfo.Software("firefish", "1.1.0-dev29-hf1"),
                         defaultInstance,
                     ),
@@ -238,9 +238,7 @@ class ServerTest(
                         Server(
                             kind = FIREFISH,
                             version = "1.1.0-dev29-hf1".toVersion(),
-                            capabilities = mapOf(
-                                ORG_JOINMASTODON_FILTERS_SERVER to "1.0.0".toVersion(),
-                            ),
+                            capabilities = emptyMap(),
                         ),
                     ),
                 ),


### PR DESCRIPTION
Firefish doesn't support the filters API, so remove filters from the list of capabilities.

Fixes #248