### PR TITLE
fix: Provide v2/instance configuration defaults

### DIFF
--- a/core/network/src/main/kotlin/app/pachli/core/network/model/InstanceV2.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/InstanceV2.kt
@@ -101,8 +101,9 @@ data class ThumbnailVersions(
 
 @JsonClass(generateAdapter = true)
 data class Configuration(
+    // May be missing (e.g., Friendica), so provide a default
     /** URLs of interest for clients apps. */
-    val urls: InstanceV2Urls,
+    val urls: InstanceV2Urls = InstanceV2Urls(),
 
     /** Limits related to accounts. */
     val accounts: InstanceV2Accounts,
@@ -116,8 +117,9 @@ data class Configuration(
     /** Limits related to polls. */
     val polls: InstanceV2Polls,
 
+    // May be missing, so provide a default
     /** Hints related to translation. */
-    val translation: InstanceV2Translation,
+    val translation: InstanceV2Translation = InstanceV2Translation(enabled = false),
 )
 
 @JsonClass(generateAdapter = true)


### PR DESCRIPTION
Some servers don't include a `urls` or `translation` block, which was preventing parsing of the block, and falling back to the v1 instance data.

Fix this by providing sensible defaults.