### PR TITLE
change: Adjust SwipeRefreshLayout offset in AccountActivity

### DIFF
--- a/app/src/main/java/app/pachli/components/account/AccountActivity.kt
+++ b/app/src/main/java/app/pachli/components/account/AccountActivity.kt
@@ -35,7 +35,6 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
-import android.view.ViewGroup.MarginLayoutParams
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.viewModels
 import androidx.annotation.ColorInt
@@ -50,7 +49,6 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsCompat.Type.systemBars
-import androidx.core.view.updateLayoutParams
 import androidx.core.view.updatePadding
 import androidx.core.widget.doAfterTextChanged
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -330,10 +328,13 @@ class AccountActivity :
             val left = insets.getInsets(systemBars()).left
             binding.accountCoordinatorLayout.updatePadding(right = right, bottom = bottom, left = left)
 
-            // Scale the swipe spinner instead of appearing to come from nowhere, and adjust the
-            // top margin to avoid the system bar
-            binding.swipeRefreshLayout.setProgressViewEndTarget(true, binding.swipeRefreshLayout.progressViewEndOffset)
-            binding.swipeRefreshLayout.updateLayoutParams<MarginLayoutParams> { topMargin = top }
+            // Normal swipe spinner startOffset is negative so it slides down from the view
+            // above it. This puts it above the systembar and it finishes too high up the
+            // screen. Move it down so it starts at the top edge, scale it so it appears to
+            // grow instead of appearing out of thin air, and keep the final resting place at
+            // the same relative offset to the start.
+            val absoluteOffset = binding.swipeRefreshLayout.progressViewEndOffset - binding.swipeRefreshLayout.progressViewStartOffset
+            binding.swipeRefreshLayout.setProgressViewOffset(true, 0, absoluteOffset)
 
             WindowInsetsCompat.CONSUMED
         }


### PR DESCRIPTION
The change in 5959d23d resulted in a stuck margin when scrolling up in the account view.

Fix the `SwipeRefreshLayout` offset in a different way that doesn't have that problem; move the spinner's start position to the top of the screen (instead of the negative offset it normally has) and keep the same relative offset from the end position.

Have it scale in on the drag to complete the effect.