### PR TITLE
refactor: Use AppCompatResources.getDrawable()

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -2430,7 +2430,7 @@
         errorLine2="     ~~~~~~~~">
         <location
             file="src/main/res/layout/item_tab_preference.xml"
-            line="27"
+            line="28"
             column="6"/>
     </issue>
 
@@ -2619,17 +2619,6 @@
             file="src/main/java/app/pachli/util/ShareShortcutHelper.kt"
             line="96"
             column="5"/>
-    </issue>
-
-    <issue
-        id="ContentDescription"
-        message="Missing `contentDescription` attribute on image"
-        errorLine1="    &lt;ImageView"
-        errorLine2="     ~~~~~~~~~">
-        <location
-            file="src/main/res/layout/item_tab_preference.xml"
-            line="14"
-            column="6"/>
     </issue>
 
     <issue

--- a/app/src/main/java/app/pachli/adapter/ReportNotificationViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/ReportNotificationViewHolder.kt
@@ -18,7 +18,7 @@
 package app.pachli.adapter
 
 import android.content.Context
-import androidx.core.content.ContextCompat
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.recyclerview.widget.RecyclerView
 import app.pachli.R
 import app.pachli.components.notifications.NotificationActionListener
@@ -79,7 +79,7 @@ class ReportNotificationViewHolder(
             itemView,
             animateEmojis,
         )
