### PR TITLE
fix: Enable talkback actions in notifications and conversations

### DIFF
--- a/app/src/main/java/app/pachli/components/conversation/ConversationsFragment.kt
+++ b/app/src/main/java/app/pachli/components/conversation/ConversationsFragment.kt
@@ -55,6 +55,7 @@ import app.pachli.fragment.SFragment
 import app.pachli.interfaces.ActionButtonActivity
 import app.pachli.interfaces.ReselectableFragment
 import app.pachli.interfaces.StatusActionListener
+import app.pachli.util.ListStatusAccessibilityDelegate
 import app.pachli.util.StatusDisplayOptionsRepository
 import at.connyduck.sparkbutton.helpers.Utils
 import com.google.android.material.color.MaterialColors
@@ -220,6 +221,15 @@ class ConversationsFragment :
     }
 
     private fun setupRecyclerView() {
+        binding.recyclerView.setAccessibilityDelegateCompat(
+            ListStatusAccessibilityDelegate(binding.recyclerView, this) { pos ->
+                if (pos in 0 until adapter.itemCount) {
+                    adapter.peek(pos)
+                } else {
+                    null
+                }
+            },
+        )
         binding.recyclerView.setHasFixedSize(true)
         binding.recyclerView.layoutManager = LinearLayoutManager(context)
 

--- a/app/src/main/java/app/pachli/util/ListStatusAccessibilityDelegate.kt
+++ b/app/src/main/java/app/pachli/util/ListStatusAccessibilityDelegate.kt
@@ -49,51 +49,50 @@ class ListStatusAccessibilityDelegate<T : IStatusViewData>(
 
             val pos = recyclerView.getChildAdapterPosition(host)
             val status = statusProvider.getStatus(pos) ?: return
-            if (status is StatusViewData) {
-                if (status.spoilerText.isNotEmpty()) {
-                    info.addAction(if (status.isExpanded) collapseCwAction else expandCwAction)
-                }
 
-                info.addAction(replyAction)
-
-                val actionable = status.actionable
-                if (actionable.rebloggingAllowed()) {
-                    info.addAction(if (actionable.reblogged) unreblogAction else reblogAction)
-                }
-                info.addAction(if (actionable.favourited) unfavouriteAction else favouriteAction)
-                info.addAction(if (actionable.bookmarked) unbookmarkAction else bookmarkAction)
-
-                val mediaActions = intArrayOf(
-                    R.id.action_open_media_1,
-                    R.id.action_open_media_2,
-                    R.id.action_open_media_3,
-                    R.id.action_open_media_4,
-                )
-                val attachmentCount = min(actionable.attachments.size, MAX_MEDIA_ATTACHMENTS)
-                for (i in 0 until attachmentCount) {
-                    info.addAction(
-                        AccessibilityActionCompat(
-                            mediaActions[i],
-                            context.getString(R.string.action_open_media_n, i + 1),
-                        ),
-                    )
-                }
-
-                info.addAction(openProfileAction)
-                if (getLinks(status).any()) info.addAction(linksAction)
-
-                val mentions = actionable.mentions
-                if (mentions.isNotEmpty()) info.addAction(mentionsAction)
-
-                if (getHashtags(status).any()) info.addAction(hashtagsAction)
-                if (!status.status.reblog?.account?.username.isNullOrEmpty()) {
-                    info.addAction(openRebloggerAction)
-                }
-                if (actionable.reblogsCount > 0) info.addAction(openRebloggedByAction)
-                if (actionable.favouritesCount > 0) info.addAction(openFavsAction)
-
-                info.addAction(moreAction)
+            if (status.spoilerText.isNotEmpty()) {
+                info.addAction(if (status.isExpanded) collapseCwAction else expandCwAction)
             }
+
+            info.addAction(replyAction)
+
+            val actionable = status.actionable
+            if (actionable.rebloggingAllowed()) {
+                info.addAction(if (actionable.reblogged) unreblogAction else reblogAction)
+            }
+            info.addAction(if (actionable.favourited) unfavouriteAction else favouriteAction)
+            info.addAction(if (actionable.bookmarked) unbookmarkAction else bookmarkAction)
+
+            val mediaActions = intArrayOf(
+                R.id.action_open_media_1,
+                R.id.action_open_media_2,
+                R.id.action_open_media_3,
+                R.id.action_open_media_4,
+            )
+            val attachmentCount = min(actionable.attachments.size, MAX_MEDIA_ATTACHMENTS)
+            for (i in 0 until attachmentCount) {
+                info.addAction(
+                    AccessibilityActionCompat(
+                        mediaActions[i],
+                        context.getString(R.string.action_open_media_n, i + 1),
+                    ),
+                )
+            }
+
+            info.addAction(openProfileAction)
+            if (getLinks(status).any()) info.addAction(linksAction)
+
+            val mentions = actionable.mentions
+            if (mentions.isNotEmpty()) info.addAction(mentionsAction)
+
+            if (getHashtags(status).any()) info.addAction(hashtagsAction)
+            if (!status.status.reblog?.account?.username.isNullOrEmpty()) {
+                info.addAction(openRebloggerAction)
+            }
+            if (actionable.reblogsCount > 0) info.addAction(openRebloggedByAction)
+            if (actionable.favouritesCount > 0) info.addAction(openFavsAction)
+
+            info.addAction(moreAction)
         }
 
         override fun performAccessibilityAction(
@@ -230,7 +229,7 @@ class ListStatusAccessibilityDelegate<T : IStatusViewData>(
         }
     }
 
-    private fun getLinks(status: StatusViewData): Sequence<LinkSpanInfo> {
+    private fun getLinks(status: IStatusViewData): Sequence<LinkSpanInfo> {
         val content = status.content
         return if (content is Spannable) {
             content.getSpans(0, content.length, URLSpan::class.java)
@@ -248,7 +247,7 @@ class ListStatusAccessibilityDelegate<T : IStatusViewData>(
         }
     }
 
-    private fun getHashtags(status: StatusViewData): Sequence<CharSequence> {
+    private fun getHashtags(status: IStatusViewData): Sequence<CharSequence> {
         val content = status.content
         return content.getSpans(0, content.length, Object::class.java)
             .asSequence()


### PR DESCRIPTION
`ListStatusAccessiblityDelegate` was ignoring notifications because it was checking the status against the concrete `StatusViewData` and not the interface `IStatusViewData`.

Fix that and now notifications have accessibility actions.

`ConversationsFragment` didn't set the accessibility delegate, so no actions appeared. Fix that so they do.