### PR TITLE
fix(deps): update agp to v8.3.0, lint to 31.3.0

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.2.2" type="baseline" client="gradle" dependencies="false" name="AGP (8.2.2)" variant="all" version="8.2.2">
+<issues format="6" by="lint 8.3.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.3.0)" variant="all" version="8.3.0">
 
     <issue
         id="InvalidPackage"
@@ -49,6 +49,28 @@
             file="src/main/AndroidManifest.xml"
             line="24"
             column="9"/>
+    </issue>
+
+    <issue
+        id="SelectedPhotoAccess"
+        message="Your app is currently not handling Selected Photos Access introduced in Android 14+"
+        errorLine1="    &lt;uses-permission android:name=&quot;android.permission.READ_MEDIA_IMAGES&quot; />"
+        errorLine2="                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/AndroidManifest.xml"
+            line="9"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="SelectedPhotoAccess"
+        message="Your app is currently not handling Selected Photos Access introduced in Android 14+"
+        errorLine1="    &lt;uses-permission android:name=&quot;android.permission.READ_MEDIA_VIDEO&quot; />"
+        errorLine2="                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/AndroidManifest.xml"
+            line="10"
+            column="36"/>
     </issue>
 
     <issue

--- a/build-logic/convention/src/main/kotlin/app/pachli/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/app/pachli/KotlinAndroid.kt
@@ -28,7 +28,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
  * Configure base Kotlin with Android options
  */
 internal fun Project.configureKotlinAndroid(
-    commonExtension: CommonExtension<*, *, *, *, *>,
+    commonExtension: CommonExtension<*, *, *, *, *, *>,
 ) {
     commonExtension.apply {
         compileSdk = 34

--- a/build-logic/convention/src/main/kotlin/app/pachli/PachliFlavor.kt
+++ b/build-logic/convention/src/main/kotlin/app/pachli/PachliFlavor.kt
@@ -25,7 +25,7 @@ import com.android.build.api.dsl.ProductFlavor
 @Suppress("EnumEntryName")
 enum class FlavorDimension {
     color,
-    store
+    store,
 }
 
 @Suppress("EnumEntryName")
@@ -47,12 +47,12 @@ enum class PachliFlavor(
     ),
     fdroid(FlavorDimension.store),
     github(FlavorDimension.store),
-    google(FlavorDimension.store)
+    google(FlavorDimension.store),
 }
 
 fun configureFlavors(
-    commonExtension: CommonExtension<*, *, *, *, *>,
-    flavorConfigurationBlock: ProductFlavor.(flavor: PachliFlavor) -> Unit = {}
+    commonExtension: CommonExtension<*, *, *, *, *, *>,
+    flavorConfigurationBlock: ProductFlavor.(flavor: PachliFlavor) -> Unit = {},
 ) {
     commonExtension.apply {
         flavorDimensions += FlavorDimension.color.name

--- a/core/network/lint-baseline.xml
+++ b/core/network/lint-baseline.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.2.2" type="baseline" client="gradle" dependencies="false" name="AGP (8.2.2)" variant="all" version="8.2.2">
+<issues format="6" by="lint 8.3.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.3.0)" variant="all" version="8.3.0">
 
 </issues>

--- a/core/network/src/main/kotlin/app/pachli/core/network/Server.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/Server.kt
@@ -162,7 +162,8 @@ data class Server(
                     rx.find(version)
                         .toResultOr { UnparseableVersion(version, ParseException("unexpected null", 0)) }
                         .andThen {
-                            val adjusted = "${it.groups["major"]?.value}.${it.groups["minor"]?.value}.${it.groups["patch"]?.value}"
+                            // Fetching groups by name instead of index requires API >= 26
+                            val adjusted = "${it.groups[1]?.value}.${it.groups[2]?.value}.${it.groups[3]?.value}"
                             runSuspendCatching { Version.parse(adjusted, strict = false) }
                                 .mapError { UnparseableVersion(version, it) }
                         }
@@ -180,7 +181,8 @@ data class Server(
                     rx.find(version)
                         .toResultOr { UnparseableVersion(version, ParseException("unexpected null", 0)) }
                         .andThen {
-                            val adjusted = "${it.groups["major"]?.value}.${it.groups["minor"]?.value}.0"
+                            // Fetching groups by name instead of index requires API >= 26
+                            val adjusted = "${it.groups[1]?.value}.${it.groups[2]?.value}.0"
                             runSuspendCatching { Version.parse(adjusted, strict = false) }
                                 .mapError { UnparseableVersion(version, it) }
                         }
@@ -216,7 +218,8 @@ data class Server(
                     val rx = """^0*(?<major>\d+)\.0*(?<minor>\d+)\.0*(?<patch>\d+)""".toRegex()
                     rx.find(version).toResultOr { UnparseableVersion(version, ParseException("unexpected null", 0)) }
                         .andThen {
-                            val adjusted = "${it.groups["major"]?.value}.${it.groups["minor"]?.value ?: 0}.${it.groups["patch"]?.value ?: 0}"
+                            // Fetching groups by name instead of index requires API >= 26
+                            val adjusted = "${it.groups[1]?.value}.${it.groups[2]?.value ?: 0}.${it.groups[3]?.value ?: 0}"
                             runSuspendCatching { Version.parse(adjusted, strict = false) }
                                 .mapError { UnparseableVersion(adjusted, it) }
                         }
@@ -228,7 +231,8 @@ data class Server(
                     val rx = """Pleroma (?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)""".toRegex()
                     rx.find(version).toResultOr { UnparseableVersion(version, ParseException("unexpected null", 0)) }
                         .andThen {
-                            val adjusted = "${it.groups["major"]?.value}.${it.groups["minor"]?.value}.${it.groups["patch"]?.value}"
+                            // Fetching groups by name instead of index requires API >= 26
+                            val adjusted = "${it.groups[1]?.value}.${it.groups[2]?.value}.${it.groups[3]?.value}"
                             runSuspendCatching { Version.parse(adjusted, strict = false) }
                                 .mapError { UnparseableVersion(adjusted, it) }
                         }
@@ -240,7 +244,8 @@ data class Server(
                     val rx = """^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)""".toRegex()
                     rx.find(version).toResultOr { UnparseableVersion(version, ParseException("unexpected null", 0)) }
                         .andThen {
-                            val adjusted = "${it.groups["major"]?.value}.${it.groups["minor"]?.value}.${it.groups["patch"]?.value}"
+                            // Fetching groups by name instead of index requires API >= 26
+                            val adjusted = "${it.groups[1]?.value}.${it.groups[2]?.value}.${it.groups[3]?.value}"
                             runSuspendCatching { Version.parse(adjusted, strict = false) }
                                 .mapError { UnparseableVersion(adjusted, it) }
                         }

--- a/core/testing/lint-baseline.xml
+++ b/core/testing/lint-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.2.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.2.0)" variant="all" version="8.2.0">
+<issues format="6" by="lint 8.3.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.3.0)" variant="all" version="8.3.0">
 
     <issue
         id="InvalidPackage"
@@ -69,83 +69,6 @@
         message="Invalid package reference in org.robolectric:utils; not included in Android: `javax.inject`. Referenced from `org.robolectric.util.inject.Injector`.">
         <location
             file="$GRADLE_USER_HOME/caches/modules-2/files-2.1/org.robolectric/utils/4.11.1/12828864aac49e8ebcf2de03d3d33919ca8a1b01/utils-4.11.1.jar"/>
-    </issue>
-
-    <issue
-        id="NewApi"
-        message="Call requires API level 24 (current min is 23): `java.util.Collection#removeIf`"
-        errorLine1="        spans.removeIf { span -> span.span == what }"
-        errorLine2="              ~~~~~~~~">
-        <location
-            file="src/main/kotlin/app/pachli/core/testing/fakes/FakeSpannable.kt"
-            line="36"
-            column="15"/>
-    </issue>
-
-    <issue
-        id="NewApi"
-        message="Call requires API level 24 (current min is 23): `java.util.Map#getOrDefault`"
-        errorLine1="    override fun getString(key: String?, defValue: String?) = store.getOrDefault(key, defValue) as String?"
-        errorLine2="                                                                    ~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/app/pachli/core/testing/fakes/InMemorySharedPreferences.kt"
-            line="42"
-            column="69"/>
-    </issue>
-
-    <issue
-        id="NewApi"
-        message="Call requires API level 24 (current min is 23): `java.util.Map#getOrDefault`"
-        errorLine1="    override fun getStringSet(key: String?, defValues: MutableSet&lt;String>?) = store.getOrDefault(key, defValues) as MutableSet&lt;String>?"
-        errorLine2="                                                                                    ~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/app/pachli/core/testing/fakes/InMemorySharedPreferences.kt"
-            line="44"
-            column="85"/>
-    </issue>
-
-    <issue
-        id="NewApi"
-        message="Call requires API level 24 (current min is 23): `java.util.Map#getOrDefault`"
-        errorLine1="    override fun getInt(key: String, defaultValue: Int) = store.getOrDefault(key, defaultValue) as Int"
-        errorLine2="                                                                ~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/app/pachli/core/testing/fakes/InMemorySharedPreferences.kt"
-            line="46"
-            column="65"/>
-    </issue>
-
-    <issue
-        id="NewApi"
-        message="Call requires API level 24 (current min is 23): `java.util.Map#getOrDefault`"
-        errorLine1="    override fun getLong(key: String, defaultValue: Long) = store.getOrDefault(key, defaultValue) as Long"
-        errorLine2="                                                                  ~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/app/pachli/core/testing/fakes/InMemorySharedPreferences.kt"
-            line="48"
-            column="67"/>
-    </issue>
-
-    <issue
-        id="NewApi"
-        message="Call requires API level 24 (current min is 23): `java.util.Map#getOrDefault`"
-        errorLine1="    override fun getFloat(key: String, defaultValue: Float) = store.getOrDefault(key, defaultValue) as Float"
-        errorLine2="                                                                    ~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/app/pachli/core/testing/fakes/InMemorySharedPreferences.kt"
-            line="50"
-            column="69"/>
-    </issue>
-
-    <issue
-        id="NewApi"
-        message="Call requires API level 24 (current min is 23): `java.util.Map#getOrDefault`"
-        errorLine1="    override fun getBoolean(key: String, defaultValue: Boolean) = store.getOrDefault(key, defaultValue) as Boolean"
-        errorLine2="                                                                        ~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/app/pachli/core/testing/fakes/InMemorySharedPreferences.kt"
-            line="52"
-            column="73"/>
     </issue>
 
 </issues>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 aboutlibraries = "10.10.0"
 acra = "5.11.3"
-agp = "8.2.2"
+agp = "8.3.0"
 androidx-activity = "1.8.2"
 androidx-appcompat = "1.6.1"
 androidx-browser = "1.7.0"
@@ -46,7 +46,7 @@ kotlin-result = "1.1.18"
 ksp = "1.9.22-1.0.17"
 image-cropper = "4.3.2"
 leakcanary = "2.13"
-lint = "31.2.2" # = agp + 23.0.0 (= 8.2.2), see https://github.com/googlesamples/android-custom-lint-rules#lint-version
+lint = "31.3.0" # = agp + 23.0.0 (= 8.3.0), see https://github.com/googlesamples/android-custom-lint-rules#lint-version
 material = "1.11.0"
 material-drawer = "9.0.2"
 material-typeface = "4.0.0.2-kotlin"


### PR DESCRIPTION
New lint rules highlighted a potential crash; the use of named match groups (used here when extracting server versions) requires API >= 26 or throws an exception.

Use the group numbers instead of names when extracting the value, but keep the group names in the regular expressions for readability.