-        val icon = ContextCompat.getDrawable(binding.root.context, R.drawable.ic_flag_24dp)
+        val icon = AppCompatResources.getDrawable(binding.root.context, R.drawable.ic_flag_24dp)
 
         binding.notificationTopText.setCompoundDrawablesWithIntrinsicBounds(icon, null, null, null)
         binding.notificationTopText.text = itemView.context.getString(

--- a/app/src/main/java/app/pachli/adapter/StatusBaseViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/StatusBaseViewHolder.kt
@@ -14,9 +14,9 @@ import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.appcompat.widget.PopupMenu
 import androidx.constraintlayout.widget.ConstraintLayout
-import androidx.core.content.ContextCompat
 import androidx.core.text.HtmlCompat
 import androidx.recyclerview.widget.RecyclerView
 import app.pachli.R
@@ -519,7 +519,7 @@ abstract class StatusBaseViewHolder<T : IStatusViewData> protected constructor(i
             )
             val type = attachment.type
             if (showingContent && type.isPlayable()) {
-                imageView.foreground = ContextCompat.getDrawable(context, R.drawable.play_indicator_overlay)
+                imageView.foreground = AppCompatResources.getDrawable(context, R.drawable.play_indicator_overlay)
             } else {
                 imageView.foreground = null
             }

--- a/app/src/main/java/app/pachli/components/compose/view/ComposeScheduleView.kt
+++ b/app/src/main/java/app/pachli/components/compose/view/ComposeScheduleView.kt
@@ -20,8 +20,8 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.constraintlayout.widget.ConstraintLayout
-import androidx.core.content.ContextCompat
 import app.pachli.R
 import app.pachli.databinding.ViewComposeScheduleBinding
 import com.google.android.material.datepicker.CalendarConstraints
@@ -91,7 +91,7 @@ class ComposeScheduleView
     }
 
     private fun setEditIcons() {
-        val icon = ContextCompat.getDrawable(context, R.drawable.ic_create_24dp) ?: return
+        val icon = AppCompatResources.getDrawable(context, R.drawable.ic_create_24dp) ?: return
         val size = binding.scheduledDateTime.lineHeight
         icon.setBounds(0, 0, size, size)
         binding.scheduledDateTime.setCompoundDrawables(null, null, icon, null)

--- a/app/src/main/java/app/pachli/components/notifications/StatusNotificationViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/notifications/StatusNotificationViewHolder.kt
@@ -30,7 +30,7 @@ import android.text.style.StyleSpan
 import android.view.View
 import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
-import androidx.core.content.ContextCompat
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.recyclerview.widget.RecyclerView
 import app.pachli.R
 import app.pachli.adapter.StatusBaseViewHolder
@@ -196,7 +196,7 @@ internal class StatusNotificationViewHolder(
         @DrawableRes drawable: Int,
         @ColorRes color: Int,
     ): Drawable? {
-        val icon = ContextCompat.getDrawable(context, drawable)
+        val icon = AppCompatResources.getDrawable(context, drawable)
         icon?.setColorFilter(context.getColor(color), PorterDuff.Mode.SRC_ATOP)
         return icon
     }

--- a/app/src/main/java/app/pachli/components/viewthread/ConversationLineItemDecoration.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/ConversationLineItemDecoration.kt
@@ -20,14 +20,14 @@ import android.content.Context
 import android.graphics.Canvas
 import android.graphics.drawable.Drawable
 import android.view.View
-import androidx.core.content.ContextCompat
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.view.forEach
 import androidx.recyclerview.widget.RecyclerView
 import app.pachli.R
 import app.pachli.core.designsystem.R as DR
 
 class ConversationLineItemDecoration(context: Context) : RecyclerView.ItemDecoration() {
-    private val divider: Drawable = ContextCompat.getDrawable(context, R.drawable.conversation_thread_line)!!
+    private val divider: Drawable = AppCompatResources.getDrawable(context, R.drawable.conversation_thread_line)!!
 
     private val avatarTopMargin = context.resources.getDimensionPixelSize(DR.dimen.account_avatar_margin)
     private val halfAvatarHeight = context.resources.getDimensionPixelSize(DR.dimen.timeline_status_avatar_height) / 2

--- a/checks/src/main/java/app/pachli/lint/checks/ContextCompatGetDrawableDetector.kt
+++ b/checks/src/main/java/app/pachli/lint/checks/ContextCompatGetDrawableDetector.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2024 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.lint.checks
+
+import com.android.tools.lint.client.api.TYPE_INT
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.LintFix
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.intellij.psi.PsiMethod
+import org.jetbrains.uast.UCallExpression
+
+// appcompat-lint doesn't detect ContextCompat.getDrawable,
+// https://issuetracker.google.com/issues/337905331
+class ContextCompatGetDrawableDetector : Detector(), SourceCodeScanner {
+    override fun getApplicableMethodNames() = listOf(METHOD_GET_DRAWABLE)
+
+    val fix = LintFix.create()
+        .name("Replace with `AppCompatResources.getDrawable`")
+        .replace()
+        .text("ContextCompat.")
+        .with("AppCompatResources.")
+        .imports("androidx.appcompat.content.res.AppCompatResources")
+        .independent(true)
+        .build()
+
+    override fun visitMethodCall(context: JavaContext, node: UCallExpression, method: PsiMethod) {
+        if (!context.evaluator.isMemberInClass(method, CLASS_CONTEXT_COMPAT)) return
+        if (method.name != METHOD_GET_DRAWABLE) return
+        if (!context.evaluator.methodMatches(
+                method,
+                CLASS_CONTEXT_COMPAT,
+                true,
+                "android.content.Context",
+                TYPE_INT,
+            )
+        ) {
+            return
+        }
+
+        context.report(
+            issue = ISSUE,
+            scope = node,
+            location = context.getCallLocation(node, includeReceiver = true, includeArguments = true),
+            message = "Use AppCompatResources.getDrawable",
+            quickfixData = fix,
+        )
+    }
+
+    companion object {
+        private const val CLASS_CONTEXT_COMPAT = "androidx.core.content.ContextCompat"
+        private const val METHOD_GET_DRAWABLE = "getDrawable"
+
+        val ISSUE = Issue.create(
+            id = "ContextCompatGetDrawableDetector",
+            briefDescription = "Don't use `ContextCompat.getDrawable()`, use `AppCompatResources.getDrawable()`",
+            explanation = """
+                AppCompatResources().getDrawable() backports features and bug fixes,
+                ContextCompat.getDrawable() does not.
+                See https://medium.com/@crafty/yes-contextcompat-just-saves-you-the-api-level-check-it-doesnt-back-port-and-features-or-bug-9cd7d5f09be4
+            """,
+            category = Category.CORRECTNESS,
+            priority = 6,
+            severity = Severity.WARNING,
+            implementation = Implementation(
+                ContextCompatGetDrawableDetector::class.java,
+                Scope.JAVA_FILE_SCOPE,
+            ),
+        )
+    }
+}

--- a/checks/src/main/java/app/pachli/lint/checks/LintRegistry.kt
+++ b/checks/src/main/java/app/pachli/lint/checks/LintRegistry.kt
@@ -10,6 +10,7 @@ class LintRegistry : IssueRegistry() {
     override val issues: List<Issue>
         get() = listOf(
             AndroidxToolbarDetector.ISSUE,
+            ContextCompatGetDrawableDetector.ISSUE,
             DateDotTimeDetector.ISSUE,
             IntentDetector.ISSUE,
         )

--- a/checks/src/test/java/app/pachli/lint/checks/ContextCompatGetDrawableDetectorTest.kt
+++ b/checks/src/test/java/app/pachli/lint/checks/ContextCompatGetDrawableDetectorTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2024 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.lint.checks
+
+import com.android.tools.lint.checks.infrastructure.LintDetectorTest
+import com.android.tools.lint.checks.infrastructure.TestMode
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Issue
+
+@Suppress("ktlint:standard:function-naming")
+class ContextCompatGetDrawableDetectorTest : LintDetectorTest() {
+    override fun getDetector(): Detector = ContextCompatGetDrawableDetector()
+
+    override fun getIssues(): List<Issue> = listOf(ContextCompatGetDrawableDetector.ISSUE)
+
+    fun `test Intent component constructor emits warning`() {
+        lint().files(
+            Context,
+            ContextCompat,
+            kotlin(
+                """
+                package test.pkg
+
+                import android.content.Context
+                import androidx.core.content.ContextCompat
+
+                fun foo() = ContextCompat.getDrawable(Context(), 0)
+            """,
+
+            ).indented(),
+        ).allowMissingSdk().testModes(TestMode.DEFAULT).run().expect(
+            """src/test/pkg/test.kt:6: Warning: Use AppCompatResources.getDrawable [ContextCompatGetDrawableDetector]
+fun foo() = ContextCompat.getDrawable(Context(), 0)
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+0 errors, 1 warnings""",
+        )
+    }
+
+    companion object Stubs {
+        /** Stub for `android.content.Context` */
+        private val Context = java(
+            """
+            package android.content;
+
+            public class Context {}
+            """,
+        ).indented()
+
+        /** Stub for `androidx.core.content.ContextCompat` */
+        private val ContextCompat = java(
+            """
+                package androidx.core.content;
+
+                import android.content.Context;
+
+                public class ContextCompat {
+                     public static void getDrawable(Context context, int resource) { return null; }
+                }
+            """,
+        ).indented()
+    }
+}


### PR DESCRIPTION
Replace `ContextCompat.getDrawable()`, as the app-compat version has platform fixes and backports.

appcompat-lint warns about bare `context.getDrawable()`, but does not cover `ContextCompat` (https://issuetracker.google.com/issues/337905331)