### PR TITLE
fix: crash on "hidden domains" page

### DIFF
--- a/app/src/main/java/app/pachli/components/instancemute/fragment/InstanceListFragment.kt
+++ b/app/src/main/java/app/pachli/components/instancemute/fragment/InstanceListFragment.kt
@@ -100,13 +100,16 @@ class InstanceListFragment :
         }
 
         viewLifecycleOwner.lifecycleScope.launch {
-            val response = api.domainBlocks(id, bottomId)
-            val instances = response.body()
-
-            if (response.isSuccessful && instances != null) {
-                onFetchInstancesSuccess(instances, response.headers()["Link"])
-            } else {
-                onFetchInstancesFailure(Exception(response.message()))
+            try {
+                val response = api.domainBlocks(id, bottomId)
+                val instances = response.body()
+                if (response.isSuccessful && instances != null) {
+                    onFetchInstancesSuccess(instances, response.headers()["Link"])
+                } else {
+                    onFetchInstancesFailure(Exception(response.message()))
+                }
+            } catch (e: Exception) {
+                onFetchInstancesFailure(e)
             }
         }
     }

--- a/app/src/main/res/layout/fragment_instance_list.xml
+++ b/app/src/main/res/layout/fragment_instance_list.xml
@@ -18,9 +18,8 @@
 
     <app.pachli.core.ui.BackgroundMessageView
         android:id="@+id/messageView"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:visibility="gone"
         tools:visibility="visible" />
 </FrameLayout>


### PR DESCRIPTION
fixes #696. The crash was caused by an uncaught exception when calling `MastodonApi#domainBlocks`. I also updated the `BackgroundMessageView` for the error message so it fills the screen like on other pages.

https://github.com/pachli/pachli-android/assets/16272279/d94bae93-d56a-4829-bf29-b458b27de0cf