### PR TITLE
feat: Show network activity in ListsActivity

### DIFF
--- a/app/src/main/java/app/pachli/ListsActivity.kt
+++ b/app/src/main/java/app/pachli/ListsActivity.kt
@@ -118,6 +118,12 @@ class ListsActivity : BaseActivity(), MenuProvider {
                 }
             }
         }
+
+        lifecycleScope.launch {
+            viewModel.operationCount.collectLatest {
+                if (it == 0) binding.progressIndicator.hide() else binding.progressIndicator.show()
+            }
+        }
     }
 
     override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {

--- a/app/src/main/res/layout/activity_lists.xml
+++ b/app/src/main/res/layout/activity_lists.xml
@@ -13,6 +13,15 @@
             android:id="@+id/includedToolbar"
             layout="@layout/toolbar_basic" />
 
+        <com.google.android.material.progressindicator.LinearProgressIndicator
+            android:id="@+id/progressIndicator"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toBottomOf="@id/includedToolbar"
+            android:visibility="gone"
+            android:indeterminate="true"
+            android:contentDescription="" />
+
         <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
             android:id="@+id/swipeRefreshLayout"
             android:layout_width="0dp"


### PR DESCRIPTION
Modify `ListsViewModel` to keep track of the number of active network operations and export as a flow. Collect this in `ListsActivity` and show a `LinearProgressIndicator` while it is non-zero.