### PR TITLE
fix: Don't crash due to Filters/ServerRepository race condition

### DIFF
--- a/app/src/main/java/app/pachli/components/preference/AccountPreferencesFragment.kt
+++ b/app/src/main/java/app/pachli/components/preference/AccountPreferencesFragment.kt
@@ -16,7 +16,6 @@
 
 package app.pachli.components.preference
 
-import app.pachli.core.designsystem.R as DR
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
@@ -37,6 +36,7 @@ import app.pachli.core.activity.extensions.startActivityWithTransition
 import app.pachli.core.common.util.unsafeLazy
 import app.pachli.core.data.repository.AccountPreferenceDataStore
 import app.pachli.core.data.repository.FiltersRepository
+import app.pachli.core.designsystem.R as DR
 import app.pachli.core.navigation.AccountListActivityIntent
 import app.pachli.core.navigation.FiltersActivityIntent
 import app.pachli.core.navigation.FollowedTagsActivityIntent

--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/FiltersRepository.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/FiltersRepository.kt
@@ -40,7 +40,6 @@ import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.andThen
 import com.github.michaelbull.result.coroutines.binding.binding
-import com.github.michaelbull.result.get
 import com.github.michaelbull.result.map
 import com.github.michaelbull.result.mapError
 import com.github.michaelbull.result.mapResult
@@ -171,7 +170,7 @@ data class Filters(
 class FiltersRepository @Inject constructor(
     @ApplicationScope private val externalScope: CoroutineScope,
     private val mastodonApi: MastodonApi,
-    private val serverRepository: ServerRepository,
+    serverRepository: ServerRepository,
 ) {
     /** Flow where emissions trigger fresh loads from the server. */
     private val reload = MutableSharedFlow<Unit>(replay = 1).apply { tryEmit(Unit) }
@@ -196,9 +195,6 @@ class FiltersRepository @Inject constructor(
         .stateIn(externalScope, SharingStarted.Lazily, Ok(null))
 
     suspend fun reload() = reload.emit(Unit)
-
-    /** @return True if the user's server can filter, false otherwise. */
-    fun canFilter() = server.get()?.let { it.canFilterV1() || it.canFilterV2() } ?: false
 
     /** Get a specific filter from the server, by [filterId]. */
     suspend fun getFilter(filterId: String): Result<Filter, FiltersError> = binding {


### PR DESCRIPTION
The `canFilter()` implementation could crash if `server` (marked `lateinit`) hadn't been initialised at the point of use.

Fix this by removing it and adjusting the two callers to use the `filters` flow and take appropriate action on error.