### PR TITLE
feat: Show any errors when registering the app during login

### DIFF
--- a/feature/login/src/main/kotlin/app/pachli/feature/login/LoginActivity.kt
+++ b/feature/login/src/main/kotlin/app/pachli/feature/login/LoginActivity.kt
@@ -22,7 +22,6 @@ import android.content.Intent
 import android.content.SharedPreferences
 import android.os.Bundle
 import android.text.method.LinkMovementMethod
-import android.util.Log
 import android.view.Menu
 import android.view.View
 import android.widget.TextView
@@ -35,6 +34,7 @@ import app.pachli.core.common.extensions.viewBinding
 import app.pachli.core.designsystem.R as DR
 import app.pachli.core.navigation.LoginActivityIntent
 import app.pachli.core.navigation.MainActivityIntent
+import app.pachli.core.network.extensions.getServerErrorMessage
 import app.pachli.core.network.model.AccessToken
 import app.pachli.core.network.retrofit.MastodonApi
 import app.pachli.core.preferences.getNonNullString
@@ -198,9 +198,9 @@ class LoginActivity : BaseActivity() {
                 { e ->
                     binding.loginButton.isEnabled = true
                     binding.domainTextInputLayout.error =
-                        getString(R.string.error_failed_app_registration)
+                        getString(R.string.error_failed_app_registration_fmt, e.getServerErrorMessage() ?: e.localizedMessage)
                     setLoading(false)
-                    Timber.e(Log.getStackTraceString(e))
+                    Timber.e(e, "Error when creating/registing app")
                     return@launch
                 },
             )

--- a/feature/login/src/main/res/values-ar/strings.xml
+++ b/feature/login/src/main/res/values-ar/strings.xml
@@ -10,7 +10,7 @@
     <string name="action_close">إغلاق</string>
     <string name="action_browser_login">الولوج باستخدام متصفح</string>
     <string name="error_invalid_domain">اسم النطاق الذي قمتَ بإدخاله غير صالح</string>
-    <string name="error_failed_app_registration">أخففت المصادقة مع مثيل الخادم هذا.</string>
+    <string name="error_failed_app_registration_fmt">%1$s :أخففت المصادقة مع مثيل الخادم هذا</string>
     <string name="error_authorization_unknown">لقد وقع هناك خطأ مجهول في التصريح.</string>
     <string name="error_authorization_denied">تم رفض التصريح.</string>
     <string name="error_retrieving_oauth_token">فشل الحصول على رمز الولوج.</string>

--- a/feature/login/src/main/res/values-be/strings.xml
+++ b/feature/login/src/main/res/values-be/strings.xml
@@ -10,7 +10,7 @@
     <string name="action_close">Закрыць</string>
     <string name="action_browser_login">Увайсці з браўзера</string>
     <string name="error_invalid_domain">Уведзены недапушчальны дамен</string>
-    <string name="error_failed_app_registration">Памылка праверкі сапраўднасці на гэтым серверы. Калі праблема застаецца, паспрабуйце ўвайсці з браўзера з меню.</string>
+    <string name="error_failed_app_registration_fmt">Памылка праверкі сапраўднасці на гэтым серверы. Калі праблема застаецца, паспрабуйце ўвайсці з браўзера з меню: %1$s</string>
     <string name="error_authorization_unknown">Адбылася невядомая памылка праверкі сапраўднасці. Калі праблема застаецца, паспрабуйце ўвайсці з браўзера з меню.</string>
     <string name="error_authorization_denied">Аўтарызацыя была адхілена. Калі ўпэўнены што ўвялі сапраўдныя ўліковыя даныя, паспрабуйце ўвайсці з браўзера з меню.</string>
     <string name="error_retrieving_oauth_token">Токен уваходу не атрыманы. Калі праблема застаецца, паспрабуйце ўвайсці з браўзера з меню.</string>

--- a/feature/login/src/main/res/values-bg/strings.xml
+++ b/feature/login/src/main/res/values-bg/strings.xml
@@ -15,7 +15,7 @@
 \nMore info can be found at <a href="https://joinmastodon.org">joinmastodon.org</a>. </string>
     <string name="action_close">Затваряне</string>
     <string name="error_invalid_domain">Въведен е невалиден домейн</string>
-    <string name="error_failed_app_registration">Неуспешно удостоверяване с тази инстанция.</string>
+    <string name="error_failed_app_registration_fmt">Неуспешно удостоверяване с тази инстанция: %1$s</string>
     <string name="error_authorization_unknown">Възникна неидентифицирана грешка при упълномощаване.</string>
     <string name="error_authorization_denied">Упълномощаването е отказано.</string>
     <string name="error_retrieving_oauth_token">Получаването на токен за вход бе неуспешно.</string>

--- a/feature/login/src/main/res/values-bn-rBD/strings.xml
+++ b/feature/login/src/main/res/values-bn-rBD/strings.xml
@@ -19,7 +19,7 @@
 \nMore info can be found at <a href="https://joinmastodon.org">joinmastodon.org</a>. </string>
     <string name="action_close">বদ্ধ</string>
     <string name="error_invalid_domain">অবৈধ ডোমেইন প্রবেশ করানো হয়েছে</string>
-    <string name="error_failed_app_registration">এই ইনস্ট্যান্স এর সঙ্গে প্রমাণীকরণ ব্যর্থ।</string>
+    <string name="error_failed_app_registration_fmt">এই ইনস্ট্যান্স এর সঙ্গে প্রমাণীকরণ ব্যর্থ।: %1$s</string>
     <string name="error_authorization_unknown">একটি অজ্ঞাত প্রমাণীকরণ ত্রুটি ঘটেছে।</string>
     <string name="error_authorization_denied">অনুমোদন অস্বীকার করা হয়েছে।</string>
     <string name="error_retrieving_oauth_token">একটি লগইন টোকেন পেতে ব্যর্থ।</string>

--- a/feature/login/src/main/res/values-bn-rIN/strings.xml
+++ b/feature/login/src/main/res/values-bn-rIN/strings.xml
@@ -9,7 +9,7 @@
 \nআরো তথ্য <a href="https://joinmastodon.org"> joinmastodon.org </a> এ পাওয়া যেতে পারে। </string>
     <string name="action_close">বদ্ধ</string>
     <string name="error_invalid_domain">অবৈধ ডোমেইন প্রবেশ করানো হয়েছে</string>
-    <string name="error_failed_app_registration">এই ইনস্ট্যান্স এর সঙ্গে প্রমাণীকরণ ব্যর্থ।</string>
+    <string name="error_failed_app_registration_fmt">এই ইনস্ট্যান্স এর সঙ্গে প্রমাণীকরণ ব্যর্থ।: %1$s</string>
     <string name="error_authorization_unknown">একটি অজ্ঞাত প্রমাণীকরণ ত্রুটি ঘটেছে।</string>
     <string name="error_authorization_denied">অনুমোদন অস্বীকার করা হয়েছে।</string>
     <string name="error_retrieving_oauth_token">একটি লগইন টোকেন পেতে ব্যর্থ।</string>

--- a/feature/login/src/main/res/values-ca/strings.xml
+++ b/feature/login/src/main/res/values-ca/strings.xml
@@ -11,7 +11,7 @@
     <string name="action_close">Tanca</string>
     <string name="action_browser_login">Inicieu sessió amb el navegador</string>
     <string name="error_invalid_domain">El domini que s\'ha introduït no és vàlid</string>
