### PR TITLE
fix: Enable server filtering on GoToSocial 0.16+

### DIFF
--- a/core/network/src/main/kotlin/app/pachli/core/network/Server.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/Server.kt
@@ -238,7 +238,7 @@ data class Server(
                 }
 
                 // Uses format "yyyy.mm.dd" with an optional ".beta..." suffix.
-                // https://git.joinsharkey.org/Sharkey/Sharkey/issues/371
+                // https://activitypub.software/TransFem-org/Sharkey/-/issues/371
                 SHARKEY -> {
                     val rx = """^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)""".toRegex()
                     rx.find(version).toResultOr { UnparseableVersion(version, ParseException("unexpected null", 0)) }
@@ -265,20 +265,22 @@ data class Server(
                         v >= "2.4.3".toVersion() -> c[ORG_JOINMASTODON_FILTERS_CLIENT] = "1.0.0".toVersion()
                     }
 
+                    // Server side filtering
                     when {
                         v >= "4.0.0".toVersion() -> c[ORG_JOINMASTODON_FILTERS_SERVER] = "1.0.0".toVersion()
                     }
                 }
 
                 GOTOSOCIAL -> {
+                    // Filters
                     when {
-                        // Implemented in https://github.com/superseriousbusiness/gotosocial/pull/2594
-                        v >= "0.15.0".toVersion() -> c[ORG_JOINMASTODON_FILTERS_CLIENT] = "1.1.0".toVersion()
                         // Implemented in https://github.com/superseriousbusiness/gotosocial/pull/2936
                         v >= "0.16.0".toVersion() -> {
                             c[ORG_JOINMASTODON_FILTERS_CLIENT] = "1.1.0".toVersion()
                             c[ORG_JOINMASTODON_FILTERS_SERVER] = "1.0.0".toVersion()
                         }
+                        // Implemented in https://github.com/superseriousbusiness/gotosocial/pull/2594
+                        v >= "0.15.0".toVersion() -> c[ORG_JOINMASTODON_FILTERS_CLIENT] = "1.1.0".toVersion()
                     }
                 }
 

--- a/core/network/src/test/kotlin/app/pachli/core/network/ServerTest.kt
+++ b/core/network/src/test/kotlin/app/pachli/core/network/ServerTest.kt
@@ -197,6 +197,39 @@ class ServerTest(
                 ),
                 arrayOf(
                     Triple(
+                        "GoToSocial 0.15.0 has client filters",
+                        NodeInfo.Software("gotosocial", "0.15.0 git-ccecf5a"),
+                        defaultInstance,
+                    ),
+                    Ok(
+                        Server(
+                            kind = GOTOSOCIAL,
+                            version = "0.15.0".toVersion(),
+                            capabilities = mapOf(
+                                ORG_JOINMASTODON_FILTERS_CLIENT to "1.1.0".toVersion(),
+                            ),
+                        ),
+                    ),
+                ),
+                arrayOf(
+                    Triple(
+                        "GoToSocial 0.16.0 has server filters",
+                        NodeInfo.Software("gotosocial", "0.16.0 git-ccecf5a"),
+                        defaultInstance,
+                    ),
+                    Ok(
+                        Server(
+                            kind = GOTOSOCIAL,
+                            version = "0.16.0".toVersion(),
+                            capabilities = mapOf(
+                                ORG_JOINMASTODON_FILTERS_CLIENT to "1.1.0".toVersion(),
+                                ORG_JOINMASTODON_FILTERS_SERVER to "1.0.0".toVersion(),
+                            ),
+                        ),
+                    ),
+                ),
+                arrayOf(
+                    Triple(
                         "Pleroma can filter",
                         NodeInfo.Software("pleroma", "2.6.50-875-g2eb5c453.service-origin+soapbox"),
                         defaultInstance,


### PR DESCRIPTION
Previous code had the version test in the wrong order, so the check for >= 0.15.0 took precedence.