### PR TITLE
refactor: Implement deleteStaleCachedMedia as a suspending function

### DIFF
--- a/app/src/main/java/app/pachli/MainActivity.kt
+++ b/app/src/main/java/app/pachli/MainActivity.kt
@@ -70,6 +70,7 @@ import app.pachli.core.activity.AccountSelectionListener
 import app.pachli.core.activity.BottomSheetActivity
 import app.pachli.core.activity.PostLookupFallbackBehavior
 import app.pachli.core.activity.emojify
+import app.pachli.core.common.di.ApplicationScope
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
 import app.pachli.core.common.extensions.viewBinding
@@ -153,13 +154,17 @@ import com.mikepenz.materialdrawer.util.updateBadge
 import com.mikepenz.materialdrawer.widget.AccountHeaderView
 import dagger.hilt.android.AndroidEntryPoint
 import de.c1710.filemojicompat_ui.helpers.EMOJI_PREFERENCE
-import io.reactivex.rxjava3.schedulers.Schedulers
 import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
 @AndroidEntryPoint
 class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
+    @Inject
+    @ApplicationScope
+    lateinit var externalScope: CoroutineScope
+
     @Inject
     lateinit var eventHub: EventHub
 
@@ -346,7 +351,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
             }
         }
 
-        Schedulers.io().scheduleDirect {
+        externalScope.launch {
             // Flush old media that was cached for sharing
             deleteStaleCachedMedia(applicationContext.getExternalFilesDir("Pachli"))
         }

--- a/app/src/main/java/app/pachli/util/MediaUtils.kt
+++ b/app/src/main/java/app/pachli/util/MediaUtils.kt
@@ -31,6 +31,8 @@ import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date
 import java.util.Locale
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import timber.log.Timber
 
 /**
@@ -165,10 +167,10 @@ fun getImageOrientation(uri: Uri, contentResolver: ContentResolver): Int {
     }
 }
 
-fun deleteStaleCachedMedia(mediaDirectory: File?) {
+suspend fun deleteStaleCachedMedia(mediaDirectory: File?) = withContext(Dispatchers.IO) {
     if (mediaDirectory == null || !mediaDirectory.exists()) {
         // Nothing to do
-        return
+        return@withContext
     }
 
     val twentyfourHoursAgo = Calendar.getInstance()
@@ -182,7 +184,7 @@ fun deleteStaleCachedMedia(mediaDirectory: File?) {
     }
     if (files == null || files.isEmpty()) {
         // Nothing to do
-        return
+        return@withContext
     }
 
     for (file in files) {


### PR DESCRIPTION
Previously a regular function launched with an rxJava scheduler, now it's a suspending function that enforces Dispatchers.IO as the context, launched in its own coroutine.