### PR TITLE
ci: Automatically send changes for review

### DIFF
--- a/.github/workflows/upload-orange-release-google-play.yml
+++ b/.github/workflows/upload-orange-release-google-play.yml
@@ -74,5 +74,4 @@ jobs:
           track: production
           whatsNewDirectory: googleplay/whatsnew
           status: completed
-          changesNotSentForReview: true
           mappingFile: app/build/outputs/mapping/orangeGoogleRelease/mapping.txt


### PR DESCRIPTION
This should work again after the most recent release was approved.

Reverts pachli/pachli-android#895