### PR TITLE
chore: Ignore any files in app/*/release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,5 @@ build
 gradle-user-home
 profile-out
 profile-out-*
-app/release
+app/*/release
 app-release.apk


### PR DESCRIPTION
Ensures release build files are ignored irrespective of the build type.