### PR TITLE
fix: Improve transitions in/out of playing video

### DIFF
--- a/app/src/main/res/layout/fragment_view_video.xml
+++ b/app/src/main/res/layout/fragment_view_video.xml
@@ -32,17 +32,8 @@
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:use_controller="false"
+        app:use_controller="true"
         app:show_previous_button="false"
-        app:show_next_button="false" />
-
-    <ProgressBar
-        android:id="@+id/progressBar"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
+        app:show_next_button="false"
+        app:show_buffering="always" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Previous code didn't trigger the transition from `ViewMediaActivity` when playing a video until the video had loaded. If the connection was slow or had other issues this resulted in the video "sticking" in the timeline until it loaded.

Change this, and trigger the transition immediately.

Fixes #598

While looking at this:

- Save the play/pause state of the video during a swipe, pause the video, and restore the state when the swipe is cancelled.
- Transition the entire video view, to improve the animated transition back to the activity.
- Remove the custom progress spinner, use the one provided by the player.
- Display the player controller via the layout XML instead of code