### PR TITLE
fix: Remove anyRTL from status root view

### DIFF
--- a/app/src/main/res/layout/item_conversation.xml
+++ b/app/src/main/res/layout/item_conversation.xml
@@ -9,8 +9,7 @@
     android:clipChildren="false"
     android:clipToPadding="false"
     android:paddingStart="12dp"
-    android:paddingEnd="14dp"
-    android:textDirection="anyRtl">
+    android:paddingEnd="14dp">
 
     <TextView
         android:id="@+id/conversation_name"

--- a/app/src/main/res/layout/item_status.xml
+++ b/app/src/main/res/layout/item_status.xml
@@ -8,8 +8,7 @@
     android:layout_height="wrap_content"
     android:clipChildren="false"
     android:clipToPadding="false"
-    android:focusable="true"
-    android:textDirection="anyRtl">
+    android:focusable="true">
 
     <TextView
         android:id="@+id/status_info"

--- a/app/src/main/res/layout/item_status_detailed.xml
+++ b/app/src/main/res/layout/item_status_detailed.xml
@@ -7,8 +7,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:clipChildren="false"
-    android:clipToPadding="false"
-    android:textDirection="anyRtl">
+    android:clipToPadding="false">
 
     <ImageView
         android:id="@+id/status_avatar"


### PR DESCRIPTION
It's overly eager to switch, and renders incorrectly with content like:

> I like the letter י because it's so small