### PR TITLE
ci: Don't compress APK files when uploading release artifacts

### DIFF
--- a/.github/workflows/upload-orange-release-google-play.yml
+++ b/.github/workflows/upload-orange-release-google-play.yml
@@ -68,6 +68,7 @@ jobs:
         with:
           name: app-release.apk
           path: ${{steps.sign_app_apk.outputs.signedReleaseFile}}
+          compression-level: 0
 
       - name: Generate whatsnew
         id: generate-whatsnew


### PR DESCRIPTION
They're already compressed, and it slows down the workflow step.