### PR TITLE
chore(deps): update agp to v8.5.0, lint to 31.5.0

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.3.2" type="baseline" client="gradle" dependencies="false" name="AGP (8.3.2)" variant="all" version="8.3.2">
+<issues format="6" by="lint 8.5.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.5.0)" variant="all" version="8.5.0">
 
     <issue
         id="InvalidPackage"
@@ -96,6 +96,22 @@
     </issue>
 
     <issue
+        id="StringFormatInvalid"
+        message="Format string &apos;`app_name`&apos; is not a valid format string so it should not be passed to `String.format`"
+        errorLine1="            val filename = &quot;%s_%s_%s.%s&quot;.format("
+        errorLine2="                           ^">
+        <location
+            file="src/main/java/app/pachli/components/compose/MediaUploader.kt"
+            line="271"
+            column="28"/>
+        <location
+            file="${:core:activity*buildDir}/generated/res/resValues/orangeFdroid/debug/values/gradleResValues.xml"
+            line="7"
+            column="5"
+            message="This definition does not require arguments"/>
+    </issue>
+
+    <issue
         id="MissingQuantity"
         message="For locale &quot;bn&quot; (Bangla) the following quantity should also be defined: `one` (e.g. &quot;সসে 1টি আপেল খেল, সেটা ভাল&quot;)"
         errorLine1="    &lt;plurals name=&quot;hint_describe_for_visually_impaired&quot;>"
@@ -135,7 +151,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-ta/strings.xml"
-            line="153"
+            line="154"
             column="5"/>
     </issue>
 
@@ -157,7 +173,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-ga/strings.xml"
-            line="164"
+            line="162"
             column="5"/>
     </issue>
 
@@ -168,7 +184,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-sl/strings.xml"
-            line="178"
+            line="174"
             column="5"/>
     </issue>
 
@@ -179,7 +195,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-cs/strings.xml"
-            line="192"
+            line="188"
             column="5"/>
     </issue>
 
@@ -190,7 +206,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-bn-rIN/strings.xml"
-            line="199"
+            line="195"
             column="5"/>
     </issue>
 
@@ -201,7 +217,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-eu/strings.xml"
-            line="201"
+            line="202"
             column="5"/>
     </issue>
 
@@ -212,7 +228,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-sl/strings.xml"
-            line="212"
+            line="208"
             column="5"/>
     </issue>
 
@@ -223,7 +239,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-ca/strings.xml"
-            line="234"
+            line="230"
             column="5"/>
     </issue>
 
@@ -234,7 +250,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-cs/strings.xml"
-            line="235"
+            line="231"
             column="5"/>
     </issue>
 
@@ -245,7 +261,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-bn-rIN/strings.xml"
-            line="240"
+            line="236"
             column="5"/>
     </issue>
 
@@ -256,7 +272,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-ga/strings.xml"
-            line="267"
+            line="263"
             column="5"/>
     </issue>
 
@@ -267,7 +283,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-hi/strings.xml"
-            line="269"
+            line="265"
             column="5"/>
     </issue>
 
@@ -275,6 +291,17 @@
         id="MissingQuantity"
         message="For locale &quot;ca&quot; (Catalan) the following quantity should also be defined: `many`"
         errorLine1="    &lt;plurals name=&quot;favs&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-ca/strings.xml"
+            line="267"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;ca&quot; (Catalan) the following quantity should also be defined: `many`"
+        errorLine1="    &lt;plurals name=&quot;reblogs&quot;>"
         errorLine2="    ^">
         <location
             file="src/main/res/values-ca/strings.xml"
@@ -284,23 +311,12 @@
 
     <issue
         id="MissingQuantity"
-        message="For locale &quot;ca&quot; (Catalan) the following quantity should also be defined: `many`"
-        errorLine1="    &lt;plurals name=&quot;reblogs&quot;>"
-        errorLine2="    ^">
-        <location
-            file="src/main/res/values-ca/strings.xml"
-            line="275"
-            column="5"/>
-    </issue>
-
-    <issue
-        id="MissingQuantity"
         message="For locale &quot;cs&quot; (Czech) the following quantity should also be defined: `many` (e.g. &quot;10.0 dne&quot;)"
         errorLine1="    &lt;plurals name=&quot;favs&quot;>"
         errorLine2="    ^">
         <location
             file="src/main/res/values-cs/strings.xml"
