### PR TITLE
refactor: Allow PachliError.formatArgs to be null

### DIFF
--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/ServerRepository.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/ServerRepository.kt
@@ -120,13 +120,13 @@ class ServerRepository @Inject constructor(
 
     sealed class Error(
         @StringRes override val resourceId: Int,
-        override val formatArgs: Array<out String> = emptyArray<String>(),
+        override val formatArgs: Array<out String>? = emptyArray<String>(),
         override val cause: PachliError? = null,
     ) : PachliError {
 
         data class GetWellKnownNodeInfo(val throwable: Throwable) : Error(
             R.string.server_repository_error_get_well_known_node_info,
-            throwable.localizedMessage?.let { arrayOf(it) }.orEmpty(),
+            throwable.localizedMessage?.let { arrayOf(it) },
         )
 
         data object UnsupportedSchema : Error(
@@ -146,7 +146,7 @@ class ServerRepository @Inject constructor(
 
         data class GetInstanceInfoV1(val throwable: Throwable) : Error(
             R.string.server_repository_error_get_instance_info,
-            throwable.localizedMessage?.let { arrayOf(it) }.orEmpty(),
+            throwable.localizedMessage?.let { arrayOf(it) },
         )
 
         data class Capabilities(val error: Server.Error) : Error(

--- a/core/network/src/main/kotlin/app/pachli/core/network/retrofit/apiresult/ApiResult.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/retrofit/apiresult/ApiResult.kt
@@ -61,7 +61,7 @@ sealed class ApiError(
 ) : PachliError {
     override val formatArgs = (
         throwable.getServerErrorMessage() ?: throwable.localizedMessage
-        )?.let { arrayOf(it) }.orEmpty()
+        )?.let { arrayOf(it) }
     override val cause: PachliError? = null
 
     companion object {


### PR DESCRIPTION
Simplifies the case where there are no format args.