### PR TITLE
fix: Ensure actionbar title is set correctly

### DIFF
--- a/app/src/main/java/app/pachli/MainActivity.kt
+++ b/app/src/main/java/app/pachli/MainActivity.kt
@@ -943,7 +943,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
 
         onTabSelectedListener = object : OnTabSelectedListener {
             override fun onTabSelected(tab: TabLayout.Tab) {
-                binding.mainToolbar.title = tab.contentDescription
+                supportActionBar?.title = tabs[tab.position].title(this@MainActivity)
 
                 refreshComposeButtonState(tabs[tab.position])
             }
@@ -962,7 +962,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
             activeTabLayout.addOnTabSelectedListener(it)
         }
 
-        binding.mainToolbar.title = tabs[position].title(this@MainActivity)
+        supportActionBar?.title = tabs[position].title(this@MainActivity)
         binding.mainToolbar.setOnClickListener {
             (tabAdapter.getFragment(activeTabLayout.selectedTabPosition) as? ReselectableFragment)?.onReselect()
         }


### PR DESCRIPTION
https://github.com/pachli/pachli-android/pull/589 changed the initial setting of the action bar title to use `binding.mainToolbar.title` instead of `supportActionBar?.title`.

Not sure why, but this doesn't work on first use, and was showing "Pachli Current" until the user changes tabs. Swap one usage back to `supportActionBar?.title` to fix this, and update the other to do the same thing to keep the code consistent.