### PR TITLE
feat: Allow user to see poll results before voting

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -751,7 +751,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="624"
+            line="625"
             column="5"/>
     </issue>
 
@@ -1543,7 +1543,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="540"
+            line="541"
             column="13"/>
     </issue>
 
@@ -1554,7 +1554,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="581"
+            line="582"
             column="13"/>
     </issue>
 
@@ -1565,7 +1565,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="587"
+            line="588"
             column="13"/>
     </issue>
 
@@ -1576,7 +1576,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="616"
+            line="617"
             column="13"/>
     </issue>
 
@@ -1587,7 +1587,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="643"
+            line="644"
             column="13"/>
     </issue>
 
@@ -2717,6 +2717,17 @@
         <location
             file="src/main/res/layout/item_follow.xml"
             line="22"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingEnd` you should probably also define `paddingStart` for right-to-left symmetry"
+        errorLine1="        android:paddingEnd=&quot;6dp&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/item_poll.xml"
+            line="36"
             column="9"/>
     </issue>
 

--- a/app/src/main/java/app/pachli/viewdata/PollViewData.kt
+++ b/app/src/main/java/app/pachli/viewdata/PollViewData.kt
@@ -19,11 +19,12 @@ package app.pachli.viewdata
 import android.content.Context
 import android.text.SpannableStringBuilder
 import android.text.Spanned
-import androidx.core.text.parseAsHtml
+import android.text.Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
 import app.pachli.R
 import app.pachli.core.network.model.Poll
 import app.pachli.core.network.model.PollOption
 import app.pachli.core.network.model.TranslatedPoll
+import app.pachli.view.VotePercentSpan
 import java.util.Date
 import kotlin.math.roundToInt
 
@@ -86,11 +87,11 @@ fun calculatePercent(fraction: Int, totalVoters: Int?, totalVotes: Int): Int {
 }
 
 fun buildDescription(title: String, percent: Int, voted: Boolean, context: Context): Spanned {
-    val builder = SpannableStringBuilder(context.getString(R.string.poll_percent_format, percent).parseAsHtml())
+    val percentStr = context.getString(R.string.poll_percent_format, percent)
+    val builder = SpannableStringBuilder(percentStr)
+    builder.setSpan(VotePercentSpan(), 0, percentStr.length, SPAN_EXCLUSIVE_EXCLUSIVE)
     if (voted) {
         builder.append(" ✓ ")
-    } else {
-        builder.append(" ")
     }
     return builder.append(title)
 }

--- a/app/src/main/res/drawable/poll_option_background_inset.xml
+++ b/app/src/main/res/drawable/poll_option_background_inset.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2024 Pachli Association
+  ~
+  ~ This file is a part of Pachli.
+  ~
+  ~ This program is free software; you can redistribute it and/or modify it under the terms of the
+  ~ GNU General Public License as published by the Free Software Foundation; either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+  ~ the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+  ~ Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License along with Pachli; if not,
+  ~ see <http://www.gnu.org/licenses>.
+  -->
+
+<inset
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:drawable="@drawable/poll_option_background"
+    android:insetTop="3dp"
+    android:insetBottom="3dp" />

--- a/app/src/main/res/layout/item_poll.xml
+++ b/app/src/main/res/layout/item_poll.xml
@@ -9,7 +9,8 @@
         android:id="@+id/status_poll_option_result"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="6dp"
+        android:layout_marginTop="2dp"
+        android:layout_marginBottom="4dp"
         android:background="@drawable/poll_option_background"
         android:maxLines="3"
         android:ellipsize="end"
@@ -20,24 +21,30 @@
         android:textAlignment="viewStart"
         android:textColor="?colorOnSecondary"
         android:textSize="?attr/status_text_medium"
+        tools:visibility="gone"
         tools:text="40%" />
 
     <RadioButton
         android:id="@+id/status_poll_radio_button"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:textColor="?android:attr/textColorPrimary"
         android:textSize="?attr/status_text_medium"
         app:buttonTint="@color/compound_button_color"
+        android:background="@drawable/poll_option_background_inset"
+        android:paddingTop="2dp"
+        android:paddingEnd="6dp"
         tools:text="Option 1" />
 
     <CheckBox
         android:id="@+id/status_poll_checkbox"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:textColor="?android:attr/textColorPrimary"
         android:textSize="?attr/status_text_medium"
         app:buttonTint="@color/compound_button_color"
+        android:background="@drawable/poll_option_background_inset"
+        tools:visibility="gone"
         tools:text="Option 1" />
 
 </FrameLayout>

--- a/app/src/main/res/layout/item_status.xml
+++ b/app/src/main/res/layout/item_status.xml
@@ -213,7 +213,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="@id/status_display_name"
         app:layout_constraintTop_toBottomOf="@id/status_media_preview_container"
-        tools:visibility="gone" />
+        tools:visibility="visible" />
 
     <TextView
         android:id="@+id/translationProvider"

--- a/app/src/main/res/layout/status_poll.xml
+++ b/app/src/main/res/layout/status_poll.xml
@@ -15,38 +15,55 @@
   ~ see <http://www.gnu.org/licenses>.
   -->
 
-<merge
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout">
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/status_poll_options"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:nestedScrollingEnabled="false" />
+        android:nestedScrollingEnabled="false"
+        tools:listitem="@layout/item_poll"
+        tools:itemCount="4" />
 
     <Button
-        android:id="@+id/status_poll_button"
+        android:id="@+id/status_poll_vote_button"
         style="@style/AppButton.Outlined"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="4dp"
-        android:gravity="center"
-        android:minWidth="150dp"
-        android:minHeight="0dp"
         android:paddingLeft="16dp"
         android:paddingTop="4dp"
         android:paddingRight="16dp"
         android:paddingBottom="4dp"
         android:text="@string/poll_vote"
-        android:textSize="?attr/status_text_medium" />
+        android:textSize="?attr/status_text_medium"
+        app:layout_constraintEnd_toStartOf="@+id/status_poll_show_results"
+        app:layout_constraintHorizontal_chainStyle="spread_inside"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/status_poll_options"
+        app:layout_constraintWidth_max="150dp" />
+
+    <CheckBox
+        android:id="@+id/status_poll_show_results"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:text="@string/poll_show_votes"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="@+id/status_poll_vote_button"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/status_poll_vote_button"
+        app:layout_constraintTop_toTopOf="@+id/status_poll_vote_button"
+        tools:visibility="visible" />
 
     <TextView
         android:id="@+id/status_poll_description"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="6dp"
-        android:textSize="?attr/status_text_medium"
+        android:layout_marginTop="8dp"
         android:textIsSelectable="true"
+        android:textSize="?attr/status_text_medium"
+        app:layout_constraintTop_toBottomOf="@id/status_poll_vote_button"
         tools:text="7 votes • 7 hours remaining" />
 </merge>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -229,7 +229,7 @@
         <item>31536000</item>
     </integer-array>
 
-    <string name="poll_percent_format"><!-- 15% --> &lt;b>%1$d%%&lt;/b></string>
+    <string name="poll_percent_format"><!-- 15% -->%1$d%%</string>
 
     <string-array name="mute_duration_names">
         <item>@string/duration_indefinite</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -513,6 +513,7 @@
     <string name="poll_info_time_absolute">ends at %s</string>
     <string name="poll_info_closed">closed</string>
     <string name="poll_vote">Vote</string>
+    <string name="poll_show_votes">Show votes</string>
     <string name="poll_ended_voted">A poll you have voted in has ended</string>
     <string name="poll_ended_created">A poll you created has ended</string>
     <!--These are for timestamps on polls -->


### PR DESCRIPTION
Show a labelled checkbox to the bottom-right of polls that the user has not voted in and that have votes. If checked the current vote tally (as percentages) will be shown, along with a bar showing the relative value of each option.