### PR TITLE
fix: Stop preview card text overlapping images

### DIFF
--- a/app/src/main/res/layout/preview_card.xml
+++ b/app/src/main/res/layout/preview_card.xml
@@ -35,7 +35,7 @@
             android:layout_height="300dp"
             android:layout_margin="1dp"
             android:importantForAccessibility="no"
-            android:scaleType="center"
+            android:scaleType="centerCrop"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             tools:srcCompat="@tools:sample/backgrounds/scenic" />


### PR DESCRIPTION
In rare occasions the preview card text could overlap the image if the image had a portrait aspect ratio.

This seems to be due to the use of the `with(...) {}` scope function and Kotlin's interoperability with Java setters.

Replace this with code that explicitly gets and sets the layout params to ensure they are set correctly.