### PR TITLE
refactor: Implement AppTheme with PreferenceEnum

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -151,7 +151,18 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-ta/strings.xml"
-            line="154"
+            line="150"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;ga&quot; (Irish) the following quantities should also be defined: `few` (e.g. &quot;3 cinn, 3 huaire, 3 chat, 3 éan, 3 bhróg&quot;), `many` (e.g. &quot;7 gcinn, 7 n-uaire, 7 gcat, 7 n-éan, 7 mbróg&quot;), `one` (e.g. &quot;1 cheann, 1 uair, 1 chat, 1 éan, 1 bhróg&quot;), `two` (e.g. &quot;2 cheann, 2 uair, 2 chat, 2 éan, 2 bhróig&quot;)"
+        errorLine1="    &lt;plurals name=&quot;notification_title_summary&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-ga/strings.xml"
+            line="157"
             column="5"/>
     </issue>
 
@@ -163,17 +174,6 @@
         <location
             file="src/main/res/values-bg/strings.xml"
             line="161"
-            column="5"/>
-    </issue>
-
-    <issue
-        id="MissingQuantity"
-        message="For locale &quot;ga&quot; (Irish) the following quantities should also be defined: `few` (e.g. &quot;3 cinn, 3 huaire, 3 chat, 3 éan, 3 bhróg&quot;), `many` (e.g. &quot;7 gcinn, 7 n-uaire, 7 gcat, 7 n-éan, 7 mbróg&quot;), `one` (e.g. &quot;1 cheann, 1 uair, 1 chat, 1 éan, 1 bhróg&quot;), `two` (e.g. &quot;2 cheann, 2 uair, 2 chat, 2 éan, 2 bhróig&quot;)"
-        errorLine1="    &lt;plurals name=&quot;notification_title_summary&quot;>"
-        errorLine2="    ^">
-        <location
-            file="src/main/res/values-ga/strings.xml"
-            line="162"
             column="5"/>
     </issue>
 
@@ -195,7 +195,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-cs/strings.xml"
-            line="188"
+            line="183"
             column="5"/>
     </issue>
 
@@ -206,7 +206,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-bn-rIN/strings.xml"
-            line="195"
+            line="190"
             column="5"/>
     </issue>
 
@@ -217,7 +217,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-eu/strings.xml"
-            line="202"
+            line="198"
             column="5"/>
     </issue>
 
@@ -239,7 +239,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-ca/strings.xml"
-            line="230"
+            line="225"
             column="5"/>
     </issue>
 
@@ -250,7 +250,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-cs/strings.xml"
-            line="231"
+            line="226"
             column="5"/>
     </issue>
 
@@ -261,7 +261,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-bn-rIN/strings.xml"
-            line="236"
+            line="231"
             column="5"/>
     </issue>
 
@@ -272,7 +272,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-ga/strings.xml"
-            line="263"
+            line="258"
             column="5"/>
     </issue>
 
@@ -283,7 +283,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-hi/strings.xml"
-            line="265"
+            line="261"
             column="5"/>
     </issue>
 
@@ -294,7 +294,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-ca/strings.xml"
-            line="267"
+            line="262"
             column="5"/>
     </issue>
 
@@ -305,7 +305,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-ca/strings.xml"
-            line="271"
+            line="266"
             column="5"/>
     </issue>
 
@@ -313,6 +313,17 @@
         id="MissingQuantity"
         message="For locale &quot;cs&quot; (Czech) the following quantity should also be defined: `many` (e.g. &quot;10.0 dne&quot;)"
         errorLine1="    &lt;plurals name=&quot;favs&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-cs/strings.xml"
+            line="267"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;cs&quot; (Czech) the following quantity should also be defined: `many` (e.g. &quot;10.0 dne&quot;)"
+        errorLine1="    &lt;plurals name=&quot;reblogs&quot;>"
         errorLine2="    ^">
         <location
             file="src/main/res/values-cs/strings.xml"
@@ -322,23 +333,12 @@
 
     <issue
         id="MissingQuantity"
-        message="For locale &quot;cs&quot; (Czech) the following quantity should also be defined: `many` (e.g. &quot;10.0 dne&quot;)"
-        errorLine1="    &lt;plurals name=&quot;reblogs&quot;>"
-        errorLine2="    ^">
-        <location
-            file="src/main/res/values-cs/strings.xml"
-            line="277"
-            column="5"/>
-    </issue>
-
-    <issue
-        id="MissingQuantity"
         message="For locale &quot;ca&quot; (Catalan) the following quantity should also be defined: `many`"
         errorLine1="    &lt;plurals name=&quot;poll_info_votes&quot;>"
         errorLine2="    ^">
         <location
             file="src/main/res/values-ca/strings.xml"
-            line="296"
+            line="291"
             column="5"/>
     </issue>
 
@@ -349,7 +349,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-cs/strings.xml"
-            line="307"
+            line="302"
             column="5"/>
     </issue>
 
@@ -357,6 +357,17 @@
         id="MissingQuantity"
         message="For locale &quot;cs&quot; (Czech) the following quantity should also be defined: `many` (e.g. &quot;10.0 dne&quot;)"
         errorLine1="    &lt;plurals name=&quot;poll_timespan_days&quot;>"
+        errorLine2="    ^">
+        <location
+            file="src/main/res/values-cs/strings.xml"
+            line="316"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="MissingQuantity"
+        message="For locale &quot;cs&quot; (Czech) the following quantity should also be defined: `many` (e.g. &quot;10.0 dne&quot;)"
+        errorLine1="    &lt;plurals name=&quot;poll_timespan_minutes&quot;>"
         errorLine2="    ^">
         <location
             file="src/main/res/values-cs/strings.xml"
@@ -367,22 +378,11 @@
     <issue
         id="MissingQuantity"
         message="For locale &quot;cs&quot; (Czech) the following quantity should also be defined: `many` (e.g. &quot;10.0 dne&quot;)"
-        errorLine1="    &lt;plurals name=&quot;poll_timespan_minutes&quot;>"
-        errorLine2="    ^">
-        <location
-            file="src/main/res/values-cs/strings.xml"
-            line="326"
-            column="5"/>
-    </issue>
-
-    <issue
-        id="MissingQuantity"
-        message="For locale &quot;cs&quot; (Czech) the following quantity should also be defined: `many` (e.g. &quot;10.0 dne&quot;)"
         errorLine1="    &lt;plurals name=&quot;poll_timespan_seconds&quot;>"
         errorLine2="    ^">
         <location
             file="src/main/res/values-cs/strings.xml"
-            line="331"
+            line="326"
             column="5"/>
     </issue>
 
@@ -393,7 +393,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-bg/strings.xml"
-            line="363"
+            line="358"
             column="5"/>
     </issue>
 
@@ -404,7 +404,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-ca/strings.xml"
-            line="363"
+            line="358"
             column="5"/>
     </issue>
 
@@ -415,7 +415,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-ca/strings.xml"
-            line="391"
+            line="386"
             column="5"/>
     </issue>
 
@@ -426,7 +426,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-ca/strings.xml"
-            line="395"
+            line="390"
             column="5"/>
     </issue>
 
@@ -437,7 +437,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-ca/strings.xml"
-            line="399"
+            line="394"
             column="5"/>
     </issue>
 
@@ -448,7 +448,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-ca/strings.xml"
-            line="403"
+            line="398"
             column="5"/>
     </issue>
 
@@ -459,7 +459,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-cs/strings.xml"
-            line="411"
+            line="406"
             column="5"/>
     </issue>
 
@@ -470,7 +470,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-cs/strings.xml"
-            line="416"
+            line="411"
             column="5"/>
     </issue>
 
@@ -481,7 +481,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-ca/strings.xml"
-            line="419"
+            line="414"
             column="5"/>
     </issue>
 
@@ -492,7 +492,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-cs/strings.xml"
-            line="421"
+            line="416"
             column="5"/>
     </issue>
 
@@ -690,7 +690,7 @@
         errorLine2="                                                                                     ^">
         <location
             file="src/main/res/values-nb-rNO/strings.xml"
-            line="390"
+            line="385"
             column="86"/>
     </issue>
 
@@ -701,7 +701,7 @@
         errorLine2="                                                  ^">
         <location
             file="src/main/res/values-nb-rNO/strings.xml"
-            line="514"
+            line="509"
             column="51"/>
     </issue>
 
@@ -712,7 +712,7 @@
         errorLine2="                                          ^">
         <location
             file="src/main/res/values-nb-rNO/strings.xml"
-            line="644"
+            line="639"
             column="43"/>
     </issue>
 
@@ -723,7 +723,7 @@
         errorLine2="                                                  ^">
         <location
             file="src/main/res/values-nb-rNO/strings.xml"
-            line="736"
+            line="731"
             column="51"/>
     </issue>
 
@@ -734,7 +734,7 @@
         errorLine2="                                                                   ^">
         <location
             file="src/main/res/values-nb-rNO/strings.xml"
-            line="760"
+            line="755"
             column="68"/>
     </issue>
 
@@ -745,7 +745,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fa/strings.xml"
-            line="171"
+            line="167"
             column="9"/>
     </issue>
 
@@ -756,7 +756,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fa/strings.xml"
-            line="200"
+            line="196"
             column="9"/>
     </issue>
 
@@ -778,7 +778,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="283"
+            line="278"
             column="5"/>
     </issue>
 
@@ -789,7 +789,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="334"
+            line="329"
             column="5"/>
     </issue>
 
@@ -800,7 +800,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="453"
+            line="448"
             column="5"/>
     </issue>
 
@@ -811,7 +811,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="626"
+            line="621"
             column="5"/>
     </issue>
 
@@ -1350,7 +1350,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="273"
+            line="268"
             column="13"/>
     </issue>
 
@@ -1361,7 +1361,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="344"
+            line="339"
             column="13"/>
     </issue>
 
@@ -1372,7 +1372,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="384"
+            line="379"
             column="13"/>
     </issue>
 
@@ -1383,7 +1383,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="420"
+            line="415"
             column="13"/>
     </issue>
 
@@ -1394,7 +1394,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="423"
+            line="418"
             column="13"/>
     </issue>
 
@@ -1405,7 +1405,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="424"
+            line="419"
             column="13"/>
     </issue>
 
@@ -1416,7 +1416,7 @@
         errorLine2="            ~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="425"
+            line="420"
             column="13"/>
     </issue>
 
@@ -1427,7 +1427,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="427"
+            line="422"
             column="13"/>
     </issue>
 
@@ -1438,7 +1438,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="439"
+            line="434"
             column="13"/>
     </issue>
 
@@ -1449,7 +1449,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="440"
+            line="435"
             column="13"/>
     </issue>
 
@@ -1460,7 +1460,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="491"
+            line="486"
             column="13"/>
     </issue>
 
@@ -1471,7 +1471,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="492"
+            line="487"
             column="13"/>
     </issue>
 
@@ -1482,7 +1482,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="503"
+            line="498"
             column="13"/>
     </issue>
 
@@ -1493,7 +1493,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="504"
+            line="499"
             column="13"/>
     </issue>
 
@@ -1504,7 +1504,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="505"
+            line="500"
             column="13"/>
     </issue>
 
@@ -1515,7 +1515,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="508"
+            line="503"
             column="13"/>
     </issue>
 
@@ -1526,7 +1526,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="546"
+            line="541"
             column="13"/>
     </issue>
 
@@ -1537,7 +1537,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="587"
+            line="582"
             column="13"/>
     </issue>
 
@@ -1548,7 +1548,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="593"
+            line="588"
             column="13"/>
     </issue>
 
@@ -1559,7 +1559,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="618"
+            line="613"
             column="13"/>
     </issue>
 
@@ -1570,7 +1570,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="644"
+            line="639"
             column="13"/>
     </issue>
 