-            line="276"
+            line="272"
             column="5"/>
     </issue>
 
@@ -311,7 +327,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-cs/strings.xml"
-            line="281"
+            line="277"
             column="5"/>
     </issue>
 
@@ -322,7 +338,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-ca/strings.xml"
-            line="300"
+            line="296"
             column="5"/>
     </issue>
 
@@ -333,7 +349,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-cs/strings.xml"
-            line="311"
+            line="307"
             column="5"/>
     </issue>
 
@@ -344,7 +360,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-cs/strings.xml"
-            line="325"
+            line="321"
             column="5"/>
     </issue>
 
@@ -355,7 +371,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-cs/strings.xml"
-            line="330"
+            line="326"
             column="5"/>
     </issue>
 
@@ -366,7 +382,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-cs/strings.xml"
-            line="335"
+            line="331"
             column="5"/>
     </issue>
 
@@ -377,7 +393,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-bg/strings.xml"
-            line="367"
+            line="363"
             column="5"/>
     </issue>
 
@@ -388,7 +404,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-ca/strings.xml"
-            line="367"
+            line="363"
             column="5"/>
     </issue>
 
@@ -399,7 +415,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-ca/strings.xml"
-            line="395"
+            line="391"
             column="5"/>
     </issue>
 
@@ -410,7 +426,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-ca/strings.xml"
-            line="399"
+            line="395"
             column="5"/>
     </issue>
 
@@ -421,7 +437,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-ca/strings.xml"
-            line="403"
+            line="399"
             column="5"/>
     </issue>
 
@@ -432,7 +448,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-ca/strings.xml"
-            line="407"
+            line="403"
             column="5"/>
     </issue>
 
@@ -443,7 +459,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-cs/strings.xml"
-            line="415"
+            line="411"
             column="5"/>
     </issue>
 
@@ -454,7 +470,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-cs/strings.xml"
-            line="420"
+            line="416"
             column="5"/>
     </issue>
 
@@ -465,7 +481,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-ca/strings.xml"
-            line="423"
+            line="419"
             column="5"/>
     </issue>
 
@@ -476,7 +492,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-cs/strings.xml"
-            line="425"
+            line="421"
             column="5"/>
     </issue>
 
@@ -575,7 +591,7 @@
         errorLine2="                                            ^">
         <location
             file="src/main/res/values-nb-rNO/strings.xml"
-            line="100"
+            line="96"
             column="45"/>
     </issue>
 
@@ -586,7 +602,7 @@
         errorLine2="                                           ^">
         <location
             file="src/main/res/values-nb-rNO/strings.xml"
-            line="104"
+            line="100"
             column="44"/>
     </issue>
 
@@ -597,7 +613,7 @@
         errorLine2="                                                ^">
         <location
             file="src/main/res/values-nb-rNO/strings.xml"
-            line="105"
+            line="101"
             column="49"/>
     </issue>
 
@@ -608,7 +624,7 @@
         errorLine2="                                     ^">
         <location
             file="src/main/res/values-nb-rNO/strings.xml"
-            line="108"
+            line="104"
             column="38"/>
     </issue>
 
@@ -619,7 +635,7 @@
         errorLine2="                                                                     ^">
         <location
             file="src/main/res/values-nb-rNO/strings.xml"
-            line="123"
+            line="119"
             column="70"/>
     </issue>
 
@@ -630,7 +646,7 @@
         errorLine2="                                                                             ^">
         <location
             file="src/main/res/values-nb-rNO/strings.xml"
-            line="156"
+            line="152"
             column="78"/>
     </issue>
 
@@ -641,7 +657,7 @@
         errorLine2="                                                                ^">
         <location
             file="src/main/res/values-nb-rNO/strings.xml"
-            line="162"
+            line="158"
             column="65"/>
     </issue>
 
