### PR TITLE
feat: Allow the user to set a list's replies policy

### DIFF
--- a/app/src/main/java/app/pachli/viewmodel/ListsViewModel.kt
+++ b/app/src/main/java/app/pachli/viewmodel/ListsViewModel.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import app.pachli.core.data.repository.ListsError
 import app.pachli.core.data.repository.ListsRepository
+import app.pachli.core.network.model.UserListRepliesPolicy
 import com.github.michaelbull.result.onFailure
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -61,18 +62,18 @@ internal class ListsViewModel @Inject constructor(
         listsRepository.refresh()
     }
 
-    fun createNewList(title: String, exclusive: Boolean) = viewModelScope.launch {
+    fun createNewList(title: String, exclusive: Boolean, repliesPolicy: UserListRepliesPolicy) = viewModelScope.launch {
         _operationCount.getAndUpdate { it + 1 }
 
-        listsRepository.createList(title, exclusive).onFailure {
+        listsRepository.createList(title, exclusive, repliesPolicy).onFailure {
             _errors.send(Error.Create(title, it))
         }
     }.invokeOnCompletion { _operationCount.getAndUpdate { it - 1 } }
 
-    fun updateList(listId: String, title: String, exclusive: Boolean) = viewModelScope.launch {
+    fun updateList(listId: String, title: String, exclusive: Boolean, repliesPolicy: UserListRepliesPolicy) = viewModelScope.launch {
         _operationCount.getAndUpdate { it + 1 }
 
-        listsRepository.editList(listId, title, exclusive).onFailure {
+        listsRepository.editList(listId, title, exclusive, repliesPolicy).onFailure {
             _errors.send(Error.Update(title, it))
         }
     }.invokeOnCompletion { _operationCount.getAndUpdate { it - 1 } }

--- a/app/src/main/res/layout/dialog_list.xml
+++ b/app/src/main/res/layout/dialog_list.xml
@@ -1,37 +1,60 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    android:orientation="vertical"
+    android:padding="?dialogPreferredPadding">
 
-    <EditText
-        android:id="@+id/nameText"
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/textField"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginEnd="8dp"
-        android:layout_marginBottom="0dp"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        android:inputType="text"
-        android:hint="@string/hint_list_name"
-        android:importantForAutofill="no"
-        />
+        android:hint="@string/hint_list_name">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/nameText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:importantForAutofill="no" />
+    </com.google.android.material.textfield.TextInputLayout>
 
     <CheckBox
         android:id="@+id/exclusiveCheckbox"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="0dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginEnd="8dp"
-        android:layout_marginBottom="0dp"
-        app:layout_constraintTop_toBottomOf="@id/nameText"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        android:text="@string/list_exclusive_label"
-        />
+        android:layout_marginTop="16dp"
+        android:text="@string/list_exclusive_label" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/replies_policy_title"
+        style="@style/TextAppearance.Material3.TitleSmall"
+        android:textColor="?attr/colorAccent" />
+
+    <RadioGroup
+        android:id="@+id/repliesPolicyGroup"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp">
+
+        <RadioButton
+            android:id="@+id/repliesPolicyFollowed"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/replies_policy_name_followed" />
+
+        <RadioButton
+            android:id="@+id/repliesPolicyList"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/replies_policy_name_list" />
+
+        <RadioButton
+            android:id="@+id/repliesPolicyNone"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/replies_policy_name_none" />
+    </RadioGroup>
+</LinearLayout>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -293,5 +293,4 @@
         <item>ONCE_PER_VERSION</item>
         <item>ALWAYS</item>
     </string-array>
-
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -717,4 +717,9 @@
     <string name="pref_update_check_no_updates">There are no updates available</string>
     <string name="pref_update_next_scheduled_check">Next scheduled check: %1$s</string>
     <string name="error_media_download">Could not download %1$s: %2$d %3$s</string>
+
+    <string name="replies_policy_title">Show replies to:</string>
+    <string name="replies_policy_name_followed">Any followed user</string>
+    <string name="replies_policy_name_list">Members of the list</string>
+    <string name="replies_policy_name_none">No one</string>
 </resources>

--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/ListsRepository.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/ListsRepository.kt
@@ -19,6 +19,7 @@ package app.pachli.core.data.repository
 
 import app.pachli.core.network.model.MastoList
 import app.pachli.core.network.model.TimelineAccount
+import app.pachli.core.network.model.UserListRepliesPolicy
 import app.pachli.core.network.retrofit.apiresult.ApiError
 import com.github.michaelbull.result.Result
 import java.text.Collator
@@ -70,7 +71,7 @@ interface ListsRepository {
      * @param exclusive True if the list is exclusive
      * @return Details of the new list if successfuly, or an error
      */
-    suspend fun createList(title: String, exclusive: Boolean): Result<MastoList, ListsError.Create>
+    suspend fun createList(title: String, exclusive: Boolean, repliesPolicy: UserListRepliesPolicy): Result<MastoList, ListsError.Create>
 
     /**
      * Edit an existing list.
@@ -80,7 +81,7 @@ interface ListsRepository {
      * @param exclusive New exclusive vale for the list
      * @return Amended list, or an error
      */
-    suspend fun editList(listId: String, title: String, exclusive: Boolean): Result<MastoList, ListsError.Update>
+    suspend fun editList(listId: String, title: String, exclusive: Boolean, repliesPolicy: UserListRepliesPolicy): Result<MastoList, ListsError.Update>
 
     /**
      * Delete an existing list

--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/NetworkListsRepository.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/NetworkListsRepository.kt
@@ -27,6 +27,7 @@ import app.pachli.core.data.repository.ListsError.Update
 import app.pachli.core.database.model.TabData
 import app.pachli.core.network.model.MastoList
 import app.pachli.core.network.model.TimelineAccount
+import app.pachli.core.network.model.UserListRepliesPolicy
 import app.pachli.core.network.retrofit.MastodonApi
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
@@ -122,18 +123,18 @@ class NetworkListsRepository @Inject constructor(
         }
     }
 
-    override suspend fun createList(title: String, exclusive: Boolean): Result<MastoList, Create> = binding {
+    override suspend fun createList(title: String, exclusive: Boolean, repliesPolicy: UserListRepliesPolicy): Result<MastoList, Create> = binding {
         externalScope.async {
-            api.createList(title, exclusive).mapError { Create(it) }.bind().run {
+            api.createList(title, exclusive, repliesPolicy).mapError { Create(it) }.bind().run {
                 refresh()
                 body
             }
         }.await()
     }
 
-    override suspend fun editList(listId: String, title: String, exclusive: Boolean): Result<MastoList, Update> = binding {
+    override suspend fun editList(listId: String, title: String, exclusive: Boolean, repliesPolicy: UserListRepliesPolicy): Result<MastoList, Update> = binding {
         externalScope.async {
-            api.updateList(listId, title, exclusive).mapError { Update(it) }.bind().run {
+            api.updateList(listId, title, exclusive, repliesPolicy).mapError { Update(it) }.bind().run {
                 refresh()
                 body
             }

--- a/core/network/src/main/kotlin/app/pachli/core/network/model/MastoList.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/MastoList.kt
@@ -16,7 +16,33 @@
 
 package app.pachli.core.network.model
 
+import app.pachli.core.network.json.Default
+import app.pachli.core.network.json.HasDefault
+import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+
+/** https://docs.joinmastodon.org/entities/List/#replies_policy */
+@HasDefault
+enum class UserListRepliesPolicy {
+    /** Show replies to any followed user */
+    @Json(name = "followed")
+    FOLLOWED,
+
+    /** Show replies to members of the list */
+    @Default
+    @Json(name = "list")
+    LIST,
+
+    /** Show replies to no one */
+    @Json(name = "none")
+    NONE,
+
+    ;
+
+    // Empty companion object so that other code can add extension functions
+    // to this enum. See e.g., ListsActivity.
+    companion object
+}
 
 @JsonClass(generateAdapter = true)
 data class MastoList(
@@ -27,4 +53,7 @@ data class MastoList(
      * Null implies the server does not support this feature.
      */
     val exclusive: Boolean? = null,
+
+    @Json(name = "replies_policy")
+    val repliesPolicy: UserListRepliesPolicy = UserListRepliesPolicy.LIST,
 )

--- a/core/network/src/main/kotlin/app/pachli/core/network/retrofit/MastodonApi.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/retrofit/MastodonApi.kt
@@ -49,6 +49,7 @@ import app.pachli.core.network.model.TimelineAccount
 import app.pachli.core.network.model.Translation
 import app.pachli.core.network.model.TrendingTag
 import app.pachli.core.network.model.TrendsLink
+import app.pachli.core.network.model.UserListRepliesPolicy
 import app.pachli.core.network.retrofit.apiresult.ApiResult
 import at.connyduck.calladapter.networkresult.NetworkResult
 import okhttp3.MultipartBody
@@ -557,6 +558,7 @@ interface MastodonApi {
     suspend fun createList(
         @Field("title") title: String,
         @Field("exclusive") exclusive: Boolean?,
+        @Field("replies_policy") repliesPolicy: UserListRepliesPolicy = UserListRepliesPolicy.LIST,
     ): ApiResult<MastoList>
 
     @FormUrlEncoded
@@ -565,6 +567,7 @@ interface MastodonApi {
         @Path("listId") listId: String,
         @Field("title") title: String,
         @Field("exclusive") exclusive: Boolean?,
+        @Field("replies_policy") repliesPolicy: UserListRepliesPolicy = UserListRepliesPolicy.LIST,
     ): ApiResult<MastoList>
 
     @DELETE("api/v1/lists/{listId}")


### PR DESCRIPTION
The replies policy controls whether replies from members of the list also appear in the list.

Display the replies policy as three radio buttons when a list is created or updated, and send the chosen replies policy via the API.

Default value if not specified is always "list", for consistency with the Mastodon API defaults.

While I'm here:

- Ensure the list dialog layout is inflated using the dialog's themed context
- Use a `TextInputLayout` wrapper around the list name in the list dialog for better UX
- Simplify the dialog layout, use LinearLayout, and standard padding and margins