### PR TITLE
fix: Ensure files are fully downloaded before sharing

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -719,4 +719,5 @@
     <string name="pref_title_update_check_now">Check for update now</string>
     <string name="pref_update_check_no_updates">There are no updates available</string>
     <string name="pref_update_next_scheduled_check">Next scheduled check: %1$s</string>
+    <string name="error_media_download">Could not download %1$s: %2$d %3$s</string>
 </resources>


### PR DESCRIPTION
The previous code would share media by either:

a. If it was an image, downloading the image using Glide in to a bitmap, then recompressing as a PNG, saving, and sharing the resulting file.

b. Otherwise, create a temporary file, enqueue a DownloadManager request to download the media in to the file, and immediately start sharing, hoping that the download had completed in time.

Both approaches have problems:

In the "image" case the image was being downloaded (or retrieved from the Glide cache), decompressed to a bitmap, then recompressed as a PNG. This uses more memory, and doesn't share the original contents of the file. E.g., if the original file was a JPEG that's lost (and the PNG might well be larger than the source image).

In the second case the DownloadManager download is not guaranteed to have completed (or even started) before the user chooses the share destination. The destination could receive a partial or even empty file.

Fix both of those cases by always fully downloading the file before sending the share intent. This guarantees the file is available to share, and in its original format. Since this uses the same OkHttpClient as the rest of the app the content is highly likely to be in the OkHttp cache, so there will no extra network traffic because of this.