### PR TITLE
fix: Parse roles without a `highlighted` property

### DIFF
--- a/app/src/main/java/app/pachli/network/ServerRepository.kt
+++ b/app/src/main/java/app/pachli/network/ServerRepository.kt
@@ -108,7 +108,8 @@ class ServerRepository @Inject constructor(
 
         mastodonApi.getInstanceV2().fold(
             { Server.from(nodeInfo.software, it).mapError(::Capabilities) },
-            {
+            { throwable ->
+                Timber.e(throwable, "Couldn't process /api/v2/instance result")
                 mastodonApi.getInstanceV1().fold(
                     { Server.from(nodeInfo.software, it).mapError(::Capabilities) },
                     { Err(GetInstanceInfoV1(it)) },

--- a/core/network/src/main/kotlin/app/pachli/core/network/model/Account.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/Account.kt
@@ -91,6 +91,10 @@ data class Role(
     val name: String,
     /** Colour to use for the role badge, may be the empty string */
     val color: String,
+    // Default value is true, since the property may be missing and the observed
+    // Mastodon behaviour when it is is to highlight the role. Also, this property
+    // being missing breaks InstanceV2 parsing.
+    // See https://github.com/mastodon/mastodon/issues/28327
     /** True if the badge should be displayed on the account profile */
-    val highlighted: Boolean,
+    val highlighted: Boolean = true,
 )


### PR DESCRIPTION
The `highlighted` property on a role may be absent. If it is this breaks account parsing, including accounts in an /api/v2/instance response. This, in turn, breaks determining server capabilities, including whether or not translation is supported.

Set the default to `true`, which matches observed Mastodon behaviour.