### PR TITLE
fix: crash when tapping "share link to post"

### DIFF
--- a/core/activity/src/main/kotlin/app/pachli/core/activity/extensions/ActivityExtensions.kt
+++ b/core/activity/src/main/kotlin/app/pachli/core/activity/extensions/ActivityExtensions.kt
@@ -37,7 +37,7 @@ fun Activity.startActivityWithTransition(intent: Intent, transitionKind: Transit
         }
     }
 
-    intent.putExtra(EXTRA_TRANSITION_KIND, transitionKind)
+    intent.putExtra(EXTRA_TRANSITION_KIND_NAME, transitionKind.name)
     startActivity(intent)
 
     if (canOverrideActivityTransitions()) {

--- a/core/activity/src/main/kotlin/app/pachli/core/activity/extensions/IntentExtensions.kt
+++ b/core/activity/src/main/kotlin/app/pachli/core/activity/extensions/IntentExtensions.kt
@@ -18,11 +18,10 @@
 package app.pachli.core.activity.extensions
 
 import android.content.Intent
-import android.os.Build
 import androidx.annotation.AnimRes
 import app.pachli.core.designsystem.R as DR
 
-const val EXTRA_TRANSITION_KIND = "transition_kind"
+const val EXTRA_TRANSITION_KIND_NAME = "transition_kind_name"
 
 /**
  * The type of transition and animation resources to use when opening and closing
@@ -62,10 +61,5 @@ enum class TransitionKind(
 
 /** @return The [TransitionKind] included in this intent, or null */
 fun Intent.getTransitionKind(): TransitionKind? {
-    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        getSerializableExtra(EXTRA_TRANSITION_KIND, TransitionKind::class.java)
-    } else {
-        @Suppress("DEPRECATION")
-        getSerializableExtra(EXTRA_TRANSITION_KIND) as? TransitionKind
-    }
+    return getStringExtra(EXTRA_TRANSITION_KIND_NAME)?.let { TransitionKind.valueOf(it) }
 }


### PR DESCRIPTION
fixes #700.

This crash is caused by a `ClassNotFoundException` that happens when we include `TransitionKind` as an extra in the intent to open Android's `ChooserActivity`. [This Stack Overflow answer](https://stackoverflow.com/a/32277046/5374261) explains the issue as "the target component doesn't have the enum definition and therefore can't deserialize it".

This PR avoids the crash by passing the ordinal name as an extra instead of the value itself.

An alternate fix would be to never include the `TransitionKind` extra for intents that target components outside the app, but that would require a bigger PR with no clear benefit.