### PR TITLE
fix: Ensure logging out accounts completes

### DIFF
--- a/app/src/main/java/app/pachli/usecase/LogoutUsecase.kt
+++ b/app/src/main/java/app/pachli/usecase/LogoutUsecase.kt
@@ -14,6 +14,7 @@ import app.pachli.core.network.retrofit.MastodonApi
 import app.pachli.util.removeShortcut
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
+import timber.log.Timber
 
 class LogoutUsecase @Inject constructor(
     @ApplicationContext private val context: Context,
@@ -37,11 +38,15 @@ class LogoutUsecase @Inject constructor(
             val clientId = activeAccount.clientId
             val clientSecret = activeAccount.clientSecret
             if (clientId != null && clientSecret != null) {
-                api.revokeOAuthToken(
-                    clientId = clientId,
-                    clientSecret = clientSecret,
-                    token = activeAccount.accessToken,
-                )
+                try {
+                    api.revokeOAuthToken(
+                        clientId = clientId,
+                        clientSecret = clientSecret,
+                        token = activeAccount.accessToken,
+                    )
+                } catch (e: Exception) {
+                    Timber.e(e, "Could not revoke OAuth token, continuing")
+                }
             }
 
             // disable push notifications


### PR DESCRIPTION
The account logout process could fail due to API exceptions; network errors for example, or if the user had already revoked the app's token for that account. This would prevent the rest of the logout process (cleaning database, etc) from completing.

Fix this by ignoring network errors during the logout process, and always cleaning up account content in the database.

Fix a related issue where a deleted account might be recreated in a partial state if the account's visible position was saved after it was deleted. The recreated account couldn't do anything as it had no tokens, but is very confusing.