### PR TITLE
feat: Toggle display of search operators with toolbar action

### DIFF
--- a/app/src/main/res/layout/activity_search.xml
+++ b/app/src/main/res/layout/activity_search.xml
@@ -21,100 +21,141 @@
             app:layout_scrollFlags="scroll|snap|enterAlways"
             app:navigationIcon="?attr/homeAsUpIndicator" />
 
-        <com.google.android.material.chip.ChipGroup
-            android:id="@+id/chipsFilter"
-            android:layout_width="match_parent"
+        <HorizontalScrollView
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:paddingStart="?listPreferredItemPaddingStart"
-            android:paddingEnd="?listPreferredItemPaddingEnd"
             app:layout_scrollFlags="scroll|snap|enterAlways"
-            android:animateLayoutChanges="true">
+            android:scrollbars="none">
 
-            <com.google.android.material.chip.Chip
-                android:id="@+id/chipFrom"
-                style="@style/Widget.Material3.Chip.Suggestion"
+            <com.google.android.material.chip.ChipGroup
+                android:id="@+id/chipsFilter"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                app:chipIconEnabled="true"
-                android:text="@string/search_operator_from_all" />
+                android:paddingStart="?listPreferredItemPaddingStart"
+                android:paddingEnd="?listPreferredItemPaddingEnd"
+                app:singleLine="true"
+                android:animateLayoutChanges="true">
 
-            <com.google.android.material.chip.Chip
-                android:id="@+id/chipDate"
-                style="@style/Widget.Material3.Chip.Suggestion"
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/chipFrom"
+                    style="@style/Widget.Material3.Chip.Suggestion"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:chipIconEnabled="true"
+                    android:text="@string/search_operator_from_all" />
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/chipDate"
+                    style="@style/Widget.Material3.Chip.Suggestion"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:chipIconEnabled="true"
+                    android:text="@string/search_operator_date_all" />
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/chipLanguage"
+                    style="@style/Widget.Material3.Chip.Suggestion"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:chipIconEnabled="true"
+                    android:text="@string/search_operator_language_all" />
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/chipWhere"
+                    style="@style/Widget.Material3.Chip.Suggestion"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:chipIconEnabled="true"
+                    android:text="@string/search_operator_where_all" />
+            </com.google.android.material.chip.ChipGroup>
+        </HorizontalScrollView>
+
+        <HorizontalScrollView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_scrollFlags="scroll|snap|enterAlways"
+            android:scrollbars="none">
+
+            <com.google.android.material.chip.ChipGroup
+                android:id="@+id/chipsFilter2"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                app:chipIconEnabled="true"
-                android:text="@string/search_operator_date_all" />
+                android:paddingStart="?listPreferredItemPaddingStart"
+                android:paddingEnd="?listPreferredItemPaddingEnd"
+                app:singleLine="true"
+                android:animateLayoutChanges="true">
 
-            <com.google.android.material.chip.Chip
-                android:id="@+id/chipLanguage"
-                style="@style/Widget.Material3.Chip.Suggestion"
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/chip_has_media"
+                    style="@style/Widget.Material3.Chip.Suggestion"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:chipIcon="@drawable/ic_attach_file_24dp"
+                    app:chipIconEnabled="true"
+                    android:text="@string/search_operator_attachment_all" />
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/chip_has_poll"
+                    style="@style/Widget.Material3.Chip.Suggestion"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:chipIcon="@drawable/ic_attach_file_24dp"
+                    app:chipIconEnabled="true"
+                    android:text="@string/search_operator_poll_all" />
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/chip_has_link"
+                    style="@style/Widget.Material3.Chip.Suggestion"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:chipIcon="@drawable/ic_link_24"
+                    app:chipIconEnabled="true"
+                    android:text="@string/search_operator_link_all" />
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/chip_has_embed"
+                    style="@style/Widget.Material3.Chip.Suggestion"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:chipIconEnabled="true"
+                    android:text="@string/search_operator_embed_all" />
+            </com.google.android.material.chip.ChipGroup>
+        </HorizontalScrollView>
+
+        <HorizontalScrollView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_scrollFlags="scroll|snap|enterAlways"
+            android:scrollbars="none">
+
+            <com.google.android.material.chip.ChipGroup
+                android:id="@+id/chipsFilter3"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                app:chipIconEnabled="true"
-                android:text="@string/search_operator_language_all" />
+                android:paddingStart="?listPreferredItemPaddingStart"
+                android:paddingEnd="?listPreferredItemPaddingEnd"
+                app:singleLine="true"
+                android:animateLayoutChanges="true">
 
