### PR TITLE
fix: Restore video transitions on androidx.media3 1.4.0 and 1.4.1

### DIFF
--- a/app/src/main/res/layout/fragment_view_video.xml
+++ b/app/src/main/res/layout/fragment_view_video.xml
@@ -24,6 +24,11 @@
         app:layout_constraintTop_toTopOf="parent"
         tools:text="Some media description" />
 
+    <!--
+     app:surface_type="texture_view" is a workaround for
+     https://github.com/androidx/media/issues/1594 and can be removed when
+     that issue is fixed.
+    -->
     <androidx.media3.ui.PlayerView
         android:id="@+id/videoView"
         android:layout_width="wrap_content"
@@ -32,6 +37,7 @@
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        app:surface_type="texture_view"
         app:use_controller="true"
         app:show_previous_button="false"
         app:show_next_button="false"


### PR DESCRIPTION
androidx.media3 1.4.0-rc01 and above (at the time of writing) has a bug that breaks shared element transitions with a `PlayerView` (see https://github.com/androidx/media/issues/1594).

This can be worked around by setting `app:surface_type="texture_view"`. This uses more power, but for the typical length of social media videos this shouldn't be a problem at the moment.

Fixes #920.