--- a/app/src/main/java/app/pachli/PachliApplication.kt
+++ b/app/src/main/java/app/pachli/PachliApplication.kt
@@ -28,7 +28,6 @@ import app.pachli.components.notifications.createWorkerNotificationChannel
 import app.pachli.core.activity.LogEntryTree
 import app.pachli.core.activity.TreeRing
 import app.pachli.core.activity.initCrashReporter
-import app.pachli.core.preferences.AppTheme
 import app.pachli.core.preferences.NEW_INSTALL_SCHEMA_VERSION
 import app.pachli.core.preferences.PrefKeys
 import app.pachli.core.preferences.SCHEMA_VERSION
@@ -101,8 +100,7 @@ class PachliApplication : Application() {
         EmojiPackHelper.init(this, DefaultEmojiPackList.get(this), allowPackImports = false)
 
         // init night mode
-        val theme = AppTheme.from(sharedPreferencesRepository)
-        setAppNightMode(theme)
+        setAppNightMode(sharedPreferencesRepository.appTheme)
 
         localeManager.setLocale()
 

--- a/app/src/main/java/app/pachli/components/account/AccountActivity.kt
+++ b/app/src/main/java/app/pachli/components/account/AccountActivity.kt
@@ -690,7 +690,8 @@ class AccountActivity :
 
         // because subscribing is Pleroma extension, enable it __only__ when we have non-null subscribing field
         // it's also now supported in Mastodon 3.3.0rc but called notifying and use different API call
-        if (!viewModel.isSelf && followState == FollowState.FOLLOWING &&
+        if (!viewModel.isSelf &&
+            followState == FollowState.FOLLOWING &&
             (relation.subscribing != null || relation.notifying != null)
         ) {
             binding.accountSubscribeButton.show()
@@ -788,7 +789,7 @@ class AccountActivity :
     private fun updateBadges() {
         binding.accountBadgeContainer.removeAllViews()
 
-        val isLight = when (AppTheme.from(sharedPreferencesRepository)) {
+        val isLight = when (sharedPreferencesRepository.appTheme) {
             AppTheme.DAY -> true
             AppTheme.NIGHT, AppTheme.BLACK -> false
             AppTheme.AUTO, AppTheme.AUTO_SYSTEM -> {

--- a/app/src/main/java/app/pachli/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeActivity.kt
@@ -241,8 +241,7 @@ class ComposeActivity :
 
         activeAccount = accountManager.activeAccount ?: return
 
-        val theme = AppTheme.from(sharedPreferencesRepository)
-        if (theme == AppTheme.BLACK) {
+        if (sharedPreferencesRepository.appTheme == AppTheme.BLACK) {
             setTheme(DR.style.AppDialogActivityBlackTheme)
         }
         setContentView(binding.root)

--- a/app/src/main/java/app/pachli/components/preference/PreferencesActivity.kt
+++ b/app/src/main/java/app/pachli/components/preference/PreferencesActivity.kt
@@ -33,7 +33,6 @@ import app.pachli.core.activity.extensions.startActivityWithDefaultTransition
 import app.pachli.core.navigation.MainActivityIntent
 import app.pachli.core.navigation.PreferencesActivityIntent
 import app.pachli.core.navigation.PreferencesActivityIntent.PreferenceScreen
-import app.pachli.core.preferences.AppTheme
 import app.pachli.core.preferences.PrefKeys
 import app.pachli.core.preferences.PrefKeys.APP_THEME
 import app.pachli.databinding.ActivityPreferencesBinding
@@ -104,7 +103,7 @@ class PreferencesActivity :
             sharedPreferencesRepository.changes.filterNotNull().collect { key ->
                 when (key) {
                     APP_THEME -> {
-                        val theme = AppTheme.from(sharedPreferencesRepository)
+                        val theme = sharedPreferencesRepository.appTheme
                         Timber.d("activeTheme: %s", theme)
                         setAppNightMode(theme)
 

--- a/app/src/main/java/app/pachli/components/preference/PreferencesFragment.kt
+++ b/app/src/main/java/app/pachli/components/preference/PreferencesFragment.kt
@@ -51,7 +51,6 @@ import app.pachli.core.database.model.AccountEntity
 import app.pachli.core.designsystem.R as DR
 import app.pachli.core.network.model.Notification
 import app.pachli.core.preferences.AppTheme
-import app.pachli.core.preferences.AppTheme.Companion.APP_THEME_DEFAULT
 import app.pachli.core.preferences.DownloadLocation
 import app.pachli.core.preferences.PrefKeys
 import app.pachli.core.preferences.SharedPreferencesRepository
@@ -140,13 +139,10 @@ class PreferencesFragment : PreferenceFragmentCompat() {
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         makePreferenceScreen {
             preferenceCategory(R.string.pref_title_appearance_settings) {
-                listPreference {
-                    setDefaultValue(APP_THEME_DEFAULT.value)
-                    setEntries(R.array.app_theme_names)
-                    entryValues = AppTheme.stringValues()
-                    key = PrefKeys.APP_THEME
-                    setSummaryProvider { entry }
+                enumListPreference<AppTheme> {
+                    setDefaultValue(AppTheme.AUTO_SYSTEM)
                     setTitle(R.string.pref_title_app_theme)
+                    key = PrefKeys.APP_THEME
                     icon = makeIcon(GoogleMaterial.Icon.gmd_palette)
                 }
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -137,11 +137,6 @@
     <string name="pref_title_app_theme">مظهر التطبيق</string>
     <string name="pref_title_timelines">الخيوط الزمنية</string>
     <string name="pref_title_timeline_filters">عوامل التصفية</string>
-    <string name="app_them_dark">داكنة</string>
-    <string name="app_theme_light">فاتحة</string>
-    <string name="app_theme_black">سوداء</string>
-    <string name="app_theme_auto">تلقائي عند غروب الشمس</string>
-    <string name="app_theme_system">استخدم مظهر النظام</string>
     <string name="pref_title_browser_settings">المتصفح</string>
     <string name="pref_title_custom_tabs">إخفاء زر المتابعة أثناء تمرير الصفحة</string>
     <string name="pref_title_hide_follow_button">إخفاء زر التحرير عند التمرير</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -108,11 +108,6 @@
     <string name="pref_title_notification_filter_mentions">згадалі</string>
     <string name="pref_title_notification_filter_follows">падпісаліся</string>
     <string name="pref_title_timeline_filters">Фільтры</string>
-    <string name="app_them_dark">Цёмная</string>
-    <string name="app_theme_light">Светлая</string>
-    <string name="app_theme_black">Чорная</string>
-    <string name="app_theme_auto">Аўтаматычна па захадзе сонца</string>
-    <string name="app_theme_system">Выкарыстоўваць сістэмную тэму</string>
     <string name="pref_title_browser_settings">Браўзер</string>
     <string name="pref_title_custom_tabs">Выкарыстоўваць укладкі браўзера Chrome</string>
     <string name="pref_title_animate_gif_avatars">Анімаваць GIF-аватаркі</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -184,11 +184,6 @@
     <string name="pref_title_hide_follow_button">Скриване на бутона за композиране, при превъртане</string>
     <string name="pref_title_custom_tabs">Използване на персонализирани раздели чрез Chrome</string>
     <string name="pref_title_browser_settings">Браузър</string>
-    <string name="app_theme_system">Използване на системния дизайн</string>
-    <string name="app_theme_auto">Автоматично при залез</string>
-    <string name="app_theme_black">Черно</string>
-    <string name="app_theme_light">Светло</string>
-    <string name="app_them_dark">Тъмно</string>
     <string name="pref_title_timeline_filters">Филтри</string>
     <string name="pref_title_timelines">Емисии</string>
     <string name="pref_title_app_theme">Тема на приложение</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -114,11 +114,6 @@
     <string name="pref_title_hide_follow_button">স্ক্রোল করার সময় রচনা বোতাম লুকান</string>
     <string name="pref_title_custom_tabs">ক্রোম কাস্টম ট্যাব ব্যবহার করুন</string>
     <string name="pref_title_browser_settings">ব্রাউজার</string>
-    <string name="app_theme_system">সিস্টেম ডিজাইন ব্যবহার করুন</string>
-    <string name="app_theme_auto">সূর্যাস্ত স্বয়ংক্রিয়</string>
-    <string name="app_theme_black">কালো</string>
-    <string name="app_theme_light">আলো</string>
-    <string name="app_them_dark">অন্ধকার</string>
     <string name="pref_title_timeline_filters">ফিল্টার</string>
     <string name="pref_title_timelines">টাইমলাইন</string>
     <string name="pref_title_app_theme">এপ্লিকেশন এর থিম</string>

--- a/app/src/main/res/values-bn-rIN/strings.xml
+++ b/app/src/main/res/values-bn-rIN/strings.xml
@@ -144,11 +144,6 @@
     <string name="pref_title_app_theme">এপ্লিকেশন এর থিম</string>
     <string name="pref_title_timelines">টাইমলাইন</string>
     <string name="pref_title_timeline_filters">ফিল্টার</string>
-    <string name="app_them_dark">অন্ধকার</string>
-    <string name="app_theme_light">আলো</string>
-    <string name="app_theme_black">কালো</string>
-    <string name="app_theme_auto">সূর্যাস্ত স্বয়ংক্রিয়</string>
-    <string name="app_theme_system">সিস্টেম ডিজাইন ব্যবহার করুন</string>
     <string name="pref_title_browser_settings">ব্রাউজার</string>
     <string name="pref_title_custom_tabs">ক্রোম কাস্টম ট্যাব ব্যবহার করুন</string>
     <string name="pref_title_hide_follow_button">স্ক্রোল করার সময় রচনা বোতাম লুকান</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -195,11 +195,6 @@
     <string name="pref_title_app_theme">Tema</string>
     <string name="pref_title_timelines">Cronologia</string>
     <string name="pref_title_timeline_filters">Filtres</string>
-    <string name="app_them_dark">Fosc</string>
-    <string name="app_theme_light">Clar</string>
-    <string name="app_theme_black">Negre</string>
-    <string name="app_theme_auto">Brillantor automàtica</string>
-    <string name="app_theme_system">Utilitzar el tema del sistema</string>
     <string name="pref_title_language">Idioma</string>
     <string name="pref_title_proxy_settings">Proxy</string>
     <string name="pref_title_http_proxy_settings">HTTP proxy</string>

--- a/app/src/main/res/values-ckb/strings.xml
+++ b/app/src/main/res/values-ckb/strings.xml
@@ -145,11 +145,6 @@
     <string name="pref_title_hide_follow_button">دوگمەی ئاوازدانان بشارەوە لەکاتی خشاندن</string>
     <string name="pref_title_custom_tabs">بەکارهێنانی خشتەبەندەکانی دڵخواز</string>
     <string name="pref_title_browser_settings">وێبگەڕ</string>
-    <string name="app_theme_system">دیزاینی سیستەم بەکاربهێنە</string>
-    <string name="app_theme_auto">خۆکار لە کاتی خۆرئاوابووندا</string>
-    <string name="app_theme_black">ڕەش</string>
-    <string name="app_theme_light">ڕووناکی</string>
-    <string name="app_them_dark">تاریک</string>
     <string name="pref_title_timeline_filters">فلتەرەکان</string>
     <string name="pref_title_app_theme">ڕووکاری ئەپ</string>
     <string name="pref_title_timelines">تایملاین</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -141,11 +141,6 @@
     <string name="pref_title_app_theme">Motiv aplikace</string>
     <string name="pref_title_timelines">Časové osy</string>
     <string name="pref_title_timeline_filters">Filtry</string>
-    <string name="app_them_dark">Tmavý</string>
-    <string name="app_theme_light">Světlý</string>
-    <string name="app_theme_black">Černý</string>
-    <string name="app_theme_auto">Automaticky při západu slunce</string>
-    <string name="app_theme_system">Použít systémový design</string>
     <string name="pref_title_browser_settings">Prohlížeč</string>
     <string name="pref_title_custom_tabs">Používat Vlastní karty Chrome</string>
     <string name="pref_title_hide_follow_button">Skrýt tlačítko pro psaní při rolování</string>

--- a/app/src/main/res/values-cy/strings.xml
+++ b/app/src/main/res/values-cy/strings.xml
@@ -124,10 +124,6 @@
     <string name="pref_title_notification_filter_favourites">mae fy negeseuon yn cael eu hoffi</string>
     <string name="pref_title_appearance_settings">Gwedd</string>
     <string name="pref_title_app_theme">Thema\'r ap</string>
-    <string name="app_them_dark">Tywyll</string>
-    <string name="app_theme_light">Golau</string>
-    <string name="app_theme_black">Du</string>
-    <string name="app_theme_auto">Awtomatig wrth iddi nosi</string>
     <string name="pref_title_browser_settings">Porwr</string>
     <string name="pref_title_custom_tabs">Defnyddio Tabiau Cyfaddas Chrome</string>
     <string name="pref_title_hide_follow_button">Cuddio\'r botwm creu wrth sgrolio </string>
@@ -379,7 +375,6 @@
     <string name="button_continue">Parhau</string>
     <string name="button_back">Nôl</string>
     <string name="hint_additional_info">Sylwadau ychwanegol</string>
-    <string name="app_theme_system">Defnyddio arddull y system</string>
     <string name="pref_main_nav_position">Prif lleoliad y panel llywio</string>
     <string name="pref_title_animate_gif_avatars">Animeiddio lluniau proffil GIF</string>
     <string name="pref_default_media_sensitivity">Nodi cyfryngau yn sensitif bob tro</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -141,11 +141,6 @@
     <string name="pref_title_app_theme">App-Design</string>
     <string name="pref_title_timelines">Timelines</string>
     <string name="pref_title_timeline_filters">Filter</string>
-    <string name="app_them_dark">Dunkel</string>
-    <string name="app_theme_light">Hell</string>
-    <string name="app_theme_black">Schwarz</string>
-    <string name="app_theme_auto">Automatisch bei Sonnenuntergang</string>
-    <string name="app_theme_system">Systemdesign verwenden</string>
     <string name="pref_title_browser_settings">Browser</string>
     <string name="pref_title_custom_tabs">Links in der App öffnen (Chrome Custom Tabs)</string>
     <string name="pref_title_hide_follow_button">»Verfassen«-Schaltfläche beim Scrollen ausblenden</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -141,11 +141,6 @@
     <string name="pref_title_app_theme">Temo de la apo</string>
     <string name="pref_title_timelines">Tempolinioj</string>
     <string name="pref_title_timeline_filters">Filtriloj</string>
-    <string name="app_them_dark">Malhela</string>
-    <string name="app_theme_light">Hela</string>
-    <string name="app_theme_black">Nigra</string>
-    <string name="app_theme_auto">Aŭtomata laŭ la horo</string>
-    <string name="app_theme_system">Uzi sisteman etoson</string>
     <string name="pref_title_browser_settings">Retumilo</string>
     <string name="pref_title_custom_tabs">Uzi la integritan retumilon</string>
     <string name="pref_title_hide_follow_button">Kaŝi butonon de verko dum rulumado</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -130,10 +130,6 @@
     <string name="pref_title_appearance_settings">Apariencia</string>
     <string name="pref_title_app_theme">Tema de la app</string>
     <string name="pref_title_timelines">Cronologia</string>
-    <string name="app_them_dark">Oscuro</string>
-    <string name="app_theme_light">Claro</string>
-    <string name="app_theme_black">Negro</string>
-    <string name="app_theme_auto">Automático</string>
     <string name="pref_title_browser_settings">Navegador</string>
     <string name="pref_title_custom_tabs">Usar pestañas de Chrome</string>
     <string name="pref_title_hide_follow_button">Ocultar botón de redacción al bajar</string>
@@ -265,7 +261,6 @@
     <string name="action_open_faved_by">Mostrar favoritos</string>
     <string name="title_mentions_dialog">Menciones</string>
     <string name="download_media">Descargar multimedia</string>
-    <string name="app_theme_system">Usar tema del sistema</string>
     <string name="pref_title_language">Idioma</string>
     <string name="action_unreblog">Dejar de impulsar</string>
     <string name="action_unfavourite">Eliminar favorito</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -126,10 +126,6 @@
     <string name="pref_title_appearance_settings">Interfazea</string>
     <string name="pref_title_app_theme">Gaia</string>
     <string name="pref_title_timelines">Denbora-lerroak</string>
-    <string name="app_them_dark">Iluna</string>
-    <string name="app_theme_light">Argia</string>
-    <string name="app_theme_black">Beltza</string>
-    <string name="app_theme_auto">Automatikoa</string>
     <string name="pref_title_browser_settings">Nabigatzailea</string>
     <string name="pref_title_custom_tabs">Chromeko fitxak erabili</string>
     <string name="pref_title_hide_follow_button">Tut berria idazteko botoia ezkutatu beherantz joan einean</string>
@@ -264,7 +260,6 @@
     <string name="mute_domain_warning_dialog_ok">Domeinu osoa ezkutatu</string>
     <string name="pref_title_notification_filter_poll">Galdeketak bukatu dira</string>
     <string name="pref_title_timeline_filters">Iragazkiak</string>
-    <string name="app_theme_system">Erabili sistemaren diseinua</string>
     <string name="pref_title_language">Hizkuntza</string>
     <string name="pref_title_bot_overlay">Botentzako erakuslea erakutsi</string>
     <string name="pref_title_animate_gif_avatars">GIF abatarrak animatu</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -125,10 +125,6 @@
     <string name="pref_title_appearance_settings">ظاهر</string>
     <string name="pref_title_app_theme">زمینهٔ کاره</string>
     <string name="pref_title_timelines">خط‌ زمانی‌ها</string>
-    <string name="app_them_dark">تاریک</string>
-    <string name="app_theme_light">روشن</string>
-    <string name="app_theme_black">سیاه</string>
-    <string name="app_theme_auto">خودکار در غروب</string>
     <string name="pref_title_browser_settings">مرورگر</string>
     <string name="pref_title_custom_tabs">استفاده از زبانه‌های سفارشی کروم</string>
     <string name="pref_title_hide_follow_button">نهفتن دکمهٔ ایجاد، هنگام پیمایش</string>
@@ -257,7 +253,6 @@
     <string name="mute_domain_warning_dialog_ok">نهفتن تمام دامنه</string>
     <string name="pref_title_notification_filter_poll">پایان نظرسنجی‌ها</string>
     <string name="pref_title_timeline_filters">پالایه‌ها</string>
-    <string name="app_theme_system">استفاده از طراحی سامانه</string>
     <string name="pref_title_language">زبان</string>
     <string name="pref_title_bot_overlay">نمایش نشانگر برای بات‌ها</string>
     <string name="pref_title_animate_gif_avatars">پویانمایی آواتارهای جیف</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="pref_title_animate_custom_emojis">Animoi mukautetut emojit</string>
     <string name="pref_title_animate_gif_avatars">Animoi GIF-avatarit</string>
-    <string name="app_theme_system">Seuraa laitteen teemaa</string>
     <string name="dialog_unfollow_warning">Lopeta tilin seuraaminen\?</string>
     <string name="dialog_delete_post_warning">Poista tuuttaus\?</string>
     <string name="action_copy_link">Kopioi linkki</string>
@@ -92,9 +91,6 @@
     <string name="pref_title_post_tabs">Välilehdet</string>
     <string name="pref_title_language">Kieli</string>
     <string name="pref_title_browser_settings">Selain</string>
-    <string name="app_theme_black">Musta</string>
-    <string name="app_theme_light">Vaalea</string>
-    <string name="app_them_dark">Tumma</string>
     <string name="pref_title_timeline_filters">Suodattimet</string>
     <string name="pref_title_timelines">Aikajanat</string>
     <string name="pref_title_notification_filter_follows">seurasi</string>
@@ -371,7 +367,6 @@
     <string name="state_follow_requested">Seuraamista pyydetty</string>
     <string name="compose_delete_draft">Poista luonnos?</string>
     <string name="notification_notification_worker">Ilmoituksia haetaan…</string>
-    <string name="app_theme_auto">Automaattisesti auringonlaskun aikaan</string>
     <string name="pref_title_notification_filter_favourites">tykätyt julkaisut</string>
     <string name="pref_post_text_size">Julkaisujen tekstikoko</string>
     <string name="send_post_notification_channel_name">Julkaisuja lähetetään</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -141,11 +141,6 @@
     <string name="pref_title_app_theme">Thème de l’application</string>
     <string name="pref_title_timelines">Fils chronologiques</string>
     <string name="pref_title_timeline_filters">Filtres</string>
-    <string name="app_them_dark">Sombre</string>
-    <string name="app_theme_light">Clair</string>
-    <string name="app_theme_black">Noir</string>
-    <string name="app_theme_auto">Basé sur le coucher du soleil</string>
-    <string name="app_theme_system">Utiliser le thème système</string>
     <string name="pref_title_browser_settings">Navigateur</string>
     <string name="pref_title_custom_tabs">Utiliser le navigateur intégré</string>
     <string name="pref_title_hide_follow_button">Masquer le bouton de composition lors du défilement</string>

--- a/app/src/main/res/values-fy/strings.xml
+++ b/app/src/main/res/values-fy/strings.xml
@@ -65,11 +65,6 @@
     <string name="pref_title_post_tabs">Ljepblêden</string>
     <string name="pref_title_language">Taal</string>
     <string name="pref_title_browser_settings">Webblêder</string>
-    <string name="app_theme_system">Systeem Opmaak Brûke</string>
-    <string name="app_theme_auto">Automatysk as de sinne ûnder giet</string>
-    <string name="app_theme_black">Swart</string>
-    <string name="app_theme_light">Ljocht</string>
-    <string name="app_them_dark">Tsjuster</string>
     <string name="pref_title_timeline_filters">Filters</string>
     <string name="pref_title_app_theme">Applikaasje Tema</string>
     <string name="pref_title_appearance_settings">Uterlik</string>

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -33,11 +33,6 @@
     <string name="pref_title_hide_follow_button">Folaigh an cnaipe cum agus tú ag scrollaigh</string>
     <string name="pref_title_custom_tabs">Úsáid Chrome Custom Tabs</string>
     <string name="pref_title_browser_settings">Brabhsálaí</string>
-    <string name="app_theme_system">Úsáid Dearadh Córais</string>
-    <string name="app_theme_auto">Uathoibríoch ag luí na gréine</string>
-    <string name="app_theme_black">Dubh</string>
-    <string name="app_theme_light">Éadrom</string>
-    <string name="app_them_dark">Dorcha</string>
     <string name="pref_title_timeline_filters">Scagairí</string>
     <string name="pref_title_timelines">Amlínte</string>
     <string name="pref_title_app_theme">Téama an Aip</string>

--- a/app/src/main/res/values-gd/strings.xml
+++ b/app/src/main/res/values-gd/strings.xml
@@ -328,11 +328,6 @@
     <string name="pref_title_hide_follow_button">Falaich am putan sgrìobhaidh fhad ’s a bhios mi ri sgroladh</string>
     <string name="pref_title_custom_tabs">Cleachd tabaichean Chrome gnàthaichte</string>
     <string name="pref_title_browser_settings">Brabhsair</string>
-    <string name="app_theme_system">Cleachd co-dhealbhachd an t-siostaim</string>
-    <string name="app_theme_auto">Gu fèin-obrachail aig beul na h-oidhche</string>
-    <string name="app_theme_black">Dubh</string>
-    <string name="app_theme_light">Soilleir</string>
-    <string name="app_them_dark">Dorcha</string>
     <string name="pref_title_timeline_filters">Criathragan</string>
     <string name="pref_title_timelines">Loidhnichean-ama</string>
     <string name="pref_title_app_theme">Ùrlar na h-aplacaid</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -318,11 +318,6 @@
     <string name="pref_title_hide_follow_button">Agochar o botón redactar ao desprazar</string>
     <string name="pref_title_custom_tabs">Usar lapelas personalizadas de Chrome</string>
     <string name="pref_title_browser_settings">Navegador</string>
-    <string name="app_theme_system">Usar deseño do sistema</string>
-    <string name="app_theme_auto">Automático ao solpor</string>
-    <string name="app_theme_black">Negro</string>
-    <string name="app_theme_light">Claro</string>
-    <string name="app_them_dark">Escuro</string>
     <string name="pref_title_timeline_filters">Filtros</string>
     <string name="pref_title_timelines">Cronoloxías</string>
     <string name="pref_title_app_theme">Decorado da app</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -76,10 +76,6 @@
     <string name="pref_title_hide_follow_button">स्क्रॉल करते समय कंपोज बटन को छिपाएं</string>
     <string name="pref_title_custom_tabs">क्रोम कस्टम टैब का उपयोग करें</string>
     <string name="pref_title_browser_settings">ब्राउज़र</string>
-    <string name="app_theme_system">सिस्टम डिज़ाइन का उपयोग करें</string>
-    <string name="app_theme_auto">सूर्यास्त के समय स्वचालित</string>
-    <string name="app_theme_black">Black</string>
-    <string name="app_them_dark">अंधकार</string>
     <string name="pref_title_timeline_filters">फिल्टर</string>
     <string name="pref_title_appearance_settings">दिखावट</string>
     <string name="pref_title_notification_filter_mentions">उल्लेख किया</string>
@@ -296,7 +292,6 @@
     <string name="pref_title_http_proxy_settings">एच टी टी पी प्रॉक्सी</string>
     <string name="pref_title_proxy_settings">प्रॉक्सी</string>
     <string name="pref_title_post_filter">टाइमलाइन छानने का काम</string>
-    <string name="app_theme_light">प्रकाश</string>
     <string name="pref_title_timelines">टाइमलाइन</string>
     <string name="pref_title_app_theme">एप्लिकेशन थीम</string>
     <string name="pref_title_notification_filter_favourites">मेरे पोस्ट पसंद किए गए</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -131,10 +131,6 @@
     <string name="pref_title_notification_filter_favourites">bejegyzésemet kedvencnek jelölték</string>
     <string name="pref_title_appearance_settings">Megjelenés</string>
     <string name="pref_title_timelines">Idővonalak</string>
-    <string name="app_them_dark">Sötét</string>
-    <string name="app_theme_light">Világos</string>
-    <string name="app_theme_black">Fekete</string>
-    <string name="app_theme_auto">Automatikus naplementekor</string>
     <string name="pref_title_browser_settings">Böngésző</string>
     <string name="pref_title_custom_tabs">Linkek megnyitása applikáción belül</string>
     <string name="pref_title_hide_follow_button">Szerkesztés gomb elrejtése görgetés közben</string>
@@ -236,7 +232,6 @@
     <string name="dialog_redraft_post_warning">Törlöd és újraírod ezt a bejegyzést\?</string>
     <string name="pref_title_notification_filter_poll">befejeződött egy szavazás</string>
     <string name="pref_title_timeline_filters">Szűrők</string>
-    <string name="app_theme_system">Rendszer téma használata</string>
     <string name="pref_title_language">Nyelv</string>
     <string name="pref_publishing">Közzététel (szerverrel szinkronizált)</string>
     <string name="notification_poll_name">Szavazások</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -82,9 +82,6 @@
     <string name="pref_title_notification_alert_sound">Beri tahu dengan suara</string>
     <string name="pref_title_notification_alert_vibrate">Beri tahu dengan getaran</string>
     <string name="pref_title_notification_alert_light">Beri tahu dengan lampu</string>
-    <string name="app_them_dark">Gelap</string>
-    <string name="app_theme_light">Terang</string>
-    <string name="app_theme_black">Hitam</string>
     <string name="pref_title_timelines">Linimasa</string>
     <string name="pref_title_app_theme">Tema Aplikasi</string>
     <string name="pref_title_browser_settings">Peramban</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -159,11 +159,6 @@
     <string name="pref_title_app_theme">Þema forrits</string>
     <string name="pref_title_timelines">Tímalínur</string>
     <string name="pref_title_timeline_filters">Síur</string>
-    <string name="app_them_dark">Dökkt</string>
-    <string name="app_theme_light">Ljóst</string>
-    <string name="app_theme_black">Svart</string>
-    <string name="app_theme_auto">Sjálfvirkt við sólarlag</string>
-    <string name="app_theme_system">Nota kerfishönnun</string>
     <string name="pref_title_browser_settings">Vafri</string>
     <string name="pref_title_custom_tabs">Nota sérsniðna flipa Chrome</string>
     <string name="pref_title_hide_follow_button">Fela \'Semja skilaboð\" hnapp sjálfvirkt við skrun</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -148,11 +148,6 @@
     <string name="pref_title_app_theme">Tema dell\'app</string>
     <string name="pref_title_timelines">Timeline</string>
     <string name="pref_title_timeline_filters">Filtri</string>
-    <string name="app_them_dark">Scuro</string>
-    <string name="app_theme_light">Chiaro</string>
-    <string name="app_theme_black">Nero</string>
-    <string name="app_theme_auto">Automatico al tramonto</string>
-    <string name="app_theme_system">Usa tema di sistema</string>
     <string name="pref_title_browser_settings">Browser</string>
     <string name="pref_title_custom_tabs">Usa schede personalizzate di Chrome</string>
     <string name="pref_title_hide_follow_button">Nascondi il pulsante Componi mentre scorri</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -133,10 +133,6 @@
     <string name="pref_title_app_theme">アプリテーマ</string>
     <string name="pref_title_timelines">タイムライン</string>
     <string name="pref_title_timeline_filters">フィルター</string>
-    <string name="app_them_dark">ダーク</string>
-    <string name="app_theme_light">ライト</string>
-    <string name="app_theme_black">ブラック</string>
-    <string name="app_theme_auto">日没による自動設定</string>
     <string name="pref_title_browser_settings">ブラウザ</string>
     <string name="pref_title_custom_tabs">Chrome Custom Tabsを使用する</string>
     <string name="pref_title_hide_follow_button">スクロール中は投稿ボタンを隠す</string>
@@ -268,7 +264,6 @@
     <string name="action_open_reblogged_by">ブーストを表示</string>
     <string name="download_media">メディアをダウンロード</string>
     <string name="downloading_media">メディアをダウンロード中</string>
-    <string name="app_theme_system">システムの設定を利用</string>
     <string name="notifications_clear">通知を削除</string>
     <string name="notifications_apply_filter">フィルター</string>
     <string name="notification_clear_text">すべての通知を完全に削除してよろしいですか？</string>

--- a/app/src/main/res/values-kab/strings.xml
+++ b/app/src/main/res/values-kab/strings.xml
@@ -61,8 +61,6 @@
     <string name="dialog_delete_post_warning">Kkes tijewwiqt-a\?</string>
     <string name="pref_title_edit_notification_settings">Ẓreg tilɣa</string>
     <string name="pref_title_appearance_settings">Agrudem</string>
-    <string name="app_theme_light">Aceɛlal</string>
-    <string name="app_theme_black">Aberkan</string>
     <string name="pref_title_language">Tutlayt</string>
     <string name="pref_title_post_tabs">Iccaren</string>
     <string name="pref_title_proxy_settings">Apṛuksi</string>
@@ -120,7 +118,6 @@
     <string name="dialog_message_uploading_media">Issalay…</string>
     <string name="pref_title_notification_filter_poll">fukken kran n wadɣaren</string>
     <string name="pref_title_timeline_filters">Imzizdigen</string>
-    <string name="app_theme_auto">Awurman akken yella yiṭij</string>
     <string name="pref_title_browser_settings">Iminig</string>
     <string name="pref_title_show_replies">Sken-d tiririyin</string>
     <string name="pref_title_http_proxy_settings">Apṛuksi HTTP</string>
@@ -276,7 +273,6 @@
     <string name="pref_update_notification_frequency_never">Werǧin</string>
     <string name="post_media_alt">ALT</string>
     <string name="action_post_failed_do_nothing">Zgel</string>
-    <string name="app_them_dark">Ubrik</string>
     <string name="pref_summary_http_proxy_disabled">Yensa</string>
     <string name="pref_main_nav_position_option_top">Afella</string>
     <string name="pref_main_nav_position_option_bottom">Adda</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -150,11 +150,6 @@
     <string name="pref_title_app_theme">어플리케이션 테마</string>
     <string name="pref_title_timelines">타임라인</string>
     <string name="pref_title_timeline_filters">필터</string>
-    <string name="app_them_dark">어두움</string>
-    <string name="app_theme_light">밝음</string>
-    <string name="app_theme_black">검정</string>
-    <string name="app_theme_auto">시간에 따라 자동으로 변경</string>
-    <string name="app_theme_system">시스템 기본값</string>
     <string name="pref_title_browser_settings">웹 브라우저</string>
     <string name="pref_title_custom_tabs">Chrome 커스텀 탭 사용</string>
     <string name="pref_title_hide_follow_button">스크롤 중에 글쓰기 버튼 감추기</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -244,9 +244,6 @@
     <string name="pref_title_notification_filter_mentions">pieminēja</string>
     <string name="pref_title_notification_filter_follows">sāka sekot</string>
     <string name="pref_title_notification_filter_sign_ups">kāds ir reģistrējies</string>
-    <string name="app_theme_black">Melna</string>
-    <string name="app_theme_auto">Automātiski saulrietā</string>
-    <string name="app_theme_system">Izmantot sistēmas dizainu</string>
     <string name="notification_mention_name">Jauni pieminējumi</string>
     <string name="notification_follow_name">Jauni sekotāji</string>
     <string name="notification_boost_name">Pastiprinājumi</string>
@@ -277,8 +274,6 @@
     <string name="dialog_unfollow_warning">Vai pārtraukt sekot šim kontam\?</string>
     <string name="pref_title_appearance_settings">Izskats</string>
     <string name="pref_title_timelines">Laika līnijas</string>
-    <string name="app_them_dark">Tumša</string>
-    <string name="app_theme_light">Gaiša</string>
     <string name="pref_title_app_theme">Lietotnes tēma</string>
     <string name="pref_title_notification_filter_poll">aptaujas ir noslēgušās</string>
     <string name="pref_main_nav_position_option_top">Augšā</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -115,7 +115,6 @@
     <string name="pref_title_thread_filter_keywords">സംഭാഷണങ്ങൾ</string>
     <string name="label_quick_reply">മറുപടി…</string>
     <string name="action_reject">നിരസിക്കുക</string>
-    <string name="app_theme_black">കറുപ്പ്</string>
     <string name="button_continue">തുടരുക</string>
     <string name="pref_title_timelines">സമയരേഖകൾ</string>
     <string name="pref_title_proxy_settings">പ്രോക്സി</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -286,11 +286,6 @@
     <string name="poll_info_time_absolute">avsluttes %s</string>
     <string name="poll_info_closed">stengt</string>
     <string name="poll_vote">Stem</string>
-    <string name="app_them_dark">Mørk</string>
-    <string name="app_theme_light">Lys</string>
-    <string name="app_theme_black">Svart</string>
-    <string name="app_theme_auto">Automatisk ved solnedgang</string>
-    <string name="app_theme_system">Bruk systeminnstillinger</string>
     <string name="post_privacy_public">Offentlig</string>
     <string name="post_privacy_unlisted">Ikke listet</string>
     <string name="post_privacy_followers_only">Kun følgere</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -138,11 +138,6 @@
     <string name="pref_title_appearance_settings">Uiterlijk</string>
     <string name="pref_title_app_theme">Thema</string>
     <string name="pref_title_timelines">Tijdlijnen</string>
-    <string name="app_them_dark">Donker</string>
-    <string name="app_theme_light">Licht</string>
-    <string name="app_theme_black">Zwart</string>
-    <string name="app_theme_auto">Automatisch tijdens zonsop- en ondergang</string>
-    <string name="app_theme_system">Systeemthema gebruiken</string>
     <string name="pref_title_browser_settings">Webbrowser</string>
     <string name="pref_title_custom_tabs">Aangepaste tabbladen gebruiken</string>
     <string name="pref_title_hide_follow_button">Verberg zwevende knop om een bericht te schrijven tijdens het scrollen</string>

--- a/app/src/main/res/values-oc/strings.xml
+++ b/app/src/main/res/values-oc/strings.xml
@@ -122,10 +122,6 @@
     <string name="pref_title_notification_filter_favourites">òm met mos tuts en favorit</string>
     <string name="pref_title_appearance_settings">Aparéncia</string>
     <string name="pref_title_app_theme">Tèma de l’app</string>
-    <string name="app_them_dark">Escur</string>
-    <string name="app_theme_light">Luminós</string>
-    <string name="app_theme_black">Negre</string>
-    <string name="app_theme_auto">Alba automatica</string>
     <string name="pref_title_browser_settings">Navegador</string>
     <string name="pref_title_custom_tabs">Onglets personalizats de Chrome</string>
     <string name="pref_title_hide_follow_button">Amagar lo boton de redaccion en desplaçament</string>
@@ -290,7 +286,6 @@
     <string name="compose_shortcut_short_label">Redactar</string>
     <string name="action_delete_and_redraft">Suprimir e reformular</string>
     <string name="dialog_redraft_post_warning">Suprimir e reformular aqueste tut \?</string>
-    <string name="app_theme_system">Utilizar lo tèma sistèma</string>
     <string name="notifications_clear">Netejar</string>
     <string name="notifications_apply_filter">Filtrar</string>
     <string name="filter_apply">Aplicar</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -120,10 +120,6 @@
     <string name="pref_title_notification_filter_favourites">moje posty zostaną dodane do ulubionych</string>
     <string name="pref_title_appearance_settings">Wygląd</string>
     <string name="pref_title_app_theme">Motyw</string>
-    <string name="app_them_dark">Ciemny</string>
-    <string name="app_theme_light">Jasny</string>
-    <string name="app_theme_black">Czarny</string>
-    <string name="app_theme_auto">Zmieniaj automatycznie po zachodzie słońca</string>
     <string name="pref_title_browser_settings">Przeglądarka</string>
     <string name="pref_title_custom_tabs">Używaj niestandardowych kart Chrome</string>
     <string name="pref_title_hide_follow_button">Ukryj przycisk nowego wpisu podczas przewijania</string>
@@ -255,7 +251,6 @@
     <string name="pref_title_notification_filter_poll">głosowania zostały zakończone</string>
     <string name="pref_title_timelines">Osi czasu</string>
     <string name="pref_title_timeline_filters">Filtry</string>
-    <string name="app_theme_system">Użyj motywu systemu</string>
     <string name="pref_title_language">Język</string>
     <string name="pref_title_bot_overlay">Pokaż oznaczenie dla botów</string>
     <string name="pref_title_animate_gif_avatars">Animuj avatary GIF</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -132,11 +132,6 @@
     <string name="pref_title_appearance_settings">Aparência</string>
     <string name="pref_title_app_theme">Tema do aplicativo</string>
     <string name="pref_title_timelines">Linhas do tempo</string>
-    <string name="app_them_dark">Escuro</string>
-    <string name="app_theme_light">Claro</string>
-    <string name="app_theme_black">AMOLED</string>
-    <string name="app_theme_auto">Automático no ocaso</string>
-    <string name="app_theme_system">Usar o tema do sistema</string>
     <string name="pref_title_browser_settings">Navegador</string>
     <string name="pref_title_custom_tabs">Usar abas personalizadas do Chrome</string>
     <string name="pref_title_hide_follow_button">Ocultar botão de compor ao rolar a tela</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -190,11 +190,6 @@
     <string name="pref_title_app_theme">Tema da Aplicação</string>
     <string name="pref_title_timelines">Timelines</string>
     <string name="pref_title_timeline_filters">Filtros</string>
-    <string name="app_them_dark">Escuro</string>
-    <string name="app_theme_light">Claro</string>
-    <string name="app_theme_black">AMOLED</string>
-    <string name="app_theme_auto">Automático ao pôr-do-sol</string>
-    <string name="app_theme_system">Usar o Tema do Sistema</string>
     <string name="pref_title_browser_settings">Navegador</string>
     <string name="pref_title_custom_tabs">Usar Separadores Personalizados do Chrome</string>
     <string name="pref_title_hide_follow_button">Esconder o botão de criação de toots ao fazer scroll</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -143,11 +143,6 @@
     <string name="pref_title_app_theme">Тема</string>
     <string name="pref_title_timelines">Ленты</string>
     <string name="pref_title_timeline_filters">Фильтры</string>
-    <string name="app_them_dark">Тёмная</string>
-    <string name="app_theme_light">Светлая</string>
-    <string name="app_theme_black">Чёрная</string>
-    <string name="app_theme_auto">Автоматическая (от заката до восхода солнца)</string>
-    <string name="app_theme_system">Как в системе</string>
     <string name="pref_title_browser_settings">Браузер</string>
     <string name="pref_title_custom_tabs">Используйте пользовательские вкладки Chrome</string>
     <string name="pref_title_hide_follow_button">Скрывать кнопку композиционирования гудка при прокрутке ленты</string>

--- a/app/src/main/res/values-sa/strings.xml
+++ b/app/src/main/res/values-sa/strings.xml
@@ -244,11 +244,6 @@
     <string name="pref_title_hide_follow_button">सारणक्रमे लेखनगण्डः छाद्यताम्</string>
     <string name="pref_title_custom_tabs">क्रोमस्वीयानुकूलपीठिकाः प्रयुज्यन्ताम्</string>
     <string name="pref_title_browser_settings">जालसञ्चारकम्</string>
-    <string name="app_theme_system">प्रणाल्याः परिकल्पना प्रयुज्यताम्</string>
-    <string name="app_theme_auto">सूर्यास्तसमये स्वचालितम्</string>
-    <string name="app_theme_black">कृष्णः</string>
-    <string name="app_theme_light">ज्योतिपूर्णः</string>
-    <string name="app_them_dark">अन्धकारः</string>
     <string name="pref_title_timeline_filters">शोधकम्</string>
     <string name="pref_title_timelines">समयतालिकाः</string>
     <string name="pref_title_app_theme">अनुप्रयोगप्रबन्धाः</string>

--- a/app/src/main/res/values-si/strings.xml
+++ b/app/src/main/res/values-si/strings.xml
@@ -68,11 +68,9 @@
     <string name="report_comment_hint">අතිරේක අදහස්\?</string>
     <string name="pref_title_notification_filter_mentions">සඳහන් කළ</string>
     <string name="send_post_link_to">වෙත ටූට් ඒ.ස.නි. බෙදාගන්න…</string>
-    <string name="app_theme_light">දීප්ත</string>
     <string name="compose_save_draft">කටුපිටපත සුරකින්නද\?</string>
     <string name="post_sensitive_media_title">සංවේදී අන්තර්ගතයකි</string>
     <string name="action_bookmark">පොත්යොමුව</string>
-    <string name="app_theme_auto">ස්වයංක්‍රීව ඉර බැසීමේදී</string>
     <string name="failed_report">වාර්තා කිරීමට අසමත් විය</string>
     <string name="abbreviated_years_ago">අවු. %d</string>
     <string name="action_open_faved_by">ප්‍රියතමයන් පෙන්වන්න</string>
@@ -135,7 +133,6 @@
     <string name="pref_default_media_sensitivity">සැමවිටම මාධ්‍ය සංවේදී ලෙස සලකුණු කරන්න</string>
     <string name="restart_required">යෙදුම යළි ඇරඹීම ඇවැසිය</string>
     <string name="restart">යළි අරඹන්න</string>
-    <string name="app_theme_black">කළු</string>
     <string name="abbreviated_in_years">වර්. %d කින්</string>
     <string name="restart_emoji">මෙම වෙනස්කම් යෙදීමට ඔබ ටුස්කි නැවත ඇරඹිය යුතුය</string>
     <string name="action_edit">සංස්කරණය</string>
@@ -230,7 +227,6 @@
     <string name="post_media_video">දෘශ්‍යකය</string>
     <string name="later">පසුව</string>
     <string name="action_edit_own_profile">සංස්කරණය</string>
-    <string name="app_them_dark">අඳුරු</string>
     <string name="send_post_notification_title">ටූට් යැවෙමින්…</string>
     <string name="system_default">පද්ධති පෙරනිමිය</string>
     <string name="action_mention">සඳැහුම</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -283,11 +283,6 @@
     <string name="poll_info_closed">zaprto</string>
     <string name="poll_vote">Glasovanje</string>
     <string name="pref_title_notification_filter_poll">ankete so se končala</string>
-    <string name="app_them_dark">Temna</string>
-    <string name="app_theme_light">Svetla</string>
-    <string name="app_theme_black">Črna</string>
-    <string name="app_theme_auto">Samodejno ob sončnem zahodu</string>
-    <string name="app_theme_system">Uporabi sistemsko temo</string>
     <string name="post_privacy_public">Javno</string>
     <string name="post_privacy_unlisted">Ni prikazano</string>
     <string name="post_privacy_followers_only">Samo za sledilce</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -139,11 +139,6 @@
     <string name="pref_title_app_theme">Apptema</string>
     <string name="pref_title_timelines">Tidslinjer</string>
     <string name="pref_title_timeline_filters">Filter</string>
-    <string name="app_them_dark">Mörkt</string>
-    <string name="app_theme_light">Ljust</string>
-    <string name="app_theme_black">Svart</string>
-    <string name="app_theme_auto">Automatiskt vid solnedgång</string>
-    <string name="app_theme_system">Använd system-tema</string>
     <string name="pref_title_browser_settings">Webbläsare</string>
     <string name="pref_title_custom_tabs">Använd Chrome-anpassade flikar</string>
     <string name="pref_title_hide_follow_button">Dölj skriv-knappen vid skrollning</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -116,10 +116,6 @@
     <string name="pref_title_notification_filter_favourites">என் பதிவுகள் பிடித்தவையானால்</string>
     <string name="pref_title_appearance_settings">தோற்றம்</string>
     <string name="pref_title_app_theme">செயலியின் தீம்</string>
-    <string name="app_them_dark">கருமை</string>
-    <string name="app_theme_light">வெளிச்சம்</string>
-    <string name="app_theme_black">பிளாக்</string>
-    <string name="app_theme_auto">தானியங்கி</string>
     <string name="pref_title_browser_settings">உலாவி</string>
     <string name="pref_title_custom_tabs">Chrome தனிப்பயன் கீற்றை பயன்படுத்து</string>
     <string name="pref_title_hide_follow_button">உருளலின் போது எழுது பொத்தானை மறை</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -198,11 +198,6 @@
     <string name="pref_title_hide_follow_button">ซ่อนปุ่มเขียนเมื่อกำลังเลื่อนจอ</string>
     <string name="pref_title_custom_tabs">ใช้ Chrome Custom Tabs</string>
     <string name="pref_title_browser_settings">เบราว์เซอร์</string>
-    <string name="app_theme_system">ใช้ตามแบบระบบ</string>
-    <string name="app_theme_auto">ปรับตามเวลา</string>
-    <string name="app_theme_black">ดำ</string>
-    <string name="app_theme_light">สว่าง</string>
-    <string name="app_them_dark">มืด</string>
     <string name="pref_title_timeline_filters">คัดกรอง</string>
     <string name="pref_title_timelines">ไทม์ไลน์</string>
     <string name="pref_title_app_theme">ธีมแอป</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -131,10 +131,6 @@
     <string name="pref_title_appearance_settings">Görünüş</string>
     <string name="pref_title_app_theme">Uygulama teması</string>
     <string name="pref_title_timelines">Ağ akışı</string>
-    <string name="app_them_dark">Koyu</string>
-    <string name="app_theme_light">Açık</string>
-    <string name="app_theme_black">Siyah</string>
-    <string name="app_theme_auto">Gün batımında otomatik</string>
     <string name="pref_title_browser_settings">Tarayıcı</string>
     <string name="pref_title_custom_tabs">Chrome Özel Sekmelerini Kullan</string>
     <string name="pref_title_hide_follow_button">Kaydırırken gönderi oluşturma düğmesi gizlensin</string>
@@ -267,7 +263,6 @@
     <string name="mute_domain_warning">%s\? alan adından gelen her şeyi engellemek istediğinden emin misin\? Bu alan adından gelen içeriği herhangi bir genel zaman tünelinde veya bildirimlerinde göremezsiniz. Bu alan adındaki takipçilerin de kaldırılacak.</string>
     <string name="pref_title_notification_filter_poll">anketler sona erdiğinde</string>
     <string name="pref_title_timeline_filters">Süzgeçler</string>
-    <string name="app_theme_system">Sistem tasarımını kullan</string>
     <string name="pref_title_language">Dil</string>
     <string name="pref_title_animate_gif_avatars">Hareketli GIF görsellerini oynat</string>
     <string name="notification_poll_name">Anketler</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -335,11 +335,6 @@
     <string name="pref_title_hide_follow_button">Ховати кнопку написати під час прокручування</string>
     <string name="pref_title_custom_tabs">Вкладки вбудованого браузера Chrome</string>
     <string name="pref_title_browser_settings">Браузер</string>
-    <string name="app_theme_system">Тема системи</string>
-    <string name="app_theme_auto">Автоматична від заходу сонця</string>
-    <string name="app_theme_black">Чорна</string>
-    <string name="app_theme_light">Світла</string>
-    <string name="app_them_dark">Темна</string>
     <string name="pref_title_timeline_filters">Фільтри</string>
     <string name="pref_title_timelines">Стрічки</string>
     <string name="pref_title_app_theme">Тема застосунку</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -171,11 +171,6 @@
     <string name="pref_title_hide_follow_button">Ẩn nút soạn tút</string>
     <string name="pref_title_custom_tabs">Mở luôn trong app</string>
     <string name="pref_title_browser_settings">Trình duyệt</string>
-    <string name="app_theme_system">Mặc định của thiết bị</string>
-    <string name="app_theme_auto">Tự động khi trời tối</string>
-    <string name="app_theme_black">Đen</string>
-    <string name="app_theme_light">Sáng</string>
-    <string name="app_them_dark">Tối</string>
     <string name="pref_title_timeline_filters">Bộ lọc</string>
     <string name="pref_title_timelines">Bảng tin</string>
     <string name="pref_title_app_theme">Chủ đề</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -144,11 +144,6 @@
     <string name="pref_title_app_theme">应用主题</string>
     <string name="pref_title_timelines">时间轴</string>
     <string name="pref_title_timeline_filters">过滤器</string>
-    <string name="app_them_dark">暗色</string>
-    <string name="app_theme_light">亮色</string>
-    <string name="app_theme_black">黑色</string>
-    <string name="app_theme_auto">自动切换</string>
-    <string name="app_theme_system">跟随系统设定</string>
     <string name="pref_title_browser_settings">浏览器</string>
     <string name="pref_title_custom_tabs">使用 Chrome Custom Tabs</string>
     <string name="pref_title_hide_follow_button">浏览时自动隐藏发嘟按钮</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -144,11 +144,6 @@
     <string name="pref_title_app_theme">佈景主題</string>
     <string name="pref_title_timelines">時間軸</string>
     <string name="pref_title_timeline_filters">過濾器</string>
-    <string name="app_them_dark">黑夜</string>
-    <string name="app_theme_light">白天</string>
-    <string name="app_theme_black">暗色</string>
-    <string name="app_theme_auto">自動切換</string>
-    <string name="app_theme_system">跟隨系統</string>
     <string name="pref_title_browser_settings">瀏覽器</string>
     <string name="pref_title_custom_tabs">使用 Chrome Custom Tabs</string>
     <string name="pref_title_hide_follow_button">瀏覽時自動隱藏發嘟按鈕</string>

--- a/app/src/main/res/values-zh-rMO/strings.xml
+++ b/app/src/main/res/values-zh-rMO/strings.xml
@@ -144,11 +144,6 @@
     <string name="pref_title_app_theme">佈景主題</string>
     <string name="pref_title_timelines">時間軸</string>
     <string name="pref_title_timeline_filters">過濾器</string>
-    <string name="app_them_dark">黑夜</string>
-    <string name="app_theme_light">白天</string>
-    <string name="app_theme_black">暗色</string>
-    <string name="app_theme_auto">自動切換</string>
-    <string name="app_theme_system">跟隨系統</string>
     <string name="pref_title_browser_settings">瀏覽器</string>
     <string name="pref_title_custom_tabs">使用 Chrome Custom Tabs</string>
     <string name="pref_title_hide_follow_button">瀏覽時自動隱藏發嘟按鈕</string>

--- a/app/src/main/res/values-zh-rSG/strings.xml
+++ b/app/src/main/res/values-zh-rSG/strings.xml
@@ -144,11 +144,6 @@
     <string name="pref_title_app_theme">应用主题</string>
     <string name="pref_title_timelines">时间轴</string>
     <string name="pref_title_timeline_filters">过滤器</string>
-    <string name="app_them_dark">黑夜</string>
-    <string name="app_theme_light">白天</string>
-    <string name="app_theme_black">暗色</string>
-    <string name="app_theme_auto">自动切换</string>
-    <string name="app_theme_system">跟随系统设定</string>
     <string name="pref_title_browser_settings">浏览器</string>
     <string name="pref_title_custom_tabs">使用 Chrome Custom Tabs</string>
     <string name="pref_title_hide_follow_button">浏览时自动隐藏发嘟按钮</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -144,11 +144,6 @@
     <string name="pref_title_app_theme">佈景主題</string>
     <string name="pref_title_timelines">時間軸</string>
     <string name="pref_title_timeline_filters">過濾器</string>
-    <string name="app_them_dark">黑夜</string>
-    <string name="app_theme_light">白天</string>
-    <string name="app_theme_black">暗色</string>
-    <string name="app_theme_auto">自動切換</string>
-    <string name="app_theme_system">跟隨系統</string>
     <string name="pref_title_browser_settings">瀏覽器</string>
     <string name="pref_title_custom_tabs">使用 Chrome Custom Tabs</string>
     <string name="pref_title_hide_follow_button">瀏覽時自動隱藏發嘟按鈕</string>

--- a/app/src/main/res/values/string-arrays.xml
+++ b/app/src/main/res/values/string-arrays.xml
@@ -1,16 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-
-    <!-- Modifications to this list or order must be kept in sync with
-         SettingsConstants.AppTheme -->
-    <string-array name="app_theme_names">
-        <item>@string/app_them_dark</item>
-        <item>@string/app_theme_light</item>
-        <item>@string/app_theme_black</item>
-        <item>@string/app_theme_auto</item>
-        <item>@string/app_theme_system</item>
-    </string-array>
-
     <string-array name="post_privacy_names">
         <item>@string/post_privacy_public</item>
         <item>@string/post_privacy_unlisted</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -256,11 +256,6 @@
     <string name="pref_title_timelines">Timelines</string>
     <string name="pref_title_timeline_filters">Filters</string>
     <string name="pref_summary_timeline_filters">Your server does not support filters</string>
-    <string name="app_them_dark">Dark</string>
-    <string name="app_theme_light">Light</string>
-    <string name="app_theme_black">Black</string>
-    <string name="app_theme_auto">Automatic at sunset</string>
-    <string name="app_theme_system">Use system design</string>
     <string name="pref_title_browser_settings">Browser</string>
     <string name="pref_title_custom_tabs">Use Chrome Custom Tabs</string>
     <string name="pref_title_hide_follow_button">Hide compose button while scrolling</string>

--- a/core/activity/src/main/kotlin/app/pachli/core/activity/BaseActivity.kt
+++ b/core/activity/src/main/kotlin/app/pachli/core/activity/BaseActivity.kt
@@ -99,7 +99,7 @@ abstract class BaseActivity : AppCompatActivity(), MenuProvider {
         }
 
         // Set the theme from preferences
-        val theme = AppTheme.from(sharedPreferencesRepository)
+        val theme = sharedPreferencesRepository.appTheme
         Timber.d("activeTheme: %s", theme)
         if (theme == AppTheme.BLACK) {
             setTheme(DR.style.Theme_Pachli_Black)

--- a/core/preferences/src/main/kotlin/app/pachli/core/preferences/AppTheme.kt
+++ b/core/preferences/src/main/kotlin/app/pachli/core/preferences/AppTheme.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.core.preferences
+
+/** Application theme choices. */
+enum class AppTheme(override val displayResource: Int, override val value: String) : PreferenceEnum {
+    NIGHT(R.string.app_theme_dark, "night"),
+    DAY(R.string.app_theme_light, "day"),
+    BLACK(R.string.app_theme_black, "black"),
+    AUTO(R.string.app_theme_auto, "auto"),
+    AUTO_SYSTEM(R.string.app_theme_system, "auto_system"),
+}

--- a/core/preferences/src/main/kotlin/app/pachli/core/preferences/PreferenceEnum.kt
+++ b/core/preferences/src/main/kotlin/app/pachli/core/preferences/PreferenceEnum.kt
@@ -18,6 +18,7 @@
 package app.pachli.core.preferences
 
 import androidx.annotation.StringRes
+import kotlin.enums.enumEntries
 
 /**
  * Interface for enums that can be saved/restored from [SharedPreferencesRepository].
@@ -39,13 +40,15 @@ interface PreferenceEnum {
          * @return The enum identified by [s], or null if the enum does not have [s] as
          * a string representation.
          */
-        inline fun <reified T : Enum<T>> from(s: String?): T? {
-            s ?: return null
-
-            return try {
-                enumValueOf<T>(s)
-            } catch (_: IllegalArgumentException) {
-                null
+        inline fun <reified E> from(
+            s: String?,
+        ): E?
+            where E : Enum<E>,
+                  E : PreferenceEnum {
+            // Can't use enumValueOf as the stored value might be the `value`
+            // property, not the enum name.
+            return s?.let {
+                enumEntries<E>().associateBy { it.value ?: it.name }[s]
             }
         }
     }

--- a/core/preferences/src/main/kotlin/app/pachli/core/preferences/SettingsConstants.kt
+++ b/core/preferences/src/main/kotlin/app/pachli/core/preferences/SettingsConstants.kt
@@ -1,34 +1,6 @@
 package app.pachli.core.preferences
 
 /**
- * Possible themes.
- *
- * The order of the values is important, and must be kept in sync with
- * R.array.app_theme_names.
- */
-enum class AppTheme(val value: String) {
-    NIGHT("night"),
-    DAY("day"),
-    BLACK("black"),
-    AUTO("auto"),
-    AUTO_SYSTEM("auto_system"),
-    ;
-
-    companion object {
-        val APP_THEME_DEFAULT = AUTO_SYSTEM
-
-        fun stringValues() = entries.map { it.value }.toTypedArray()
-
-        fun from(sharedPreferencesRepository: SharedPreferencesRepository): AppTheme {
-            val pref = sharedPreferencesRepository.getString(PrefKeys.APP_THEME, null)
-                ?: return APP_THEME_DEFAULT
-
-            return enumValueOf(pref.uppercase())
-        }
-    }
-}
-
-/**
  * Current preferences schema version. Format is 4-digit year + 2 digit month (zero padded) + 2
  * digit day (zero padded) + 2 digit counter (zero padded).
  *

--- a/core/preferences/src/main/kotlin/app/pachli/core/preferences/SharedPreferencesExtensions.kt
+++ b/core/preferences/src/main/kotlin/app/pachli/core/preferences/SharedPreferencesExtensions.kt
@@ -11,8 +11,11 @@ fun SharedPreferences.getNonNullString(key: String, defValue: String): String {
  * in preferences, or the value can not be converted to [E], then [defValue] is
  * returned.
  */
-inline fun <reified E : Enum<E>> SharedPreferences.getEnum(key: String, defValue: E): E {
-    val enumVal = getString(key, null) ?: return defValue
-
-    return PreferenceEnum.from<E>(enumVal) ?: defValue
+inline fun <reified E> SharedPreferences.getEnum(
+    key: String,
+    defValue: E,
+): E
+    where E : Enum<E>,
+          E : PreferenceEnum {
+    return getString(key, null)?.let { PreferenceEnum.from<E>(it) } ?: defValue
 }

--- a/core/preferences/src/main/kotlin/app/pachli/core/preferences/SharedPreferencesRepository.kt
+++ b/core/preferences/src/main/kotlin/app/pachli/core/preferences/SharedPreferencesRepository.kt
@@ -45,6 +45,10 @@ class SharedPreferencesRepository @Inject constructor(
      */
     val changes = MutableSharedFlow<String?>()
 
+    /** Application theme. */
+    val appTheme: AppTheme
+        get() = getEnum(PrefKeys.APP_THEME, AppTheme.AUTO_SYSTEM)
+
     /** Location of downloaded files. */
     val downloadLocation: DownloadLocation
         get() = getEnum(PrefKeys.DOWNLOAD_LOCATION, DownloadLocation.DOWNLOADS)

--- a/core/preferences/src/main/res/values-ar/strings.xml
+++ b/core/preferences/src/main/res/values-ar/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">فاتحة</string>
+    <string name="app_theme_black">سوداء</string>
+    <string name="app_theme_auto">تلقائي عند غروب الشمس</string>
+    <string name="app_theme_dark">داكنة</string>
+    <string name="app_theme_system">استخدم مظهر النظام</string>
+</resources>

--- a/core/preferences/src/main/res/values-be/strings.xml
+++ b/core/preferences/src/main/res/values-be/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">Светлая</string>
+    <string name="app_theme_black">Чорная</string>
+    <string name="app_theme_auto">Аўтаматычна па захадзе сонца</string>
+    <string name="app_theme_dark">Цёмная</string>
+    <string name="app_theme_system">Выкарыстоўваць сістэмную тэму</string>
+</resources>

--- a/core/preferences/src/main/res/values-bg/strings.xml
+++ b/core/preferences/src/main/res/values-bg/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">Светло</string>
+    <string name="app_theme_black">Черно</string>
+    <string name="app_theme_auto">Автоматично при залез</string>
+    <string name="app_theme_dark">Тъмно</string>
+    <string name="app_theme_system">Използване на системния дизайн</string>
+</resources>

--- a/core/preferences/src/main/res/values-bn-rBD/strings.xml
+++ b/core/preferences/src/main/res/values-bn-rBD/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">আলো</string>
+    <string name="app_theme_black">কালো</string>
+    <string name="app_theme_auto">সূর্যাস্ত স্বয়ংক্রিয়</string>
+    <string name="app_theme_dark">অন্ধকার</string>
+    <string name="app_theme_system">সিস্টেম ডিজাইন ব্যবহার করুন</string>
+</resources>

--- a/core/preferences/src/main/res/values-bn-rIN/strings.xml
+++ b/core/preferences/src/main/res/values-bn-rIN/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">আলো</string>
+    <string name="app_theme_black">কালো</string>
+    <string name="app_theme_auto">সূর্যাস্ত স্বয়ংক্রিয়</string>
+    <string name="app_theme_dark">অন্ধকার</string>
+    <string name="app_theme_system">সিস্টেম ডিজাইন ব্যবহার করুন</string>
+</resources>

--- a/core/preferences/src/main/res/values-ca/strings.xml
+++ b/core/preferences/src/main/res/values-ca/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">Clar</string>
+    <string name="app_theme_black">Negre</string>
+    <string name="app_theme_auto">Brillantor automàtica</string>
+    <string name="app_theme_dark">Fosc</string>
+    <string name="app_theme_system">Utilitzar el tema del sistema</string>
+</resources>

--- a/core/preferences/src/main/res/values-ckb/strings.xml
+++ b/core/preferences/src/main/res/values-ckb/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">ڕووناکی</string>
+    <string name="app_theme_black">ڕەش</string>
+    <string name="app_theme_auto">خۆکار لە کاتی خۆرئاوابووندا</string>
+    <string name="app_theme_dark">تاریک</string>
+    <string name="app_theme_system">دیزاینی سیستەم بەکاربهێنە</string>
+</resources>

--- a/core/preferences/src/main/res/values-cs/strings.xml
+++ b/core/preferences/src/main/res/values-cs/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">Světlý</string>
+    <string name="app_theme_black">Černý</string>
+    <string name="app_theme_auto">Automaticky při západu slunce</string>
+    <string name="app_theme_dark">Tmavý</string>
+    <string name="app_theme_system">Použít systémový design</string>
+</resources>

--- a/core/preferences/src/main/res/values-cy/strings.xml
+++ b/core/preferences/src/main/res/values-cy/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">Golau</string>
+    <string name="app_theme_black">Du</string>
+    <string name="app_theme_auto">Awtomatig wrth iddi nosi</string>
+    <string name="app_theme_dark">Tywyll</string>
+    <string name="app_theme_system">Defnyddio arddull y system</string>
+</resources>

--- a/core/preferences/src/main/res/values-de/strings.xml
+++ b/core/preferences/src/main/res/values-de/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">Hell</string>
+    <string name="app_theme_black">Schwarz</string>
+    <string name="app_theme_auto">Automatisch bei Sonnenuntergang</string>
+    <string name="app_theme_dark">Dunkel</string>
+    <string name="app_theme_system">Systemdesign verwenden</string>
+</resources>

--- a/core/preferences/src/main/res/values-eo/strings.xml
+++ b/core/preferences/src/main/res/values-eo/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">Hela</string>
+    <string name="app_theme_black">Nigra</string>
+    <string name="app_theme_auto">Aŭtomata laŭ la horo</string>
+    <string name="app_theme_dark">Malhela</string>
+    <string name="app_theme_system">Uzi sisteman etoson</string>
+</resources>

--- a/core/preferences/src/main/res/values-es/strings.xml
+++ b/core/preferences/src/main/res/values-es/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">Claro</string>
+    <string name="app_theme_black">Negro</string>
+    <string name="app_theme_auto">Automático</string>
+    <string name="app_theme_dark">Oscuro</string>
+    <string name="app_theme_system">Usar tema del sistema</string>
+</resources>

--- a/core/preferences/src/main/res/values-eu/strings.xml
+++ b/core/preferences/src/main/res/values-eu/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">Argia</string>
+    <string name="app_theme_black">Beltza</string>
+    <string name="app_theme_auto">Automatikoa</string>
+    <string name="app_theme_dark">Iluna</string>
+    <string name="app_theme_system">Erabili sistemaren diseinua</string>
+</resources>

--- a/core/preferences/src/main/res/values-fa/strings.xml
+++ b/core/preferences/src/main/res/values-fa/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">روشن</string>
+    <string name="app_theme_black">سیاه</string>
+    <string name="app_theme_auto">خودکار در غروب</string>
+    <string name="app_theme_dark">تاریک</string>
+    <string name="app_theme_system">استفاده از طراحی سامانه</string>
+</resources>

--- a/core/preferences/src/main/res/values-fi/strings.xml
+++ b/core/preferences/src/main/res/values-fi/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">Vaalea</string>
+    <string name="app_theme_black">Musta</string>
+    <string name="app_theme_auto">Automaattisesti auringonlaskun aikaan</string>
+    <string name="app_theme_dark">Tumma</string>
+    <string name="app_theme_system">Seuraa laitteen teemaa</string>
+</resources>

--- a/core/preferences/src/main/res/values-fr/strings.xml
+++ b/core/preferences/src/main/res/values-fr/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">Clair</string>
+    <string name="app_theme_black">Noir</string>
+    <string name="app_theme_auto">Basé sur le coucher du soleil</string>
+    <string name="app_theme_dark">Sombre</string>
+    <string name="app_theme_system">Utiliser le thème système</string>
+</resources>

--- a/core/preferences/src/main/res/values-fy/strings.xml
+++ b/core/preferences/src/main/res/values-fy/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">Ljocht</string>
+    <string name="app_theme_black">Swart</string>
+    <string name="app_theme_auto">Automatysk as de sinne ûnder giet</string>
+    <string name="app_theme_dark">Tsjuster</string>
+    <string name="app_theme_system">Systeem Opmaak Brûke</string>
+</resources>

--- a/core/preferences/src/main/res/values-ga/strings.xml
+++ b/core/preferences/src/main/res/values-ga/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">Éadrom</string>
+    <string name="app_theme_black">Dubh</string>
+    <string name="app_theme_auto">Uathoibríoch ag luí na gréine</string>
+    <string name="app_theme_dark">Dorcha</string>
+    <string name="app_theme_system">Úsáid Dearadh Córais</string>
+</resources>

--- a/core/preferences/src/main/res/values-gd/strings.xml
+++ b/core/preferences/src/main/res/values-gd/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">Soilleir</string>
+    <string name="app_theme_black">Dubh</string>
+    <string name="app_theme_auto">Gu fèin-obrachail aig beul na h-oidhche</string>
+    <string name="app_theme_dark">Dorcha</string>
+    <string name="app_theme_system">Cleachd co-dhealbhachd an t-siostaim</string>
+</resources>

--- a/core/preferences/src/main/res/values-gl/strings.xml
+++ b/core/preferences/src/main/res/values-gl/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">Claro</string>
+    <string name="app_theme_black">Negro</string>
+    <string name="app_theme_auto">Automático ao solpor</string>
+    <string name="app_theme_dark">Escuro</string>
+    <string name="app_theme_system">Usar deseño do sistema</string>
+</resources>

--- a/core/preferences/src/main/res/values-hi/strings.xml
+++ b/core/preferences/src/main/res/values-hi/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">प्रकाश</string>
+    <string name="app_theme_black">Black</string>
+    <string name="app_theme_auto">सूर्यास्त के समय स्वचालित</string>
+    <string name="app_theme_dark">अंधकार</string>
+    <string name="app_theme_system">सिस्टम डिज़ाइन का उपयोग करें</string>
+</resources>

--- a/core/preferences/src/main/res/values-hu/strings.xml
+++ b/core/preferences/src/main/res/values-hu/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">Világos</string>
+    <string name="app_theme_black">Fekete</string>
+    <string name="app_theme_auto">Automatikus naplementekor</string>
+    <string name="app_theme_dark">Sötét</string>
+    <string name="app_theme_system">Rendszer téma használata</string>
+</resources>

--- a/core/preferences/src/main/res/values-in/strings.xml
+++ b/core/preferences/src/main/res/values-in/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">Terang</string>
+    <string name="app_theme_black">Hitam</string>
+    <string name="app_theme_dark">Gelap</string>
+</resources>

--- a/core/preferences/src/main/res/values-is/strings.xml
+++ b/core/preferences/src/main/res/values-is/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">Ljóst</string>
+    <string name="app_theme_black">Svart</string>
+    <string name="app_theme_auto">Sjálfvirkt við sólarlag</string>
+    <string name="app_theme_dark">Dökkt</string>
+    <string name="app_theme_system">Nota kerfishönnun</string>
+</resources>

--- a/core/preferences/src/main/res/values-it/strings.xml
+++ b/core/preferences/src/main/res/values-it/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">Chiaro</string>
+    <string name="app_theme_black">Nero</string>
+    <string name="app_theme_auto">Automatico al tramonto</string>
+    <string name="app_theme_dark">Scuro</string>
+    <string name="app_theme_system">Usa tema di sistema</string>
+</resources>

--- a/core/preferences/src/main/res/values-ja/strings.xml
+++ b/core/preferences/src/main/res/values-ja/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">ライト</string>
+    <string name="app_theme_black">ブラック</string>
+    <string name="app_theme_auto">日没による自動設定</string>
+    <string name="app_theme_dark">ダーク</string>
+    <string name="app_theme_system">システムの設定を利用</string>
+</resources>

--- a/core/preferences/src/main/res/values-kab/strings.xml
+++ b/core/preferences/src/main/res/values-kab/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">Aceɛlal</string>
+    <string name="app_theme_black">Aberkan</string>
+    <string name="app_theme_auto">Awurman akken yella yiṭij</string>
+    <string name="app_theme_dark">Ubrik</string>
+</resources>

--- a/core/preferences/src/main/res/values-ko/strings.xml
+++ b/core/preferences/src/main/res/values-ko/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">밝음</string>
+    <string name="app_theme_black">검정</string>
+    <string name="app_theme_auto">시간에 따라 자동으로 변경</string>
+    <string name="app_theme_dark">어두움</string>
+    <string name="app_theme_system">시스템 기본값</string>
+</resources>

--- a/core/preferences/src/main/res/values-lv/strings.xml
+++ b/core/preferences/src/main/res/values-lv/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">Gaiša</string>
+    <string name="app_theme_black">Melna</string>
+    <string name="app_theme_auto">Automātiski saulrietā</string>
+    <string name="app_theme_dark">Tumša</string>
+    <string name="app_theme_system">Izmantot sistēmas dizainu</string>
+</resources>

--- a/core/preferences/src/main/res/values-ml/strings.xml
+++ b/core/preferences/src/main/res/values-ml/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_black">കറുപ്പ്</string>
+</resources>

--- a/core/preferences/src/main/res/values-nb-rNO/strings.xml
+++ b/core/preferences/src/main/res/values-nb-rNO/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">Lys</string>
+    <string name="app_theme_black">Svart</string>
+    <string name="app_theme_auto">Automatisk ved solnedgang</string>
+    <string name="app_theme_dark">Mørk</string>
+    <string name="app_theme_system">Bruk systeminnstillinger</string>
+</resources>

--- a/core/preferences/src/main/res/values-nl/strings.xml
+++ b/core/preferences/src/main/res/values-nl/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">Licht</string>
+    <string name="app_theme_black">Zwart</string>
+    <string name="app_theme_auto">Automatisch tijdens zonsop- en ondergang</string>
+    <string name="app_theme_dark">Donker</string>
+    <string name="app_theme_system">Systeemthema gebruiken</string>
+</resources>

--- a/core/preferences/src/main/res/values-oc/strings.xml
+++ b/core/preferences/src/main/res/values-oc/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">Luminós</string>
+    <string name="app_theme_black">Negre</string>
+    <string name="app_theme_auto">Alba automatica</string>
+    <string name="app_theme_dark">Escur</string>
+    <string name="app_theme_system">Utilizar lo tèma sistèma</string>
+</resources>

--- a/core/preferences/src/main/res/values-pl/strings.xml
+++ b/core/preferences/src/main/res/values-pl/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">Jasny</string>
+    <string name="app_theme_black">Czarny</string>
+    <string name="app_theme_auto">Zmieniaj automatycznie po zachodzie słońca</string>
+    <string name="app_theme_dark">Ciemny</string>
+    <string name="app_theme_system">Użyj motywu systemu</string>
+</resources>

--- a/core/preferences/src/main/res/values-pt-rBR/strings.xml
+++ b/core/preferences/src/main/res/values-pt-rBR/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">Claro</string>
+    <string name="app_theme_black">AMOLED</string>
+    <string name="app_theme_auto">Automático no ocaso</string>
+    <string name="app_theme_dark">Escuro</string>
+    <string name="app_theme_system">Usar o tema do sistema</string>
+</resources>

--- a/core/preferences/src/main/res/values-pt-rPT/strings.xml
+++ b/core/preferences/src/main/res/values-pt-rPT/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">Claro</string>
+    <string name="app_theme_black">AMOLED</string>
+    <string name="app_theme_auto">Automático ao pôr-do-sol</string>
+    <string name="app_theme_dark">Escuro</string>
+    <string name="app_theme_system">Usar o Tema do Sistema</string>
+</resources>

--- a/core/preferences/src/main/res/values-ru/strings.xml
+++ b/core/preferences/src/main/res/values-ru/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">Светлая</string>
+    <string name="app_theme_black">Чёрная</string>
+    <string name="app_theme_auto">Автоматическая (от заката до восхода солнца)</string>
+    <string name="app_theme_dark">Тёмная</string>
+    <string name="app_theme_system">Как в системе</string>
+</resources>

--- a/core/preferences/src/main/res/values-sa/strings.xml
+++ b/core/preferences/src/main/res/values-sa/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">ज्योतिपूर्णः</string>
+    <string name="app_theme_black">कृष्णः</string>
+    <string name="app_theme_auto">सूर्यास्तसमये स्वचालितम्</string>
+    <string name="app_theme_dark">अन्धकारः</string>
+    <string name="app_theme_system">प्रणाल्याः परिकल्पना प्रयुज्यताम्</string>
+</resources>

--- a/core/preferences/src/main/res/values-si/strings.xml
+++ b/core/preferences/src/main/res/values-si/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">දීප්ත</string>
+    <string name="app_theme_black">කළු</string>
+    <string name="app_theme_auto">ස්වයංක්‍රීව ඉර බැසීමේදී</string>
+    <string name="app_theme_dark">අඳුරු</string>
+</resources>

--- a/core/preferences/src/main/res/values-sl/strings.xml
+++ b/core/preferences/src/main/res/values-sl/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">Svetla</string>
+    <string name="app_theme_black">Črna</string>
+    <string name="app_theme_auto">Samodejno ob sončnem zahodu</string>
+    <string name="app_theme_dark">Temna</string>
+    <string name="app_theme_system">Uporabi sistemsko temo</string>
+</resources>

--- a/core/preferences/src/main/res/values-sv/strings.xml
+++ b/core/preferences/src/main/res/values-sv/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">Ljust</string>
+    <string name="app_theme_black">Svart</string>
+    <string name="app_theme_auto">Automatiskt vid solnedgång</string>
+    <string name="app_theme_dark">Mörkt</string>
+    <string name="app_theme_system">Använd system-tema</string>
+</resources>

--- a/core/preferences/src/main/res/values-ta/strings.xml
+++ b/core/preferences/src/main/res/values-ta/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">வெளிச்சம்</string>
+    <string name="app_theme_black">பிளாக்</string>
+    <string name="app_theme_auto">தானியங்கி</string>
+    <string name="app_theme_dark">கருமை</string>
+</resources>

--- a/core/preferences/src/main/res/values-th/strings.xml
+++ b/core/preferences/src/main/res/values-th/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">สว่าง</string>
+    <string name="app_theme_black">ดำ</string>
+    <string name="app_theme_auto">ปรับตามเวลา</string>
+    <string name="app_theme_dark">มืด</string>
+    <string name="app_theme_system">ใช้ตามแบบระบบ</string>
+</resources>

--- a/core/preferences/src/main/res/values-tr/strings.xml
+++ b/core/preferences/src/main/res/values-tr/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">Açık</string>
+    <string name="app_theme_black">Siyah</string>
+    <string name="app_theme_auto">Gün batımında otomatik</string>
+    <string name="app_theme_dark">Koyu</string>
+    <string name="app_theme_system">Sistem tasarımını kullan</string>
+</resources>

--- a/core/preferences/src/main/res/values-uk/strings.xml
+++ b/core/preferences/src/main/res/values-uk/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">Світла</string>
+    <string name="app_theme_black">Чорна</string>
+    <string name="app_theme_auto">Автоматична від заходу сонця</string>
+    <string name="app_theme_dark">Темна</string>
+    <string name="app_theme_system">Тема системи</string>
+</resources>

--- a/core/preferences/src/main/res/values-vi/strings.xml
+++ b/core/preferences/src/main/res/values-vi/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">Sáng</string>
+    <string name="app_theme_black">Đen</string>
+    <string name="app_theme_auto">Tự động khi trời tối</string>
+    <string name="app_theme_dark">Tối</string>
+    <string name="app_theme_system">Mặc định của thiết bị</string>
+</resources>

--- a/core/preferences/src/main/res/values-zh-rCN/strings.xml
+++ b/core/preferences/src/main/res/values-zh-rCN/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">亮色</string>
+    <string name="app_theme_black">黑色</string>
+    <string name="app_theme_auto">自动切换</string>
+    <string name="app_theme_dark">暗色</string>
+    <string name="app_theme_system">跟随系统设定</string>
+</resources>

--- a/core/preferences/src/main/res/values-zh-rHK/strings.xml
+++ b/core/preferences/src/main/res/values-zh-rHK/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">白天</string>
+    <string name="app_theme_black">暗色</string>
+    <string name="app_theme_auto">自動切換</string>
+    <string name="app_theme_dark">黑夜</string>
+    <string name="app_theme_system">跟隨系統</string>
+</resources>

--- a/core/preferences/src/main/res/values-zh-rMO/strings.xml
+++ b/core/preferences/src/main/res/values-zh-rMO/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">白天</string>
+    <string name="app_theme_black">暗色</string>
+    <string name="app_theme_auto">自動切換</string>
+    <string name="app_theme_dark">黑夜</string>
+    <string name="app_theme_system">跟隨系統</string>
+</resources>

--- a/core/preferences/src/main/res/values-zh-rSG/strings.xml
+++ b/core/preferences/src/main/res/values-zh-rSG/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">白天</string>
+    <string name="app_theme_black">暗色</string>
+    <string name="app_theme_auto">自动切换</string>
+    <string name="app_theme_dark">黑夜</string>
+    <string name="app_theme_system">跟随系统设定</string>
+</resources>

--- a/core/preferences/src/main/res/values-zh-rTW/strings.xml
+++ b/core/preferences/src/main/res/values-zh-rTW/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="app_theme_light">白天</string>
+    <string name="app_theme_black">暗色</string>
+    <string name="app_theme_auto">自動切換</string>
+    <string name="app_theme_dark">黑夜</string>
+    <string name="app_theme_system">跟隨系統</string>
+</resources>

--- a/core/preferences/src/main/res/values/strings.xml
+++ b/core/preferences/src/main/res/values/strings.xml
@@ -20,4 +20,9 @@
     <string name="pref_title_downloads">Download location</string>
     <string name="download_location_downloads">Downloads folder</string>
     <string name="download_location_per_account">Per-account folders, in Downloads folder</string>
+    <string name="app_theme_light">Light</string>
+    <string name="app_theme_black">Black</string>
+    <string name="app_theme_auto">Automatic at sunset</string>
+    <string name="app_theme_dark">Dark</string>
+    <string name="app_theme_system">Use system design</string>
 </resources>

--- a/feature/login/lint-baseline.xml
+++ b/feature/login/lint-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.5.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.5.0)" variant="all" version="8.5.0">
+<issues format="6" by="lint 8.5.2" type="baseline" client="gradle" dependencies="false" name="AGP (8.5.2)" variant="all" version="8.5.2">
 
     <issue
         id="StringFormatInvalid"
@@ -12,7 +12,7 @@
             column="22"/>
         <location
             file="src/main/res/values/strings.xml"
-            line="17"
+            line="16"
             column="5"
             message="This definition does not require arguments"/>
     </issue>
@@ -28,7 +28,7 @@
             column="22"/>
         <location
             file="src/main/res/values/strings.xml"
-            line="17"
+            line="16"
             column="5"
             message="This definition does not require arguments"/>
     </issue>


### PR DESCRIPTION
Provde an `appTheme` property in `SharedPreferenceRepository` to manage read access, simplifying calling code.

Update `PreferenceEnum.from` to check the `value` property of the enum first.

Fixes #950