### PR TITLE
fix: Setup compose button when creating MainActivity

### DIFF
--- a/app/src/main/java/app/pachli/MainActivity.kt
+++ b/app/src/main/java/app/pachli/MainActivity.kt
@@ -962,10 +962,12 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
             activeTabLayout.addOnTabSelectedListener(it)
         }
 
-        supportActionBar?.title = tabs[position].title(this@MainActivity)
+        binding.mainToolbar.title = tabs[position].title(this@MainActivity)
         binding.mainToolbar.setOnClickListener {
             (tabAdapter.getFragment(activeTabLayout.selectedTabPosition) as? ReselectableFragment)?.onReselect()
         }
+
+        refreshComposeButtonState(tabs[position])
 
         updateProfiles()
     }


### PR DESCRIPTION
The compose button isn't initially working on `MainActivity`. It is only properly setup after changing tabs.

Fix by calling `MainActivity.refreshComposeButtonState(TabViewData)` on creation.