### PR TITLE
fix: Only include transitionKind in intents for Pachli activities

### DIFF
--- a/app/src/main/java/app/pachli/fragment/SFragment.kt
+++ b/app/src/main/java/app/pachli/fragment/SFragment.kt
@@ -95,7 +95,11 @@ abstract class SFragment<T : IStatusViewData> : Fragment(), StatusActionListener
     private var serverCanTranslate = false
 
     override fun startActivity(intent: Intent) {
-        requireActivity().startActivityWithDefaultTransition(intent)
+        if (intent.component?.className?.startsWith("app.pachli.") == true) {
+            requireActivity().startActivityWithDefaultTransition(intent)
+        } else {
+            super.startActivity(intent)
+        }
     }
 
     override fun onAttach(context: Context) {

--- a/core/activity/src/main/kotlin/app/pachli/core/activity/extensions/ActivityExtensions.kt
+++ b/core/activity/src/main/kotlin/app/pachli/core/activity/extensions/ActivityExtensions.kt
@@ -27,8 +27,12 @@ import app.pachli.core.activity.BaseActivity
 import app.pachli.core.activity.BuildConfig
 
 /**
- * Starts the activity in [intent] (which must be a subclass of [BaseActivity])
- * using [transitionKind] as the open/close transition.
+ * Starts the activity in [intent]. Should only be called on subclasses of [BaseActivity].
+ *
+ * If the activity is a Pachli activity then [transitionKind] is included in the intent and
+ * used as the open/close transition.
+ *
+ * See [BaseActivity.onCreate] for the other half of this code.
  */
 fun Activity.startActivityWithTransition(intent: Intent, transitionKind: TransitionKind) {
     if (BuildConfig.DEBUG) {
@@ -37,7 +41,9 @@ fun Activity.startActivityWithTransition(intent: Intent, transitionKind: Transit
         }
     }
 
-    intent.putExtra(EXTRA_TRANSITION_KIND, transitionKind)
+    if (intent.component?.className?.startsWith("app.pachli.") == true) {
+        intent.putExtra(EXTRA_TRANSITION_KIND, transitionKind)
+    }
     startActivity(intent)
 
     if (canOverrideActivityTransitions()) {
@@ -60,7 +66,7 @@ fun Activity.startActivityWithDefaultTransition(intent: Intent) = startActivityW
 fun Activity.setCloseTransition(transitionKind: TransitionKind) {
     if (BuildConfig.DEBUG) {
         if (this !is BaseActivity) {
-            throw IllegalStateException("startActivityWithTransition must be used with BaseActivity subclass")
+            throw IllegalStateException("setCloseTransition must be used with BaseActivity subclass")
         }
     }
 

--- a/core/activity/src/main/kotlin/app/pachli/core/activity/extensions/ActivityExtensions.kt
+++ b/core/activity/src/main/kotlin/app/pachli/core/activity/extensions/ActivityExtensions.kt
@@ -40,8 +40,8 @@ fun Activity.startActivityWithTransition(intent: Intent, transitionKind: Transit
             throw IllegalStateException("startActivityWithTransition must be used with BaseActivity subclass")
         }
     }
-    intent.putExtra(EXTRA_TRANSITION_KIND, transitionKind)
 
+    intent.putExtra(EXTRA_TRANSITION_KIND, transitionKind)
     startActivity(intent)
 
     if (canOverrideActivityTransitions()) {

--- a/core/activity/src/main/kotlin/app/pachli/core/activity/extensions/ActivityExtensions.kt
+++ b/core/activity/src/main/kotlin/app/pachli/core/activity/extensions/ActivityExtensions.kt
@@ -40,10 +40,8 @@ fun Activity.startActivityWithTransition(intent: Intent, transitionKind: Transit
             throw IllegalStateException("startActivityWithTransition must be used with BaseActivity subclass")
         }
     }
+    intent.putExtra(EXTRA_TRANSITION_KIND, transitionKind)
 
-    if (intent.component?.className?.startsWith("app.pachli.") == true) {
-        intent.putExtra(EXTRA_TRANSITION_KIND, transitionKind)
-    }
     startActivity(intent)
 
     if (canOverrideActivityTransitions()) {


### PR DESCRIPTION
Previous code always included the transitionKind enum as an extra, and could cause a crash if the activity launched by the intent was not a Pachli activity.

Fixes #700.