### PR TITLE
feat: Show preview image for video attachments

### DIFF
--- a/app/src/main/java/app/pachli/fragment/ViewMediaFragment.kt
+++ b/app/src/main/java/app/pachli/fragment/ViewMediaFragment.kt
@@ -131,16 +131,16 @@ abstract class ViewMediaFragment : Fragment() {
         super.onAttach(context)
         mediaActivity = activity as ViewMediaActivity
         mediaActionsListener = context as MediaActionsListener
+
+        attachment = arguments?.getParcelable(ARG_ATTACHMENT)
+            ?: throw IllegalArgumentException("ARG_ATTACHMENT has to be set")
+
+        shouldCallMediaReady = arguments?.getBoolean(ARG_SHOULD_CALL_MEDIA_READY)
+            ?: throw IllegalArgumentException("ARG_SHOULD_CALL_MEDIA_READY has to be set")
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        attachment = arguments?.getParcelable<Attachment>(ARG_ATTACHMENT)
-            ?: throw IllegalArgumentException("ARG_ATTACHMENT has to be set")
-
-        shouldCallMediaReady = arguments?.getBoolean(ARG_SHOULD_CALL_MEDIA_READY)
-            ?: throw IllegalArgumentException("ARG_START_POSTPONED_TRANSITION has to be set")
 
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) {

--- a/app/src/main/res/layout/fragment_view_video.xml
+++ b/app/src/main/res/layout/fragment_view_video.xml
@@ -29,12 +29,22 @@
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:use_controller="false"
         app:show_previous_button="false"
         app:show_next_button="false" />
+
+    <ImageView
+        android:id="@+id/previewImage"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:ignore="ContentDescription" />
 
     <ProgressBar
         android:id="@+id/progressBar"


### PR DESCRIPTION
Video attachments may have a preview image. If they do, try and show that image (from the cache) before the video loads, so the user has something to look at. If there's no preview image, or it fails to load fall back to a black screen with a progress spinner as normal.

This also provides a smooth transition when playing the first video attachment, and fixes #598.