### PR TITLE
ci: apk-on-comment: Checkout by SHA

### DIFF
--- a/.github/workflows/apk-on-comment.yml
+++ b/.github/workflows/apk-on-comment.yml
@@ -24,10 +24,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           status: pending
 
-      - name: Checkout PR branch ${{ steps.comment-branch.outputs.head_ref }}
+      - name: Checkout PR branch ${{ steps.comment-branch.outputs.head_ref }} / ${{ steps.comment-branch.outputs.head_sha }}
         uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4
         with:
-          ref: ${{ steps.comment-branch.outputs.head_ref }}
+          ref: ${{ steps.comment-branch.outputs.head_sha }}
 
       - uses: ./.github/actions/setup-build-env
         with:


### PR DESCRIPTION
apk-on-comment checkout is failing on PRs from forked repositories, possibly because it can't find the ref.

Try and fix this by using the SHA when checking out.