### PR TITLE
fix: Search filters use correct colours in dark and black mode

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -499,23 +499,23 @@
     <issue
         id="Typos"
         message="&quot;media&quot; is a common misspelling; did you mean &quot;medier&quot;?"
-        errorLine1="    &lt;string name=&quot;error_media_upload_permission&quot;>Trenger tillatelse til å lese media.&lt;/string>"
-        errorLine2="                                                                               ^">
+        errorLine1="    &lt;string name=&quot;error_media_upload_permission&quot;>Pachli tenger tillatelse for å lese media.&lt;/string>"
+        errorLine2="                                                                                     ^">
         <location
             file="src/main/res/values-nb-rNO/strings.xml"
             line="8"
-            column="80"/>
+            column="86"/>
     </issue>
 
     <issue
         id="Typos"
         message="&quot;media&quot; is a common misspelling; did you mean &quot;medier&quot;?"
-        errorLine1="    &lt;string name=&quot;error_media_download_permission&quot;>Trenger tillatelse for å lagre media.&lt;/string>"
-        errorLine2="                                                                                  ^">
+        errorLine1="    &lt;string name=&quot;error_media_download_permission&quot;>Pachli trenger tillatelse for å lagre media.&lt;/string>"
+        errorLine2="                                                                                         ^">
         <location
             file="src/main/res/values-nb-rNO/strings.xml"
             line="9"
-            column="83"/>
+            column="90"/>
     </issue>
 
     <issue

--- a/app/src/main/java/app/pachli/components/search/SearchActivity.kt
+++ b/app/src/main/java/app/pachli/components/search/SearchActivity.kt
@@ -131,7 +131,7 @@ class SearchActivity :
 
     private lateinit var searchView: SearchView
 
-    val showFilterIcon: Boolean
+    private val showFilterIcon: Boolean
         get() = viewModel.availableOperators.value.isNotEmpty()
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -662,10 +662,6 @@ class SearchActivity :
         }
     }
 
-    // binding.chipLink
-    // empty operator (LinkOperator() here)
-    // options to string map
-    // Dialog title resource
     private fun bindHasLinkChip(server: Server) {
         if (!server.can(ORG_JOINMASTODON_SEARCH_QUERY_HAS_LINK, ">=1.0.0".toConstraint())) {
             binding.chipHasLink.hide()

--- a/app/src/main/res/drawable/ic_link_24.xml
+++ b/app/src/main/res/drawable/ic_link_24.xml
@@ -15,7 +15,7 @@
   ~ see <http://www.gnu.org/licenses>.
   -->
 
-<vector xmlns:android="http://schemas.android.com/apk/res/android" android:autoMirrored="true" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:autoMirrored="true" android:height="24dp" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
 
     <path android:fillColor="?attr/colorControlNormal" android:pathData="M3.9,12c0,-1.71 1.39,-3.1 3.1,-3.1h4L11,7L7,7c-2.76,0 -5,2.24 -5,5s2.24,5 5,5h4v-1.9L7,15.1c-1.71,0 -3.1,-1.39 -3.1,-3.1zM8,13h8v-2L8,11v2zM17,7h-4v1.9h4c1.71,0 3.1,1.39 3.1,3.1s-1.39,3.1 -3.1,3.1h-4L13,17h4c2.76,0 5,-2.24 5,-5s-2.24,-5 -5,-5z"/>
 

--- a/app/src/main/res/layout/activity_search.xml
+++ b/app/src/main/res/layout/activity_search.xml
@@ -22,7 +22,7 @@
             app:navigationIcon="?attr/homeAsUpIndicator" />
 
         <HorizontalScrollView
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:layout_scrollFlags="scroll|snap|enterAlways"
             android:scrollbars="none">
@@ -71,7 +71,7 @@
         </HorizontalScrollView>
 
         <HorizontalScrollView
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:layout_scrollFlags="scroll|snap|enterAlways"
             android:scrollbars="none">
@@ -123,7 +123,7 @@
         </HorizontalScrollView>
 
         <HorizontalScrollView
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:layout_scrollFlags="scroll|snap|enterAlways"
             android:scrollbars="none">

--- a/core/designsystem/src/main/res/values/styles.xml
+++ b/core/designsystem/src/main/res/values/styles.xml
@@ -156,14 +156,21 @@
         <item name="iconColor">?attr/colorControlNormal</item>
 
         <item name="toolbarStyle">@style/Pachli.Widget.Toolbar.Black</item>
-        <item name="tabStyle">@style/Pachli.Widget.Material3.TabLayout</item>
+        <item name="tabStyle">@style/Pachli.Widget.Material3.TabLayout.Black</item>
+        <item name="android:horizontalScrollViewStyle">
+            @style/Pachli.Widget.HorizontalScrollView.Black
+        </item>
     </style>
 
     <style name="Pachli.Widget.Toolbar.Black" parent="Widget.Material3.Toolbar">
         <item name="android:background">@color/black</item>
     </style>
 
-    <style name="Pachli.Widget.Material3.TabLayout" parent="Widget.Material3.TabLayout">
+    <style name="Pachli.Widget.Material3.TabLayout.Black" parent="Widget.Material3.TabLayout">
+        <item name="android:background">@color/black</item>
+    </style>
+
+    <style name="Pachli.Widget.HorizontalScrollView.Black" parent="">
         <item name="android:background">@color/black</item>
     </style>
 


### PR DESCRIPTION
Two problems with the previous code when search filters were visible:

1. The link icon overrode the tint, so didn't appear correctly in dark and black mode.

2. The horizontal scroll view had the wrong background colour in black mode.

Fix both, by updating the icon and adding a new style for the scroll view.

While I'm here remove an obsolete comment and tighten up visibility.

Fixes #875