### PR TITLE
fix: Show/hide the list of lists appropriately when showing errors

### DIFF
--- a/feature/lists/src/main/kotlin/app/pachli/feature/lists/ListsActivity.kt
+++ b/feature/lists/src/main/kotlin/app/pachli/feature/lists/ListsActivity.kt
@@ -222,6 +222,7 @@ class ListsActivity : BaseActivity(), MenuProvider {
 
     private fun bind(state: Result<Lists, ApiError>) {
         state.onFailure {
+            binding.listsRecycler.hide()
             binding.messageView.show()
             binding.swipeRefreshLayout.isRefreshing = false
 
@@ -238,9 +239,11 @@ class ListsActivity : BaseActivity(), MenuProvider {
                     adapter.submitList(lists.lists.sortedWith(compareByListTitle))
                     binding.swipeRefreshLayout.isRefreshing = false
                     if (lists.lists.isEmpty()) {
+                        binding.listsRecycler.hide()
                         binding.messageView.show()
                         binding.messageView.setup(BackgroundMessage.Empty())
                     } else {
+                        binding.listsRecycler.show()
                         binding.messageView.hide()
                     }
                 }


### PR DESCRIPTION
Previous code didn't hide the list-of-lists if an error occurred after the list was displayed (e.g., load the list, turn on airplane mode, reload the list).

Hide the list when errors are shown, and show it when there is content.