### PR TITLE
fix: Don't crash if a conversation has no participants

### DIFF
--- a/app/src/main/java/app/pachli/components/conversation/ConversationViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/conversation/ConversationViewHolder.kt
@@ -102,6 +102,7 @@ class ConversationViewHolder internal constructor(
 
     private fun setConversationName(accounts: List<ConversationAccountEntity>) {
         conversationNameTextView.text = when (accounts.size) {
+            0 -> context.getString(R.string.conversation_0_recipients)
             1 -> context.getString(
                 R.string.conversation_1_recipients,
                 accounts[0].username,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -444,6 +444,7 @@
     </plurals>
     <string name="title_reblogged_by">Boosted by</string>
     <string name="title_favourited_by">Favorited by</string>
+    <string name="conversation_0_recipients">No other participants</string>
     <string name="conversation_1_recipients">%1$s</string>
     <string name="conversation_2_recipients">%1$s and %2$s</string>
     <string name="conversation_more_recipients">%1$s, %2$s and %3$d more</string>


### PR DESCRIPTION
It's possible for some servers to return a conversation that has an empty (or possibly missing) `accounts` property. In the previous code this would crash trying to access an item in an empty list.

Fix this by handling the "no participants" case.

Fixes #971