### PR TITLE
fix: Show previews for playable audio media from accounts

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -218,17 +218,6 @@
 
     <issue
         id="MissingQuantity"
-        message="For locale &quot;ru&quot; (Russian) the following quantities should also be defined: `few` (e.g. &quot;из 2 книг за 2 дня&quot;), `many` (e.g. &quot;из 5 книг за 5 дней&quot;), `one` (e.g. &quot;из 1 книги за 1 день&quot;)"
-        errorLine1="    &lt;plurals name=&quot;hint_describe_for_visually_impaired&quot;>"
-        errorLine2="    ^">
-        <location
-            file="src/main/res/values-ru/strings.xml"
-            line="279"
-            column="5"/>
-    </issue>
-
-    <issue
-        id="MissingQuantity"
         message="For locale &quot;hi&quot; (Hindi) the following quantity should also be defined: `one` (e.g. &quot;1 घंटा&quot;)"
         errorLine1="    &lt;plurals name=&quot;hint_describe_for_visually_impaired&quot;>"
         errorLine2="    ^">

--- a/app/src/main/java/app/pachli/adapter/StatusBaseViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/StatusBaseViewHolder.kt
@@ -897,14 +897,14 @@ abstract class StatusBaseViewHolder<T : IStatusViewData> protected constructor(i
     }
 
     companion object {
+        /**
+         * @return True if all [attachments] are previewable.
+         *
+         * @see Attachment.isPreviewable
+         */
         @JvmStatic
         protected fun hasPreviewableAttachment(attachments: List<Attachment>): Boolean {
-            for (attachment in attachments) {
-                if (attachment.type == Attachment.Type.UNKNOWN) return false
-
-                if (attachment.meta?.original?.width == null && attachment.meta?.small?.width == null) return false
-            }
-            return true
+            return attachments.all { it.isPreviewable() }
         }
 
         private fun getReblogDescription(context: Context, status: IStatusViewData): CharSequence {

--- a/core/designsystem/src/main/res/values/dimens.xml
+++ b/core/designsystem/src/main/res/values/dimens.xml
@@ -63,8 +63,6 @@
 
     <dimen name="profile_media_spacing">3dp</dimen>
 
-    <dimen name="profile_media_audio_icon_padding">16dp</dimen>
-
     <dimen name="preview_image_spacing">4dp</dimen>
 
     <dimen name="graph_line_thickness">1dp</dimen>

--- a/core/network/src/main/kotlin/app/pachli/core/network/model/Attachment.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/Attachment.kt
@@ -103,4 +103,13 @@ data class Attachment(
                 return (width / height).toDouble()
             }
     }
+
+    /**
+     * @return True if this attachment can be previewed. A previewable attachment
+     *     must be a known type and have a non-null width for the preview image.
+     */
+    fun isPreviewable(): Boolean {
+        if (type == Type.UNKNOWN) return false
+        return !(meta?.original?.width == null && meta?.small?.width == null)
+    }
 }


### PR DESCRIPTION
Previous code showed a generic placeholder for audio media on the account's "Media" tab.

Fix this so the preview image is shown (if it's available).

- Move the "is this attachment previewable?" code to `Attachment` so it can be reused here.

- Restructure the logic in `AccountMediaGridAdapter` to use the new `isPreviewable()` method when deciding whether to show a preview.

- Attachments have dedicated placeholder drawables, use those when the preview is not available.