### PR TITLE
fix: Ensure initial status length calculation includes the content warning

### DIFF
--- a/app/src/main/java/app/pachli/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeActivity.kt
@@ -396,11 +396,11 @@ class ComposeActivity :
     }
 
     private fun setupContentWarningField(startingContentWarning: String?) {
-        if (startingContentWarning != null) {
-            binding.composeContentWarningField.setText(startingContentWarning)
-        }
         binding.composeContentWarningField.doOnTextChanged { newContentWarning, _, _, _ ->
             viewModel.onContentWarningChanged(newContentWarning?.toString() ?: "")
+        }
+        if (startingContentWarning != null) {
+            binding.composeContentWarningField.setText(startingContentWarning)
         }
     }
 


### PR DESCRIPTION
Previous code set `doOnTextChanged` listener for the content warning *after* the initial value had been set. This meant the initial content warning text was not included when calculating the status' initial length.

Fix that by setting the listener before the text is set.

Fixes #815