### PR TITLE
remove: remove janky animation warning

### DIFF
--- a/app/src/main/java/app/pachli/MainActivity.kt
+++ b/app/src/main/java/app/pachli/MainActivity.kt
@@ -46,7 +46,6 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.app.ActivityCompat
-import androidx.core.content.edit
 import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.view.GravityCompat
@@ -108,7 +107,6 @@ import app.pachli.core.navigation.TrendingActivityIntent
 import app.pachli.core.network.model.Account
 import app.pachli.core.network.model.Notification
 import app.pachli.core.preferences.PrefKeys
-import app.pachli.core.ui.extensions.await
 import app.pachli.core.ui.extensions.reduceSwipeSensitivity
 import app.pachli.databinding.ActivityMainBinding
 import app.pachli.db.DraftsAlert
@@ -459,22 +457,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
             recreate()
         }
 
-        // TODO: This can be removed after 2024-03-01, assume everyone has upgraded by then
-        if (sharedPreferencesRepository.getBoolean(PrefKeys.SHOW_JANKY_ANIMATION_WARNING, true)) {
-            showJankyAnimationWarning()
-        }
-
         lifecycleScope.launch { updateCheck.checkForUpdate(this@MainActivity) }
-    }
-
-    /** Warn the user about possibly-broken animations. */
-    private fun showJankyAnimationWarning() = lifecycleScope.launch {
-        AlertDialog.Builder(this@MainActivity)
-            .setTitle(R.string.janky_animation_title)
-            .setMessage(R.string.janky_animation_msg)
-            .create()
-            .await(android.R.string.ok)
-        sharedPreferencesRepository.edit { putBoolean(PrefKeys.SHOW_JANKY_ANIMATION_WARNING, false) }
     }
 
     override fun onStart() {
@@ -838,7 +821,6 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
                 arrayOf(
                     "Clear home timeline cache",
                     "Remove first 40 statuses",
-                    "Reset janky animation warning flag",
                 ),
             ) { _, which ->
                 Timber.d("Developer tools: %d", which)
@@ -858,9 +840,6 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
                                 developerToolsUseCase.deleteFirstKStatuses(it.id, 40)
                             }
                         }
-                    }
-                    2 -> {
-                        developerToolsUseCase.resetJankyAnimationWarningFlag()
                     }
                 }
             }

--- a/app/src/main/java/app/pachli/PachliApplication.kt
+++ b/app/src/main/java/app/pachli/PachliApplication.kt
@@ -19,7 +19,6 @@ package app.pachli
 
 import android.app.Application
 import android.content.Context
-import androidx.core.content.edit
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Constraints
 import androidx.work.ExistingPeriodicWorkPolicy
