### PR TITLE
fix: Ensure trending tag name is fully visible

### DIFF
--- a/app/src/main/res/layout/item_trending_cell.xml
+++ b/app/src/main/res/layout/item_trending_cell.xml
@@ -40,7 +40,7 @@
 
         <TextView
             android:id="@+id/tag"
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:ellipsize="end"
             android:importantForAccessibility="no"


### PR DESCRIPTION
Previously re-binding the tag's text wouldn't re-measure the layout when the text changed. So scrolling down a longer tag could be placed in a textview that previously held a shorter tag.

Then it was cut off and the user couldn't see what the tag was. Use `wrap_content` so size is measured when the content changes.