### PR TITLE
change: Log the trigger for a refresh/reload

### DIFF
--- a/app/src/main/java/app/pachli/components/timeline/CachedTimelineRepository.kt
+++ b/app/src/main/java/app/pachli/components/timeline/CachedTimelineRepository.kt
@@ -180,6 +180,7 @@ class CachedTimelineRepository @Inject constructor(
 
     /** Remove all statuses and invalidate the pager, for the active account */
     suspend fun clearAndReload() = externalScope.launch {
+        Timber.d("clearAndReload()")
         timelineDao.removeAll(activeAccount!!.id)
         factory?.invalidate()
     }.join()

--- a/app/src/main/java/app/pachli/components/timeline/TimelineFragment.kt
+++ b/app/src/main/java/app/pachli/components/timeline/TimelineFragment.kt
@@ -492,6 +492,7 @@ class TimelineFragment :
         return when (menuItem.itemId) {
             R.id.action_refresh -> {
                 if (isSwipeToRefreshEnabled) {
+                    Timber.d("Reload because user chose refresh menu item")
                     refreshContent()
                     true
                 } else {
@@ -499,6 +500,7 @@ class TimelineFragment :
                 }
             }
             R.id.action_load_newest -> {
+                Timber.d("Reload because user choose load newest menu item")
                 viewModel.accept(InfallibleUiAction.LoadNewest)
                 refreshContent()
                 true
@@ -556,6 +558,7 @@ class TimelineFragment :
 
     /** Refresh the displayed content, as if the user had swiped on the SwipeRefreshLayout */
     override fun refreshContent() {
+        Timber.d("Reloading via refreshContent")
         binding.swipeRefreshLayout.isRefreshing = true
         onRefresh()
     }
@@ -565,6 +568,7 @@ class TimelineFragment :
      * handled displaying the animated spinner.
      */
     override fun onRefresh() {
+        Timber.d("Reloading via onRefresh")
         binding.statusView.hide()
         snackbar?.dismiss()
         adapter.refresh()

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/TimelineViewModel.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/TimelineViewModel.kt
@@ -430,6 +430,7 @@ abstract class TimelineViewModel(
                         activeAccount.lastVisibleHomeTimelineStatusId = null
                         accountManager.saveAccount(activeAccount)
                     }
+                    Timber.d("Reload because InfallibleUiAction.LoadNewest")
                     reloadFromNewest()
                 }
         }
@@ -523,6 +524,7 @@ abstract class TimelineViewModel(
         .filter { filterContextMatchesKind(timelineKind, listOf(it.filterKind)) }
         .map {
             getFilters()
+            Timber.d("Reload because FilterChangedEvent")
             reloadKeepingReadingPosition()
         }
         .onStart { getFilters() }
@@ -552,6 +554,7 @@ abstract class TimelineViewModel(
                 val oldRemoveReplies = filterRemoveReplies
                 filterRemoveReplies = timelineKind is TimelineKind.Home && !filter
                 if (oldRemoveReplies != filterRemoveReplies) {
+                    Timber.d("Reload because TAB_FILTER_HOME_REPLIES changed")
                     reloadKeepingReadingPosition()
                 }
             }
@@ -560,6 +563,7 @@ abstract class TimelineViewModel(
                 val oldRemoveReblogs = filterRemoveReblogs
                 filterRemoveReblogs = timelineKind is TimelineKind.Home && !filter
                 if (oldRemoveReblogs != filterRemoveReblogs) {
+                    Timber.d("Reload because TAB_FILTER_HOME_BOOSTS changed")
                     reloadKeepingReadingPosition()
                 }
             }
@@ -568,6 +572,7 @@ abstract class TimelineViewModel(
                 val oldRemoveSelfReblogs = filterRemoveSelfReblogs
                 filterRemoveSelfReblogs = timelineKind is TimelineKind.Home && !filter
                 if (oldRemoveSelfReblogs != filterRemoveSelfReblogs) {
+                    Timber.d("Reload because TAB_SHOW_SOME_SELF_BOOSTS changed")
                     reloadKeepingReadingPosition()
                 }
             }
@@ -580,7 +585,10 @@ abstract class TimelineViewModel(
             is ReblogEvent -> handleReblogEvent(event)
             is BookmarkEvent -> handleBookmarkEvent(event)
             is PinEvent -> handlePinEvent(event)
-            is MuteConversationEvent -> reloadKeepingReadingPosition()
+            is MuteConversationEvent -> {
+                Timber.d("Reload because MuteConversationEvent")
+                reloadKeepingReadingPosition()
+            }
             is UnfollowEvent -> {
                 if (timelineKind is TimelineKind.Home) {
                     val id = event.accountId


### PR DESCRIPTION
A user is reporting that a refresh is happening in the middle of loading content, borne out by the existing logs.

Those logs don't say what has triggered the refresh attempt, so add additional logging whenever a refresh can occur to record what triggered it.