-    <string name="error_failed_app_registration">No s\'ha pogut autenticar amb aquesta instància. Si això continua, proveu d\'iniciar sessió al navegador des del menú.</string>
+    <string name="error_failed_app_registration_fmt">No s\'ha pogut autenticar amb aquesta instància. Si això continua, proveu d\'iniciar sessió al navegador des del menú: %1$s</string>
     <string name="error_authorization_unknown">S\'ha produït un error d\'autorització no identificat. Si això continua, proveu d\'iniciar sessió al navegador des del menú.</string>
     <string name="error_authorization_denied">S\'ha denegat l\'autorització. Si esteu segur que heu proporcionat les credencials correctes, proveu d\'iniciar sessió al navegador des del menú.</string>
     <string name="error_retrieving_oauth_token">No s\'ha pogut obtenir el token d\'inici de sessió. Si això continua, proveu d\'iniciar sessió al navegador des del menú.</string>

--- a/feature/login/src/main/res/values-ckb/strings.xml
+++ b/feature/login/src/main/res/values-ckb/strings.xml
@@ -9,7 +9,7 @@
 \nزانیاری زیاتر دەتوانرێت بدۆزرێتەوە لە <a href="https://joinmastodon.org">joinmastodon.org</a>. </string>
     <string name="action_close">دابخە</string>
     <string name="error_invalid_domain">دۆمەینێکی نادروستت نووسیوە</string>
-    <string name="error_failed_app_registration">سەرکەوتوو نەبوو، ڕاستکردنەوە لەگەڵ ئەم نمونەیە.</string>
+    <string name="error_failed_app_registration_fmt">%1$s :سەرکەوتوو نەبوو، ڕاستکردنەوە لەگەڵ ئەم نمونەیە</string>
     <string name="error_authorization_unknown">هەڵەیەک بۆ مۆڵەتدانی نەناسراو ڕووی دا.</string>
     <string name="error_authorization_denied">ڕێپێدان ڕەتکرایەوە.</string>
     <string name="error_retrieving_oauth_token">سەرکەوتوو نەبوو لە بەدەستهێنانی نیشانەی چوونەژوورەوە.</string>

--- a/feature/login/src/main/res/values-cs/strings.xml
+++ b/feature/login/src/main/res/values-cs/strings.xml
@@ -11,7 +11,7 @@
     </string>
     <string name="action_close">Zavřít</string>
     <string name="error_invalid_domain">Byla zadána neplatná doména</string>
-    <string name="error_failed_app_registration">Autentizace s tímto serverem nebyla úspěšná.</string>
+    <string name="error_failed_app_registration_fmt">Autentizace s tímto serverem nebyla úspěšná: %1$s</string>
     <string name="error_authorization_unknown">Vyskytla se neidentifikovaná chyba autorizace.</string>
     <string name="error_authorization_denied">Autorizace byla zamítnuta.</string>
     <string name="error_retrieving_oauth_token">Nepodařilo se získat přihlašovací token.</string>

--- a/feature/login/src/main/res/values-cy/strings.xml
+++ b/feature/login/src/main/res/values-cy/strings.xml
@@ -10,7 +10,7 @@
     <string name="action_close">Cau</string>
     <string name="action_browser_login">Mewngofnodi â phorwr</string>
     <string name="error_invalid_domain">Rhoddwyd parth annilys</string>
-    <string name="error_failed_app_registration">Methu awdurdodi gyda\'r gweinydd hwnnw. Os bydd hyn yn parhau, ceisiwch Mewngofnodi yn Porwr o\'r ddewislen.</string>
+    <string name="error_failed_app_registration_fmt">Methu awdurdodi gyda\'r gweinydd hwnnw. Os bydd hyn yn parhau, ceisiwch Mewngofnodi yn Porwr o\'r ddewislen: %1$s</string>
     <string name="error_authorization_unknown">Bu gwall awdurdodi anhysbys. Os bydd hyn yn parhau, ceisiwch Mewngofnodi yn Porwr o\'r ddewislen.</string>
     <string name="error_authorization_denied">Gwrthodwyd awdurdodi. Os ydych chi\'n siŵr dy fod di wedi gyflenwi\'r manylion cywir, ceisiwch Mewngofnodi yn Porwr o\'r ddewislen.</string>
     <string name="error_retrieving_oauth_token">Methu cael tocyn mewngofnodi. Os bydd hyn yn parhau, ceisiwch Mewngofnodi yn Porwr o\'r ddewislen.</string>

--- a/feature/login/src/main/res/values-de/strings.xml
+++ b/feature/login/src/main/res/values-de/strings.xml
@@ -10,7 +10,7 @@
     <string name="action_close">Schließen</string>
     <string name="action_browser_login">Mit Browser anmelden</string>
     <string name="error_invalid_domain">Ungültige Domain angegeben</string>
-    <string name="error_failed_app_registration">Authentifizieren mit dieser Instanz fehlgeschlagen. Falls das Problem weiter besteht, versuche dich über den Browser anzumelden.</string>
+    <string name="error_failed_app_registration_fmt">Authentifizieren mit dieser Instanz fehlgeschlagen. Falls das Problem weiter besteht, versuche dich über den Browser anzumelden: %1$s</string>
     <string name="error_authorization_unknown">Ein unbekannter Fehler ist bei der Autorisierung aufgetreten. Falls das Problem weiter besteht, versuche dich über den Browser anzumelden.</string>
     <string name="error_authorization_denied">Autorisierung wurde abgelehnt. Wenn du dir sicher bist, dass du die korrekten Anmeldedaten eingegeben hast, versuche dich über den Browser anzumelden.</string>
     <string name="error_retrieving_oauth_token">Es konnte kein Anmelde-Token abgerufen werden. Falls das Problem weiter besteht, versuche dich über den Browser anzumelden.</string>

--- a/feature/login/src/main/res/values-en-rGB/strings.xml
+++ b/feature/login/src/main/res/values-en-rGB/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
     <string name="error_invalid_domain">Invalid domain entered</string>
-    <string name="error_failed_app_registration">Failed authenticating with that instance.</string>
+    <string name="error_failed_app_registration_fmt">Failed authenticating with that instance: %1$s</string>
     <string name="error_authorization_unknown">An unidentified authorisation error occurred.</string>
     <string name="error_authorization_denied">Authorisation was denied.</string>
     <string name="error_retrieving_oauth_token">Failed getting a login token.</string>

--- a/feature/login/src/main/res/values-eo/strings.xml
+++ b/feature/login/src/main/res/values-eo/strings.xml
@@ -9,7 +9,7 @@
 \nPliaj informoj troviĝas ĉe <a href="https://joinmastodon.org">joinmastodon.org</a>. </string>
     <string name="action_close">Fermi</string>
     <string name="error_invalid_domain">Enmetita domajno estas nevalida</string>
-    <string name="error_failed_app_registration">Aŭtentigo en ĉi tiu nodo malsukcesis.</string>
+    <string name="error_failed_app_registration_fmt">Aŭtentigo en ĉi tiu nodo malsukcesis: %1$s</string>
     <string name="error_authorization_unknown">Nekonata eraro de aŭtentigo okazis.</string>
     <string name="error_authorization_denied">Rajtigo rifuzita.</string>
     <string name="error_retrieving_oauth_token">Akiro de atingoĵetono malsukcesis.</string>

--- a/feature/login/src/main/res/values-es/strings.xml
+++ b/feature/login/src/main/res/values-es/strings.xml
@@ -12,7 +12,7 @@
     <string name="action_close">Cerrar</string>
     <string name="action_browser_login">Iniciar sesión con el navegador</string>
     <string name="error_invalid_domain">Nombre de dominio incorrecto</string>
