### PR TITLE
fix: Re-enable accessiblity actions in all timelines

### DIFF
--- a/app/src/main/java/app/pachli/util/ListStatusAccessibilityDelegate.kt
+++ b/app/src/main/java/app/pachli/util/ListStatusAccessibilityDelegate.kt
@@ -54,7 +54,9 @@ class ListStatusAccessibilityDelegate<T : IStatusViewData>(
             // Ignore notifications that don't have an associated statusViewData,
             // otherwise the accessors throw IllegalStateException.
             // See https://github.com/pachli/pachli-android/issues/669
-            if ((status as? NotificationViewData)?.statusViewData == null) return
+            if (status as? NotificationViewData != null) {
+                if (status.statusViewData == null) return
+            }
 
             if (status.spoilerText.isNotEmpty()) {
                 info.addAction(if (status.isExpanded) collapseCwAction else expandCwAction)


### PR DESCRIPTION
22729df1 broke accessiblity actions in non-notification timelines by returning too early if the status was not a NotificationViewData.