### PR TITLE
revert: Downgrade androidx-paging to version 3.2.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,12 @@ androidx-hilt = "1.2.0"
 androidx-junit = "1.2.0"
 androidx-lifecycle = "2.8.2"
 androidx-media3 = "1.3.1"
-androidx-paging = "3.3.0"
+# Deliberate downgrade until a version with the fix in
+# https://android-review.googlesource.com/c/platform/frameworks/support/+/3156343
+# is released.
+# - https://issuetracker.google.com/issues/343124454
+# - https://issuetracker.google.com/issues/349090863
+androidx-paging = "3.2.1"
 androidx-preference = "1.2.1"
 androidx-recyclerview = "1.3.2"
 androidx-sharetarget = "1.2.0"


### PR DESCRIPTION
3.3.0 has a race condition when `getItem` is called.

The fix is in https://android-review.googlesource.com/c/platform/frameworks/support/+/3156343
but not released yet.

See:

- https://issuetracker.google.com/issues/343124454
- https://issuetracker.google.com/issues/349090863