@@ -652,7 +668,7 @@
         errorLine2="                               ^">
         <location
             file="src/main/res/values-nb-rNO/strings.xml"
-            line="198"
+            line="194"
             column="32"/>
     </issue>
 
@@ -663,7 +679,7 @@
         errorLine2="                                          ^">
         <location
             file="src/main/res/values-nb-rNO/strings.xml"
-            line="266"
+            line="262"
             column="43"/>
     </issue>
 
@@ -674,7 +690,7 @@
         errorLine2="                                                                                     ^">
         <location
             file="src/main/res/values-nb-rNO/strings.xml"
-            line="394"
+            line="390"
             column="86"/>
     </issue>
 
@@ -685,7 +701,7 @@
         errorLine2="                                                                                                                                                                                                                                                                                                     ^">
         <location
             file="src/main/res/values-tr/strings.xml"
-            line="502"
+            line="498"
             column="294"/>
     </issue>
 
@@ -696,29 +712,29 @@
         errorLine2="                                                  ^">
         <location
             file="src/main/res/values-nb-rNO/strings.xml"
-            line="524"
+            line="520"
             column="51"/>
     </issue>
 
     <issue
         id="ImpliedQuantity"
-        message="The quantity `&apos;one&apos;` matches more than one specific number in this locale (0, 1), but the message did not \&#xA;include a formatting argument (such as `%d`). This is usually an internationalization error. See full issue \&#xA;explanation for more."
+        message="The quantity `&apos;one&apos;` matches more than one specific number in this locale (0, 1), but the message did not include a formatting argument (such as `%d`). This is usually an internationalization error. See full issue explanation for more."
         errorLine1="        &lt;item quantity=&quot;one&quot;>برهم‌کنشی جدید&lt;/item>"
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fa/strings.xml"
-            line="170"
+            line="171"
             column="9"/>
     </issue>
 
     <issue
         id="ImpliedQuantity"
-        message="The quantity `&apos;one&apos;` matches more than one specific number in this locale (0, 1), but the message did not \&#xA;include a formatting argument (such as `%d`). This is usually an internationalization error. See full issue \&#xA;explanation for more."
+        message="The quantity `&apos;one&apos;` matches more than one specific number in this locale (0, 1), but the message did not include a formatting argument (such as `%d`). This is usually an internationalization error. See full issue explanation for more."
         errorLine1="        &lt;item quantity=&quot;one&quot;>توصیف محتوا برای کم‌بینایان (کران ۱ نویسه)&lt;/item>"
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fa/strings.xml"
-            line="199"
+            line="200"
             column="9"/>
     </issue>
 
@@ -740,7 +756,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="287"
+            line="283"
             column="5"/>
     </issue>
 
@@ -751,7 +767,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="338"
+            line="334"
             column="5"/>
     </issue>
 
@@ -762,7 +778,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="457"
+            line="453"
             column="5"/>
     </issue>
 
@@ -773,7 +789,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="632"
+            line="629"
             column="5"/>
     </issue>
 
@@ -1345,7 +1361,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="203"
+            line="199"
             column="13"/>
     </issue>
 
@@ -1356,7 +1372,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="224"
+            line="220"
             column="13"/>
     </issue>
 
@@ -1367,7 +1383,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="225"
+            line="221"
             column="13"/>
     </issue>
 
@@ -1378,7 +1394,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="248"
+            line="244"
             column="13"/>
     </issue>
 
@@ -1389,7 +1405,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="277"
+            line="273"
             column="13"/>
     </issue>
 
@@ -1400,7 +1416,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="348"
+            line="344"
             column="13"/>
     </issue>
 
@@ -1411,7 +1427,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="388"
+            line="384"
             column="13"/>
     </issue>
 
@@ -1422,7 +1438,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="424"
+            line="420"
             column="13"/>
     </issue>
 
@@ -1433,7 +1449,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="427"
+            line="423"
             column="13"/>
     </issue>
 
@@ -1444,7 +1460,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="428"
+            line="424"
             column="13"/>
     </issue>
 
