### PR TITLE
change: Remove copyWithCollapsed helper

### DIFF
--- a/app/src/main/java/app/pachli/adapter/StatusDetailedViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/StatusDetailedViewHolder.kt
@@ -114,7 +114,7 @@ class StatusDetailedViewHolder(
     ) {
         // We never collapse statuses in the detail view
         val uncollapsedStatus =
-            if (viewData.isCollapsible && viewData.isCollapsed) viewData.copyWithCollapsed(false) else viewData
+            if (viewData.isCollapsible && viewData.isCollapsed) viewData.copy(isCollapsed = false) else viewData
         super.setupWithStatus(uncollapsedStatus, listener, statusDisplayOptions, payloads)
         setupCard(
             uncollapsedStatus,

--- a/app/src/main/java/app/pachli/viewdata/StatusViewData.kt
+++ b/app/src/main/java/app/pachli/viewdata/StatusViewData.kt
@@ -195,9 +195,6 @@ data class StatusViewData(
         this.isCollapsible = shouldTrimStatus(this.content)
     }
 
-    /** Helper for Java */
-    fun copyWithCollapsed(isCollapsed: Boolean) = copy(isCollapsed = isCollapsed)
-
     companion object {
         fun from(
             status: Status,


### PR DESCRIPTION
Holdover from when Java interoperability was required.