### PR TITLE
refactor: Implement updateShortcut as a suspending function

### DIFF
--- a/app/src/main/java/app/pachli/MainActivity.kt
+++ b/app/src/main/java/app/pachli/MainActivity.kt
@@ -979,7 +979,9 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
         }
 
         updateProfiles()
-        updateShortcut(applicationContext, accountManager.activeAccount!!)
+        externalScope.launch {
+            updateShortcut(applicationContext, accountManager.activeAccount!!)
+        }
     }
 
     @SuppressLint("CheckResult")


### PR DESCRIPTION
Previously a regular function that created and subscribed to an rxJava callable, now it's a suspending function that enforces Dispatchers.IO as the context, launched in its own coroutine.