### PR TITLE
wip: Instrument calls to refresh the cached timeline

### DIFF
--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/CachedTimelineRemoteMediator.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/CachedTimelineRemoteMediator.kt
@@ -71,6 +71,7 @@ class CachedTimelineRemoteMediator(
         return try {
             val response = when (loadType) {
                 LoadType.REFRESH -> {
+                    Timber.e(RuntimeException(), "Stack trace for LoadType.REFRESH")
                     val closestItem = state.anchorPosition?.let {
                         state.closestItemToPosition(maxOf(0, it - (state.config.pageSize / 2)))
                     }?.status?.serverId


### PR DESCRIPTION
A user report shows what appears to be spurious / unexpected calls to refresh the cached timeline occuring while scrolling. Have confirmed these calls aren't coming from any Pachli code, so adding additional instrumentation that can be included in a custom APK to debug further.