### PR TITLE
feat: Experimental preference to reverse home timeline

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -1091,83 +1091,6 @@
     </issue>
 
     <issue
-        id="Overdraw"
-        message="Possible overdraw: Root element paints background `?android:attr/colorBackground` with a theme that also paints a background (inferred theme is `@style/AppTheme`)"
-        errorLine1="    android:background=&quot;?android:attr/colorBackground&quot;>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/layout/fragment_timeline_notifications.xml"
-            line="23"
-            column="5"/>
-    </issue>
-
-    <issue
-        id="Overdraw"
-        message="Possible overdraw: Root element paints background `?attr/selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/AppTheme`)"
-        errorLine1="    android:background=&quot;?attr/selectableItemBackground&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/layout/item_account.xml"
-            line="8"
-            column="5"/>
-    </issue>
-
-    <issue
-        id="Overdraw"
-        message="Possible overdraw: Root element paints background `?attr/selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/AppTheme`)"
-        errorLine1="    android:background=&quot;?attr/selectableItemBackground&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/layout/item_draft.xml"
-            line="8"
-            column="5"/>
-    </issue>
-
-    <issue
-        id="Overdraw"
-        message="Possible overdraw: Root element paints background `?attr/selectableItemBackgroundBorderless` with a theme that also paints a background (inferred theme is `@style/AppTheme`)"
-        errorLine1="    android:background=&quot;?attr/selectableItemBackgroundBorderless&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/layout/item_emoji_button.xml"
-            line="4"
-            column="5"/>
-    </issue>
-
-    <issue
-        id="Overdraw"
-        message="Possible overdraw: Root element paints background `?attr/selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/AppTheme`)"
-        errorLine1="    android:background=&quot;?attr/selectableItemBackground&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/layout/item_hashtag.xml"
-            line="16"
-            column="5"/>
-    </issue>
-
-    <issue
-        id="Overdraw"
-        message="Possible overdraw: Root element paints background `?android:colorBackground` with a theme that also paints a background (inferred theme is `@style/AppTheme`)"
-        errorLine1="    android:background=&quot;?android:colorBackground&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/layout/item_tab_preference.xml"
-            line="7"
-            column="5"/>
-    </issue>
-
-    <issue
-        id="Overdraw"
-        message="Possible overdraw: Root element paints background `?attr/selectableItemBackground` with a theme that also paints a background (inferred theme is `@style/AppTheme`)"
-        errorLine1="    android:background=&quot;?attr/selectableItemBackground&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/layout/item_tab_preference_small.xml"
-            line="7"
-            column="5"/>
-    </issue>
-
-    <issue
         id="UnusedResources"
         message="The resource `R.menu.activity_scheduled_status` appears to be unused"
         errorLine1="&lt;menu xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
@@ -2281,7 +2204,7 @@
         errorLine2="     ~~~~~~~~">
         <location
             file="src/main/res/layout/item_status.xml"
-            line="247"
+            line="246"
             column="6"/>
     </issue>
 
@@ -2292,7 +2215,7 @@
         errorLine2="     ~~~~~~~~">
         <location
             file="src/main/res/layout/item_status.xml"
-            line="275"
+            line="274"
             column="6"/>
     </issue>
 
@@ -2303,7 +2226,7 @@
         errorLine2="     ~~~~~~~~">
         <location
             file="src/main/res/layout/item_status.xml"
-            line="303"
+            line="302"
             column="6"/>
     </issue>
 
@@ -2600,7 +2523,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/item_status.xml"
-            line="237"
+            line="236"
             column="9"/>
     </issue>
 

