### PR TITLE
fix: Use colorPrimary for checked/selected dialog items

### DIFF
--- a/core/designsystem/src/main/res/values/styles.xml
+++ b/core/designsystem/src/main/res/values/styles.xml
@@ -102,6 +102,9 @@
     <style name="AppDialog" parent="@style/ThemeOverlay.Material3.Dialog.Alert">
         <item name="android:letterSpacing">0</item>
         <item name="dialogCornerRadius">8dp</item>
+
+        <!-- Sets the colour of the radio button or checkbox in a dialog. -->
+        <item name="colorSecondary">?colorPrimary</item>
     </style>
 
     <style name="AppDialogFragmentStyle" parent="@style/ThemeOverlay.MaterialComponents.Dialog">


### PR DESCRIPTION
RadioButton and CheckBox color the selected radio button or check box using `colorPrimary`. For some reason Material dialogs don't, and use `colorSecondary` for this (and only this), which leads to visual inconstencices through the app.

Fix this by setting `colorSecondary` to `colorPrimary` to force it.