### PR TITLE
fix: Reduce preview cards to minimum height required

### DIFF
--- a/app/src/main/res/layout/item_status.xml
+++ b/app/src/main/res/layout/item_status.xml
@@ -181,7 +181,6 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
         android:layout_marginEnd="14dp"
-        android:minHeight="80dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="@id/status_display_name"
         app:layout_constraintTop_toBottomOf="@id/button_toggle_content"


### PR DESCRIPTION
Previous code set a min-height, which is no longer necessary after the other layout changes. But it meant that a preview card with a one-line title, no synopsis, and a URL, was taking up too much vertical space.