--- a/app/src/main/java/app/pachli/components/preference/LabPreferencesFragment.kt
+++ b/app/src/main/java/app/pachli/components/preference/LabPreferencesFragment.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2024 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.components.preference
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.preference.PreferenceFragmentCompat
+import androidx.preference.SwitchPreferenceCompat
+import app.pachli.R
+import app.pachli.core.preferences.PrefKeys
+import app.pachli.databinding.FragmentLabPreferencesWarningBinding
+import app.pachli.settings.makePreferenceScreen
+import app.pachli.settings.switchPreference
+
+class LabPreferencesFragment : PreferenceFragmentCompat() {
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        val defaultView = super.onCreateView(inflater, container, savedInstanceState)
+
+        // Insert a warning message as the first child in the layout.
+        val warningBinding = FragmentLabPreferencesWarningBinding.inflate(inflater, null, false)
+        (defaultView as? ViewGroup)?.addView(warningBinding.root, 0)
+
+        return defaultView
+    }
+
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        val context = requireContext()
+
+        makePreferenceScreen {
+            switchPreference {
+                key = PrefKeys.LAB_REVERSE_TIMELINE
+                setTitle(R.string.pref_labs_reverse_home_timeline_title)
+                setSummaryProvider {
+                    if ((it as SwitchPreferenceCompat).isChecked) {
+                        context.getString(R.string.pref_labs_reverse_home_timeline_on_summary)
+                    } else {
+                        context.getString(R.string.pref_labs_reverse_home_timeline_off_summary)
+                    }
+                }
+                isIconSpaceReserved = false
+            }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        requireActivity().setTitle(R.string.pref_title_labs)
+    }
+
+    companion object {
+        fun newInstance() = LabPreferencesFragment()
+    }
+}

--- a/app/src/main/java/app/pachli/components/preference/PreferencesFragment.kt
+++ b/app/src/main/java/app/pachli/components/preference/PreferencesFragment.kt
@@ -366,6 +366,14 @@ class PreferencesFragment : PreferenceFragmentCompat() {
                     icon = makeIcon(GoogleMaterial.Icon.gmd_refresh)
                 }
             }
+
+            preferenceCategory(R.string.pref_title_labs) {
+                it.icon = makeIcon(GoogleMaterial.Icon.gmd_science)
+                preference {
+                    setTitle(R.string.pref_title_labs)
+                    fragment = LabPreferencesFragment::class.qualifiedName
+                }
+            }
         }
     }
 

--- a/app/src/main/java/app/pachli/components/timeline/TimelineFragment.kt
+++ b/app/src/main/java/app/pachli/components/timeline/TimelineFragment.kt
@@ -324,7 +324,17 @@ class TimelineFragment :
                 // Collect the uiState. Nothing is done with it, but if you don't collect it then
                 // accessing viewModel.uiState.value (e.g., to check whether the FAB should be
                 // hidden) always returns the initial state.
-                launch { viewModel.uiState.collect() }
+                launch {
+                    viewModel.uiState.collect { uiState ->
+                        if (layoutManager.reverseLayout != uiState.reverseTimeline) {
+                            layoutManager.reverseLayout = uiState.reverseTimeline
+                            layoutManager.stackFromEnd = uiState.reverseTimeline
+                            // Force recyclerView to re-layout everything.
+                            binding.recyclerView.layoutManager = null
+                            binding.recyclerView.layoutManager = layoutManager
+                        }
+                    }
+                }
 
                 // Update status display from statusDisplayOptions. If the new options request
                 // relative time display collect the flow to periodically re-bind the UI.

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/TimelineViewModel.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/TimelineViewModel.kt
@@ -82,6 +82,9 @@ import timber.log.Timber
 data class UiState(
     /** True if the FAB should be shown while scrolling */
     val showFabWhileScrolling: Boolean,
+
+    /** True if the timeline should be shown in reverse order (oldest first) */
+    val reverseTimeline: Boolean,
 )
 
 // TODO: Ui* classes are copied from NotificationsViewModel. Not yet sure whether these actions
@@ -403,16 +406,21 @@ abstract class TimelineViewModel(
             }
         }
 
+        val watchedPrefs = setOf(PrefKeys.FAB_HIDE, PrefKeys.LAB_REVERSE_TIMELINE)
         uiState = sharedPreferencesRepository.changes
-            .filter { it == PrefKeys.FAB_HIDE }
+            .filter { watchedPrefs.contains(it) }
             .map {
                 UiState(
                     showFabWhileScrolling = !sharedPreferencesRepository.getBoolean(PrefKeys.FAB_HIDE, false),
+                    reverseTimeline = sharedPreferencesRepository.getBoolean(PrefKeys.LAB_REVERSE_TIMELINE, false),
                 )
             }.stateIn(
                 scope = viewModelScope,
                 started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5000),
