### PR TITLE
ci: Run CI on release as well as debug builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
       matrix:
         color: ["orange"]
         store: ["fdroid", "github", "google"]
-        type: ["debug"]
+        type: ["debug", "release"]
     name: Android Lint
     runs-on: ubuntu-latest
 
@@ -90,7 +90,7 @@ jobs:
       matrix:
         color: ["orange"]
         store: ["fdroid", "github", "google"]
-        type: ["debug"]
+        type: ["debug", "release"]
     name: Android Test
     runs-on: ubuntu-latest
 
@@ -111,7 +111,7 @@ jobs:
       matrix:
         color: ["orange"]
         store: ["fdroid", "github", "google"]
-        type: ["debug"]
+        type: ["debug", "release"]
     name: Android Assemble
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Experiment to see if CI can run on release builds without a large performance impact.