### PR TITLE
fix: Correctly position preview card images, show card description

### DIFF
--- a/app/src/main/res/layout/preview_card.xml
+++ b/app/src/main/res/layout/preview_card.xml
@@ -42,14 +42,15 @@
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/card_info"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            app:layout_constraintTop_toBottomOf="@id/card_image"
-            app:layout_constraintStart_toStartOf="parent"
             android:paddingLeft="6dp"
             android:paddingTop="6dp"
             android:paddingRight="6dp"
-            android:paddingBottom="6dp">
+            android:paddingBottom="6dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/card_image">
 
             <TextView
                 android:id="@+id/card_title"
@@ -102,8 +103,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="6dp"
-                app:layout_constraintTop_toBottomOf="@id/card_link"
-                app:layout_constraintStart_toStartOf="parent" />
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/card_link" />
 
             <TextView
                 android:id="@+id/author_info"


### PR DESCRIPTION
Byline changes inadvertently changed how the preview image is laid out, breaking the "Image at start, info at end" variant.

Previous code did not always show the card description if the text was present, fix that.