### PR TITLE
fix: Show edit history for status' with polls

### DIFF
--- a/app/src/main/java/app/pachli/adapter/PollAdapter.kt
+++ b/app/src/main/java/app/pachli/adapter/PollAdapter.kt
@@ -24,11 +24,13 @@ import app.pachli.core.common.extensions.visible
 import app.pachli.core.network.model.Emoji
 import app.pachli.core.ui.BindingHolder
 import app.pachli.databinding.ItemPollBinding
+import app.pachli.util.makeIcon
 import app.pachli.viewdata.PollOptionViewData
 import app.pachli.viewdata.buildDescription
 import app.pachli.viewdata.calculatePercent
 import com.google.android.material.R
 import com.google.android.material.color.MaterialColors
+import com.mikepenz.iconics.typeface.library.googlematerial.GoogleMaterial
 import kotlin.properties.Delegates
 
 /** Listener for user clicks on poll items */
@@ -65,6 +67,9 @@ class PollAdapter(
 
         /** Multiple choice (display as check boxes) */
         MULTIPLE_CHOICE,
+
+        /** Snapshot of a poll from a status' edit history */
+        EDIT_HISTORY,
     }
 
     /**
@@ -92,9 +97,16 @@ class PollAdapter(
         val radioButton = holder.binding.statusPollRadioButton
         val checkBox = holder.binding.statusPollCheckbox
 
-        resultTextView.visible(displayMode == DisplayMode.RESULT)
+        resultTextView.visible(displayMode == DisplayMode.RESULT || displayMode == DisplayMode.EDIT_HISTORY)
         radioButton.visible(displayMode == DisplayMode.SINGLE_CHOICE)
         checkBox.visible(displayMode == DisplayMode.MULTIPLE_CHOICE)
+
+        // Poll edit history doesn't indicate if it was single or multiple choice at this point, so use
+        // a general "vote" icon instead of a radio button or checkbox.
+        if (displayMode == DisplayMode.EDIT_HISTORY) {
+            val icon = makeIcon(resultTextView.context, GoogleMaterial.Icon.gmd_how_to_vote, resultTextView.textSize.toInt())
+            resultTextView.setCompoundDrawablesRelativeWithIntrinsicBounds(icon, null, null, null)
+        }
 
         // Enable/disable the option widgets as appropriate. Disabling them will also change
         // the text colour, which is undesirable (this happens when showing status edits) so
@@ -137,7 +149,7 @@ class PollAdapter(
         }
 
         when (displayMode) {
-            DisplayMode.RESULT -> with(resultTextView) {
+            DisplayMode.RESULT, DisplayMode.EDIT_HISTORY -> with(resultTextView) {
                 text = itemText
                 background.level = level
                 background.setTint(tintColor)

--- a/app/src/main/java/app/pachli/components/viewthread/edits/ViewEditsAdapter.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/edits/ViewEditsAdapter.kt
@@ -135,12 +135,12 @@ class ViewEditsAdapter(
             // binding.statusEditPollDescription.show()
 
             val pollAdapter = PollAdapter(
-                options = poll.options.map { PollOptionViewData.from(it, false) },
+                options = poll.options.map { PollOptionViewData.from(it) },
                 votesCount = 0,
                 votersCount = null,
                 edit.emojis,
                 animateEmojis = animateEmojis,
-                displayMode = if (poll.multiple) DisplayMode.MULTIPLE_CHOICE else DisplayMode.SINGLE_CHOICE,
+                displayMode = DisplayMode.EDIT_HISTORY,
                 enabled = false,
                 resultClickListener = null,
                 pollOptionClickListener = null,

--- a/app/src/main/java/app/pachli/viewdata/PollViewData.kt
+++ b/app/src/main/java/app/pachli/viewdata/PollViewData.kt
@@ -23,6 +23,7 @@ import android.text.Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
 import app.pachli.R
 import app.pachli.core.network.model.Poll
 import app.pachli.core.network.model.PollOption
+import app.pachli.core.network.model.PollOptionEdit
 import app.pachli.core.network.model.TranslatedPoll
 import app.pachli.view.VotePercentSpan
 import java.util.Date
@@ -73,6 +74,13 @@ data class PollOptionViewData(
             votesCount = pollOption.votesCount,
             selected = false,
             voted = voted,
+        )
+
+        fun from(pollOptionEdit: PollOptionEdit) = PollOptionViewData(
+            title = pollOptionEdit.title,
+            votesCount = 0,
+            selected = false,
+            voted = false,
         )
     }
 }

--- a/app/src/main/res/layout/fragment_view_edits.xml
+++ b/app/src/main/res/layout/fragment_view_edits.xml
@@ -102,8 +102,8 @@
 
     <app.pachli.core.ui.BackgroundMessageView
         android:id="@+id/statusView"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:layout_gravity="center"
         android:visibility="gone" />
 

--- a/app/src/main/res/layout/item_poll.xml
+++ b/app/src/main/res/layout/item_poll.xml
@@ -18,6 +18,7 @@
         android:paddingTop="2dp"
         android:paddingEnd="6dp"
         android:paddingBottom="2dp"
+        android:drawablePadding="8dp"
         android:textAlignment="viewStart"
         android:textColor="?colorOnSecondary"
         android:textSize="?attr/status_text_medium"

--- a/core/network/src/main/kotlin/app/pachli/core/network/model/StatusEdit.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/StatusEdit.kt
@@ -4,6 +4,11 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import java.util.Date
 
+/**
+ * A snapshot of a status from its edit history
+ *
+ * See [StatusEdit](https://docs.joinmastodon.org/entities/StatusEdit/)
+ */
 @JsonClass(generateAdapter = true)
 data class StatusEdit(
     val content: String,
@@ -11,7 +16,23 @@ data class StatusEdit(
     val sensitive: Boolean,
     @Json(name = "created_at") val createdAt: Date,
     val account: TimelineAccount,
-    val poll: Poll?,
+    val poll: PollEdit?,
     @Json(name = "media_attachments") val mediaAttachments: List<Attachment>,
     val emojis: List<Emoji>,
+)
+
+/**
+ * A snapshot of a poll from a status' edit history.
+ */
+@JsonClass(generateAdapter = true)
+data class PollEdit(
+    val options: List<PollOptionEdit>,
+)
+
+/**
+ * A snapshot of a poll option from a status' edit history.
+ */
+@JsonClass(generateAdapter = true)
+data class PollOptionEdit(
+    val title: String,
 )


### PR DESCRIPTION
Edited polls only include the list of options with titles; no other metadata (poll ID, single/multiple choice, vote counts, etc). Since the data shape didn't match Moshi wasn't decoding the data.

Provide dedicated data classes to model the response, and add a fourth poll display option to represent viewing an edit history snapshot.