-    <string name="error_failed_app_registration">Fallo de autenticación con esta instancia. Si esto persiste, prueba en el menú Iniciar sesión con el navegador.</string>
+    <string name="error_failed_app_registration_fmt">Fallo de autenticación con esta instancia. Si esto persiste, prueba en el menú Iniciar sesión con el navegador: %1$s</string>
     <string name="error_authorization_unknown">Ocurrió un error de autorización no identificado. Si esto persiste, prueba en el menú Iniciar sesión con el navegador.</string>
     <string name="error_authorization_denied">La autorización falló. Si estás seguro de que has suministrado las credenciales correctas, prueba en el menú Iniciar sesión con el navegador.</string>
     <string name="error_retrieving_oauth_token">Fallo al obtener identificador de login. Si esto persiste, prueba en el menú Iniciar sesión con el navegador.</string>

--- a/feature/login/src/main/res/values-eu/strings.xml
+++ b/feature/login/src/main/res/values-eu/strings.xml
@@ -10,7 +10,7 @@
     <string name="action_close">Itxi</string>
     <string name="action_browser_login">Nabigatzailearekin saioa hasi</string>
     <string name="error_invalid_domain">Domeinu baliogabea sartu da</string>
-    <string name="error_failed_app_registration">Akatsa instantzia horrekin autentikatzerakoan. Akatsak badarrai, menutik, nabigatzailean saioa hasteko aukerarekin saiatu.</string>
+    <string name="error_failed_app_registration_fmt">Akatsa instantzia horrekin autentikatzerakoan. Akatsak badarrai, menutik, nabigatzailean saioa hasteko aukerarekin saiatu: %1$s</string>
     <string name="error_authorization_unknown">Identifikatu gabeko baimen-akatsa gertatu da. Akatsak badarrai, menutik, nabigatzailean saioa hasteko aukerarekin saiatu.</string>
     <string name="error_authorization_denied">Baimena ukatu da. Ziur bazaude zuk sartutako egiaztagiriak zuzenak direla, menutik, nabigatzailean saioa hasteko aukerarekin saiatu.</string>
     <string name="error_retrieving_oauth_token">Akatsa saio-hasieraren identifikatzailea eskuratzerakoan. Akatsak badarrai, menutik, nabigatzailean saioa hasteko aukerarekin saiatu.</string>

--- a/feature/login/src/main/res/values-fa/strings.xml
+++ b/feature/login/src/main/res/values-fa/strings.xml
@@ -10,7 +10,7 @@
     <string name="action_close">بستن</string>
     <string name="action_browser_login">ورود با مرورگر</string>
     <string name="error_invalid_domain">دامنهٔ نامعتبر وارد شده</string>
-    <string name="error_failed_app_registration">احراز هویت با این نمونه شکست خورد. اگر مشکل ادامه داشت، ورود در مرورگر را از فهرست بیازمایید.</string>
+    <string name="error_failed_app_registration_fmt">%1$s: احراز هویت با این نمونه شکست خورد. اگر مشکل ادامه داشت، ورود در مرورگر را از فهرست بیازمایید.</string>
     <string name="error_authorization_unknown">خطای احراز هویت ناشناخته‌ای رخ داد. اگر مشکل ادامه داشت، ورود در مرورگر را از فهرست بیازمایید.</string>
     <string name="error_authorization_denied">احراز هویت رد شد. اگر مطمئنید که اطّلاعات را درست وارد کرده‌اید، ورود در مرورگر را از فهرست بیازمایید.</string>
     <string name="error_retrieving_oauth_token">دریافت ژتون ورود شکست خورد. اگر مشکل ادامه داشت، ورود در مرورگر را از فهرست بیازمایید.</string>

--- a/feature/login/src/main/res/values-fi/strings.xml
+++ b/feature/login/src/main/res/values-fi/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="action_close">Sulje</string>
     <string name="error_invalid_domain">Syöttämäsi verkkonimi on virheellinen</string>
-    <string name="error_failed_app_registration">Tunnistautuminen valitsemasi instanssin kanssa epäonnistui.</string>
+    <string name="error_failed_app_registration_fmt">Tunnistautuminen valitsemasi instanssin kanssa epäonnistui: %1$s</string>
     <string name="error_loading_account_details">Tilitietojen lataaminen epäonnistui</string>
     <string name="hint_domain">Mikä instanssi\?</string>
     <string name="action_login">Kirjaudu Mastodonilla</string>
@@ -13,12 +13,12 @@
     <string name="action_browser_login">Kirjaudu selaimella</string>
     <string name="error_authorization_denied">Kirjautumista ei hyväksytty. Jos olet varma, että annoit oikeat tiedot, valitse valikosta Kirjaudu selaimella.</string>
     <string name="error_authorization_unknown">Tapahtui tuntematon kirjautumisvirhe. Jos tämä jatkuu, valitse valikosta Kirjaudu selaimella.</string>
-    <string name="dialog_whats_an_instance">Tähän voi kirjoittaa minkä tahansa instanssin osoitteen, esimerkiksi mastodon.social, icosahedron.website, social.tchncs.de, ja <a href="https://instances.social">enemmän!</a> 
-\n 
+    <string name="dialog_whats_an_instance">Tähän voi kirjoittaa minkä tahansa instanssin osoitteen, esimerkiksi mastodon.social, icosahedron.website, social.tchncs.de, ja <a href="https://instances.social">enemmän!</a>
+\n
 \nEllei sinulla vielä ole tiliä, voit kirjoittaa haluamasi instanssin nimen ja luoda tilin sinne.
-\n 
+\n
 \nInstanssi on paikka, jossa tilisi sijaitsee, mutta voit helposti olla yhteydessä ja seurata ihmisiä toisilla instansseilla, aivan kuin olisitte samalla sivustolla.
-\n 
+\n
 \nLisää tietoa täällä: <a href="https://joinmastodon.org">joinmastodon.org</a> \u0020</string>
     <string name="error_retrieving_oauth_token">Kirjautumispolettia ei saatu. Jos tämä jatkuu, valitse valikosta Kirjaudu selaimella.</string>
     <string name="instance_rule_title">Palvelimen %s säännöt</string>

--- a/feature/login/src/main/res/values-fr/strings.xml
+++ b/feature/login/src/main/res/values-fr/strings.xml
@@ -12,7 +12,7 @@
     <string name="action_close">Fermer</string>
     <string name="action_browser_login">Se connecter avec le navigateur</string>
     <string name="error_invalid_domain">Le domaine saisi est invalide</string>
-    <string name="error_failed_app_registration">Échec d’authentification auprès de l’instance. Si cela continue à se produire, essayez Se connecter avec le navigateur depuis le menu.</string>
+    <string name="error_failed_app_registration_fmt">Échec d’authentification auprès de l’instance. Si cela continue à se produire, essayez Se connecter avec le navigateur depuis le menu: %1$s</string>
     <string name="error_authorization_unknown">Une erreur d’autorisation inconnue s’est produite. Si cela continue à se produire, essayez Se connecter avec le navigateur depuis le menu.</string>
     <string name="error_authorization_denied">Authentification refusée. Si vous êtes sur·e d\'avoir entré les bons identifiants, essayez Se connecter avec le navigateur depuis le menu.</string>
     <string name="error_retrieving_oauth_token">Impossible de récupérer le jeton d’authentification. Si cela continue à se produire, essayez Se connecter avec le navigateur depuis le menu.</string>

--- a/feature/login/src/main/res/values-ga/strings.xml
+++ b/feature/login/src/main/res/values-ga/strings.xml
@@ -9,7 +9,7 @@
 \nIs féidir tuilleadh faisnéise a fháil ag <a href="https://joinmastodon.org"> joinmastodon.org </a>. </string>
     <string name="action_close">Dún</string>
     <string name="error_invalid_domain">Fearann neamhbhailí iontráilte</string>
