### PR TITLE
refactor: Enable core library desugaring as build convention logic

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,10 +53,6 @@ android {
         }
     }
 
-    compileOptions {
-        isCoreLibraryDesugaringEnabled = true
-    }
-
     packaging {
         resources.excludes.apply {
             add("LICENSE_OFL")
@@ -116,8 +112,6 @@ configurations {
 }
 
 dependencies {
-    coreLibraryDesugaring(libs.desugar.jdk.libs)
-
     // CachedTimelineRemoteMediator needs the @Transaction annotation from Room
     compileOnly(libs.bundles.room)
     testCompileOnly(libs.bundles.room)

--- a/build-logic/convention/src/main/kotlin/app/pachli/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/app/pachli/KotlinAndroid.kt
@@ -15,9 +15,11 @@
  * see <http://www.gnu.org/licenses>.
  */
 
+import app.pachli.libs
 import com.android.build.api.dsl.CommonExtension
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.provideDelegate
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
@@ -33,6 +35,12 @@ internal fun Project.configureKotlinAndroid(
 
         defaultConfig {
             minSdk = 23
+        }
+
+        compileOptions {
+            isCoreLibraryDesugaringEnabled = true
+            sourceCompatibility = JavaVersion.VERSION_17
+            targetCompatibility = JavaVersion.VERSION_17
         }
 
         testOptions {
@@ -55,6 +63,10 @@ internal fun Project.configureKotlinAndroid(
     }
 
     configureKotlin()
+
+    dependencies {
+        add("coreLibraryDesugaring", libs.findLibrary("desugar.jdk.libs").get())
+    }
 }
 
 /**

--- a/core/activity/build.gradle.kts
+++ b/core/activity/build.gradle.kts
@@ -27,10 +27,6 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments["disableAnalytics"] = "true"
     }
-
-    compileOptions {
-        isCoreLibraryDesugaringEnabled = true
-    }
 }
 
 dependencies {
@@ -54,7 +50,6 @@ dependencies {
     // Crash reporting in orange (Pachli Current) builds only
     orangeImplementation(libs.bundles.acra)
 
-    coreLibraryDesugaring(libs.desugar.jdk.libs)
     orangeCompileOnly(libs.auto.service.annotations)
     kspOrange(libs.auto.service.ksp)
 

--- a/core/data/src/test/kotlin/app/pachli/core/data/repository/InstanceInfoRepositoryTest.kt
+++ b/core/data/src/test/kotlin/app/pachli/core/data/repository/InstanceInfoRepositoryTest.kt
@@ -22,7 +22,6 @@ import app.pachli.core.database.dao.InstanceDao
 import app.pachli.core.database.model.AccountEntity
 import app.pachli.core.network.model.InstanceConfiguration
 import app.pachli.core.network.model.InstanceV1
-import app.pachli.core.network.model.StatusConfiguration
 import app.pachli.core.network.retrofit.MastodonApi
 import at.connyduck.calladapter.networkresult.NetworkResult
 import kotlinx.coroutines.test.runTest
@@ -121,29 +120,41 @@ class InstanceInfoRepositoryTest {
         assertEquals(customMaximum * 2, instanceInfo.maxChars)
     }
 
-    private fun getInstanceWithCustomConfiguration(maximumLegacyTootCharacters: Int? = null, configuration: InstanceConfiguration? = null): InstanceV1 {
+    private fun getInstanceWithCustomConfiguration(maximumLegacyTootCharacters: Int? = null, configuration: InstanceConfiguration = InstanceConfiguration()): InstanceV1 {
         return InstanceV1(
             uri = "https://example.token",
             version = "2.6.3",
             maxTootChars = maximumLegacyTootCharacters,
             pollConfiguration = null,
             configuration = configuration,
-            maxMediaAttachments = null,
             pleroma = null,
             uploadLimit = null,
             rules = emptyList(),
         )
     }
 
-    private fun getCustomInstanceConfiguration(maximumStatusCharacters: Int? = null, charactersReservedPerUrl: Int? = null): InstanceConfiguration {
-        return InstanceConfiguration(
-            statuses = StatusConfiguration(
-                maxCharacters = maximumStatusCharacters,
-                maxMediaAttachments = null,
-                charactersReservedPerUrl = charactersReservedPerUrl,
-            ),
-            mediaAttachments = null,
-            polls = null,
-        )
+    private fun getCustomInstanceConfiguration(
+        maximumStatusCharacters: Int? = null,
+        charactersReservedPerUrl: Int? = null,
+    ): InstanceConfiguration {
+        var result = InstanceConfiguration()
+
+        maximumStatusCharacters?.let {
+            result = result.copy(
+                statuses = result.statuses.copy(
+                    maxCharacters = it,
+                ),
+            )
+        }
+
+        charactersReservedPerUrl?.let {
+            result = result.copy(
+                statuses = result.statuses.copy(
+                    charactersReservedPerUrl = it,
+                ),
+            )
+        }
+
+        return result
     }
 }

--- a/core/database/build.gradle.kts
+++ b/core/database/build.gradle.kts
@@ -28,10 +28,6 @@ android {
     defaultConfig {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
-
-    compileOptions {
-        isCoreLibraryDesugaringEnabled = true
-    }
 }
 
 dependencies {
@@ -43,6 +39,4 @@ dependencies {
     implementation(libs.moshi)
     implementation(libs.moshi.adapters)
     ksp(libs.moshi.codegen)
-    // Instant in LogEntryEntity
-    coreLibraryDesugaring(libs.desugar.jdk.libs)
 }

--- a/feature/about/build.gradle.kts
+++ b/feature/about/build.gradle.kts
@@ -30,10 +30,6 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments["disableAnalytics"] = "true"
     }
-
-    compileOptions {
-        isCoreLibraryDesugaringEnabled = true
-    }
 }
 
 aboutLibraries {
@@ -65,7 +61,4 @@ dependencies {
 
     // For FixedSizeDrawable
     implementation(libs.glide.core)
-
-    // For Instant.now() in NotificationLogFragment
-    coreLibraryDesugaring(libs.desugar.jdk.libs)
 }


### PR DESCRIPTION
Once desugaring is enabled it needs to be enabled for up/down the dependency chain, so enable it in the shared configuration defined by the build convention code.

Highlighted a failing test that wasn't being run, so fix that too.