-            <com.google.android.material.chip.Chip
-                android:id="@+id/chip_has_media"
-                style="@style/Widget.Material3.Chip.Suggestion"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:chipIcon="@drawable/ic_attach_file_24dp"
-                app:chipIconEnabled="true"
-                android:text="@string/search_operator_attachment_all" />
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/chip_is_reply"
+                    style="@style/Widget.Material3.Chip.Suggestion"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:chipIcon="@drawable/ic_reply_all_24dp"
+                    app:chipIconEnabled="true"
+                    android:text="@string/search_operator_replies_all" />
 
-            <com.google.android.material.chip.Chip
-                android:id="@+id/chip_is_reply"
-                style="@style/Widget.Material3.Chip.Suggestion"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:chipIcon="@drawable/ic_reply_all_24dp"
-                app:chipIconEnabled="true"
-                android:text="@string/search_operator_replies_all" />
-
-            <com.google.android.material.chip.Chip
-                android:id="@+id/chip_is_sensitive"
-                style="@style/Widget.Material3.Chip.Suggestion"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:chipIcon="@drawable/ic_eye_24dp"
-                app:chipIconEnabled="true"
-                android:text="@string/search_operator_sensitive_all" />
-
-            <com.google.android.material.chip.Chip
-                android:id="@+id/chip_has_poll"
-                style="@style/Widget.Material3.Chip.Suggestion"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:chipIcon="@drawable/ic_attach_file_24dp"
-                app:chipIconEnabled="true"
-                android:text="@string/search_operator_poll_all" />
-
-            <com.google.android.material.chip.Chip
-                android:id="@+id/chip_has_embed"
-                style="@style/Widget.Material3.Chip.Suggestion"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:chipIconEnabled="true"
-                android:text="@string/search_operator_embed_all" />
-
-            <com.google.android.material.chip.Chip
-                android:id="@+id/chip_has_link"
-                style="@style/Widget.Material3.Chip.Suggestion"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:chipIcon="@drawable/ic_link_24"
-                app:chipIconEnabled="true"
-                android:text="@string/search_operator_link_all" />
-
-            <com.google.android.material.chip.Chip
-                android:id="@+id/chipWhere"
-                style="@style/Widget.Material3.Chip.Suggestion"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:chipIconEnabled="true"
-                android:text="@string/search_operator_where_all" />
-        </com.google.android.material.chip.ChipGroup>
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/chip_is_sensitive"
+                    style="@style/Widget.Material3.Chip.Suggestion"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:chipIcon="@drawable/ic_eye_24dp"
+                    app:chipIconEnabled="true"
+                    android:text="@string/search_operator_sensitive_all" />
+            </com.google.android.material.chip.ChipGroup>
+        </HorizontalScrollView>
 
         <com.google.android.material.tabs.TabLayout
             android:id="@+id/tabs"

--- a/app/src/main/res/menu/search_toolbar.xml
+++ b/app/src/main/res/menu/search_toolbar.xml
@@ -9,4 +9,9 @@
         app:actionViewClass="androidx.appcompat.widget.SearchView"
         android:actionLayout="@layout/search_view"
         app:showAsAction="always" />
+
+    <item
+        android:id="@+id/action_filter_search"
+        android:title="Filter search"
+        app:showAsAction="always" />
 </menu>

--- a/core/common/src/main/kotlin/app/pachli/core/common/extensions/ViewExtensions.kt
+++ b/core/common/src/main/kotlin/app/pachli/core/common/extensions/ViewExtensions.kt
@@ -30,3 +30,11 @@ fun View.hide() {
 fun View.visible(visible: Boolean, or: Int = View.GONE) {
     this.visibility = if (visible) View.VISIBLE else or
 }
+
+fun View.toggleVisibility() {
+    when (this.visibility) {
+        View.GONE -> this.show()
+        View.INVISIBLE -> this.show()
+        View.VISIBLE -> this.hide()
+    }
+}


### PR DESCRIPTION
Default to hiding the search operators, and provide a new toolbar icon (always visible) to show them.

The toolbar icon is displayed with a badge if any operators are present.

Adjust the operator display to three horizontal scrolling rows, to further limit the maximum amount of vertical space the operators use.