### PR TITLE
fix: Render hashtags, mentions, and initial paras correctly in RTL

### DIFF
--- a/app/src/main/res/layout/item_conversation.xml
+++ b/app/src/main/res/layout/item_conversation.xml
@@ -9,7 +9,8 @@
     android:clipChildren="false"
     android:clipToPadding="false"
     android:paddingStart="12dp"
-    android:paddingEnd="14dp">
+    android:paddingEnd="14dp"
+    android:textDirection="anyRtl">
 
     <TextView
         android:id="@+id/conversation_name"

--- a/app/src/main/res/layout/item_status.xml
+++ b/app/src/main/res/layout/item_status.xml
@@ -8,7 +8,8 @@
     android:layout_height="wrap_content"
     android:clipChildren="false"
     android:clipToPadding="false"
-    android:focusable="true">
+    android:focusable="true"
+    android:textDirection="anyRtl">
 
     <TextView
         android:id="@+id/status_info"

--- a/app/src/main/res/layout/item_status_detailed.xml
+++ b/app/src/main/res/layout/item_status_detailed.xml
@@ -7,7 +7,8 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:clipChildren="false"
-    android:clipToPadding="false">
+    android:clipToPadding="false"
+    android:textDirection="anyRtl">
 
     <ImageView
         android:id="@+id/status_avatar"

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/LinkHelper.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/LinkHelper.kt
@@ -29,6 +29,7 @@ import android.widget.TextView
 import androidx.annotation.VisibleForTesting
 import androidx.core.net.toUri
 import app.pachli.core.activity.EmojiSpan
+import app.pachli.core.common.string.unicodeWrap
 import app.pachli.core.network.model.HashTag
 import app.pachli.core.network.model.Status.Mention
 import com.mikepenz.iconics.IconicsColor
@@ -142,7 +143,11 @@ fun setClickableText(
     val start = getSpanStart(span)
     val end = getSpanEnd(span)
     val flags = getSpanFlags(span)
+
     val text = subSequence(start, end)
+    // Wrap the text so that "@foo" or "#foo" is rendered that way in RTL text, and
+    // not "foo@" or "foo#".
+    val wrappedText = text.unicodeWrap()
 
     val customSpan = when (text[0]) {
         '#' -> getCustomSpanForTag(text, tags, span, listener)
@@ -153,7 +158,8 @@ fun setClickableText(
     }
 
     removeSpan(span)
-    setSpan(customSpan, start, end, flags)
+    replace(start, end, wrappedText)
+    setSpan(customSpan, start, end + 1, flags)
 }
 
 @VisibleForTesting


### PR DESCRIPTION
Previous code didn't set the textDirection for the status content, so the first para of RTL text might be rendered incorrectly.

In addition, mentions and tags weren't BIDI wrapped, so would appear as "foo@" and "foo#" in RTL statuses, instead of "@foo" and "#foo".

Fix both of these issues.

Fixes #870