-    <string name="error_failed_app_registration">Theip ar fhíordheimhniú leis an ásc sin.</string>
+    <string name="error_failed_app_registration_fmt">Theip ar fhíordheimhniú leis an ásc sin: %1$s</string>
     <string name="error_authorization_unknown">Tharla earráid údaraithe neamhaitheanta.</string>
     <string name="error_authorization_denied">Diúltaíodh údarú.</string>
     <string name="error_retrieving_oauth_token">Theip ar chomhartha logála isteach a fháil.</string>

--- a/feature/login/src/main/res/values-gd/strings.xml
+++ b/feature/login/src/main/res/values-gd/strings.xml
@@ -10,7 +10,7 @@
     <string name="action_close">Dùin</string>
     <string name="action_browser_login">Clàraich a-steach le brabhsair</string>
     <string name="error_invalid_domain">Chuir thu a-steach àrainn-lìn mì-dhligheach</string>
-    <string name="error_failed_app_registration">Dh’fhàillig leis an dearbhadh leis an ionstans ud. Ma mhaireas an duilgheadas seo, feuch “Clàraich a-steach le brabhsair” on chlàr-taice.</string>
+    <string name="error_failed_app_registration_fmt">Dh’fhàillig leis an dearbhadh leis an ionstans ud. Ma mhaireas an duilgheadas seo, feuch “Clàraich a-steach le brabhsair” on chlàr-taice: %1$s</string>
     <string name="error_authorization_unknown">Thachair mearachd leis an ùghdarrachadh nach do dh’aithnich sinn. Ma mhaireas an duilgheadas seo, feuch “Clàraich a-steach le brabhsair” on chlàr-taice.</string>
     <string name="error_authorization_denied">Chaidh an t-ùghdarrachadh a dhiùltadh. Ma tha thu cinnteach gun do chuir thu a-steach an teisteas ceart, feuch “Clàraich a-steach le brabhsair” on chlàr-taice.</string>
     <string name="error_retrieving_oauth_token">Cha deach leinn tòcan clàraidh a-steach fhaighinn. Ma mhaireas an duilgheadas seo, feuch “Clàraich a-steach le brabhsair” on chlàr-taice.</string>

--- a/feature/login/src/main/res/values-gl/strings.xml
+++ b/feature/login/src/main/res/values-gl/strings.xml
@@ -10,7 +10,7 @@
     <string name="action_close">Pechar</string>
     <string name="action_browser_login">Acceder no Navegador</string>
     <string name="error_invalid_domain">O dominio escrito non é válido</string>
-    <string name="error_failed_app_registration">Fallou a autenticación nesta instancia. Se persiste, inténtao desde Acceder no Navegador no menú.</string>
+    <string name="error_failed_app_registration_fmt">Fallou a autenticación nesta instancia. Se persiste, inténtao desde Acceder no Navegador no menú: %1$s</string>
     <string name="error_authorization_unknown">Aconteceu un erro non identificado na autorización. Se persiste, inténtao desde Acceder no Navedor.</string>
     <string name="error_authorization_denied">A autorización foi rexeitada. Se tes a certeza de que as credenciais son correctas, inténtao desde Acceder no Navegador no menú.</string>
     <string name="error_retrieving_oauth_token">Non se obtivo o token de acceso. Se non o consigues, inténtao desde Acceder no Navegador.</string>

--- a/feature/login/src/main/res/values-hi/strings.xml
+++ b/feature/login/src/main/res/values-hi/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="action_close">बंद करें</string>
     <string name="error_invalid_domain">अमान्य डोमेन दर्ज किया गया</string>
-    <string name="error_failed_app_registration">उस सर्वर से प्रमाणित करने में विफल।</string>
+    <string name="error_failed_app_registration_fmt">उस सर्वर से प्रमाणित करने में विफल।: %1$s</string>
     <string name="error_authorization_unknown">एक अज्ञात प्राधिकरण त्रुटि हुई।</string>
     <string name="error_authorization_denied">प्राधिकरण करने के से इनकार कर दिया।</string>
     <string name="error_retrieving_oauth_token">लॉगिन टोकन प्राप्त करने में विफल।</string>

--- a/feature/login/src/main/res/values-hu/strings.xml
+++ b/feature/login/src/main/res/values-hu/strings.xml
@@ -10,7 +10,7 @@
     <string name="action_close">Bezárás</string>
     <string name="action_browser_login">Bejelentkezés Böngészővel</string>
     <string name="error_invalid_domain">Helytelen domain</string>
-    <string name="error_failed_app_registration">Sikertelen hitelesítés ezen a példányon. Ha ez továbbra is fennáll, próbáld a Bejelentkezés Böngészőben opciót a menüben.</string>
+    <string name="error_failed_app_registration_fmt">Sikertelen hitelesítés ezen a példányon. Ha ez továbbra is fennáll, próbáld a Bejelentkezés Böngészőben opciót a menüben: %1$s</string>
     <string name="error_authorization_unknown">Azonosítatlan hitelesítési hiba történt. Ha ez továbbra is fennáll, próbáld a Bejelentkezés Böngészőben opciót a menüben.</string>
     <string name="error_authorization_denied">Engedély megtagadva. Ha biztos vagy benne, hogy a megfelelő hitelesítési adatokat adtad meg, próbáld a Bejelentkezés Böngészőben funkciót a menüben.</string>
     <string name="error_retrieving_oauth_token">Bejelentkezési token megszerzése sikertelen. Ha ez továbbra is fennáll, próbáld a Bejelentkezés Böngészőben opciót a menüben.</string>

--- a/feature/login/src/main/res/values-in/strings.xml
+++ b/feature/login/src/main/res/values-in/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="action_close">Tutup</string>
     <string name="error_invalid_domain">Domain yang dimasukkan tidak valid</string>
-    <string name="error_failed_app_registration">Gagal mengautentikasi dengan instance tersebut. Jika ini berlanjut, coba Masuk di Browser dari menu.</string>
+    <string name="error_failed_app_registration_fmt">Gagal mengautentikasi dengan instance tersebut. Jika ini berlanjut, coba Masuk di Browser dari menu: %1$s</string>
     <string name="error_authorization_unknown">"Terjadi kesalahan otorisasi yang tidak diketahui. Jika ini  berlanjut, coba Masuk di Browser dari menu."</string>
     <string name="error_authorization_denied">Otorisasi ditolak. Jika Anda yakin telah memberikan kredensial yang benar, coba Masuk di Browser dari menu.</string>
     <string name="error_retrieving_oauth_token">Gagal mendapatkan token masuk. Jika ini terus berlanjut, coba Masuk di Browser dari menu.</string>

--- a/feature/login/src/main/res/values-is/strings.xml
+++ b/feature/login/src/main/res/values-is/strings.xml
@@ -10,7 +10,7 @@
     <string name="action_close">Loka</string>
     <string name="action_browser_login">Skrá inn í vafra</string>
     <string name="error_invalid_domain">Ógilt lén sett inn</string>
-    <string name="error_failed_app_registration">Mistókst að auðkenna gagnvart þessu tilviki. Ef þetta er viðvarandi skaltu prófa \'Skrá inn í vafra\' úr valmyndinni.</string>
+    <string name="error_failed_app_registration_fmt">Mistókst að auðkenna gagnvart þessu tilviki. Ef þetta er viðvarandi skaltu prófa \'Skrá inn í vafra\' úr valmyndinni: %1$s</string>
     <string name="error_authorization_unknown">Óskilgreind auðkenningarvilla kom upp. Mistókst að auðkenna gagnvart þessu tilviki. Ef þetta er viðvarandi skaltu prófa \'Skrá inn í vafra\' úr valmyndinni.</string>
     <string name="error_authorization_denied">Heimild var hafnað. Mistókst að auðkenna gagnvart þessu tilviki. Ef þetta er viðvarandi skaltu prófa \'Skrá inn í vafra\' úr valmyndinni.</string>
     <string name="error_retrieving_oauth_token">Mistókst að fá innskráningarteikn. Mistókst að auðkenna gagnvart þessu tilviki. Ef þetta er viðvarandi skaltu prófa \'Skrá inn í vafra\' úr valmyndinni.</string>

