### PR TITLE
feat: Include "Notifications" in the left-side navigation menu

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -122,6 +122,7 @@
         <activity
             android:name=".components.account.AccountActivity"
             android:configChanges="orientation|screenSize|keyboardHidden|screenLayout|smallestScreenSize" />
+        <activity android:name=".components.notifications.NotificationsActivity" />
         <activity android:name=".EditProfileActivity" />
         <activity android:name=".components.preference.PreferencesActivity" />
         <activity android:name=".StatusListActivity" />

--- a/app/src/main/java/app/pachli/MainActivity.kt
+++ b/app/src/main/java/app/pachli/MainActivity.kt
@@ -89,6 +89,7 @@ import app.pachli.core.navigation.ListActivityIntent
 import app.pachli.core.navigation.LoginActivityIntent
 import app.pachli.core.navigation.LoginActivityIntent.LoginMode
 import app.pachli.core.navigation.MainActivityIntent
+import app.pachli.core.navigation.NotificationsActivityIntent
 import app.pachli.core.navigation.PreferencesActivityIntent
 import app.pachli.core.navigation.PreferencesActivityIntent.PreferenceScreen
 import app.pachli.core.navigation.ScheduledStatusActivityIntent
@@ -575,10 +576,19 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
             tintStatusBar = true
             addItems(
                 primaryDrawerItem {
-                    nameRes = R.string.action_edit_profile
-                    iconicsIcon = GoogleMaterial.Icon.gmd_person
+                    nameRes = R.string.title_notifications
+                    iconicsIcon = GoogleMaterial.Icon.gmd_notifications
                     onClick = {
-                        val intent = EditProfileActivityIntent(context)
+                        startActivityWithSlideInAnimation(
+                            NotificationsActivityIntent(context),
+                        )
+                    }
+                },
+                primaryDrawerItem {
+                    nameRes = R.string.action_view_bookmarks
+                    iconicsIcon = GoogleMaterial.Icon.gmd_bookmark
+                    onClick = {
+                        val intent = StatusListActivityIntent.bookmarks(context)
                         startActivityWithSlideInAnimation(intent)
                     }
                 },
@@ -588,14 +598,6 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
                     iconicsIcon = GoogleMaterial.Icon.gmd_star
                     onClick = {
                         val intent = StatusListActivityIntent.favourites(context)
-                        startActivityWithSlideInAnimation(intent)
-                    }
-                },
-                primaryDrawerItem {
-                    nameRes = R.string.action_view_bookmarks
-                    iconicsIcon = GoogleMaterial.Icon.gmd_bookmark
-                    onClick = {
-                        val intent = StatusListActivityIntent.bookmarks(context)
                         startActivityWithSlideInAnimation(intent)
                     }
                 },
@@ -655,6 +657,14 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
                     iconicsIcon = GoogleMaterial.Icon.gmd_settings
                     onClick = {
                         val intent = PreferencesActivityIntent(context, PreferenceScreen.GENERAL)
+                        startActivityWithSlideInAnimation(intent)
+                    }
+                },
+                primaryDrawerItem {
+                    nameRes = R.string.action_edit_profile
+                    iconicsIcon = GoogleMaterial.Icon.gmd_person
+                    onClick = {
+                        val intent = EditProfileActivityIntent(context)
                         startActivityWithSlideInAnimation(intent)
                     }
                 },

--- a/app/src/main/java/app/pachli/components/notifications/NotificationsActivity.kt
+++ b/app/src/main/java/app/pachli/components/notifications/NotificationsActivity.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2024 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.components.notifications
+
+import android.os.Bundle
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
+import androidx.core.view.MenuProvider
+import androidx.fragment.app.commit
+import app.pachli.R
+import app.pachli.core.activity.BottomSheetActivity
+import app.pachli.core.common.extensions.viewBinding
+import app.pachli.core.navigation.ComposeActivityIntent
+import app.pachli.databinding.ActivityNotificationsBinding
+import app.pachli.interfaces.ActionButtonActivity
+import app.pachli.interfaces.AppBarLayoutHost
+import app.pachli.util.unsafeLazy
+import com.google.android.material.appbar.AppBarLayout
+
+class NotificationsActivity : BottomSheetActivity(), ActionButtonActivity, AppBarLayoutHost, MenuProvider {
+    private val binding by viewBinding(ActivityNotificationsBinding::inflate)
+
+    override val actionButton by unsafeLazy { binding.composeButton }
+
+    override val appBarLayout: AppBarLayout
+        get() = binding.includedToolbar.appbar
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(binding.root)
+
+        setSupportActionBar(binding.includedToolbar.toolbar)
+
+        supportActionBar?.run {
+            setTitle(R.string.title_notifications)
+            setDisplayHomeAsUpEnabled(true)
+            setDisplayShowHomeEnabled(true)
+        }
+
+        if (supportFragmentManager.findFragmentById(R.id.fragmentContainer) == null) {
+            supportFragmentManager.commit {
+                val fragment = NotificationsFragment.newInstance()
+                replace(R.id.fragmentContainer, fragment)
+            }
+        }
+
+        binding.composeButton.setOnClickListener {
+            val composeIntent = ComposeActivityIntent(applicationContext)
+            startActivity(composeIntent)
+        }
+    }
+
+    override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+        super.onCreateMenu(menu, menuInflater)
+        menuInflater.inflate(R.menu.activity_trending, menu)
+    }
+
+    override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+        super.onMenuItemSelected(menuItem)
+        return super.onOptionsItemSelected(menuItem)
+    }
+}

--- a/app/src/main/res/layout/activity_notifications.xml
+++ b/app/src/main/res/layout/activity_notifications.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2024 Pachli Association
+  ~
+  ~ This file is a part of Pachli.
+  ~
+  ~ This program is free software; you can redistribute it and/or modify it under the terms of the
+  ~ GNU General Public License as published by the Free Software Foundation; either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+  ~ the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+  ~ Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License along with Pachli; if not,
+  ~ see <http://www.gnu.org/licenses>.
+  -->
+
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="app.pachli.components.notifications.NotificationsActivity">
+
+    <include
+        android:id="@+id/includedToolbar"
+        layout="@layout/toolbar_basic" />
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/fragmentContainer"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/composeButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/fabMargin"
+        android:contentDescription="@string/action_compose"
+        app:layout_anchor="@id/fragmentContainer"
+        app:layout_anchorGravity="bottom|end"
+        app:srcCompat="@drawable/ic_create_24dp" />
+
+    <include layout="@layout/item_status_bottom_sheet" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/core/navigation/src/main/kotlin/app/pachli/core/navigation/Navigation.kt
+++ b/core/navigation/src/main/kotlin/app/pachli/core/navigation/Navigation.kt
@@ -562,6 +562,12 @@ class LoginWebViewActivityIntent(context: Context) : Intent() {
     }
 }
 
+class NotificationsActivityIntent(context: Context) : Intent() {
+    init {
+        setClassName(context, QuadrantConstants.NOTIFICATIONS_ACTIVITY)
+    }
+}
+
 class ScheduledStatusActivityIntent(context: Context) : Intent() {
     init {
         setClassName(context, QuadrantConstants.SCHEDULED_STATUS_ACTIVITY)


### PR DESCRIPTION
Previously the only way to access notifications was to dedicate a tab to them. Now notifications are available from the left-side navigation menu so they're always accessible.

Add them to the top of the list, and swap the order of bookmarks and favourites, assuming that users are more likely to want to see their bookmarks than their favourites.

Move "Edit profile" to the bottom with the other settings options, assuming that editing their profile does not happen very often, so should not be at the top of the list.