### PR TITLE
chore(deps): update gradle/actions digest to 6cec5d4

### DIFF
--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -13,13 +13,13 @@ runs:
         distribution: 'temurin'
 
     - name: Gradle Wrapper Validation
-      uses: gradle/wrapper-validation-action@b231772637bb498f11fdbc86052b6e8a8dc9fc92 # v2
+      uses: gradle/actions/wrapper-validation@6cec5d49d4d6d4bb982fbed7047db31ea6d38f11 # v3
 
     - name: Copy CI gradle.properties
       shell: bash
       run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@1168cd3d07c1876a65e1724114de42ccbdfa7b78 # v3
+      uses: gradle/actions/setup-gradle@6cec5d49d4d6d4bb982fbed7047db31ea6d38f11 # v3
       with:
         cache-encryption-key: ${{ inputs.gradle_cache_encryption_key }}


### PR DESCRIPTION
The new version bundles the wrapper validation action, so switch to that.