--- a/feature/login/src/main/res/values-it/strings.xml
+++ b/feature/login/src/main/res/values-it/strings.xml
@@ -10,7 +10,7 @@
     <string name="action_close">Chiudi</string>
     <string name="action_browser_login">Accedi dal browser</string>
     <string name="error_invalid_domain">Inserito un dominio non valido</string>
-    <string name="error_failed_app_registration">Autenticazione con quell\'istanza fallita. Se il problema persiste, prova a collegarti dal browser nel menu.</string>
+    <string name="error_failed_app_registration_fmt">Autenticazione con quell\'istanza fallita. Se il problema persiste, prova a collegarti dal browser nel menu: %1$s</string>
     <string name="error_authorization_unknown">Si è verificato un errore di autenticazione non identificato. Se il problema persiste, prova a collegarti dal browser nel menu.</string>
     <string name="error_authorization_denied">Autorizzazione negata. Se sei sicuro di aver usato le credenziali corrette, prova a collegarti con il browser nel menu.</string>
     <string name="error_retrieving_oauth_token">Acquisizione token di accesso fallita. Se il problema persiste, prova a collegarti dal browser nel menu.</string>

--- a/feature/login/src/main/res/values-ja/strings.xml
+++ b/feature/login/src/main/res/values-ja/strings.xml
@@ -10,7 +10,7 @@
     <string name="action_close">閉じる</string>
     <string name="action_browser_login">ブラウザでログイン</string>
     <string name="error_invalid_domain">無効なドメインです</string>
-    <string name="error_failed_app_registration">そのインスタンスでの認証に失敗しました。失敗が続く場合、メニューからブラウザでのログインを試してください。</string>
+    <string name="error_failed_app_registration_fmt">そのインスタンスでの認証に失敗しました。失敗が続く場合、メニューからブラウザでのログインを試してください。: %1$s</string>
     <string name="error_authorization_unknown">不明な承認エラーが発生しました。失敗が続く場合、メニューからブラウザでのログインを試してください。</string>
     <string name="error_authorization_denied">認証が拒否されました。正しい認証情報を入力したことが確かな場合、メニューからブラウザでのログインを試してください。</string>
     <string name="error_retrieving_oauth_token">ログイントークンの取得に失敗しました。もし失敗が続く場合、メニューからブラウザでのログインを試してください。</string>

--- a/feature/login/src/main/res/values-ko/strings.xml
+++ b/feature/login/src/main/res/values-ko/strings.xml
@@ -9,7 +9,7 @@
 \n자세한 사항은 <a href="https://joinmastodon.org">joinmastodon.org</a>을 참조하세요. </string>
     <string name="action_close">닫기</string>
     <string name="error_invalid_domain">도메인이 올바르지 않습니다</string>
-    <string name="error_failed_app_registration">해당 인스턴스에 대한 인증에 실패했습니다.</string>
+    <string name="error_failed_app_registration_fmt">해당 인스턴스에 대한 인증에 실패했습니다: %1$s</string>
     <string name="error_authorization_unknown">알 수 없는 인증 오류가 발생했습니다.</string>
     <string name="error_authorization_denied">인증이 거부되었습니다.</string>
     <string name="error_retrieving_oauth_token">로그인 토큰을 받아올 수 없습니다.</string>

--- a/feature/login/src/main/res/values-lv/strings.xml
+++ b/feature/login/src/main/res/values-lv/strings.xml
@@ -10,7 +10,7 @@
     <string name="action_close">Aizvērt</string>
     <string name="action_browser_login">Pieslēgties ar pārlūku</string>
     <string name="error_invalid_domain">Ievadīts nederīgs domēns</string>
-    <string name="error_failed_app_registration">Autentificēšana ar šo instanci neizdevās. Ja tas atkārtojas, izmantojot izvēlni, mēģiniet pieslēgties pārlūkā.</string>
+    <string name="error_failed_app_registration_fmt">Autentificēšana ar šo instanci neizdevās. Ja tas atkārtojas, izmantojot izvēlni, mēģiniet pieslēgties pārlūkā: %1$s</string>
     <string name="error_authorization_unknown">Radās neidentificēta autorizācijas kļūda. Ja tas atkārtojas, izmantojot izvēlni, mēģiniet pieslēgties pārlūkā.</string>
     <string name="error_authorization_denied">Autorizācija tika liegta. Ja ir pārliecība, ka ievadīti pareizi pieslēgšanās dati, izmantojot izvēlni, mēģiniet pieslēgties pārlūkā.</string>
     <string name="error_retrieving_oauth_token">Neizdevās iegūt pieteikšanās pilnvaru. Ja tas atkārtojas, izmantojot izvēlni, mēģiniet pieslēgties pārlūkā.</string>

--- a/feature/login/src/main/res/values-ml/strings.xml
+++ b/feature/login/src/main/res/values-ml/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="action_close">നിർത്തുക</string>
     <string name="error_invalid_domain">അസാധുവായ ഡൊമൈൻ നൽകിയിരിക്കുന്നു</string>
-    <string name="error_failed_app_registration">ആ ഇൻസ്റ്റൻസുമായി ആധികാരികത ഉറപ്പുവരുത്തുന്നതിൽ പരാജയപ്പെട്ടിരിക്കുന്നു.</string>
+    <string name="error_failed_app_registration_fmt">ആ ഇൻസ്റ്റൻസുമായി ആധികാരികത ഉറപ്പുവരുത്തുന്നതിൽ പരാജയപ്പെട്ടിരിക്കുന്നു: %1$s</string>
     <string name="error_authorization_unknown">അജ്ഞാതമായ ഒരു ആധികാരികതാപിഴവ് സംഭവിച്ചിരിക്കുന്നു.</string>
     <string name="error_authorization_denied">ആധികാരികത ഉറപ്പുവരുത്താനായില്ല.</string>
     <string name="error_retrieving_oauth_token">ഒരു പ്രവേശന ടോക്കൺ ലഭ്യമാക്കുന്നതിൽ പരാജയപ്പെട്ടു.</string>

--- a/feature/login/src/main/res/values-nb-rNO/strings.xml
+++ b/feature/login/src/main/res/values-nb-rNO/strings.xml
@@ -10,7 +10,7 @@
     <string name="action_close">Steng</string>
     <string name="action_browser_login">Logg inn med nettleseren</string>
     <string name="error_invalid_domain">Ugyldig domene</string>
-    <string name="error_failed_app_registration">Kunne ikke autentisere med den instansen. Hvis dette fortsetter å skje, prøv å logge inn i nettleseren fra menyen.</string>
+    <string name="error_failed_app_registration_fmt">Kunne ikke autentisere med den instansen. Hvis dette fortsetter å skje, prøv å logge inn i nettleseren fra menyen: %1$s</string>
     <string name="error_authorization_unknown">En ukjent autoriseringsfeil oppsto. Hvis dette fortsetter, prøv å logge inn i nettleseren fra menyen.</string>
     <string name="error_authorization_denied">Autorisasjon ble nektet. Hvis du er sikker på at du ga riktige data, prøv å logge inn i nettleseren fra menyen.</string>
     <string name="error_retrieving_oauth_token">Henting av logintoken feilet. Hvis dette fortsetter prøv å logge in i nettleseren fra menyen.</string>

