### PR TITLE
feat: Auto-hide Image Viewer toolbar

### DIFF
--- a/app/src/main/java/app/pachli/fragment/ViewMediaFragment.kt
+++ b/app/src/main/java/app/pachli/fragment/ViewMediaFragment.kt
@@ -95,7 +95,7 @@ abstract class ViewMediaFragment : Fragment() {
         hideToolbarJob?.cancel()
         hideToolbarJob = lifecycleScope.launch {
             delay(CONTROLS_TIMEOUT)
-            mediaActivity.onMediaTap()
+            mediaActionsListener.onMediaTap()
         }
     }
 


### PR DESCRIPTION
When viewing an Image, it is not straightforward to understand that tapping on it will hide the toolbar and alt sheet, and those elements might get in the way of them viewing the full image.

Automatically hiding the toolbar and alt sheet after some short time might help the user two ways:
1. Get out of their way when they're viewing an image with an aspect ratio so that those elements are on top of it.
2. Showing them that those elements are hide-able, which might nudge into tapping to restore them and, consequently, learn about the "tap to hide/show" feature.

Interacting with the alt sheet cancels the auto-hide.

Fixes #505 