### PR TITLE
feat: Fetch more trending posts, links, and hashtags

### DIFF
--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelineRemoteMediator.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelineRemoteMediator.kt
@@ -125,7 +125,7 @@ class NetworkTimelineRemoteMediator(
             Timeline.Home -> api.homeTimeline(maxId = maxId, minId = minId, limit = loadSize)
             Timeline.PublicFederated -> api.publicTimeline(local = false, maxId = maxId, minId = minId, limit = loadSize)
             Timeline.PublicLocal -> api.publicTimeline(local = true, maxId = maxId, minId = minId, limit = loadSize)
-            Timeline.TrendingStatuses -> api.trendingStatuses()
+            Timeline.TrendingStatuses -> api.trendingStatuses(limit = LIMIT_TRENDING_STATUSES)
             is Timeline.Hashtags -> {
                 val firstHashtag = timeline.tags.first()
                 val additionalHashtags = timeline.tags.subList(1, timeline.tags.size)
@@ -166,5 +166,14 @@ class NetworkTimelineRemoteMediator(
             )
             else -> throw IllegalStateException("NetworkTimelineRemoteMediator does not support $timeline")
         }
+    }
+
+    companion object {
+        /**
+         * How many trending statuses to fetch. These are not paged, so fetch the
+         * documented (https://docs.joinmastodon.org/methods/trends/#query-parameters-1)
+         * maximum.
+         */
+        const val LIMIT_TRENDING_STATUSES = 40
     }
 }

--- a/app/src/main/java/app/pachli/components/trending/TrendingLinksRepository.kt
+++ b/app/src/main/java/app/pachli/components/trending/TrendingLinksRepository.kt
@@ -23,5 +23,14 @@ import javax.inject.Inject
 class TrendingLinksRepository @Inject constructor(
     private val api: MastodonApi,
 ) {
-    suspend fun getTrendingLinks() = api.trendingLinks()
+    suspend fun getTrendingLinks() = api.trendingLinks(limit = LIMIT_TRENDING_LINKS)
+
+    companion object {
+        /**
+         * How many trending links to fetch. These are not paged, so fetch the
+         * documented (https://docs.joinmastodon.org/methods/trends/#query-parameters-2)
+         * maximum.
+         */
+        const val LIMIT_TRENDING_LINKS = 20
+    }
 }

--- a/app/src/main/java/app/pachli/components/trending/viewmodel/TrendingTagsViewModel.kt
+++ b/app/src/main/java/app/pachli/components/trending/viewmodel/TrendingTagsViewModel.kt
@@ -88,7 +88,7 @@ class TrendingTagsViewModel @Inject constructor(
 
         val deferredFilters = async { mastodonApi.getFilters() }
 
-        mastodonApi.trendingTags().fold(
+        mastodonApi.trendingTags(limit = LIMIT_TRENDING_HASHTAGS).fold(
             { tagResponse ->
 
                 val firstTag = tagResponse.firstOrNull()
@@ -128,5 +128,14 @@ class TrendingTagsViewModel @Inject constructor(
             .maxOrNull() ?: 1
 
         return map { TrendingViewData.Tag.from(it, maxTrendingValue) }
+    }
+
+    companion object {
+        /**
+         * How many trending hashtags to fetch. These are not paged, so fetch the
+         * documented (https://docs.joinmastodon.org/methods/trends/#query-parameters)
+         * maximum.
+         */
+        const val LIMIT_TRENDING_HASHTAGS = 20
     }
 }

--- a/core/network/src/main/kotlin/app/pachli/core/network/retrofit/MastodonApi.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/retrofit/MastodonApi.kt
@@ -787,11 +787,17 @@ interface MastodonApi {
     suspend fun unfollowTag(@Path("name") name: String): NetworkResult<HashTag>
 
     @GET("api/v1/trends/tags")
-    suspend fun trendingTags(): NetworkResult<List<TrendingTag>>
+    suspend fun trendingTags(
+        @Query("limit") limit: Int? = null,
+    ): NetworkResult<List<TrendingTag>>
 
     @GET("api/v1/trends/links")
-    suspend fun trendingLinks(): NetworkResult<List<TrendsLink>>
+    suspend fun trendingLinks(
+        @Query("limit") limit: Int? = null,
+    ): NetworkResult<List<TrendsLink>>
 
     @GET("api/v1/trends/statuses")
-    suspend fun trendingStatuses(): Response<List<Status>>
+    suspend fun trendingStatuses(
+        @Query("limit") limit: Int? = null,
+    ): Response<List<Status>>
 }


### PR DESCRIPTION
The previous code didn't set a limit for the number of posts, links, and hashtags to fetch on the trending pages, so used the conservative defaults.

Increase these to the API maximums to show the user more information.