### PR TITLE
refactor: Use LinearProgressIndicator with delayed show/hide

### DIFF
--- a/app/src/main/res/layout/dialog_select_list.xml
+++ b/app/src/main/res/layout/dialog_select_list.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2024 Pachli Association
+  ~
+  ~ This file is a part of Pachli.
+  ~
+  ~ This program is free software; you can redistribute it and/or modify it under the terms of the
+  ~ GNU General Public License as published by the Free Software Foundation; either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+  ~ the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+  ~ Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License along with Pachli; if not,
+  ~ see <http://www.gnu.org/licenses>.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:layout_gravity="top">
+
+    <com.google.android.material.progressindicator.LinearProgressIndicator
+        android:id="@+id/progressBar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingStart="?dialogPreferredPadding"
+        android:paddingEnd="?dialogPreferredPadding"
+        android:layout_gravity="top"
+        android:indeterminate="true"
+        android:visibility="gone" />
+
+    <TextView
+        android:id="@+id/noLists"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingStart="?dialogPreferredPadding"
+        android:paddingEnd="?dialogPreferredPadding"
+        android:text="@string/select_list_empty"
+        android:visibility="gone" />
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_view_thread.xml
+++ b/app/src/main/res/layout/fragment_view_thread.xml
@@ -45,7 +45,7 @@
         </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
     </LinearLayout>
 
-    <ProgressBar
+    <com.google.android.material.progressindicator.LinearProgressIndicator
         android:id="@+id/initialProgressBar"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/core/designsystem/src/main/res/values/styles.xml
+++ b/core/designsystem/src/main/res/values/styles.xml
@@ -84,6 +84,8 @@
         <item name="graphViewStyle">@style/Pachli.Widget.GraphView</item>
 
         <item name="snackbarTextViewStyle">@style/snackbar_text</item>
+
+        <item name="linearProgressIndicatorStyle">@style/Pachli.Widget.Material3.LinearProgressIndicator</item>
     </style>
 
     <style name="AppTheme" parent="Theme.Pachli" />
@@ -167,6 +169,11 @@
         <item name="primaryLineColor">@color/pachli_blue</item>
         <item name="secondaryLineColor">@color/pachli_orange</item>
         <item name="lineWidth">2sp</item>
+    </style>
+
+    <style name="Pachli.Widget.Material3.LinearProgressIndicator" parent="Widget.Material3.LinearProgressIndicator">
+        <item name="minHideDelay">500</item>
+        <item name="showDelay">500</item>
     </style>
 
     <style name="Theme.Pachli.Black" parent="Base.Theme.Black" />


### PR DESCRIPTION
Previous code used a normal ProgressBar and a coroutine to delay hiding/showing the bar for a snappier UI perception.

This is built-in functionality in LinearProgressIndicator, so switch to that.

While I'm here, implement the "Select list" dialog's layout as a layout resource.