### PR TITLE
feat: Show autocomplete hashtags with usage counts, sort by popularity

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -1848,17 +1848,6 @@
     <issue
         id="SelectableText"
         message="Consider making the text value selectable by specifying `android:textIsSelectable=&quot;true&quot;`"
-        errorLine1="&lt;TextView xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
-        errorLine2=" ~~~~~~~~">
-        <location
-            file="src/main/res/layout/item_autocomplete_hashtag.xml"
-            line="2"
-            column="2"/>
-    </issue>
-
-    <issue
-        id="SelectableText"
-        message="Consider making the text value selectable by specifying `android:textIsSelectable=&quot;true&quot;`"
         errorLine1="    &lt;TextView"
         errorLine2="     ~~~~~~~~">
         <location

--- a/app/src/main/java/app/pachli/components/compose/ComposeAutoCompleteAdapter.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeAutoCompleteAdapter.kt
@@ -28,6 +28,7 @@ import app.pachli.core.activity.databinding.ItemAutocompleteAccountBinding
 import app.pachli.core.activity.emojify
 import app.pachli.core.activity.loadAvatar
 import app.pachli.core.common.extensions.visible
+import app.pachli.core.common.util.formatNumber
 import app.pachli.core.designsystem.R as DR
 import app.pachli.core.network.model.Emoji
 import app.pachli.core.network.model.TimelineAccount
@@ -125,7 +126,8 @@ class ComposeAutoCompleteAdapter(
             }
             is ItemAutocompleteHashtagBinding -> {
                 val result = getItem(position) as AutocompleteResult.HashtagResult
-                binding.root.text = formatHashtag(result)
+                binding.hashtag.text = formatHashtag(result)
+                binding.usage7d.text = formatNumber(result.usage7d.toLong(), 10000)
             }
             is ItemAutocompleteEmojiBinding -> {
                 val emojiResult = getItem(position) as AutocompleteResult.EmojiResult
@@ -150,11 +152,11 @@ class ComposeAutoCompleteAdapter(
     }
 
     sealed interface AutocompleteResult {
-        class AccountResult(val account: TimelineAccount) : AutocompleteResult
+        data class AccountResult(val account: TimelineAccount) : AutocompleteResult
 
-        class HashtagResult(val hashtag: String) : AutocompleteResult
+        data class HashtagResult(val hashtag: String, val usage7d: Int) : AutocompleteResult
 
-        class EmojiResult(val emoji: Emoji) : AutocompleteResult
+        data class EmojiResult(val emoji: Emoji) : AutocompleteResult
     }
 
     interface AutocompletionProvider {

--- a/app/src/main/java/app/pachli/components/compose/ComposeViewModel.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeViewModel.kt
@@ -497,7 +497,12 @@ class ComposeViewModel @Inject constructor(
             '#' -> {
                 return api.search(query = token, type = SearchType.Hashtag.apiParameter, limit = 10)
                     .fold({ searchResult ->
-                        searchResult.hashtags.map { AutocompleteResult.HashtagResult(it.name) }
+                        searchResult.hashtags.map {
+                            AutocompleteResult.HashtagResult(
+                                hashtag = it.name,
+                                usage7d = it.history.sumOf { it.uses },
+                            )
+                        }.sortedByDescending { it.usage7d }
                     }, { e ->
                         Timber.e(e, "Autocomplete search for %s failed.", token)
                         emptyList()

--- a/app/src/main/java/app/pachli/components/followedtags/FollowedTagsViewModel.kt
+++ b/app/src/main/java/app/pachli/components/followedtags/FollowedTagsViewModel.kt
@@ -53,7 +53,12 @@ class FollowedTagsViewModel @Inject constructor(
     suspend fun searchAutocompleteSuggestions(token: String): List<ComposeAutoCompleteAdapter.AutocompleteResult> {
         return api.search(query = token, type = SearchType.Hashtag.apiParameter, limit = 10)
             .fold({ searchResult ->
-                searchResult.hashtags.map { ComposeAutoCompleteAdapter.AutocompleteResult.HashtagResult(it.name) }
+                searchResult.hashtags.map {
+                    ComposeAutoCompleteAdapter.AutocompleteResult.HashtagResult(
+                        hashtag = it.name,
+                        usage7d = it.history.sumOf { it.uses },
+                    )
+                }
             }, { e ->
                 Timber.e(e, "Autocomplete search for %s failed.", token)
                 emptyList()

--- a/app/src/main/res/layout/item_autocomplete_hashtag.xml
+++ b/app/src/main/res/layout/item_autocomplete_hashtag.xml
@@ -1,13 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
-<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/hashtag"
-    android:layout_width="match_parent"
+    android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:ellipsize="end"
-    android:maxLines="1"
     android:paddingHorizontal="16dp"
-    android:paddingVertical="12dp"
-    android:textSize="?attr/status_text_medium"
-    android:textStyle="normal|bold"
-    tools:text="#Pachli" />
+    android:paddingVertical="12dp">
+
+    <TextView
+        android:id="@+id/hashtag"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:layout_weight="1"
+        android:textSize="?attr/status_text_medium"
+        android:textStyle="normal|bold"
+        tools:ignore="SelectableText"
+        tools:text="#Pachli" />
+
+    <TextView
+        android:id="@+id/usage7d"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:ems="6"
+        android:textSize="?attr/status_text_medium"
+        android:textAlignment="textEnd"
+        tools:ignore="SelectableText"
+        tools:text="99" />
+</LinearLayout>

--- a/core/network/src/main/kotlin/app/pachli/core/network/model/HashTag.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/HashTag.kt
@@ -3,4 +3,16 @@ package app.pachli.core.network.model
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
-data class HashTag(val name: String, val url: String, val following: Boolean? = null)
+data class HashTag(
+    val name: String,
+    val url: String,
+    val history: List<HashTagHistory> = emptyList(),
+    val following: Boolean? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class HashTagHistory(
+    val day: String,
+    val accounts: Int,
+    val uses: Int,
+)


### PR DESCRIPTION
When autocompleting hashtags while composing a status the previous code showed the hashtags in the same order they're returned by the server, with no additional information.

This doesn't allow the user to make an informed choice about which hashtag might be better to use. For example, trying to choose between "#nivenly" and "#NivenlyFoundation".

To fix that, include the hashtag's usage when receiving data from the server. Sum that, and show it to the user in the hashtag list. Sort the hashtags by popularity, most popular first.