--- a/feature/login/src/main/res/values-nl/strings.xml
+++ b/feature/login/src/main/res/values-nl/strings.xml
@@ -10,7 +10,7 @@
     <string name="action_close">Sluiten</string>
     <string name="action_browser_login">Inloggen met een browser</string>
     <string name="error_invalid_domain">Ongeldige domeinnaam ingevoerd</string>
-    <string name="error_failed_app_registration">Authenticatie met die server is mislukt. Als het probleem blijft, probeer dan de browser login via het menu.</string>
+    <string name="error_failed_app_registration_fmt">Authenticatie met die server is mislukt. Als het probleem blijft, probeer dan de browser login via het menu: %1$s</string>
     <string name="error_authorization_unknown">Er deed zich een onbekende autorisatiefout voor. Als dit blijft, probeer dan “ Via de browser inloggen” in het menu.</string>
     <string name="error_authorization_denied">Autorisatie werd geweigerd. Als u zeker weet dat u de correcte gegevens heeft ingevoerd, probeer dan in te loggen in de browser via het menu.</string>
     <string name="error_retrieving_oauth_token">Kon geen inlogsleutel verkrijgen. Als het probleem zich blijft herhalen; probeer dan de browser login via menu.</string>

--- a/feature/login/src/main/res/values-oc/strings.xml
+++ b/feature/login/src/main/res/values-oc/strings.xml
@@ -10,7 +10,7 @@
     <string name="action_close">Tampar</string>
     <string name="action_browser_login">Connexion via Navigador</string>
     <string name="error_invalid_domain">Lo domeni picat es pas valid</string>
-    <string name="error_failed_app_registration">L\'autenticacion en aquesta instància a fracassat. Se ten de se produire, ensajatz la connexion via Navigador via lo menú.</string>
+    <string name="error_failed_app_registration_fmt">L\'autenticacion en aquesta instància a fracassat. Se ten de se produire, ensajatz la connexion via Navigador via lo menú: %1$s</string>
     <string name="error_authorization_unknown">S\'es produch una error d\'autorizacion pas identificada. Se ten de se produire, ensajatz la connexion via Navigador via lo menú.</string>
     <string name="error_authorization_denied">L\'autorizacion es estada regetada.</string>
     <string name="error_retrieving_oauth_token">Fracàs de l’obtencion del geton d\'iniciacion de session.</string>

--- a/feature/login/src/main/res/values-pl/strings.xml
+++ b/feature/login/src/main/res/values-pl/strings.xml
@@ -10,7 +10,7 @@
     <string name="action_close">Zamknij</string>
     <string name="action_browser_login">Zaloguj się przez przeglądarkę</string>
     <string name="error_invalid_domain">Wprowadzono nieprawidłową domenę</string>
-    <string name="error_failed_app_registration">Nie udało się uwierzytelnić z tą instancją. Jeśli problem będzie się powtarzał, spróbuj zalogować się za pomocą przeglądarki z menu aplikacji.</string>
+    <string name="error_failed_app_registration_fmt">Nie udało się uwierzytelnić z tą instancją. Jeśli problem będzie się powtarzał, spróbuj zalogować się za pomocą przeglądarki z menu aplikacji: %1$s</string>
     <string name="error_authorization_unknown">Wystąpił nieokreślony błąd podczas próby autoryzacji. Jeśli problem będzie się powtarzał, spróbuj zalogować się za pomocą przeglądarki z menu aplikacji.</string>
     <string name="error_authorization_denied">Odmówiono autoryzacji. Jeśli jesteś pewien poprawności wprowadzonych danych, spróbuj zalogowania się za pomocą przeglądarki dostępnej w menu.</string>
     <string name="error_retrieving_oauth_token">Nie udało się uzyskać tokenu logowania. Jeśli problem będzie się powtarzał, spróbuj zalogować się za pomocą przeglądarki z menu aplikacji.</string>

--- a/feature/login/src/main/res/values-pt-rBR/strings.xml
+++ b/feature/login/src/main/res/values-pt-rBR/strings.xml
@@ -10,7 +10,7 @@
     <string name="action_close">Fechar</string>
     <string name="action_browser_login">Entrar com navegador</string>
     <string name="error_invalid_domain">Domínio inválido</string>
-    <string name="error_failed_app_registration">Falha na autenticação com essa instância. Se isso persistir, tente Entrar pelo Navegador no menu.</string>
+    <string name="error_failed_app_registration_fmt">Falha na autenticação com essa instância. Se isso persistir, tente Entrar pelo Navegador no menu: %1$s</string>
     <string name="error_authorization_unknown">Ocorreu um erro de autorização não identificado. Se isso persistir, tente Entrar pelo Navegador no menu.</string>
     <string name="error_authorization_denied">A autorização foi negada. Se você tiver certeza de que forneceu as credenciais corretas, tente Entrar pelo Navegador no menu.</string>
     <string name="error_retrieving_oauth_token">Falha ao obter um Token de login. Se isso persistir, tente Entrar pelo Navegador no menu.</string>

--- a/feature/login/src/main/res/values-pt-rPT/strings.xml
+++ b/feature/login/src/main/res/values-pt-rPT/strings.xml
@@ -10,7 +10,7 @@
     <string name="action_close">Fechar</string>
     <string name="action_browser_login">Iniciar sessão com navegador</string>
     <string name="error_invalid_domain">A instância inserida é inválida</string>
-    <string name="error_failed_app_registration">Erro ao autenticar com esta instância.</string>
+    <string name="error_failed_app_registration_fmt">Erro ao autenticar com esta instância: %1$s</string>
     <string name="error_authorization_unknown">Ocorreu um erro de autorização não identificado.</string>
     <string name="error_authorization_denied">Autorização negada.</string>
     <string name="error_retrieving_oauth_token">Erro ao adquirir token de login.</string>

--- a/feature/login/src/main/res/values-ru/strings.xml
+++ b/feature/login/src/main/res/values-ru/strings.xml
@@ -10,7 +10,7 @@
     <string name="action_close">Закрыть</string>
     <string name="action_browser_login">Вход через Браузер</string>
     <string name="error_invalid_domain">Некорректный домен</string>
-    <string name="error_failed_app_registration">Ошибка аутентификации на этом узле. Если это повторится, попробуйте Вход через Браузер в меню.</string>
+    <string name="error_failed_app_registration_fmt">Ошибка аутентификации на этом узле. Если это повторится, попробуйте Вход через Браузер в меню: %1$s</string>
     <string name="error_authorization_unknown">Произошла ошибка неопознанной авторизации. Если это повторится, попробуйте Вход через Браузер в меню.</string>
     <string name="error_authorization_denied">Авторизация была отклонена.</string>
     <string name="error_retrieving_oauth_token">Не удалось получить токен авторизации.</string>

--- a/feature/login/src/main/res/values-sa/strings.xml
+++ b/feature/login/src/main/res/values-sa/strings.xml
@@ -10,7 +10,7 @@
     <string name="action_close">पिधीयताम्</string>
     <string name="action_browser_login">जालसञ्चारकेन सम्प्रविश्यताम्</string>
     <string name="error_invalid_domain">अवैधानिकप्रदेशः प्रविष्टः</string>
