### PR TITLE
fix: Catch and swallow snackbar exception

### DIFF
--- a/app/src/main/java/app/pachli/fragment/SFragment.kt
+++ b/app/src/main/java/app/pachli/fragment/SFragment.kt
@@ -127,9 +127,16 @@ abstract class SFragment<T : IStatusViewData> : Fragment(), StatusActionListener
                             it.msg(requireContext()),
                         )
                         Timber.e(msg)
-                        Snackbar.make(requireView(), msg, Snackbar.LENGTH_INDEFINITE)
-                            .setAction(R.string.action_retry) { serverRepository.retry() }
-                            .show()
+                        try {
+                            Snackbar.make(requireView(), msg, Snackbar.LENGTH_INDEFINITE)
+                                .setAction(R.string.action_retry) { serverRepository.retry() }
+                                .show()
+                        } catch (e: IllegalArgumentException) {
+                            // On rare occasions this code is running before the fragment's
+                            // view is connected to the parent. This causes Snackbar.make()
+                            // to crash.  See https://issuetracker.google.com/issues/228215869.
+                            // For now, swallow the exception.
+                        }
                         serverCanTranslate = false
                     }
                 }


### PR DESCRIPTION
For reasons not fully understood the root of a fragment's view might not have relevant view from the activity set as its parent. This causes `Snackbar.make()` to throw an exception, and crash.

See https://issuetracker.google.com/issues/228215869.

For now, "fix" this by swallowing the exception. Not showing the error is better than crashing.