@@ -1455,7 +1471,7 @@
         errorLine2="            ~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="429"
+            line="425"
             column="13"/>
     </issue>
 
@@ -1466,7 +1482,7 @@
         errorLine2="            ~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="430"
+            line="426"
             column="13"/>
     </issue>
 
@@ -1477,7 +1493,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="431"
+            line="427"
             column="13"/>
     </issue>
 
@@ -1488,7 +1504,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="443"
+            line="439"
             column="13"/>
     </issue>
 
@@ -1499,7 +1515,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="444"
+            line="440"
             column="13"/>
     </issue>
 
@@ -1510,7 +1526,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="495"
+            line="491"
             column="13"/>
     </issue>
 
@@ -1521,7 +1537,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="496"
+            line="492"
             column="13"/>
     </issue>
 
@@ -1532,7 +1548,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="507"
+            line="503"
             column="13"/>
     </issue>
 
@@ -1543,7 +1559,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="508"
+            line="504"
             column="13"/>
     </issue>
 
@@ -1554,7 +1570,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="509"
+            line="505"
             column="13"/>
     </issue>
 
@@ -1565,7 +1581,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="511"
+            line="508"
             column="13"/>
     </issue>
 
@@ -1576,7 +1592,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="549"
+            line="546"
             column="13"/>
     </issue>
 
@@ -1587,7 +1603,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="590"
+            line="587"
             column="13"/>
     </issue>
 
@@ -1598,7 +1614,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="596"
+            line="593"
             column="13"/>
     </issue>
 
@@ -1609,7 +1625,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="624"
+            line="621"
             column="13"/>
     </issue>
 
@@ -1620,7 +1636,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="650"
+            line="647"
             column="13"/>
     </issue>
 
@@ -2619,6 +2635,17 @@
             file="src/main/res/layout/material_drawer_header.xml"
             line="8"
             column="5"/>
+    </issue>
+
+    <issue
+        id="SetTextI18n"
+        message="Do not concatenate text displayed with `setText`. Use resource string with placeholders."
+        errorLine1="            binding.scheduledDateTime.text = &quot;&quot;"
+        errorLine2="                                             ~~">
+        <location
+            file="src/main/java/app/pachli/components/compose/view/ComposeScheduleView.kt"
+            line="79"
+            column="46"/>
     </issue>
 
     <issue

--- a/app/src/main/java/app/pachli/TabPreferenceActivity.kt
+++ b/app/src/main/java/app/pachli/TabPreferenceActivity.kt
@@ -241,7 +241,7 @@ class TabPreferenceActivity : BaseActivity(), ItemInteractionListener {
 
         val editText = AppCompatEditText(this)
         editText.setHint(R.string.edit_hashtag_hint)
-        editText.setText("")
+        editText.text?.clear()
         frameLayout.addView(editText)
 
         val dialog = AlertDialog.Builder(this)

--- a/app/src/main/java/app/pachli/components/compose/ComposeAutoCompleteAdapter.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeAutoCompleteAdapter.kt
@@ -167,15 +167,15 @@ class ComposeAutoCompleteAdapter(
         private const val EMOJI_VIEW_TYPE = 2
 
         private fun formatUsername(result: AutocompleteResult.AccountResult): String {
-            return String.format("@%s", result.account.username)
+            return "@${result.account.username}"
         }
 
         private fun formatHashtag(result: AutocompleteResult.HashtagResult): String {
-            return String.format("#%s", result.hashtag)
+            return "#${result.hashtag}"
         }
 
         private fun formatEmoji(result: AutocompleteResult.EmojiResult): String {
-            return String.format(":%s:", result.emoji.shortcode)
+            return ":${result.emoji.shortcode}:"
         }
     }
 }

--- a/app/src/main/java/app/pachli/components/compose/view/ComposeScheduleView.kt
+++ b/app/src/main/java/app/pachli/components/compose/view/ComposeScheduleView.kt
@@ -82,8 +82,8 @@ class ComposeScheduleView
         }
 
         val scheduled = scheduleDateTimeUtc!!.time
