### PR TITLE
change: Drop any mention of account creation

### DIFF
--- a/feature/login/src/main/res/values-bg/strings.xml
+++ b/feature/login/src/main/res/values-bg/strings.xml
@@ -8,8 +8,6 @@
 \n
 \nПовече информация можете да намерите на &lt;a href=\"https://joinmastodon.org\"&gt;joinmastodon.org&lt;/a&gt;. <a href="https://instances.social">more!</a>
 \n
-\nIf you don\'t yet have an account, you can enter the name of the instance you\'d like to join and create an account there.
-\n
 \nAn instance is a single place where your account is hosted, but you can easily communicate with and follow folks on other instances as though you were on the same site.
 \n
 \nMore info can be found at <a href="https://joinmastodon.org">joinmastodon.org</a>. </string>

--- a/feature/login/src/main/res/values-bn-rBD/strings.xml
+++ b/feature/login/src/main/res/values-bn-rBD/strings.xml
@@ -12,8 +12,6 @@
 \n
 \nআরো তথ্য &lt;a href=\"https://joinmastodon.org\"&gt; joinmastodon.org &lt;/a&gt; এ পাওয়া যেতে পারে। <a href="https://instances.social">more!</a>
 \n
-\nIf you don\'t yet have an account, you can enter the name of the instance you\'d like to join and create an account there.
-\n
 \nAn instance is a single place where your account is hosted, but you can easily communicate with and follow folks on other instances as though you were on the same site.
 \n
 \nMore info can be found at <a href="https://joinmastodon.org">joinmastodon.org</a>. </string>

--- a/feature/login/src/main/res/values/strings.xml
+++ b/feature/login/src/main/res/values/strings.xml
@@ -3,8 +3,7 @@
     <string name="dialog_whats_an_instance">The address or domain of any instance can be entered
         here, such as mastodon.social, icosahedron.website, social.tchncs.de, and
         <a href="https://instances.social">more!</a>
-        \n\nIf you don\'t yet have an account, you can enter the name of the instance you\'d like to
-        join and create an account there.\n\nAn instance is a single place where your account is
+        \n\nAn instance is a single place where your account is
         hosted, but you can easily communicate with and follow folks on other instances as though
         you were on the same site.
         \n\nMore info can be found at <a href="https://joinmastodon.org">joinmastodon.org</a>.


### PR DESCRIPTION
The help text used to mention that an account could be created at the user's server. This was not done in Pachli, but could confuse reviewers into thinking it was.

Drop the reference to prevent this confusion.