### PR TITLE
fix: Don't exceed the maximum number of created shortcuts

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -2625,8 +2625,8 @@
     <issue
         id="ReportShortcutUsage"
         message="Calling this method indicates use of dynamic shortcuts, but there are no calls to methods that track shortcut usage, such as `pushDynamicShortcut` or `reportShortcutUsed`. Calling these methods is recommended, as they track shortcut usage and allow launchers to adjust which shortcuts appear based on activation history. Please see https://developer.android.com/develop/ui/views/launch/shortcuts/managing-shortcuts#track-usage"
-        errorLine1="    ShortcutManagerCompat.addDynamicShortcuts(context, listOf(shortcutInfo))"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        errorLine1="    ShortcutManagerCompat.setDynamicShortcuts(context, shortcuts)"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/util/ShareShortcutHelper.kt"
             line="96"

--- a/app/src/main/java/app/pachli/MainActivity.kt
+++ b/app/src/main/java/app/pachli/MainActivity.kt
@@ -120,7 +120,7 @@ import app.pachli.updatecheck.UpdateCheck
 import app.pachli.usecase.DeveloperToolsUseCase
 import app.pachli.usecase.LogoutUsecase
 import app.pachli.util.getDimension
-import app.pachli.util.updateShortcut
+import app.pachli.util.updateShortcuts
 import at.connyduck.calladapter.networkresult.fold
 import com.bumptech.glide.Glide
 import com.bumptech.glide.RequestManager
@@ -1085,7 +1085,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
         updateProfiles()
 
         externalScope.launch {
-            updateShortcut(applicationContext, accountManager.activeAccount!!)
+            updateShortcuts(applicationContext, accountManager)
         }
     }
 

--- a/core/designsystem/lint-baseline.xml
+++ b/core/designsystem/lint-baseline.xml
@@ -8,7 +8,7 @@
         errorLine2="                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/styles.xml"
-            line="135"
+            line="134"
             column="42"/>
     </issue>
 
@@ -19,7 +19,7 @@
         errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/styles.xml"
-            line="136"
+            line="135"
             column="43"/>
     </issue>
 


### PR DESCRIPTION
Previous code created one shortcut per account, which could exceed the maximum number of shortcuts allowed, causing a crash.

Fix this by creating no more than the max number of shortcuts while ensuring that the active account is always included.

Fixes #752