### PR TITLE
fix: Update PageCache to handle non-chronological ordering

### DIFF
--- a/app/src/main/java/app/pachli/components/timeline/NetworkTimelineRepository.kt
+++ b/app/src/main/java/app/pachli/components/timeline/NetworkTimelineRepository.kt
@@ -132,7 +132,7 @@ class NetworkTimelineRepository @Inject constructor(
 
     fun removeStatusWithId(statusId: String) {
         synchronized(pageCache) {
-            pageCache.floorEntry(statusId)?.value?.data?.removeAll { status ->
+            pageCache.getPageById(statusId)?.data?.removeAll { status ->
                 status.id == statusId || status.reblog?.id == statusId
             }
         }
@@ -141,7 +141,7 @@ class NetworkTimelineRepository @Inject constructor(
 
     fun updateStatusById(statusId: String, updater: (Status) -> Status) {
         synchronized(pageCache) {
-            pageCache.floorEntry(statusId)?.value?.let { page ->
+            pageCache.getPageById(statusId)?.let { page ->
                 val index = page.data.indexOfFirst { it.id == statusId }
                 if (index != -1) {
                     page.data[index] = updater(page.data[index])
@@ -153,7 +153,7 @@ class NetworkTimelineRepository @Inject constructor(
 
     fun updateActionableStatusById(statusId: String, updater: (Status) -> Status) {
         synchronized(pageCache) {
-            pageCache.floorEntry(statusId)?.value?.let { page ->
+            pageCache.getPageById(statusId)?.let { page ->
                 val index = page.data.indexOfFirst { it.id == statusId }
                 if (index != -1) {
                     val status = page.data[index]

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelinePagingSource.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelinePagingSource.kt
@@ -26,7 +26,11 @@ import timber.log.Timber
 
 private val INVALID = LoadResult.Invalid<String, Status>()
 
-/** [PagingSource] for Mastodon Status, identified by the Status ID */
+/**
+ * [PagingSource] for Mastodon Status, identified by the Status ID
+ *
+ * @param pageCache The [PageCache] backing this source
+ */
 class NetworkTimelinePagingSource @Inject constructor(
     private val pageCache: PageCache,
 ) : PagingSource<String, Status>() {
@@ -36,68 +40,17 @@ class NetworkTimelinePagingSource @Inject constructor(
         pageCache.debug()
 
         val page = synchronized(pageCache) {
-            if (pageCache.isEmpty()) {
-                return@synchronized null
-            }
+            if (pageCache.isEmpty()) return@synchronized null
 
             when (params) {
                 is LoadParams.Refresh -> {
-                    // Return the page that contains the given key, or the most recent page if
-                    // the key isn't in the cache.
-                    params.key?.let { key ->
-                        pageCache.floorEntry(key)?.value
-                    } ?: pageCache.lastEntry()?.value
+                    pageCache.getPageById(params.key) ?: pageCache.firstPage
                 }
-                // Loading previous / next pages (`Prepend` or `Append`) is a little complicated.
-                //
-                // Append and Prepend requests have a `params.key` that corresponds to the previous
-                // or next page. For some timeline types those keys have the same form as the
-                // item keys, and are valid item keys.
-                //
-                // But for some timeline types they are completely different.
-                //
-                // For example, bookmarks might have item keys that look like 110542553707722778
-                // but prevKey / nextKey values that look like 1480606 / 1229303.
-                //
-                // There's no guarantee that the `nextKey` value for one page matches the `prevKey`
-                // value of the page immediately before it.
-                //
-                // E.g., suppose `pages` has the following entries (older entries have lower page
-                // indices).
-                //
-                // .--- page index
-                // |     .-- ID of last item (key in `pageCache`)
-                // v     V
-                // 0: k: 109934818460629189, prevKey: 995916, nextKey: 941865
-                // 1: k: 110033940961955385, prevKey: 1073324, nextKey: 997376
-                // 2: k: 110239564017438509, prevKey: 1224838, nextKey: 1073352
-                // 3: k: 110542553707722778, prevKey: 1480606, nextKey: 1229303
-                //
-                // And the request is `LoadParams.Append` with `params.key` == 1073352. This means
-                // "fetch the page *before* the page that has `nextKey` == 1073352".
-                //
-                // The desired page has index 1. But that can't be found directly, because although
-                // the page after it (index 2) points back to it with the `nextKey` value, the page
-                // at index 1 **does not** have a `prevKey` value of 1073352. There can be gaps in
-                // the `prevKey` / `nextKey` chain -- I assume this is a Mastodon implementation
-                // detail.
-                //
-                // Further, we can't assume anything about the structure of the keys.
-                //
-                // To find the correct page for Append we must:
-                //
-                // 1. Find the page that has a `nextKey` value that matches `params.key` (page 2)
-                // 2. Get that page's key ("110239564017438509")
-                // 3. Return the page with the key that is immediately lower than the key from step 2
-                //
-                // The approach for Prepend is the same, except it is `prevKey` that is checked.
                 is LoadParams.Append -> {
-                    pageCache.firstNotNullOfOrNull { entry -> entry.takeIf { it.value.nextKey == params.key }?.value }
-                        ?.let { page -> pageCache.lowerEntry(page.data.last().id)?.value }
+                    pageCache.getNextPage(params.key)
                 }
                 is LoadParams.Prepend -> {
-                    pageCache.firstNotNullOfOrNull { entry -> entry.takeIf { it.value.prevKey == params.key }?.value }
-                        ?.let { page -> pageCache.higherEntry(page.data.last().id)?.value }
+                    pageCache.getPrevPage(params.key)
                 }
             }
         }
@@ -117,22 +70,14 @@ class NetworkTimelinePagingSource @Inject constructor(
             return INVALID
         }
 
-        // Calculate itemsBefore and itemsAfter values to include in the returned Page.
+        // Set itemsBefore and itemsAfter values to include in the returned Page.
         // If you do not do this (and this is not documented anywhere) then the anchorPosition
         // in the PagingState (used in getRefreshKey) is bogus, and refreshing the list can
         // result in large jumps in the user's position.
         //
         // The items are calculated relative to the local cache, not the remote data source.
-        val itemsBefore = page?.let {
-            it.prevKey?.let { key ->
-                pageCache.tailMap(key).values.fold(0) { sum, p -> sum + p.data.size }
-            }
-        } ?: 0
-        val itemsAfter = page?.let {
-            // Note: headMap and tailMap have different behaviour, tailMap is greater-or-equal,
-            // headMap is strictly less than, so `it.nextKey` does not work here.
-            pageCache.headMap(it.data.first().id).values.fold(0) { sum, p -> sum + p.data.size }
-        } ?: 0
+        val itemsBefore = pageCache.itemsBefore(page?.prevKey)
+        val itemsAfter = pageCache.itemsAfter(page?.nextKey)
 
         return LoadResult.Page(
             page?.data ?: emptyList(),
@@ -146,7 +91,7 @@ class NetworkTimelinePagingSource @Inject constructor(
     override fun getRefreshKey(state: PagingState<String, Status>): String? {
         val refreshKey = state.anchorPosition?.let {
             state.closestItemToPosition(it)?.id
-        } ?: pageCache.firstEntry()?.value?.data?.let {
+        } ?: pageCache.firstPage?.data?.let {
             it.getOrNull(it.size / 2)?.id
         }
 

--- a/app/src/test/java/app/pachli/components/timeline/NetworkTimelinePagingSourceTest.kt
+++ b/app/src/test/java/app/pachli/components/timeline/NetworkTimelinePagingSourceTest.kt
@@ -17,6 +17,7 @@
 
 package app.pachli.components.timeline
 
+import androidx.paging.LoadType
 import androidx.paging.PagingSource
 import androidx.paging.PagingSource.LoadResult
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -58,9 +59,9 @@ class NetworkTimelinePagingSourceTest {
     fun `load() for an item in a page returns the page containing that item and next, prev keys`() = runTest {
         // Given
         val pages = PageCache().apply {
-            upsert(Page(data = mutableListOf(mockStatus(id = "2")), nextKey = "1"))
-            upsert(Page(data = mutableListOf(mockStatus(id = "1")), nextKey = "0", prevKey = "2"))
-            upsert(Page(data = mutableListOf(mockStatus(id = "0")), prevKey = "1"))
+            add(Page(data = mutableListOf(mockStatus(id = "3")), nextKey = "1", prevKey = "4"), LoadType.REFRESH)
+            add(Page(data = mutableListOf(mockStatus(id = "1"), mockStatus(id = "2")), nextKey = "0", prevKey = "3"), LoadType.APPEND)
+            add(Page(data = mutableListOf(mockStatus(id = "0")), prevKey = "1"), LoadType.APPEND)
         }
         val pagingSource = NetworkTimelinePagingSource(pages)
 
@@ -72,8 +73,8 @@ class NetworkTimelinePagingSourceTest {
         assertThat((loadResult as? LoadResult.Page))
             .isEqualTo(
                 LoadResult.Page(
-                    data = listOf(mockStatus(id = "1")),
-                    prevKey = "2",
+                    data = listOf(mockStatus(id = "1"), mockStatus(id = "2")),
+                    prevKey = "3",
                     nextKey = "0",
                     itemsBefore = 1,
                     itemsAfter = 1,
@@ -85,9 +86,9 @@ class NetworkTimelinePagingSourceTest {
     fun `append returns the page after`() = runTest {
         // Given
         val pages = PageCache().apply {
-            upsert(Page(data = mutableListOf(mockStatus(id = "2")), nextKey = "1"))
-            upsert(Page(data = mutableListOf(mockStatus(id = "1")), nextKey = "0", prevKey = "2"))
-            upsert(Page(data = mutableListOf(mockStatus(id = "0")), prevKey = "1"))
+            add(Page(data = mutableListOf(mockStatus(id = "2")), nextKey = "1"), LoadType.REFRESH)
+            add(Page(data = mutableListOf(mockStatus(id = "1")), nextKey = "0", prevKey = "2"), LoadType.APPEND)
+            add(Page(data = mutableListOf(mockStatus(id = "0")), prevKey = "1"), LoadType.APPEND)
         }
         val pagingSource = NetworkTimelinePagingSource(pages)
 
@@ -112,9 +113,9 @@ class NetworkTimelinePagingSourceTest {
     fun `prepend returns the page before`() = runTest {
         // Given
         val pages = PageCache().apply {
-            upsert(Page(data = mutableListOf(mockStatus(id = "2")), nextKey = "1"))
-            upsert(Page(data = mutableListOf(mockStatus(id = "1")), nextKey = "0", prevKey = "2"))
-            upsert(Page(data = mutableListOf(mockStatus(id = "0")), prevKey = "1"))
+            add(Page(data = mutableListOf(mockStatus(id = "2")), nextKey = "1"), LoadType.REFRESH)
+            add(Page(data = mutableListOf(mockStatus(id = "1")), nextKey = "0", prevKey = "2"), LoadType.APPEND)
+            add(Page(data = mutableListOf(mockStatus(id = "0")), prevKey = "1"), LoadType.APPEND)
         }
         val pagingSource = NetworkTimelinePagingSource(pages)
 
@@ -139,9 +140,9 @@ class NetworkTimelinePagingSourceTest {
     fun `Refresh with null key returns the latest page`() = runTest {
         // Given
         val pages = PageCache().apply {
-            upsert(Page(data = mutableListOf(mockStatus(id = "2")), nextKey = "1"))
-            upsert(Page(data = mutableListOf(mockStatus(id = "1")), nextKey = "0", prevKey = "2"))
-            upsert(Page(data = mutableListOf(mockStatus(id = "0")), prevKey = "1"))
+            add(Page(data = mutableListOf(mockStatus(id = "2")), nextKey = "1"), LoadType.REFRESH)
+            add(Page(data = mutableListOf(mockStatus(id = "1")), nextKey = "0", prevKey = "2"), LoadType.APPEND)
+            add(Page(data = mutableListOf(mockStatus(id = "0")), prevKey = "1"), LoadType.APPEND)
         }
         val pagingSource = NetworkTimelinePagingSource(pages)
 
@@ -166,8 +167,8 @@ class NetworkTimelinePagingSourceTest {
     fun `Append with a too-old key returns empty list`() = runTest {
         // Given
         val pages = PageCache().apply {
-            upsert(Page(data = mutableListOf(mockStatus(id = "20")), nextKey = "10"))
-            upsert(Page(data = mutableListOf(mockStatus(id = "10")), prevKey = "20"))
+            add(Page(data = mutableListOf(mockStatus(id = "20")), nextKey = "10"), LoadType.REFRESH)
+            add(Page(data = mutableListOf(mockStatus(id = "10")), prevKey = "20"), LoadType.APPEND)
         }
         val pagingSource = NetworkTimelinePagingSource(pages)
 
@@ -193,8 +194,8 @@ class NetworkTimelinePagingSourceTest {
     fun `Prepend with a too-new key returns empty list`() = runTest {
         // Given
         val pages = PageCache().apply {
-            upsert(Page(data = mutableListOf(mockStatus(id = "20")), nextKey = "10"))
-            upsert(Page(data = mutableListOf(mockStatus(id = "10")), prevKey = "20"))
+            add(Page(data = mutableListOf(mockStatus(id = "20")), nextKey = "10"), LoadType.REFRESH)
+            add(Page(data = mutableListOf(mockStatus(id = "10")), prevKey = "20"), LoadType.APPEND)
         }
         val pagingSource = NetworkTimelinePagingSource(pages)
 

--- a/app/src/test/java/app/pachli/components/timeline/NetworkTimelineRemoteMediatorTest.kt
+++ b/app/src/test/java/app/pachli/components/timeline/NetworkTimelineRemoteMediatorTest.kt
@@ -149,18 +149,19 @@ class NetworkTimelineRemoteMediatorTest {
 
         // Then
         val expectedPages = PageCache().apply {
-            upsert(
+            add(
                 Page(
                     data = mutableListOf(mockStatus("7"), mockStatus("6"), mockStatus("5")),
                     prevKey = "7",
                     nextKey = "5",
                 ),
+                LoadType.REFRESH,
             )
         }
 
         assertThat(result).isInstanceOf(RemoteMediator.MediatorResult.Success::class.java)
         assertThat((result as RemoteMediator.MediatorResult.Success).endOfPaginationReached).isFalse()
-        assertThat(pages).containsExactlyEntriesIn(expectedPages)
+        assertThat(pages.idToPage).containsExactlyEntriesIn(expectedPages.idToPage)
 
         // Page cache was modified, so the pager should have been invalidated
         verify(pagingSourceFactory).invalidate()
@@ -171,12 +172,13 @@ class NetworkTimelineRemoteMediatorTest {
     fun `should prepend statuses`() = runTest {
         // Given
         val pages = PageCache().apply {
-            upsert(
+            add(
                 Page(
                     data = mutableListOf(mockStatus("7"), mockStatus("6"), mockStatus("5")),
                     prevKey = "7",
                     nextKey = "5",
                 ),
+                LoadType.REFRESH,
             )
         }
 
@@ -212,25 +214,27 @@ class NetworkTimelineRemoteMediatorTest {
 
         // Then
         val expectedPages = PageCache().apply {
-            upsert(
+            add(
                 Page(
                     data = mutableListOf(mockStatus("7"), mockStatus("6"), mockStatus("5")),
                     prevKey = "7",
                     nextKey = "5",
                 ),
+                LoadType.REFRESH,
             )
-            upsert(
+            add(
                 Page(
                     data = mutableListOf(mockStatus("10"), mockStatus("9"), mockStatus("8")),
                     prevKey = "10",
                     nextKey = "8",
                 ),
+                LoadType.PREPEND,
             )
         }
 
         assertThat(result).isInstanceOf(RemoteMediator.MediatorResult.Success::class.java)
         assertThat((result as RemoteMediator.MediatorResult.Success).endOfPaginationReached).isFalse()
-        assertThat(pages).containsExactlyEntriesIn(expectedPages)
+        assertThat(pages.idToPage).containsExactlyEntriesIn(expectedPages.idToPage)
 
         // Page cache was modified, so the pager should have been invalidated
         verify(pagingSourceFactory).invalidate()
@@ -241,12 +245,13 @@ class NetworkTimelineRemoteMediatorTest {
     fun `should append statuses`() = runTest {
         // Given
         val pages = PageCache().apply {
-            upsert(
+            add(
                 Page(
                     data = mutableListOf(mockStatus("7"), mockStatus("6"), mockStatus("5")),
                     prevKey = "7",
                     nextKey = "5",
                 ),
+                LoadType.REFRESH,
             )
         }
 
@@ -282,25 +287,27 @@ class NetworkTimelineRemoteMediatorTest {
 
         // Then
         val expectedPages = PageCache().apply {
-            upsert(
+            add(
                 Page(
                     data = mutableListOf(mockStatus("7"), mockStatus("6"), mockStatus("5")),
                     prevKey = "7",
                     nextKey = "5",
                 ),
+                LoadType.REFRESH,
             )
-            upsert(
+            add(
                 Page(
                     data = mutableListOf(mockStatus("4"), mockStatus("3"), mockStatus("2")),
                     prevKey = "4",
                     nextKey = "2",
                 ),
+                LoadType.APPEND,
             )
         }
 
         assertThat(result).isInstanceOf(RemoteMediator.MediatorResult.Success::class.java)
         assertThat((result as RemoteMediator.MediatorResult.Success).endOfPaginationReached).isFalse()
-        assertThat(pages).containsExactlyEntriesIn(expectedPages)
+        assertThat(pages.idToPage).containsExactlyEntriesIn(expectedPages.idToPage)
 
         // Page cache was modified, so the pager should have been invalidated
         verify(pagingSourceFactory).invalidate()


### PR DESCRIPTION
The PageCache implementation wasn't properly dealing with timelines that could return statuses in non-chronological order.

For example, if you bookmark a recent status, then go back in the timeline and bookmark an older status; the bookmarks timeline is ordered by the time of the bookmark event, not the creation time of the status that was bookmarked.

If a sufficiently old status was bookmarked so it straddled a page boundary you could have a situation where the range of status IDs in two different cached pages overlapped.

E.g., this log extract:

```
0: k: 110912736679636090, prev: 3521487, next: 3057175, size: 40, range: 112219564107059218..110912736679636090
1: k: 111651744569170291, prev: 3049659, next: 2710596, size: 40, range: 111926741634665808..111651744569170291
```

The range of IDs in page 0 overlaps with the range of IDs in page 1.

The previous `PageCache` assumed this couldn't happen, and broke in various interesting ways when it did.

E.g., you can't find the page that contains a given status by looking for the largest key less than the needle's status id. Given the pages above looking for ID 112219564107059218 (first status in page 0) would suggest page 1 as having the greatest key less than that ID. This manifested as the correct page briefly appearing in the UI (page 0), then being completely replaced with page 1.

Rewrite PageCache to fix this. The previous implementation used a single `TreeMap` assuming items were always sorted by ID. The new code keeps an unordered map from status IDs to the page that contains that status, and a separate `LinkedList` that contains the pages in order they're provided by the API. This decouples the ordering of pages in the cache with the overall ordering of items within the pages.