### PR TITLE
fix: Allow filter expiration to be set to "indefinite"

### DIFF
--- a/app/src/main/java/app/pachli/components/filters/EditFilterActivity.kt
+++ b/app/src/main/java/app/pachli/components/filters/EditFilterActivity.kt
@@ -301,15 +301,11 @@ class EditFilterActivity : BaseActivity() {
     companion object {
         // Mastodon *stores* the absolute date in the filter,
         // but create/edit take a number of seconds (relative to the time the operation is posted)
-        fun getSecondsForDurationIndex(index: Int, context: Context?, default: Date? = null): Int? {
+        fun getSecondsForDurationIndex(index: Int, context: Context?, default: Date? = null): String? {
             return when (index) {
-                -1 -> if (default == null) {
-                    default
-                } else {
-                    ((default.time - System.currentTimeMillis()) / 1000).toInt()
-                }
-                0 -> null
-                else -> context?.resources?.getIntArray(R.array.filter_duration_values)?.get(index)
+                -1 -> default?.let { ((default.time - System.currentTimeMillis()) / 1000).toString() }
+                0 -> ""
+                else -> context?.resources?.getStringArray(R.array.filter_duration_values)?.get(index)
             }
         }
     }

--- a/app/src/main/java/app/pachli/components/filters/EditFilterViewModel.kt
+++ b/app/src/main/java/app/pachli/components/filters/EditFilterViewModel.kt
@@ -168,13 +168,13 @@ class EditFilterViewModel @Inject constructor(val api: MastodonApi, val eventHub
         )
     }
 
-    private suspend fun createFilterV1(contexts: List<FilterContext>, expiresInSeconds: Int?): Boolean {
+    private suspend fun createFilterV1(contexts: List<FilterContext>, expiresInSeconds: String?): Boolean {
         return keywords.value.map { keyword ->
             api.createFilterV1(keyword.keyword, contexts, false, keyword.wholeWord, expiresInSeconds)
         }.none { it.isFailure }
     }
 
-    private suspend fun updateFilterV1(contexts: List<FilterContext>, expiresInSeconds: Int?): Boolean {
+    private suspend fun updateFilterV1(contexts: List<FilterContext>, expiresInSeconds: String?): Boolean {
         val results = keywords.value.map { keyword ->
             if (originalFilter == null) {
                 api.createFilterV1(

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -264,7 +264,7 @@
         <item>@string/duration_7_days</item>
     </string-array>
 
-    <integer-array name="filter_duration_values"> <!-- values in seconds, corresponding to mute_duration_names -->
+    <string-array name="filter_duration_values"> <!-- values in seconds, corresponding to filter_duration_names -->
         <item>0</item>
         <item>300</item>
         <item>1800</item>
@@ -273,7 +273,7 @@
         <item>86400</item>
         <item>259200</item>
         <item>604800</item>
-    </integer-array>
+    </string-array>
 
     <string-array name="filter_action_values">
         <item>warn</item>

--- a/app/src/test/java/app/pachli/FilterV1Test.kt
+++ b/app/src/test/java/app/pachli/FilterV1Test.kt
@@ -260,7 +260,7 @@ class FilterV1Test {
         val expiredBySeconds = 3600
         val expiredDate = Date.from(Instant.now().minusSeconds(expiredBySeconds.toLong()))
         val updatedDuration = EditFilterActivity.getSecondsForDurationIndex(-1, null, expiredDate)
-        assert(updatedDuration != null && updatedDuration <= -expiredBySeconds)
+        assert(updatedDuration != null && updatedDuration.toInt() <= -expiredBySeconds)
     }
 
     @Test
@@ -268,7 +268,7 @@ class FilterV1Test {
         val expiresInSeconds = 3600
         val expiredDate = Date.from(Instant.now().plusSeconds(expiresInSeconds.toLong()))
         val updatedDuration = EditFilterActivity.getSecondsForDurationIndex(-1, null, expiredDate)
-        assert(updatedDuration != null && updatedDuration > (expiresInSeconds - 60))
+        assert(updatedDuration != null && updatedDuration.toInt() > (expiresInSeconds - 60))
     }
 
     companion object {

--- a/core/network/src/main/kotlin/app/pachli/core/network/retrofit/MastodonApi.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/retrofit/MastodonApi.kt
@@ -614,7 +614,9 @@ interface MastodonApi {
         @Field("context[]") context: List<FilterContext>,
         @Field("irreversible") irreversible: Boolean?,
         @Field("whole_word") wholeWord: Boolean?,
-        @Field("expires_in") expiresInSeconds: Int?,
+        // String not Int because the empty string is used to represent "indefinite",
+        // see https://github.com/mastodon/documentation/issues/1216#issuecomment-2030222940
+        @Field("expires_in") expiresInSeconds: String?,
     ): NetworkResult<FilterV1>
 
     @FormUrlEncoded
@@ -625,7 +627,9 @@ interface MastodonApi {
         @Field("context[]") context: List<FilterContext>,
         @Field("irreversible") irreversible: Boolean?,
         @Field("whole_word") wholeWord: Boolean?,
-        @Field("expires_in") expiresInSeconds: Int?,
+        // String not Int because the empty string is used to represent "indefinite",
+        // see https://github.com/mastodon/documentation/issues/1216#issuecomment-2030222940
+        @Field("expires_in") expiresInSeconds: String?,
     ): NetworkResult<FilterV1>
 
     @DELETE("api/v1/filters/{id}")
@@ -639,7 +643,9 @@ interface MastodonApi {
         @Field("title") title: String,
         @Field("context[]") context: List<FilterContext>,
         @Field("filter_action") filterAction: Filter.Action,
-        @Field("expires_in") expiresInSeconds: Int?,
+        // String not Int because the empty string is used to represent "indefinite",
+        // see https://github.com/mastodon/documentation/issues/1216#issuecomment-2030222940
+        @Field("expires_in") expiresInSeconds: String?,
     ): NetworkResult<Filter>
 
     @FormUrlEncoded
@@ -649,7 +655,9 @@ interface MastodonApi {
         @Field("title") title: String? = null,
         @Field("context[]") context: List<FilterContext>? = null,
         @Field("filter_action") filterAction: Filter.Action? = null,
-        @Field("expires_in") expiresInSeconds: Int? = null,
+        // String not Int because the empty string is used to represent "indefinite",
+        // see https://github.com/mastodon/documentation/issues/1216#issuecomment-2030222940
+        @Field("expires_in") expiresInSeconds: String? = null,
     ): NetworkResult<Filter>
 
     @DELETE("api/v2/filters/{id}")


### PR DESCRIPTION
Mastodon API uses an "empty" `expires_in` value for a filter to mean "Does not expire" (i.e., indefinite).

This was modelled as a null. Which doesn't work, because Retrofit does not send name/value pairs in encoded forms if the value is null.

Fix this by making the API type a `String?`, and explicitly using the empty string when indefinite expiry is used. This has to be converted back to an Int? in a few places.

See https://github.com/mastodon/documentation/issues/1216#issuecomment-2030222940