### PR TITLE
test: close DB in TimelineDaoTest

### DIFF
--- a/core/database/src/test/kotlin/app/pachli/core/database/dao/TimelineDaoTest.kt
+++ b/core/database/src/test/kotlin/app/pachli/core/database/dao/TimelineDaoTest.kt
@@ -28,6 +28,7 @@ import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import javax.inject.Inject
 import kotlinx.coroutines.runBlocking
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
@@ -49,6 +50,11 @@ class TimelineDaoTest {
     @Before
     fun setup() {
         hilt.inject()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
     }
 
     @Test


### PR DESCRIPTION
# Overview
The previous code forgot to close the DB after TimelineDaoTest was run, so a warning message was displayed when the test was run locally.

Therefore, solve this with closing the DB using the `@After` annotation.

Fixes #511