-        binding.scheduledDateTime.text = String.format(
-            "%s %s",
+        binding.scheduledDateTime.text = context.getString(
+            R.string.compose_schedule_date_time_fmt,
             dateFormat.format(scheduled),
             timeFormat.format(scheduled),
         )

--- a/app/src/main/java/app/pachli/components/drafts/DraftHelper.kt
+++ b/app/src/main/java/app/pachli/components/drafts/DraftHelper.kt
@@ -175,7 +175,7 @@ class DraftHelper @Inject constructor(
             map.getExtensionFromMimeType(mimeType)
         }
 
-        val filename = String.format("Pachli_Draft_Media_%s_%d.%s", timeStamp, index, fileExtension)
+        val filename = "Pachli_Draft_Media_${timeStamp}_$index.$fileExtension"
         val file = File(folder, filename)
 
         if (scheme == "https") {

--- a/app/src/main/java/app/pachli/components/notifications/NotificationFetcher.kt
+++ b/app/src/main/java/app/pachli/components/notifications/NotificationFetcher.kt
@@ -147,7 +147,7 @@ class NotificationFetcher @Inject constructor(
      */
     private suspend fun fetchNewNotifications(account: AccountEntity): List<Notification> {
         Timber.d("fetchNewNotifications(%s)", account.fullName)
-        val authHeader = String.format("Bearer %s", account.accessToken)
+        val authHeader = "Bearer ${account.accessToken}"
 
         // Figure out where to read from. Choose the most recent notification ID from:
         //

--- a/app/src/main/java/app/pachli/components/search/adapter/SearchHashtagsAdapter.kt
+++ b/app/src/main/java/app/pachli/components/search/adapter/SearchHashtagsAdapter.kt
@@ -20,6 +20,7 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.DiffUtil
+import app.pachli.R
 import app.pachli.core.network.model.HashTag
 import app.pachli.core.ui.BindingHolder
 import app.pachli.core.ui.LinkListener
@@ -35,7 +36,7 @@ class SearchHashtagsAdapter(private val linkListener: LinkListener) :
 
     override fun onBindViewHolder(holder: BindingHolder<ItemHashtagBinding>, position: Int) {
         getItem(position)?.let { (name) ->
-            holder.binding.root.text = String.format("#%s", name)
+            holder.binding.root.text = holder.binding.root.context.getString(R.string.title_tag, name)
             holder.binding.root.setOnClickListener { linkListener.onViewTag(name) }
         }
     }

--- a/app/src/main/java/app/pachli/network/FilterModel.kt
+++ b/app/src/main/java/app/pachli/network/FilterModel.kt
@@ -63,7 +63,7 @@ class FilterModel(private val filterContext: FilterContext, v1filters: List<Filt
         val phrase = filter.phrase
         val quotedPhrase = Pattern.quote(phrase)
         return if (filter.wholeWord && ALPHANUMERIC.matcher(phrase).matches()) {
-            String.format("(^|\\W)%s($|\\W)", quotedPhrase)
+            "(^|\\W)$quotedPhrase($|\\W)"
         } else {
             quotedPhrase
         }

--- a/app/src/main/java/app/pachli/util/StatusViewHelper.kt
+++ b/app/src/main/java/app/pachli/util/StatusViewHelper.kt
@@ -235,7 +235,7 @@ class StatusViewHelper(private val itemView: View) {
         var labelText = getLabelTypeText(context, attachments[0].type)
         if (sensitive) {
             val sensitiveText = context.getString(R.string.post_sensitive_media_title)
-            labelText += String.format(" (%s)", sensitiveText)
+            labelText += " ($sensitiveText)"
         }
         mediaLabel.text = labelText
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -503,6 +503,7 @@
     <string name="filter_apply">Apply</string>
     <string name="compose_shortcut_long_label">Compose post</string>
     <string name="compose_shortcut_short_label">Compose</string>
+    <string name="compose_schedule_date_time_fmt">%1$s %2$s</string>
     <string name="notification_clear_text">Are you sure you want to permanently clear all your notifications?</string>
     <string name="compose_preview_image_description">Actions for image %s</string>
     <string name="poll_info_format"><!-- 15 votes • 1 hour left -->%1$s • %2$s</string>

--- a/core/common/lint-baseline.xml
+++ b/core/common/lint-baseline.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.2.2" type="baseline" client="gradle" dependencies="false" name="AGP (8.2.2)" variant="all" version="8.2.2">
+<issues format="6" by="lint 8.5.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.5.0)" variant="all" version="8.5.0">
 
 </issues>

--- a/core/common/src/main/kotlin/app/pachli/core/common/util/NumberUtils.kt
+++ b/core/common/src/main/kotlin/app/pachli/core/common/util/NumberUtils.kt
@@ -17,6 +17,7 @@
 
 package app.pachli.core.common.util
 
+import androidx.core.os.LocaleListCompat
 import java.text.NumberFormat
 import kotlin.math.abs
 import kotlin.math.ln
@@ -38,6 +39,8 @@ fun formatNumber(num: Long, min: Int = 100000): String {
 
     val exp = (ln(absNum.toDouble()) / ln_1k).toInt()
 
-    // Suffixes here are locale-agnostic
-    return String.format("%.1f%c", num / 1000.0.pow(exp.toDouble()), "KMGTPE"[exp - 1])
+    // Formatting of the number is locale-specific, but the suffixes
+    // are locale-agnostic.
+    val locale = LocaleListCompat.getAdjustedDefault()[0]
+    return String.format(locale, "%.1f%c", num / 1000.0.pow(exp.toDouble()), "KMGTPE"[exp - 1])
 }

--- a/feature/login/lint-baseline.xml
+++ b/feature/login/lint-baseline.xml
@@ -1,5 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.2.2" type="baseline" client="gradle" dependencies="false" name="AGP (8.2.2)" variant="all" version="8.2.2">
+<issues format="6" by="lint 8.5.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.5.0)" variant="all" version="8.5.0">
+
+    <issue
+        id="StringFormatInvalid"
+        message="Format string &apos;`error_authorization_denied`&apos; is not a valid format string so it should not be passed to `String.format`"
+        errorLine1="            Timber.e(&quot;%s %s&quot;.format(getString(R.string.error_authorization_denied), error))"
+        errorLine2="                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/app/pachli/feature/login/LoginActivity.kt"
+            line="270"
+            column="22"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="17"
+            column="5"
+            message="This definition does not require arguments"/>
+    </issue>
+
+    <issue
+        id="StringFormatInvalid"
+        message="Format string &apos;`error_authorization_denied`&apos; is not a valid format string so it should not be passed to `String.format`"
+        errorLine1="            Timber.e(&quot;%s %s&quot;.format(getString(R.string.error_authorization_denied), error))"
+        errorLine2="                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/app/pachli/feature/login/LoginActivity.kt"
+            line="270"
+            column="22"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="17"
+            column="5"
+            message="This definition does not require arguments"/>
+    </issue>
 
     <issue
         id="SelectableText"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 aboutlibraries = "11.1.3"
 acra = "5.11.3"
-agp = "8.3.2"
+agp = "8.5.0"
 androidx-activity = "1.9.0"
 androidx-appcompat = "1.6.1"
 androidx-browser = "1.8.0"
@@ -49,7 +49,7 @@ kotlin-result = "1.1.20"
 ksp = "2.0.0-1.0.21"
 image-cropper = "4.3.2"
 leakcanary = "2.14"
-lint = "31.3.2" # = agp + 23.0.0 (= 8.3.2), see https://github.com/googlesamples/android-custom-lint-rules#lint-version
+lint = "31.5.0" # = agp + 23.0.0 (= 8.5.0), see https://github.com/googlesamples/android-custom-lint-rules#lint-version
 material = "1.11.0"
 material-drawer = "9.0.2"
 material-iconics = "5.4.0"


### PR DESCRIPTION
New lint checks mean:

- Some trivial uses of String.format() are replaced with templates
- Use a string resource for the scheduled date and time

Some reported SetTextI18n warnings have been ignored, as they relate to e.g., clearing a view's text by setting it to "".