### PR TITLE
refactor: Remove duplicate strings from Filter.Action

### DIFF
--- a/app/src/main/java/app/pachli/StatusListActivity.kt
+++ b/app/src/main/java/app/pachli/StatusListActivity.kt
@@ -290,7 +290,7 @@ class StatusListActivity : BottomSheetActivity(), AppBarLayoutHost, ActionButton
             mastodonApi.createFilter(
                 title = tagWithHash,
                 context = listOf(FilterContext.HOME),
-                filterAction = Filter.Action.WARN.action,
+                filterAction = Filter.Action.WARN,
                 expiresInSeconds = null,
             ).fold(
                 { filter ->

--- a/app/src/main/java/app/pachli/components/filters/EditFilterViewModel.kt
+++ b/app/src/main/java/app/pachli/components/filters/EditFilterViewModel.kt
@@ -87,7 +87,7 @@ class EditFilterViewModel @Inject constructor(val api: MastodonApi, val eventHub
         val contexts = contexts.value
         val title = title.value
         val durationIndex = duration.value
-        val action = action.value.action
+        val action = action.value
 
         return withContext(viewModelScope.coroutineContext) {
             val success = originalFilter?.let { filter ->
@@ -108,7 +108,7 @@ class EditFilterViewModel @Inject constructor(val api: MastodonApi, val eventHub
         }
     }
 
-    private suspend fun createFilter(title: String, contexts: List<FilterContext>, action: String, durationIndex: Int, context: Context): Boolean {
+    private suspend fun createFilter(title: String, contexts: List<FilterContext>, action: Filter.Action, durationIndex: Int, context: Context): Boolean {
         val expiresInSeconds = EditFilterActivity.getSecondsForDurationIndex(durationIndex, context)
         api.createFilter(
             title = title,
@@ -132,7 +132,7 @@ class EditFilterViewModel @Inject constructor(val api: MastodonApi, val eventHub
         )
     }
 
-    private suspend fun updateFilter(originalFilter: Filter, title: String, contexts: List<FilterContext>, action: String, durationIndex: Int, context: Context): Boolean {
+    private suspend fun updateFilter(originalFilter: Filter, title: String, contexts: List<FilterContext>, action: Filter.Action, durationIndex: Int, context: Context): Boolean {
         val expiresInSeconds = EditFilterActivity.getSecondsForDurationIndex(durationIndex, context)
         api.updateFilter(
             id = originalFilter.id,

--- a/core/network/src/main/kotlin/app/pachli/core/network/model/Filter.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/Filter.kt
@@ -25,15 +25,15 @@ data class Filter(
     // val statuses: List<FilterStatus>,
 ) : Parcelable {
     @HasDefault
-    enum class Action(val action: String) {
+    enum class Action {
         @Json(name = "none")
-        NONE("none"),
+        NONE,
 
         @Json(name = "warn")
         @Default
-        WARN("warn"),
+        WARN,
 
         @Json(name = "hide")
-        HIDE("hide"),
+        HIDE,
     }
 }

--- a/core/network/src/main/kotlin/app/pachli/core/network/retrofit/MastodonApi.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/retrofit/MastodonApi.kt
@@ -642,7 +642,7 @@ interface MastodonApi {
     suspend fun createFilter(
         @Field("title") title: String,
         @Field("context[]") context: List<FilterContext>,
-        @Field("filter_action") filterAction: String,
+        @Field("filter_action") filterAction: Filter.Action,
         @Field("expires_in") expiresInSeconds: Int?,
     ): NetworkResult<Filter>
 
@@ -652,7 +652,7 @@ interface MastodonApi {
         @Path("id") id: String,
         @Field("title") title: String? = null,
         @Field("context[]") context: List<FilterContext>? = null,
-        @Field("filter_action") filterAction: String? = null,
+        @Field("filter_action") filterAction: Filter.Action? = null,
         @Field("expires_in") expiresInSeconds: Int? = null,
     ): NetworkResult<Filter>
 


### PR DESCRIPTION
Simplify code that users `Filter.Action` by deserialising directly into the type instead of storing / using strings throughout the API.