### PR TITLE
fix: Don't focus search query when returning to the results list

### DIFF
--- a/app/src/main/java/app/pachli/components/search/SearchActivity.kt
+++ b/app/src/main/java/app/pachli/components/search/SearchActivity.kt
@@ -139,7 +139,10 @@ class SearchActivity : BottomSheetActivity(), MenuProvider, SearchView.OnQueryTe
         searchView.setOnQueryTextListener(this)
         searchView.setQuery(viewModel.currentSearchFieldContent ?: "", false)
 
-        searchView.requestFocus()
+        // Only focus if the query is empty. This ensures that if the user is returning
+        // to the search results after visiting a result the full list is available,
+        // instead of being obscured by the keyboard.
+        if (searchView.query.isBlank()) searchView.requestFocus()
     }
 
     override fun onQueryTextSubmit(query: String?): Boolean {


### PR DESCRIPTION
Previous code always focused the search query. This meant that if the user:

1. Searched for something
2. Opened a result (post, hashtag, account)
3. Navigated back to the search results

then because the query was focused the soft-keyboard would open, obscuring the list of results. The user had to press "Back" again to dismiss the keyboard.

New code only focuses the search query view if it is empty. This allows the user to come back to the list of results and immediately open a new result.