-    <string name="error_failed_app_registration">तेन विशिष्टस्थलेन प्रमाणीकरणं विफलं जातम् ।</string>
+    <string name="error_failed_app_registration_fmt">तेन विशिष्टस्थलेन प्रमाणीकरणं विफलं जातम् ।: %1$s</string>
     <string name="error_authorization_unknown">अज्ञातः प्रमाणीकरणदोषो जातः ।</string>
     <string name="error_authorization_denied">प्रमाणीकरणं निषिद्धम् ।</string>
     <string name="error_retrieving_oauth_token">सम्प्रवेशस्तोकं न लब्धम् ।</string>

--- a/feature/login/src/main/res/values-sk/strings.xml
+++ b/feature/login/src/main/res/values-sk/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
     <string name="error_invalid_domain">Neplatná doména</string>
-    <string name="error_failed_app_registration">Autentizácia servru zlyhala.</string>
+    <string name="error_failed_app_registration_fmt">Autentizácia servru zlyhala: %1$s</string>
     <string name="error_authorization_unknown">Vyskytla sa neidentifikovaná chyba autorizácie.</string>
     <string name="error_authorization_denied">Autorizácia bola zamietnutá.</string>
     <string name="error_retrieving_oauth_token">Nepodarilo sa získať prihlasovací token.</string>

--- a/feature/login/src/main/res/values-sl/strings.xml
+++ b/feature/login/src/main/res/values-sl/strings.xml
@@ -9,7 +9,7 @@
 \nVeč informacij najdete na naslovu <a href="https://joinmastodon.org">joinmastodon.org</a>. </string>
     <string name="action_close">Zapri</string>
     <string name="error_invalid_domain">Vnesena je neveljavna domena</string>
-    <string name="error_failed_app_registration">Overitev s to instanco ni uspela.</string>
+    <string name="error_failed_app_registration_fmt">Overitev s to instanco ni uspela: %1$s</string>
     <string name="error_authorization_unknown">Prišlo je do neznane napake pri pooblastitvi.</string>
     <string name="error_authorization_denied">Pooblastitev je bila zavrnjena.</string>
     <string name="error_retrieving_oauth_token">Ni bilo mogoče pridobiti žetona za prijavo.</string>

--- a/feature/login/src/main/res/values-sv/strings.xml
+++ b/feature/login/src/main/res/values-sv/strings.xml
@@ -11,7 +11,7 @@
     <string name="action_close">Stäng</string>
     <string name="action_browser_login">Inloggning via webbläsaren</string>
     <string name="error_invalid_domain">Ogiltig domän angiven</string>
-    <string name="error_failed_app_registration">Misslyckades att autentisera med den instansen. Om detta kvarstår, försök Logga in i webbläsaren från menyn.</string>
+    <string name="error_failed_app_registration_fmt">Misslyckades att autentisera med den instansen. Om detta kvarstår, försök Logga in i webbläsaren från menyn: %1$s</string>
     <string name="error_authorization_unknown">Ett oidentifierat auktoriseringsfel inträffade. Om detta kvarstår, försök Logga in i webbläsaren från menyn.</string>
     <string name="error_authorization_denied">Auktorisering nekades. Om du är säker på att du har angett rätt referenser, prova Logga in i webbläsaren från menyn.</string>
     <string name="error_retrieving_oauth_token">Misslyckades med att hämta en inloggningstoken. Om detta kvarstår, försök Logga in i webbläsaren från menyn.</string>

--- a/feature/login/src/main/res/values-ta/strings.xml
+++ b/feature/login/src/main/res/values-ta/strings.xml
@@ -7,7 +7,7 @@
     </string>
     <string name="action_close">மூடு</string>
     <string name="error_invalid_domain">தவறான டொமைன் உள்ளிடப்பட்டுள்ளது</string>
-    <string name="error_failed_app_registration">அந்த instance(களத்தினை)-யை அங்கீகரிப்பதில் தோல்வி.</string>
+    <string name="error_failed_app_registration_fmt">அந்த instance(களத்தினை)-யை அங்கீகரிப்பதில் தோல்வி: %1$s</string>
     <string name="error_authorization_unknown">அடையாளம் தெரியாத அங்கீகார பிழை ஏற்பட்டுள்ளது.</string>
     <string name="error_authorization_denied">அங்கீகாரம் மறுக்கப்பட்டுள்ளது</string>
     <string name="error_retrieving_oauth_token">உள்நுழைவு டோக்கனைப் பெறுவதில் தோல்வி.</string>

--- a/feature/login/src/main/res/values-th/strings.xml
+++ b/feature/login/src/main/res/values-th/strings.xml
@@ -9,7 +9,7 @@
 \nพบข้อมูลเพิ่มเติมได้ที่ <a href="https://joinmastodon.org">joinmastodon.org</a> </string>
     <string name="action_close">ปิด</string>
     <string name="error_invalid_domain">โดเมนที่ป้อนไม่ถูกต้อง</string>
-    <string name="error_failed_app_registration">การยืนยันตัวตนกับเซิร์ฟเวอร์นั้นล้มเหลว</string>
+    <string name="error_failed_app_registration_fmt">การยืนยันตัวตนกับเซิร์ฟเวอร์นั้นล้มเหลว: %1$s</string>
     <string name="error_authorization_unknown">เกิดข้อผิดพลาดในการขออนุญาตสิทธิโดยไม่ทราบสาเหตุ</string>
     <string name="error_authorization_denied">การขออนุญาตสิทธิถูกปฏิเสธ</string>
     <string name="error_retrieving_oauth_token">ไม่สามารถรับโทเค็นการเข้าสู่ระบบ</string>

--- a/feature/login/src/main/res/values-tr/strings.xml
+++ b/feature/login/src/main/res/values-tr/strings.xml
@@ -10,7 +10,7 @@
     <string name="action_close">Kapat</string>
     <string name="action_browser_login">Tarayıcı ile Giriş Yap</string>
     <string name="error_invalid_domain">Girilen alan adı geçersiz</string>
-    <string name="error_failed_app_registration">Bu sunucuda kimlik doğrulama başarısız oldu. Sorun devam ederse menüdeki Tarayıcı ile Giriş Yap seçeneğini dene.</string>
+    <string name="error_failed_app_registration_fmt">Bu sunucuda kimlik doğrulama başarısız oldu. Sorun devam ederse menüdeki Tarayıcı ile Giriş Yap seçeneğini dene: %1$s</string>
     <string name="error_authorization_unknown">Tanımlanamayan bir yetkilendirme hatası oluştu. Sorun devam ederse menüdeki Tarayıcı ile Giriş Yap seçeneğini dene.</string>
     <string name="error_authorization_denied">Yetkilendirme reddedildi. Doğru hesap bilgilerini girdiğinden eminsen menüdeki Tarayıcı ile Giriş Yap seçeneğini dene.</string>
     <string name="error_retrieving_oauth_token">Giriş belirteci alınırken hata oluştu. Sorun devam ederse menüdeki Tarayıcı ile Giriş Yap seçeneğini dene.</string>

--- a/feature/login/src/main/res/values-uk/strings.xml
+++ b/feature/login/src/main/res/values-uk/strings.xml
@@ -10,7 +10,7 @@
     <string name="action_close">Закрити</string>
     <string name="action_browser_login">Увійти через браузер</string>
     <string name="error_invalid_domain">Введено недійсний домен</string>
-    <string name="error_failed_app_registration">Помилка автентифікації цього сервера. Якщо проблема не зникає, спробуйте увійти через браузер з меню.</string>
+    <string name="error_failed_app_registration_fmt">Помилка автентифікації цього сервера. Якщо проблема не зникає, спробуйте увійти через браузер з меню: %1$s</string>
     <string name="error_authorization_unknown">Сталася помилка невпізнання авторизації. Якщо проблема не зникає, спробуйте увійти через браузер з меню.</string>
     <string name="error_authorization_denied">Авторизацію відхилено. Якщо ви впевнені, що вказали правильні облікові дані, спробуйте увійти через браузер з меню.</string>
     <string name="error_retrieving_oauth_token">Не вдалося отримати токен входу. Якщо проблема не зникає, спробуйте увійти через браузер з меню.</string>

