### PR TITLE
fix: Prompt user to save/discard changes after editing bio

### DIFF
--- a/app/src/main/java/app/pachli/EditProfileActivity.kt
+++ b/app/src/main/java/app/pachli/EditProfileActivity.kt
@@ -234,6 +234,10 @@ class EditProfileActivity : BaseActivity() {
             viewModel.onChange(currentProfileData)
         }
 
+        binding.noteEditText.doAfterTextChanged {
+            viewModel.onChange(currentProfileData)
+        }
+
         binding.lockedCheckBox.setOnCheckedChangeListener { _, _ ->
             viewModel.onChange(currentProfileData)
         }


### PR DESCRIPTION
Previous code didn't get the viewmodel to check if the content had changed, so `onBackPressedCallback` wasn't enabled, and the user could edit the bio and press "back" without being prompted to save their changes.