@@ -149,14 +148,6 @@ class PachliApplication : Application() {
     private fun upgradeSharedPreferences(oldVersion: Int, newVersion: Int) {
         Timber.d("Upgrading shared preferences: %d -> %d", oldVersion, newVersion)
         val editor = sharedPreferencesRepository.edit()
-
-        if (oldVersion != NEW_INSTALL_SCHEMA_VERSION) {
-            // Upgrading rather than a new install. Possibly show the janky animation warning,
-            // see https://github.com/material-components/material-components-android/issues/3644
-            if (!sharedPreferencesRepository.contains(PrefKeys.SHOW_JANKY_ANIMATION_WARNING)) {
-                sharedPreferencesRepository.edit { putBoolean(PrefKeys.SHOW_JANKY_ANIMATION_WARNING, true) }
-            }
-        }
 
         // General usage is:
         //

--- a/app/src/main/java/app/pachli/usecase/DeveloperToolsUseCase.kt
+++ b/app/src/main/java/app/pachli/usecase/DeveloperToolsUseCase.kt
@@ -17,11 +17,8 @@
 
 package app.pachli.usecase
 
-import androidx.core.content.edit
 import app.pachli.core.database.dao.TimelineDao
 import app.pachli.core.database.di.TransactionProvider
-import app.pachli.core.preferences.PrefKeys
-import app.pachli.core.preferences.SharedPreferencesRepository
 import javax.inject.Inject
 
 /**
@@ -31,7 +28,6 @@ import javax.inject.Inject
 class DeveloperToolsUseCase @Inject constructor(
     private val transactionProvider: TransactionProvider,
     private val timelineDao: TimelineDao,
-    private val sharedPreferencesRepository: SharedPreferencesRepository,
 ) {
     /**
      * Clear the home timeline cache.
@@ -48,10 +44,5 @@ class DeveloperToolsUseCase @Inject constructor(
             val ids = timelineDao.getMostRecentNStatusIds(accountId, 40)
             timelineDao.deleteRange(accountId, ids.last(), ids.first())
         }
-    }
-
-    /** Reset the SHOW_JANKY_ANIMATION_WARNING flag */
-    fun resetJankyAnimationWarningFlag() = sharedPreferencesRepository.edit {
-        putBoolean(PrefKeys.SHOW_JANKY_ANIMATION_WARNING, true)
     }
 }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -621,7 +621,6 @@
     <string name="filter_keyword_addition_title">إضافة كلمة مفتاحية</string>
     <string name="label_filter_keywords">كلمات مفتاحية أو عبارات للتصفية</string>
     <string name="hint_description">الوصف</string>
-    <string name="janky_animation_title">قد تحتاج إلى إعادة تشغيل جهازك</string>
     <string name="title_tab_public_trending_statuses">المنشورات</string>
     <string name="pref_update_notification_frequency_once_per_version">مرة واحدة كل نسخة</string>
     <string name="filter_description_hide">إخفاء تماما</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -630,6 +630,4 @@
     <string name="reaction_name_and_count">%1$s %2$d</string>
     <string name="announcement_date">%1$s %2$s</string>
     <string name="announcement_date_updated">(Aktualisiert: %1$s)</string>
-    <string name="janky_animation_title">Möglicherweise müssen Sie Ihr Gerät neu starten</string>
-    <string name="janky_animation_msg">Diese Version von Pachli kann auf einigen Geräten einen Android-Bug auslösen und fehlerhafte Animationen anzeigen.\n\nZum Beispiel, wenn Sie auf einen Beitrag tippen, um ein Thema anzuzeigen.\n\nWenn Sie dies sehen, müssen Sie Ihr Gerät neu starten.\n\nSie müssen dies nur einmal tun.\n\nDies ist ein Android-Fehler, für den Pachli nichts kann.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -612,15 +612,6 @@
     <string name="dialog_delete_filter_text">Elimina filtro \'%1$s\'?</string>
     <string name="error_media_playback">La reproducción falló: %s</string>
     <string name="title_public_trending">En tendencia</string>
-    <string name="janky_animation_msg">Esta versión de Pachli puede desencadenar un error de Android en algunos dispositivos, y mostrar animaciones rotas.
-\n
-\nPor ejemplo, al tocar una publicación para ver una conversación.
-\n
-\nSi ves esto, necesitarás reiniciar tu dispositivo.
-\n
-\nSólo tienes que hacer esto una vez.
-\n
-\nEsto es un error de Android, no hay nada que Pachli pueda hacer.</string>
     <string name="translation_provider_fmt">%1$s</string>
     <string name="pref_title_update_settings">Actualizaciones de programa</string>
     <string name="title_public_trending_statuses">Publicaciones en tendencia</string>
@@ -633,7 +624,6 @@
     <string name="pref_title_show_self_boosts_description">Alguien impulsa su propia publicación</string>
     <string name="ui_error_filter_v1_load_fmt">La carga de filtros falló: %1$s</string>
     <string name="confirmation_hashtag_muted">#%s oculto(s)</string>
-    <string name="janky_animation_title">Puede que tengas que reiniciar tu dispositivo</string>
     <string name="confirmation_hashtag_unmuted">#%s visible</string>
     <string name="pref_title_show_self_boosts">Mostrar auto-impulsos</string>
     <string name="announcement_date_updated">(Actualizado: %1$s)</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -489,7 +489,6 @@
     <string name="account_date_joined">Liittyi %1$s</string>
     <string name="ui_error_unknown">tuntematon syy</string>
     <string name="ui_error_filter_v1_load_fmt">Suodattimien lataaminen epäonnistui: %1$s</string>
-    <string name="janky_animation_title">Saatat joutua käynnistämään laitteesi uudelleen</string>
     <string name="announcement_date_updated">(Päivitetty: %1$s)</string>
     <string name="tips_push_notification_migration">Kirjaudu uudelleen kaikille tileille push-ilmoitusten ottamiseksi käyttöön.</string>
     <string name="pref_update_notification_frequency_once_per_version">Kerran jokaisesta versiosta</string>
@@ -551,15 +550,6 @@
     </plurals>
     <string name="title_favourited_by">Tykännyt</string>
     <string name="send_post_notification_saved_content">Kopio julkaisusta on tallennettu luonnoksiisi</string>
-    <string name="janky_animation_msg">Tämä Pachlin versio voi laukaista Android-virheen joissakin laitteissa ja näyttää rikkinäisiä animaatioita.
-\n
-\nEsimerkiksi, kun napautat viestiä katsoaksesi ketjun.
-\n
-\nJos näin tapahtuu, sinun täytyy käynnistää laite uudelleen.
-\n
-\nNäin tarvitsee tehdä vain kerran.
-\n
-\nTämä on Androidin bugi, jolle Pachli ei voi mitään.</string>
     <string name="description_browser_login">Saattaa tukea muita tunnistautumistapoja, mutta vaatii tuetun verkkoselaimen.</string>
     <string name="report_description_1">Raportti lähetetään palvelimesi moderaattorille. Alla voit selittää miksi raportoit tämän tilin:</string>
     <plurals name="reblogs">

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -618,7 +618,6 @@
     <string name="update_dialog_neutral">Ne plus me rappeller pour cette version</string>
     <string name="translating">Traduction …</string>
     <string name="translation_provider_fmt">%1$s</string>
-    <string name="janky_animation_title">Vous aurez besoin de redémarrer votre appareil</string>
     <string name="confirmation_hashtag_muted">#%s caché</string>
     <string name="label_image">Image</string>
     <string name="pref_summary_timeline_filters">Votre serveur ne supporte pas les filtres</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -622,14 +622,4 @@
     <string name="action_translate">翻訳</string>
     <string name="update_dialog_title">アップデート可能です</string>
     <string name="action_translate_undo">翻訳を元に戻す</string>
-    <string name="janky_animation_msg">このバージョンのPachliは、一部のデバイスでAndroidのバグにより、アニメーションが崩れる可能性があります
-\n
-\n例えば、投稿をタップしてスレッドを見る場合などです
-\n
-\nこのバグが発生したら、デバイスを再起動する必要があります。
-\n
-\nこの作業は一度だけで大丈夫です。
-\n
-\nこれはAndroid側のバグであり、Pachliではどうすることもできません。</string>
-    <string name="janky_animation_title">デバイスを再起動する必要があるかもしれません</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -588,15 +588,6 @@
     <string name="reaction_name_and_count">%1$s %2$d</string>
     <string name="error_media_playback">Afspelen mislukt: %s</string>
     <string name="title_public_trending">Opkomend</string>
-    <string name="janky_animation_msg">Deze versie van Pachli kan mogelijk een Android bug veroorzaken op sommige apparaten, en toont kapotte animaties.
-\n
-\nBijvoorbeeld als je een post aanklikt om een gesprek te bekijken.
-\n
-\nAls je dit ziet, dan moet je je apparaat herstarten.
-\n
-\nJe hoeft dit enkel eenmalig te doen.
-\n
-\nDit is een bug in Android, Pachli kan hier niet iets aan doen.</string>
     <string name="description_browser_login">Mogelijk ondersteunt dit extra authenticatie opties, maar dit vereist een ondersteunde browser.</string>
     <string name="translation_provider_fmt">%1$s</string>
     <string name="description_login">Werkt in de meeste gevallen. Geen data wordt gelekt naar andere apps.</string>
@@ -616,7 +607,6 @@
     <string name="pref_title_show_self_boosts_description">Iemand die hun eigen post boost</string>
     <string name="ui_error_filter_v1_load_fmt">Laden van filters faalde: %1$s</string>
     <string name="confirmation_hashtag_muted">#%s verborgen</string>
-    <string name="janky_animation_title">Mogelijk is het noodzakelijk om je apparaat opnieuw op te starten</string>
     <string name="confirmation_hashtag_unmuted">#%s niet meer verborgen</string>
     <string name="pref_title_show_self_boosts">Toon zelf-boosts</string>
     <string name="announcement_date_updated">(Bijgewerkt: %1$s)</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -558,15 +558,6 @@
     <string name="ui_success_accepted_follow_request">Pedido para seguir aceito</string>
     <string name="error_media_playback">Reprodução falhou: %s</string>
     <string name="title_public_trending">Em alta</string>
-    <string name="janky_animation_msg">Esta versão do Pachli pode acionar uma falha do Android em alguns dispositivos e exibir animações falhas.
-\n
-\nPor exemplo, ao tocar em uma postagem para visualizar um tópico.
-\n
-\nSe ver isso, precisará reiniciar o dispositivo.
-\n
-\nSó precisa fazer isso uma vez.
-\n
-\nEsta é uma falha do Android, não há nada que Pachli possa fazer.</string>
     <string name="notification_header_report_format">%s denunciou %s</string>
     <string name="accessibility_talking_about_tag">%1$d pessoas estão comentando sobre a Hashtag %2$s</string>
     <string name="compose_delete_draft">Apagar o rascunho?</string>
@@ -604,7 +595,6 @@
     <string name="ui_error_filter_v1_load_fmt">Falha ao carregar os filtros: %1$s</string>
     <string name="notification_sign_up_name">Inscrições</string>
     <string name="confirmation_hashtag_muted">#%s oculto</string>
-    <string name="janky_animation_title">Pode ser necessário reiniciar o teu dispositivo</string>
     <string name="confirmation_hashtag_unmuted">#%s reexibido</string>
     <string name="pref_title_show_self_boosts">Mostrar auto-Boosts</string>
     <string name="announcement_date_updated">(Atualizado: %1$s)</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -613,7 +613,6 @@
     <string name="dialog_delete_filter_text">Radera filter \'%1$s\'?</string>
     <string name="error_media_playback">Uppspelning misslyckades: %s</string>
     <string name="title_public_trending">Trendande</string>
-    <string name="janky_animation_msg">Denna version av Pachli kan visa ett Android-fel på några enheter som visar trasiga animationer, t.ex. vid tappning av en toot för att visa en tråd. Om du ser denna bör du starta om din enhet.</string>
     <string name="translation_provider_fmt">%1$s</string>
     <string name="pref_title_update_settings">Mjukvaruuppdateringar</string>
     <string name="title_public_trending_statuses">Trendande toots</string>
@@ -626,7 +625,6 @@
     <string name="pref_title_show_self_boosts_description">Någon som knuffar sin toot</string>
     <string name="ui_error_filter_v1_load_fmt">Laddning av filter misslyckades: %1$s</string>
     <string name="confirmation_hashtag_muted">#%s dold</string>
-    <string name="janky_animation_title">Du behöver kanske starta om din enhet</string>
     <string name="confirmation_hashtag_unmuted">#%s avdold</string>
     <string name="pref_title_show_self_boosts">Visa självknuffar</string>
     <string name="announcement_date_updated">(Uppdaterad: %1$s)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -685,8 +685,6 @@
     <string name="update_dialog_negative">Never remind me</string>
     <string name="translating">Translating…</string>
     <string name="translation_provider_fmt">%1$s</string>
-    <string name="janky_animation_title">You may need to restart your device</string>
-    <string name="janky_animation_msg">This version of Pachli may trigger an Android bug on some devices, and show broken animations.\n\nFor example, when tapping a post to view a thread.\n\nIf you see this you will need to restart your device.\n\nYou only need to do this once.\n\nThis is Android bug, there is nothing Pachli can do.</string>
 
     <string name="server_repository_error">Could not fetch server info for %1$s: %2$s</string>
     <string name="server_repository_error_get_well_known_node_info">fetching /.well-known/nodeinfo failed: %1$s</string>

--- a/core/preferences/src/main/kotlin/app/pachli/core/preferences/SettingsConstants.kt
+++ b/core/preferences/src/main/kotlin/app/pachli/core/preferences/SettingsConstants.kt
@@ -127,9 +127,6 @@ object PrefKeys {
     const val UPDATE_NOTIFICATION_VERSIONCODE = "updateNotificationVersioncode"
     const val UPDATE_NOTIFICATION_LAST_NOTIFICATION_MS = "updateNotificationLastNotificationMs"
 
-    /* Flag to show the "janky animation" warning dialog */
-    const val SHOW_JANKY_ANIMATION_WARNING = "showJankyAnimationWarning"
-
     /** Keys that are no longer used (e.g., the preference has been removed */
     object Deprecated {
         // Empty at this time


### PR DESCRIPTION
This warning (added in #274) includes a comment saying that we can remove it after 2024-03-01, so the time has come :)

I think it's worth mentioning that I've been seeing this warning on new installs of Pachli 2.4.0, even though the code suggests that the warning should only be shown following upgrades from previous versions. Seems like something to watch out for if we ever need to build similar behavior in the future.