### PR TITLE
fix: Use default "Navigate up" content description in ViewThreadActivity

### DIFF
--- a/app/src/main/res/layout/activity_view_thread.xml
+++ b/app/src/main/res/layout/activity_view_thread.xml
@@ -20,8 +20,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:contentInsetStartWithNavigation="0dp"
-            app:layout_scrollFlags="scroll|enterAlways"
-            app:navigationContentDescription="@string/action_open_drawer" />
+            app:layout_scrollFlags="scroll|enterAlways" />
     </com.google.android.material.appbar.AppBarLayout>
 
     <androidx.fragment.app.FragmentContainerView


### PR DESCRIPTION
Previous layout set `navigationContentDescription` to `action_open_drawer`, which is not correct for that part of the UI.

Remove it, and the default "Navigate up" is used.