### PR TITLE
fix: Show posting app name if app link is missing

### DIFF
--- a/app/src/main/java/app/pachli/adapter/StatusDetailedViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/StatusDetailedViewHolder.kt
@@ -65,10 +65,9 @@ class StatusDetailedViewHolder(
             }
         }
 
-        app?.also { application ->
-            val (name, website) = application
+        app?.also { (name, website) ->
             sb.append(metadataJoiner)
-            website?.also { sb.append(createClickableText(name, it)) ?: sb.append(name) }
+            website?.also { sb.append(createClickableText(name, it)) } ?: sb.append(name)
         }
 
         metaInfo.movementMethod = LinkMovementMethod.getInstance()


### PR DESCRIPTION
Previous code had a bug/typo, which meant the app the user was posting from was not shown if the app did not have an associated website. But the bullet separating the parts of the text was still shown, resulting in a spurious dangling bullet.