### PR TITLE
fix: Mark tab drag icon as unimportant for accessiblity

### DIFF
--- a/app/src/main/res/layout/item_tab_preference.xml
+++ b/app/src/main/res/layout/item_tab_preference.xml
@@ -20,6 +20,7 @@
         android:paddingBottom="8dp"
         android:src="@drawable/ic_drag_indicator_24dp"
         app:tint="?attr/colorControlNormal"
+        android:importantForAccessibility="no"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="@id/textView"/>


### PR DESCRIPTION
Talkback was speaking it as "Unlabeled". It's not necessary for Talkback, as the tab name describes it in the list.