-                initialValue = UiState(showFabWhileScrolling = !sharedPreferencesRepository.getBoolean(PrefKeys.FAB_HIDE, false)),
+                initialValue = UiState(
+                    showFabWhileScrolling = !sharedPreferencesRepository.getBoolean(PrefKeys.FAB_HIDE, false),
+                    reverseTimeline = sharedPreferencesRepository.getBoolean(PrefKeys.LAB_REVERSE_TIMELINE, false),
+                ),
             )
 
         if (timeline is Timeline.Home) {

--- a/app/src/main/res/layout/fragment_lab_preferences_warning.xml
+++ b/app/src/main/res/layout/fragment_lab_preferences_warning.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2024 Pachli Association
+  ~
+  ~ This file is a part of Pachli.
+  ~
+  ~ This program is free software; you can redistribute it and/or modify it under the terms of the
+  ~ GNU General Public License as published by the Free Software Foundation; either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+  ~ the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+  ~ Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License along with Pachli; if not,
+  ~ see <http://www.gnu.org/licenses>.
+  -->
+
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    style="@style/TextSizeMedium"
+    android:textColor="?colorError"
+    android:background="?colorErrorContainer"
+    android:paddingStart="?listPreferredItemPaddingStart"
+    android:paddingEnd="?listPreferredItemPaddingEnd"
+    android:paddingTop="8dp"
+    android:paddingBottom="8dp"
+    android:text="@string/pref_labs_warning"
+    tools:ignore="Overdraw" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -677,6 +677,11 @@
     <string name="update_dialog_title">An update is available</string>
     <string name="update_dialog_neutral">Don\'t remind me for this version</string>
     <string name="update_dialog_negative">Never remind me</string>
+    <string name="pref_title_labs">Lab experiments</string>
+    <string name="pref_labs_warning">These are experimental features. There is no guarantee they work, or will be included in future versions. Use at your own risk.</string>
+    <string name="pref_labs_reverse_home_timeline_title">Reverse timeline order</string>
+    <string name="pref_labs_reverse_home_timeline_off_summary">Posts are ordered newest first</string>
+    <string name="pref_labs_reverse_home_timeline_on_summary">Posts are ordered oldest first</string>
     <string name="translating">Translating…</string>
     <string name="translation_provider_fmt">%1$s</string>
 

--- a/app/src/test/java/app/pachli/components/timeline/CachedTimelineViewModelTestUiState.kt
+++ b/app/src/test/java/app/pachli/components/timeline/CachedTimelineViewModelTestUiState.kt
@@ -37,6 +37,7 @@ class CachedTimelineViewModelTestUiState : CachedTimelineViewModelTestBase() {
 
     private val initialUiState = UiState(
         showFabWhileScrolling = true,
+        reverseTimeline = false,
     )
 
     @Test

--- a/app/src/test/java/app/pachli/components/timeline/NetworkTimelineViewModelTestUiState.kt
+++ b/app/src/test/java/app/pachli/components/timeline/NetworkTimelineViewModelTestUiState.kt
@@ -37,6 +37,7 @@ class NetworkTimelineViewModelTestUiState : NetworkTimelineViewModelTestBase() {
 
     private val initialUiState = UiState(
         showFabWhileScrolling = true,
+        reverseTimeline = false,
     )
 
     @Test

--- a/core/preferences/src/main/kotlin/app/pachli/core/preferences/SettingsConstants.kt
+++ b/core/preferences/src/main/kotlin/app/pachli/core/preferences/SettingsConstants.kt
@@ -127,6 +127,8 @@ object PrefKeys {
     const val UPDATE_NOTIFICATION_VERSIONCODE = "updateNotificationVersioncode"
     const val UPDATE_NOTIFICATION_LAST_NOTIFICATION_MS = "updateNotificationLastNotificationMs"
 
+    const val LAB_REVERSE_TIMELINE = "labReverseTimeline"
+
     /** Keys that are no longer used (e.g., the preference has been removed */
     object Deprecated {
         // Empty at this time


### PR DESCRIPTION
Add a new set of preferences, "Lab experiments", to control features that are under investigation and may never make it into the mainstream.

Add the first experimental feature, which reverses the order of the home timeline, so posts are shown oldest first instead of newest first.