### PR TITLE
feat: Show author bylines on preview cards, tap to view profile

### DIFF
--- a/app/src/main/java/app/pachli/adapter/StatusBaseViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/StatusBaseViewHolder.kt
@@ -31,6 +31,7 @@ import app.pachli.core.common.util.formatNumber
 import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.database.model.TranslationState
 import app.pachli.core.designsystem.R as DR
+import app.pachli.core.navigation.AccountActivityIntent
 import app.pachli.core.navigation.ViewMediaActivityIntent
 import app.pachli.core.network.model.Attachment
 import app.pachli.core.network.model.Emoji
@@ -831,14 +832,20 @@ abstract class StatusBaseViewHolder<T : IStatusViewData> protected constructor(i
             (!viewData.isCollapsible || !viewData.isCollapsed)
         ) {
             cardView.visibility = View.VISIBLE
-            cardView.bind(card, viewData.actionable.sensitive, statusDisplayOptions) { target ->
-                if (card.kind == PreviewCardKind.PHOTO && card.embedUrl.isNotEmpty() && target == PreviewCardView.Target.IMAGE) {
-                    context.startActivity(
-                        ViewMediaActivityIntent(context, card.embedUrl),
-                    )
-                } else {
-                    listener.onViewUrl(card.url)
+            cardView.bind(card, viewData.actionable.sensitive, statusDisplayOptions) { card, target ->
+                if (target == PreviewCardView.Target.BYLINE) {
+                    card.authors?.firstOrNull()?.account?.id?.let {
+                        context.startActivity(AccountActivityIntent(context, it))
+                    }
+                    return@bind
                 }
+
+                if (card.kind == PreviewCardKind.PHOTO && card.embedUrl.isNotEmpty() && target == PreviewCardView.Target.IMAGE) {
+                    context.startActivity(ViewMediaActivityIntent(context, card.embedUrl))
+                    return@bind
+                }
+
+                listener.onViewUrl(card.url)
             }
         } else {
             cardView.visibility = View.GONE

--- a/app/src/main/java/app/pachli/components/trending/TrendingLinkViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/trending/TrendingLinkViewHolder.kt
@@ -21,14 +21,17 @@ import androidx.recyclerview.widget.RecyclerView
 import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.network.model.TrendsLink
 import app.pachli.databinding.ItemTrendingLinkBinding
+import app.pachli.view.PreviewCardView
 
 class TrendingLinkViewHolder(
     private val binding: ItemTrendingLinkBinding,
-    private val onClick: (String) -> Unit,
+    private val onClick: PreviewCardView.OnClickListener,
 ) : RecyclerView.ViewHolder(binding.root) {
+    internal lateinit var link: TrendsLink
+
     fun bind(link: TrendsLink, statusDisplayOptions: StatusDisplayOptions) {
-        binding.statusCardView.bind(link, sensitive = false, statusDisplayOptions) {
-            onClick(link.url)
-        }
+        this.link = link
+
+        binding.statusCardView.bind(link, sensitive = false, statusDisplayOptions, onClick)
     }
 }

--- a/app/src/main/java/app/pachli/components/trending/TrendingLinksAccessibilityDelegate.kt
+++ b/app/src/main/java/app/pachli/components/trending/TrendingLinksAccessibilityDelegate.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2024 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.components.trending
+
+import android.content.Context
+import android.os.Bundle
+import android.view.View
+import android.view.accessibility.AccessibilityManager
+import androidx.core.view.AccessibilityDelegateCompat
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat.AccessibilityActionCompat
+import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerViewAccessibilityDelegate
+import app.pachli.R
+import app.pachli.view.PreviewCardView
+import app.pachli.view.PreviewCardView.Target
+
+/**
+ * Accessbility delete for [TrendingLinkViewHolder].
+ *
+ * Each item shows an action to open the link.
+ *
+ * If present, an item to show the author's account is also included.
+ */
+internal class TrendingLinksAccessibilityDelegate(
+    private val recyclerView: RecyclerView,
+    val listener: PreviewCardView.OnClickListener,
+) : RecyclerViewAccessibilityDelegate(recyclerView) {
+    private val context = recyclerView.context
+
+    private val a11yManager = context.getSystemService(Context.ACCESSIBILITY_SERVICE)
+        as AccessibilityManager
+
+    private val openLinkAction = AccessibilityActionCompat(
+        app.pachli.core.ui.R.id.action_open_link,
+        context.getString(R.string.action_open_link),
+    )
+
+    private val openBylineAccountAction = AccessibilityActionCompat(
+        app.pachli.core.ui.R.id.action_open_byline_account,
+        context.getString(R.string.action_open_byline_account),
+    )
+
+    private val delegate = object : ItemDelegate(this) {
+        override fun onInitializeAccessibilityNodeInfo(host: View, info: AccessibilityNodeInfoCompat) {
+            super.onInitializeAccessibilityNodeInfo(host, info)
+
+            val viewHolder = recyclerView.findContainingViewHolder(host)
+                as TrendingLinkViewHolder
+
+            info.addAction(openLinkAction)
+
+            viewHolder.link.authors?.firstOrNull()?.account?.let {
+                info.addAction(openBylineAccountAction)
+            }
+        }
+
+        override fun performAccessibilityAction(host: View, action: Int, args: Bundle?): Boolean {
+            val viewHolder = recyclerView.findContainingViewHolder(host)
+                as TrendingLinkViewHolder
+
+            return when (action) {
+                app.pachli.core.ui.R.id.action_open_link -> {
+                    interrupt()
+                    listener.onClick(viewHolder.link, Target.CARD)
+                    true
+                }
+                app.pachli.core.ui.R.id.action_open_byline_account -> {
+                    interrupt()
+                    listener.onClick(viewHolder.link, Target.BYLINE)
+                    true
+                }
+                else -> super.performAccessibilityAction(host, action, args)
+            }
+        }
+    }
+
+    private fun interrupt() = a11yManager.interrupt()
+
+    override fun getItemDelegate(): AccessibilityDelegateCompat = delegate
+}

--- a/app/src/main/java/app/pachli/components/trending/TrendingLinksAdapter.kt
+++ b/app/src/main/java/app/pachli/components/trending/TrendingLinksAdapter.kt
@@ -25,10 +25,11 @@ import app.pachli.R
 import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.network.model.TrendsLink
 import app.pachli.databinding.ItemTrendingLinkBinding
+import app.pachli.view.PreviewCardView
 
 class TrendingLinksAdapter(
     statusDisplayOptions: StatusDisplayOptions,
-    private val onViewLink: (String) -> Unit,
+    private val onViewLink: PreviewCardView.OnClickListener,
 ) : ListAdapter<TrendsLink, TrendingLinkViewHolder>(diffCallback) {
     var statusDisplayOptions = statusDisplayOptions
         set(value) {

--- a/app/src/main/java/app/pachli/util/ListStatusAccessibilityDelegate.kt
+++ b/app/src/main/java/app/pachli/util/ListStatusAccessibilityDelegate.kt
@@ -100,6 +100,10 @@ class ListStatusAccessibilityDelegate<T : IStatusViewData>(
             if (actionable.reblogsCount > 0) info.addAction(openRebloggedByAction)
             if (actionable.favouritesCount > 0) info.addAction(openFavsAction)
 
+            status.actionable.card?.authors?.firstOrNull()?.account?.let {
+                info.addAction(openBylineAccountAction)
+            }
+
             info.addAction(moreAction)
         }
 
@@ -169,6 +173,12 @@ class ListStatusAccessibilityDelegate<T : IStatusViewData>(
                 app.pachli.core.ui.R.id.action_open_faved_by -> {
                     interrupt()
                     statusActionListener.onShowFavs(status.actionableId)
+                }
+                app.pachli.core.ui.R.id.action_open_byline_account -> {
+                    status.actionable.card?.authors?.firstOrNull()?.account?.let {
+                        interrupt()
+                        statusActionListener.onViewAccount(it.id)
+                    }
                 }
                 app.pachli.core.ui.R.id.action_more -> {
                     statusActionListener.onMore(host, status)
@@ -356,6 +366,11 @@ class ListStatusAccessibilityDelegate<T : IStatusViewData>(
     private val openFavsAction = AccessibilityActionCompat(
         app.pachli.core.ui.R.id.action_open_faved_by,
         context.getString(R.string.action_open_faved_by),
+    )
+
+    private val openBylineAccountAction = AccessibilityActionCompat(
+        app.pachli.core.ui.R.id.action_open_byline_account,
+        context.getString(R.string.action_open_byline_account),
     )
 
     private val moreAction = AccessibilityActionCompat(

--- a/app/src/main/res/layout/preview_card.xml
+++ b/app/src/main/res/layout/preview_card.xml
@@ -50,7 +50,6 @@
                 android:id="@+id/card_title"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="4dp"
                 android:ellipsize="end"
                 android:fontFamily="sans-serif-medium"
                 android:maxLines="2"
@@ -62,7 +61,7 @@
                 android:id="@+id/card_description"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="4dp"
+                android:layout_marginTop="4dp"
                 android:ellipsize="end"
                 android:lineSpacingMultiplier="1.1"
                 android:maxLines="3"
@@ -74,11 +73,43 @@
                 android:id="@+id/card_link"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
                 android:ellipsize="end"
                 android:lines="1"
                 android:textColor="?android:attr/textColorLink"
                 android:textSize="?attr/status_text_small"
                 tools:ignore="SelectableText" />
+
+            <LinearLayout
+                android:id="@+id/byline"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:minHeight="48dp"
+                android:gravity="bottom"
+                android:orientation="vertical">
+
+                <com.google.android.material.divider.MaterialDivider
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="6dp" />
+
+                <TextView
+                    android:id="@+id/author_info"
+                    android:layout_width="wrap_content"
+                    android:layout_height="0dp"
+                    android:layout_weight="1"
+                    android:layout_marginTop="6dp"
+                    android:textColor="?android:textColorTertiary"
+                    android:textSize="?attr/status_text_medium"
+                    android:ellipsize="end"
+                    android:drawablePadding="10dp"
+                    android:gravity="center"
+                    android:lines="1"
+                    android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
+                    android:paddingBottom="2dp"
+                    tools:ignore="SelectableText" />
+            </LinearLayout>
         </LinearLayout>
     </LinearLayout>
 </merge>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -709,4 +709,7 @@
     <string name="error_prepare_media_unknown_mime_type">file\'s type is not known</string>
 
     <string name="error_pick_media_fmt">Could not attach file to post: %1$s</string>
+    <string name="preview_card_byline_fmt">See more from %1$s</string>
+    <string name="action_open_byline_account">Show article author\'s profile</string>
+    <string name="action_open_link">Open link</string>
 </resources>

--- a/core/designsystem/src/main/res/values/dimens.xml
+++ b/core/designsystem/src/main/res/values/dimens.xml
@@ -50,6 +50,7 @@
     <dimen name="profile_badge_icon_end_padding">0dp</dimen>
 
     <dimen name="card_radius">5dp</dimen>
+    <dimen name="card_byline_avatar_dimen">36dp</dimen>
 
     <dimen name="poll_preview_padding">12dp</dimen>
     <dimen name="poll_preview_min_width">120dp</dimen>

--- a/core/network/src/main/kotlin/app/pachli/core/network/model/Card.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/Card.kt
@@ -45,6 +45,7 @@ data class Card(
     @Json(name = "embed_url") override val embedUrl: String = "",
     // Missing from Pleroma, https://git.pleroma.social/pleroma/pleroma/-/issues/3238
     override val blurhash: String? = null,
+    override val authors: List<PreviewCardAuthor>? = null,
 ) : PreviewCard {
 
     override fun hashCode() = url.hashCode()

--- a/core/network/src/main/kotlin/app/pachli/core/network/model/TrendsLink.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/TrendsLink.kt
@@ -58,7 +58,23 @@ interface PreviewCard {
     val image: String?
     val embedUrl: String
     val blurhash: String?
+    val authors: List<PreviewCardAuthor>?
 }
+
+/**
+ * An author of a link in a [PreviewCard].
+ *
+ * @property name Author's name, equivalent to [PreviewCard.authorName]
+ * @property url Author's URL, equivalent to [PreviewCard.authorUrl]
+ * @property account Author's account information, may be null if the link target
+ * did not include metadata about the author's account.
+ */
+@JsonClass(generateAdapter = true)
+data class PreviewCardAuthor(
+    val name: String,
+    val url: String,
+    val account: TimelineAccount? = null,
+)
 
 @JsonClass(generateAdapter = true)
 data class LinkHistory(
@@ -84,5 +100,6 @@ data class TrendsLink(
     override val image: String? = null,
     @Json(name = "embed_url") override val embedUrl: String,
     override val blurhash: String? = null,
+    override val authors: List<PreviewCardAuthor>? = null,
     val history: List<LinkHistory>,
 ) : PreviewCard

--- a/core/preferences/src/main/kotlin/app/pachli/core/preferences/CardViewMode.kt
+++ b/core/preferences/src/main/kotlin/app/pachli/core/preferences/CardViewMode.kt
@@ -1,7 +1,15 @@
 package app.pachli.core.preferences
 
 enum class CardViewMode {
+    /** User has disabled link previews. */
     NONE,
+
+    /**
+     * Display the card as the full-width of the view, used in a status'
+     * detailed view.
+     */
     FULL_WIDTH,
+
+    /** Display the card indented from the left edge, the normal timeline view. */
     INDENTED,
 }

--- a/core/ui/src/main/res/values/actions.xml
+++ b/core/ui/src/main/res/values/actions.xml
@@ -39,6 +39,12 @@
     <item name="action_open_reblogger" type="id" />
     <item name="action_open_reblogged_by" type="id" />
     <item name="action_open_faved_by" type="id" />
+
+    <!-- Open the account on a preview card's byline -->
+    <item name="action_open_byline_account" type="id" />
+    <!-- Open the link in a preview card -->
+    <item name="action_open_link" type="id" />
+
     <item name="action_more" type="id" />
 
     <item name="action_dismiss_follow_suggestion" type="id" />


### PR DESCRIPTION
Mastodon now supports additional (optional) author information to show as a byline on preview cards.

Use this (if included), to show the author's avatar, name, and link to their profile. If tapped a click on a new `Target.BYLINE` target is registered allowing fragments/activities to launch `ViewProfileActivity`.

Include this as an action in `ListStatusAccessibilityDelegate`, and provide `TrendingLinksAccessibilityDelegate` to provide accessibility actions when viewing trending links.