--- a/feature/login/src/main/res/values-vi/strings.xml
+++ b/feature/login/src/main/res/values-vi/strings.xml
@@ -10,7 +10,7 @@
     <string name="action_close">Đóng</string>
     <string name="action_browser_login">Đăng nhập bằng trình duyệt</string>
     <string name="error_invalid_domain">Tên miền không hợp lệ</string>
-    <string name="error_failed_app_registration">Máy chủ này không cấp quyền truy cập.</string>
+    <string name="error_failed_app_registration_fmt">Máy chủ này không cấp quyền truy cập: %1$s</string>
     <string name="error_authorization_unknown">Xảy ra lỗi khi cố gắng truy cập.</string>
     <string name="error_authorization_denied">Truy cập bị từ chối.</string>
     <string name="error_retrieving_oauth_token">Lấy token đăng nhập thất bại.</string>

--- a/feature/login/src/main/res/values-zh-rCN/strings.xml
+++ b/feature/login/src/main/res/values-zh-rCN/strings.xml
@@ -10,7 +10,7 @@
     <string name="action_close">关闭</string>
     <string name="action_browser_login">用浏览器登录</string>
     <string name="error_invalid_domain">该域名无效</string>
-    <string name="error_failed_app_registration">未能通过该实例的身份验证。如果这个问题持续，请从菜单处尝试“在浏览器中登录”。</string>
+    <string name="error_failed_app_registration_fmt">未能通过该实例的身份验证。如果这个问题持续，请从菜单处尝试“在浏览器中登录”。: %1$s</string>
     <string name="error_authorization_unknown">发生不明授权错误。如果这个问题持续，请从菜单处尝试 “在浏览器中登录”。</string>
     <string name="error_authorization_denied">授权被拒绝。如果你确定提供了正确的凭据，请从菜单处尝试“在浏览器中登录”。</string>
     <string name="error_retrieving_oauth_token">未能获取登录令牌。如果这个问题持续，请从菜单处尝试 “在浏览器中登录”。</string>

--- a/feature/login/src/main/res/values-zh-rHK/strings.xml
+++ b/feature/login/src/main/res/values-zh-rHK/strings.xml
@@ -9,7 +9,7 @@
 \n更多資訊可以在 <a href="https://joinmastodon.org">joinmastodon.org</a> 查看。 </string>
     <string name="action_close">關閉</string>
     <string name="error_invalid_domain">該域名無效</string>
-    <string name="error_failed_app_registration">無法連接此伺服器。</string>
+    <string name="error_failed_app_registration_fmt">無法連接此伺服器。: %1$s</string>
     <string name="error_authorization_unknown">認證過程出現未知錯誤。</string>
     <string name="error_authorization_denied">授權被拒絕。</string>
     <string name="error_retrieving_oauth_token">無法獲取登入資訊。</string>

--- a/feature/login/src/main/res/values-zh-rMO/strings.xml
+++ b/feature/login/src/main/res/values-zh-rMO/strings.xml
@@ -3,7 +3,7 @@
     <string name="dialog_whats_an_instance">請輸入你帳號所在的 Mastodon 站點的域名或地址</string>
     <string name="action_close">關閉</string>
     <string name="error_invalid_domain">該域名無效</string>
-    <string name="error_failed_app_registration">無法連接此伺服器</string>
+    <string name="error_failed_app_registration_fmt">無法連接此伺服器: %1$s</string>
     <string name="error_authorization_unknown">認證過程出現未知錯誤</string>
     <string name="error_authorization_denied">授權被拒絕</string>
     <string name="error_retrieving_oauth_token">無法獲取登入資訊</string>

--- a/feature/login/src/main/res/values-zh-rSG/strings.xml
+++ b/feature/login/src/main/res/values-zh-rSG/strings.xml
@@ -7,7 +7,7 @@
 \n在 Mastodon 里，跨站互动和站内互动一样简单。可以前往 <a href="https://joinmastodon.org">https://joinmastodon.org</a> 了解更多信息。 </string>
     <string name="action_close">关闭</string>
     <string name="error_invalid_domain">该域名无效</string>
-    <string name="error_failed_app_registration">无法连接此服务器</string>
+    <string name="error_failed_app_registration_fmt">无法连接此服务器: %1$s</string>
     <string name="error_authorization_unknown">认证过程出现未知错误</string>
     <string name="error_authorization_denied">授权被拒绝</string>
     <string name="error_retrieving_oauth_token">无法获取登录信息</string>

--- a/feature/login/src/main/res/values-zh-rTW/strings.xml
+++ b/feature/login/src/main/res/values-zh-rTW/strings.xml
@@ -9,7 +9,7 @@
 \n更多資訊可以在 <a href="https://joinmastodon.org">joinmastodon.org</a> 查看。 </string>
     <string name="action_close">關閉</string>
     <string name="error_invalid_domain">該域名無效</string>
-    <string name="error_failed_app_registration">無法通過該伺服器的身份驗證。如果此問題持續發生，請嘗試選單中的“在瀏覽器中登錄”。</string>
+    <string name="error_failed_app_registration_fmt">無法通過該伺服器的身份驗證。如果此問題持續發生，請嘗試選單中的“在瀏覽器中登錄”。: %1$s</string>
     <string name="error_authorization_unknown">認證過程出現未知錯誤。如果此問題持續發生，請嘗試選單中的“在瀏覽器中登錄”。</string>
     <string name="error_authorization_denied">授權被拒絕。</string>
     <string name="error_retrieving_oauth_token">無法獲取登入資訊。</string>

--- a/feature/login/src/main/res/values/strings.xml
+++ b/feature/login/src/main/res/values/strings.xml
@@ -12,7 +12,6 @@
     <string name="action_close">Close</string>
     <string name="action_browser_login">Login with Browser</string>
     <string name="error_invalid_domain">Invalid domain entered</string>
-    <string name="error_failed_app_registration">Failed authenticating with that instance. If this persists, try "Login in Browser" from the menu.</string>
     <string name="error_failed_app_registration_fmt">Failed authenticating with that instance: %1$s</string>
     <string name="error_authorization_unknown">An unidentified authorization error occurred. If this persists, try "Login in Browser" from the menu.</string>
     <string name="error_authorization_denied">Authorization was denied. If you\'re sure that you supplied the correct credentials, try "Login in Browser" from the menu.</string>

--- a/feature/login/src/main/res/values/strings.xml
+++ b/feature/login/src/main/res/values/strings.xml
@@ -13,6 +13,7 @@
     <string name="action_browser_login">Login with Browser</string>
     <string name="error_invalid_domain">Invalid domain entered</string>
     <string name="error_failed_app_registration">Failed authenticating with that instance. If this persists, try "Login in Browser" from the menu.</string>
+    <string name="error_failed_app_registration_fmt">Failed authenticating with that instance: %1$s</string>
     <string name="error_authorization_unknown">An unidentified authorization error occurred. If this persists, try "Login in Browser" from the menu.</string>
     <string name="error_authorization_denied">Authorization was denied. If you\'re sure that you supplied the correct credentials, try "Login in Browser" from the menu.</string>
     <string name="error_retrieving_oauth_token">Failed getting a login token. If this persists, try "Login in Browser" from the menu.</string>


### PR DESCRIPTION
Should make it easier for users to figure out what's gone wrong and either fix it on their end, or provide more detailed bug reports.