### PR TITLE
refactor: Remove synchronous search functions

### DIFF
--- a/app/src/main/java/app/pachli/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeActivity.kt
@@ -1257,7 +1257,7 @@ class ComposeActivity :
         }
     }
 
-    override fun search(token: String): List<ComposeAutoCompleteAdapter.AutocompleteResult> {
+    override suspend fun search(token: String): List<ComposeAutoCompleteAdapter.AutocompleteResult> {
         return viewModel.searchAutocompleteSuggestions(token)
     }
 

--- a/app/src/main/java/app/pachli/components/compose/ComposeAutoCompleteAdapter.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeAutoCompleteAdapter.kt
@@ -34,6 +34,7 @@ import app.pachli.core.network.model.TimelineAccount
 import app.pachli.databinding.ItemAutocompleteEmojiBinding
 import app.pachli.databinding.ItemAutocompleteHashtagBinding
 import com.bumptech.glide.Glide
+import kotlinx.coroutines.runBlocking
 
 class ComposeAutoCompleteAdapter(
     private val autocompletionProvider: AutocompletionProvider,
@@ -70,7 +71,10 @@ class ComposeAutoCompleteAdapter(
             override fun performFiltering(constraint: CharSequence?): FilterResults {
                 val filterResults = FilterResults()
                 if (constraint != null) {
-                    val results = autocompletionProvider.search(constraint.toString())
+                    // runBlocking here is OK because this happens in a worker thread
+                    val results = runBlocking {
+                        autocompletionProvider.search(constraint.toString())
+                    }
                     filterResults.values = results
                     filterResults.count = results.size
                 }
@@ -154,7 +158,7 @@ class ComposeAutoCompleteAdapter(
     }
 
     interface AutocompletionProvider {
-        fun search(token: String): List<AutocompleteResult>
+        suspend fun search(token: String): List<AutocompleteResult>
     }
 
     companion object {

--- a/app/src/main/java/app/pachli/components/compose/ComposeViewModel.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeViewModel.kt
@@ -378,10 +378,10 @@ class ComposeViewModel @Inject constructor(
         }
     }
 
-    fun searchAutocompleteSuggestions(token: String): List<AutocompleteResult> {
+    suspend fun searchAutocompleteSuggestions(token: String): List<AutocompleteResult> {
         when (token[0]) {
             '@' -> {
-                return api.searchAccountsSync(query = token.substring(1), limit = 10)
+                return api.searchAccounts(query = token.substring(1), limit = 10)
                     .fold({ accounts ->
                         accounts.map { AutocompleteResult.AccountResult(it) }
                     }, { e ->
@@ -390,7 +390,7 @@ class ComposeViewModel @Inject constructor(
                     })
             }
             '#' -> {
-                return api.searchSync(query = token, type = SearchType.Hashtag.apiParameter, limit = 10)
+                return api.search(query = token, type = SearchType.Hashtag.apiParameter, limit = 10)
                     .fold({ searchResult ->
                         searchResult.hashtags.map { AutocompleteResult.HashtagResult(it.name) }
                     }, { e ->

--- a/app/src/main/java/app/pachli/components/followedtags/FollowedTagsActivity.kt
+++ b/app/src/main/java/app/pachli/components/followedtags/FollowedTagsActivity.kt
@@ -170,7 +170,7 @@ class FollowedTagsActivity :
         }
     }
 
-    override fun search(token: String): List<ComposeAutoCompleteAdapter.AutocompleteResult> {
+    override suspend fun search(token: String): List<ComposeAutoCompleteAdapter.AutocompleteResult> {
         return viewModel.searchAutocompleteSuggestions(token)
     }
 

--- a/app/src/main/java/app/pachli/components/followedtags/FollowedTagsViewModel.kt
+++ b/app/src/main/java/app/pachli/components/followedtags/FollowedTagsViewModel.kt
@@ -36,8 +36,8 @@ class FollowedTagsViewModel @Inject constructor(
         },
     ).flow.cachedIn(viewModelScope)
 
-    fun searchAutocompleteSuggestions(token: String): List<ComposeAutoCompleteAdapter.AutocompleteResult> {
-        return api.searchSync(query = token, type = SearchType.Hashtag.apiParameter, limit = 10)
+    suspend fun searchAutocompleteSuggestions(token: String): List<ComposeAutoCompleteAdapter.AutocompleteResult> {
+        return api.search(query = token, type = SearchType.Hashtag.apiParameter, limit = 10)
             .fold({ searchResult ->
                 searchResult.hashtags.map { ComposeAutoCompleteAdapter.AutocompleteResult.HashtagResult(it.name) }
             }, { e ->

--- a/app/src/test/java/app/pachli/components/compose/ComposeActivityTest.kt
+++ b/app/src/test/java/app/pachli/components/compose/ComposeActivityTest.kt
@@ -98,7 +98,7 @@ class ComposeActivityTest {
                     }
                 }
             }
-            onBlocking { searchSync(any(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull()) } doReturn NetworkResult.success(
+            onBlocking { search(any(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull()) } doReturn NetworkResult.success(
                 SearchResult(emptyList(), emptyList(), emptyList()),
             )
         }

--- a/core/network/src/main/kotlin/app/pachli/core/network/retrofit/MastodonApi.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/retrofit/MastodonApi.kt
@@ -363,14 +363,6 @@ interface MastodonApi {
         @Query("following") following: Boolean? = null,
     ): NetworkResult<List<TimelineAccount>>
 
-    @GET("api/v1/accounts/search")
-    fun searchAccountsSync(
-        @Query("q") query: String,
-        @Query("resolve") resolve: Boolean? = null,
-        @Query("limit") limit: Int? = null,
-        @Query("following") following: Boolean? = null,
-    ): NetworkResult<List<TimelineAccount>>
-
     @GET("api/v1/accounts/{id}")
     suspend fun account(
         @Path("id") accountId: String,
@@ -723,16 +715,6 @@ interface MastodonApi {
     @GET("api/v2/search")
     suspend fun search(
         @Query("q") query: String?,
-        @Query("type") type: String? = null,
-        @Query("resolve") resolve: Boolean? = null,
-        @Query("limit") limit: Int? = null,
-        @Query("offset") offset: Int? = null,
-        @Query("following") following: Boolean? = null,
-    ): NetworkResult<SearchResult>
-
-    @GET("api/v2/search")
-    fun searchSync(
-        @Query("q") query: String,
         @Query("type") type: String? = null,
         @Query("resolve") resolve: Boolean? = null,
         @Query("limit") limit: Int? = null,


### PR DESCRIPTION
The previous code used synchronous (i.e., non-suspending) functions to call the /api/v2/search and /api/v2/accounts/search endpoints.

This is not necessary as the search was always performed in a separate thread.

Remove, and replace their usage with the equivalent functions that suspend.