### PR TITLE
refactor: Pass the active account ID to activities, fragments, etc

### DIFF
--- a/app/src/main/java/app/pachli/MainActivity.kt
+++ b/app/src/main/java/app/pachli/MainActivity.kt
@@ -93,7 +93,7 @@ import app.pachli.core.navigation.ComposeActivityIntent
 import app.pachli.core.navigation.DraftsActivityIntent
 import app.pachli.core.navigation.EditProfileActivityIntent
 import app.pachli.core.navigation.FollowedTagsActivityIntent
-import app.pachli.core.navigation.ListActivityIntent
+import app.pachli.core.navigation.ListsActivityIntent
 import app.pachli.core.navigation.LoginActivityIntent
 import app.pachli.core.navigation.LoginActivityIntent.LoginMode
 import app.pachli.core.navigation.MainActivityIntent
@@ -105,6 +105,7 @@ import app.pachli.core.navigation.SuggestionsActivityIntent
 import app.pachli.core.navigation.TabPreferenceActivityIntent
 import app.pachli.core.navigation.TimelineActivityIntent
 import app.pachli.core.navigation.TrendingActivityIntent
+import app.pachli.core.navigation.pachliAccountId
 import app.pachli.core.network.model.Account
 import app.pachli.core.network.model.Notification
 import app.pachli.core.preferences.PrefKeys
@@ -247,9 +248,9 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
 
         // check for savedInstanceState in order to not handle intent events more than once
         if (intent != null && savedInstanceState == null) {
+            // Cancel the notification that opened this activity (if opened from a notification).
             val notificationId = MainActivityIntent.getNotificationId(intent)
             if (notificationId != -1) {
-                // opened from a notification action, cancel the notification
                 val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
                 notificationManager.cancel(MainActivityIntent.getNotificationTag(intent), notificationId)
             }
@@ -258,7 +259,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
              * - from our code as Long Intent Extra PACHLI_ACCOUNT_ID
              * - from share shortcuts as String 'android.intent.extra.shortcut.ID'
              */
-            var pachliAccountId = MainActivityIntent.getPachliAccountId(intent)
+            var pachliAccountId = intent.pachliAccountId
             if (pachliAccountId == -1L) {
                 val accountIdString = intent.getStringExtra(ShortcutManagerCompat.EXTRA_SHORTCUT_ID)
                 if (accountIdString != null) {
@@ -291,7 +292,6 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
                                 } else {
                                     // A different account was requested, restart the activity,
                                     // forwarding this intent to the restarted activity.
-                                    MainActivityIntent.setPachliAccountId(intent, requestedId)
                                     changeAccountAndRestart(requestedId, intent)
                                 }
                             }
@@ -299,13 +299,13 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
                     )
                 }
             } else if (openDrafts) {
-                val intent = DraftsActivityIntent(this)
+                val intent = DraftsActivityIntent(this, intent.pachliAccountId)
                 startActivity(intent)
             } else if (accountSwitchRequested && MainActivityIntent.hasNotificationType(intent)) {
                 // user clicked a notification, show follow requests for type FOLLOW_REQUEST,
                 // otherwise show notification tab
                 if (MainActivityIntent.getNotificationType(intent) == Notification.Type.FOLLOW_REQUEST) {
-                    val intent = AccountListActivityIntent(this, AccountListActivityIntent.Kind.FOLLOW_REQUESTS)
+                    val intent = AccountListActivityIntent(this, intent.pachliAccountId, AccountListActivityIntent.Kind.FOLLOW_REQUESTS)
                     startActivityWithDefaultTransition(intent)
                 } else {
                     showNotificationTab = true
@@ -340,6 +340,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
         binding.viewPager.reduceSwipeSensitivity()
 
         setupDrawer(
+            intent.pachliAccountId,
             savedInstanceState,
             addSearchButton = hideTopToolbar,
         )
@@ -365,6 +366,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
                     is ProfileEditedEvent -> onFetchUserInfoSuccess(event.newProfileData)
                     is MainTabsChangedEvent -> {
                         refreshMainDrawerItems(
+                            intent.pachliAccountId,
                             addSearchButton = hideTopToolbar,
                         )
 
@@ -383,7 +385,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
             listsRepository.lists.collect { result ->
                 result.onSuccess { lists ->
                     // Update the list of lists in the main drawer
-                    refreshMainDrawerItems(addSearchButton = hideTopToolbar)
+                    refreshMainDrawerItems(intent.pachliAccountId, addSearchButton = hideTopToolbar)
 
                     // Any lists in tabs might have changed titles, update those
                     if (lists is Lists.Loaded && tabAdapter.tabs.any { it.timeline is Timeline.UserList }) {
@@ -434,7 +436,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
         super.onMenuItemSelected(menuItem)
         return when (menuItem.itemId) {
             R.id.action_search -> {
-                startActivity(SearchActivityIntent(this@MainActivity))
+                startActivity(SearchActivityIntent(this@MainActivity, intent.pachliAccountId))
                 true
             }
             R.id.action_remove_tab -> {
@@ -449,7 +451,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
                 true
             }
             R.id.action_tab_preferences -> {
-                startActivity(TabPreferenceActivityIntent(this))
+                startActivity(TabPreferenceActivityIntent(this, intent.pachliAccountId))
                 true
             }
             else -> super.onOptionsItemSelected(menuItem)
@@ -490,7 +492,12 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
                 return true
             }
             KeyEvent.KEYCODE_SEARCH -> {
-                startActivityWithDefaultTransition(SearchActivityIntent(this))
+                startActivityWithDefaultTransition(
+                    SearchActivityIntent(
+                        this,
+                        intent.pachliAccountId,
+                    ),
+                )
                 return true
             }
         }
@@ -514,7 +521,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
         if (intent != null) {
             val redirectUrl = MainActivityIntent.getRedirectUrl(intent)
             if (redirectUrl != null) {
-                viewUrl(redirectUrl, PostLookupFallbackBehavior.DISPLAY_ERROR)
+                viewUrl(intent.pachliAccountId, redirectUrl, PostLookupFallbackBehavior.DISPLAY_ERROR)
             }
         }
     }
@@ -541,6 +548,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
     }
 
     private fun setupDrawer(
+        activeAccountId: Long,
         savedInstanceState: Bundle?,
         addSearchButton: Boolean,
     ) {
@@ -590,7 +598,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
         DrawerImageLoader.init(MainDrawerImageLoader(glide, animateAvatars))
 
         binding.mainDrawer.apply {
-            refreshMainDrawerItems(addSearchButton)
+            refreshMainDrawerItems(activeAccountId, addSearchButton)
             setSavedInstance(savedInstanceState)
         }
 
@@ -609,7 +617,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
         })
     }
 
-    private fun refreshMainDrawerItems(addSearchButton: Boolean) {
+    private fun refreshMainDrawerItems(pachliAccountId: Long, addSearchButton: Boolean) {
         val (listsDrawerItems, listsSectionTitle) = listsRepository.lists.value.get()?.let { result ->
             when (result) {
                 Lists.Loading -> Pair(emptyList(), R.string.title_lists_loading)
@@ -621,7 +629,12 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
                                 iconicsIcon = GoogleMaterial.Icon.gmd_list
                                 onClick = {
                                     startActivityWithDefaultTransition(
-                                        TimelineActivityIntent.list(this@MainActivity, list.id, list.title),
+                                        TimelineActivityIntent.list(
+                                            this@MainActivity,
+                                            pachliAccountId,
+                                            list.id,
+                                            list.title,
+                                        ),
                                     )
                                 }
                             }
@@ -640,7 +653,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
                     iconicsIcon = GoogleMaterial.Icon.gmd_notifications
                     onClick = {
                         startActivityWithDefaultTransition(
-                            TimelineActivityIntent.notifications(context),
+                            TimelineActivityIntent.notifications(context, pachliAccountId),
                         )
                     }
                 },
@@ -649,7 +662,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
                     iconRes = R.drawable.ic_local_24dp
                     onClick = {
                         startActivityWithDefaultTransition(
-                            TimelineActivityIntent.publicLocal(context),
+                            TimelineActivityIntent.publicLocal(context, pachliAccountId),
                         )
                     }
                 },
@@ -658,7 +671,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
                     iconRes = R.drawable.ic_public_24dp
                     onClick = {
                         startActivityWithDefaultTransition(
-                            TimelineActivityIntent.publicFederated(context),
+                            TimelineActivityIntent.publicFederated(context, pachliAccountId),
                         )
                     }
                 },
@@ -667,7 +680,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
                     iconRes = R.drawable.ic_reblog_direct_24dp
                     onClick = {
                         startActivityWithDefaultTransition(
-                            TimelineActivityIntent.conversations(context),
+                            TimelineActivityIntent.conversations(context, pachliAccountId),
                         )
                     }
                 },
@@ -675,7 +688,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
                     nameRes = R.string.action_view_bookmarks
                     iconicsIcon = GoogleMaterial.Icon.gmd_bookmark
                     onClick = {
-                        val intent = TimelineActivityIntent.bookmarks(context)
+                        val intent = TimelineActivityIntent.bookmarks(context, pachliAccountId)
                         startActivityWithDefaultTransition(intent)
                     }
                 },
@@ -684,7 +697,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
                     isSelectable = false
                     iconicsIcon = GoogleMaterial.Icon.gmd_star
                     onClick = {
-                        val intent = TimelineActivityIntent.favourites(context)
+                        val intent = TimelineActivityIntent.favourites(context, pachliAccountId)
                         startActivityWithDefaultTransition(intent)
                     }
                 },
@@ -692,21 +705,21 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
                     nameRes = R.string.title_public_trending
                     iconicsIcon = GoogleMaterial.Icon.gmd_trending_up
                     onClick = {
-                        startActivityWithDefaultTransition(TrendingActivityIntent(context))
+                        startActivityWithDefaultTransition(TrendingActivityIntent(context, pachliAccountId))
                     }
                 },
                 primaryDrawerItem {
                     nameRes = R.string.title_followed_hashtags
                     iconRes = R.drawable.ic_hashtag
                     onClick = {
-                        startActivityWithDefaultTransition(FollowedTagsActivityIntent(context))
+                        startActivityWithDefaultTransition(FollowedTagsActivityIntent(context, pachliAccountId))
                     }
                 },
                 primaryDrawerItem {
                     nameRes = R.string.action_view_follow_requests
                     iconicsIcon = GoogleMaterial.Icon.gmd_person_add
                     onClick = {
-                        val intent = AccountListActivityIntent(context, AccountListActivityIntent.Kind.FOLLOW_REQUESTS)
+                        val intent = AccountListActivityIntent(context, pachliAccountId, AccountListActivityIntent.Kind.FOLLOW_REQUESTS)
                         startActivityWithDefaultTransition(intent)
                     }
                 },
@@ -714,18 +727,20 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
                     nameRes = R.string.action_suggestions
                     iconicsIcon = GoogleMaterial.Icon.gmd_explore
                     onClick = {
-                        startActivityWithDefaultTransition(SuggestionsActivityIntent(context))
+                        startActivityWithDefaultTransition(SuggestionsActivityIntent(context, pachliAccountId))
                     }
                 },
                 SectionDrawerItem().apply {
-                    nameRes = listsSectionTitle
+                    identifier = DRAWER_ITEM_LISTS
+                    nameRes = app.pachli.feature.lists.R.string.title_lists
                 },
-                *listsDrawerItems.toTypedArray(),
                 primaryDrawerItem {
                     nameRes = R.string.manage_lists
                     iconicsIcon = GoogleMaterial.Icon.gmd_settings
                     onClick = {
-                        startActivityWithDefaultTransition(ListActivityIntent(context))
+                        startActivityWithDefaultTransition(
+                            ListsActivityIntent(context, pachliAccountId),
+                        )
                     }
                 },
                 DividerDrawerItem(),
@@ -733,7 +748,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
                     nameRes = R.string.action_access_drafts
                     iconRes = R.drawable.ic_notebook
                     onClick = {
-                        val intent = DraftsActivityIntent(context)
+                        val intent = DraftsActivityIntent(context, pachliAccountId)
                         startActivityWithDefaultTransition(intent)
                     }
                 },
@@ -741,7 +756,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
                     nameRes = R.string.action_access_scheduled_posts
                     iconRes = R.drawable.ic_access_time
                     onClick = {
-                        startActivityWithDefaultTransition(ScheduledStatusActivityIntent(context))
+                        startActivityWithDefaultTransition(ScheduledStatusActivityIntent(context, pachliAccountId))
                     }
                 },
                 primaryDrawerItem {
@@ -749,7 +764,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
                     nameRes = R.string.title_announcements
                     iconRes = R.drawable.ic_bullhorn_24dp
                     onClick = {
-                        startActivityWithDefaultTransition(AnnouncementsActivityIntent(context))
+                        startActivityWithDefaultTransition(AnnouncementsActivityIntent(context, pachliAccountId))
                     }
                     badgeStyle = BadgeStyle().apply {
                         textColor = ColorHolder.fromColor(MaterialColors.getColor(binding.mainDrawer, com.google.android.material.R.attr.colorOnPrimary))
@@ -761,7 +776,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
                     nameRes = R.string.action_view_account_preferences
                     iconRes = R.drawable.ic_account_settings
                     onClick = {
-                        val intent = PreferencesActivityIntent(context, PreferenceScreen.ACCOUNT)
+                        val intent = PreferencesActivityIntent(context, pachliAccountId, PreferenceScreen.ACCOUNT)
                         startActivityWithDefaultTransition(intent)
                     }
                 },
@@ -769,7 +784,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
                     nameRes = R.string.action_view_preferences
                     iconicsIcon = GoogleMaterial.Icon.gmd_settings
                     onClick = {
-                        val intent = PreferencesActivityIntent(context, PreferenceScreen.GENERAL)
+                        val intent = PreferencesActivityIntent(context, pachliAccountId, PreferenceScreen.GENERAL)
                         startActivityWithDefaultTransition(intent)
                     }
                 },
@@ -777,7 +792,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
                     nameRes = R.string.action_edit_profile
                     iconicsIcon = GoogleMaterial.Icon.gmd_person
                     onClick = {
-                        val intent = EditProfileActivityIntent(context)
+                        val intent = EditProfileActivityIntent(context, pachliAccountId)
                         startActivityWithDefaultTransition(intent)
                     }
                 },
@@ -803,7 +818,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
                         nameRes = R.string.action_search
                         iconicsIcon = GoogleMaterial.Icon.gmd_search
                         onClick = {
-                            startActivityWithDefaultTransition(SearchActivityIntent(context))
+                            startActivityWithDefaultTransition(SearchActivityIntent(context, pachliAccountId))
                         }
                     },
                 )
@@ -846,17 +861,13 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
                     0 -> {
                         Timber.d("Clearing home timeline cache")
                         lifecycleScope.launch {
-                            accountManager.activeAccount?.let {
-                                developerToolsUseCase.clearHomeTimelineCache(it.id)
-                            }
+                            developerToolsUseCase.clearHomeTimelineCache(intent.pachliAccountId)
                         }
                     }
                     1 -> {
                         Timber.d("Removing most recent 40 statuses")
                         lifecycleScope.launch {
-                            accountManager.activeAccount?.let {
-                                developerToolsUseCase.deleteFirstKStatuses(it.id, 40)
-                            }
+                            developerToolsUseCase.deleteFirstKStatuses(intent.pachliAccountId, 40)
                         }
                     }
                 }
@@ -902,7 +913,14 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
         val previousTabIndex = binding.viewPager.currentItem
         val previousTab = tabAdapter.tabs.getOrNull(previousTabIndex)
 
-        val tabs = accountManager.activeAccount!!.tabPreferences.map { TabViewData.from(it) }
+        val tabs = accountManager.activeAccount?.let { account ->
+            account.tabPreferences.map {
+                TabViewData.from(
+                    account.id,
+                    it,
+                )
+            }
+        }.orEmpty()
 
         // Detach any existing mediator before changing tab contents and attaching a new mediator
         tabLayoutMediator?.detach()
@@ -910,8 +928,11 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
         tabAdapter.tabs = tabs
         tabAdapter.notifyItemRangeChanged(0, tabs.size)
 
-        tabLayoutMediator = TabLayoutMediator(activeTabLayout, binding.viewPager, true) {
-                tab: TabLayout.Tab, position: Int ->
+        tabLayoutMediator = TabLayoutMediator(
+            activeTabLayout,
+            binding.viewPager,
+            true,
+        ) { tab: TabLayout.Tab, position: Int ->
             tab.icon = AppCompatResources.getDrawable(this@MainActivity, tabs[position].icon)
             tab.contentDescription = tabs[position].title(this@MainActivity)
         }.also { it.attach() }
@@ -993,7 +1014,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
 
         // open profile when active image was clicked
         if (current && activeAccount != null) {
-            val intent = AccountActivityIntent(this, activeAccount.accountId)
+            val intent = AccountActivityIntent(this, activeAccount.id, activeAccount.accountId)
             startActivityWithDefaultTransition(intent)
             return
         }
@@ -1015,7 +1036,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
     private fun changeAccountAndRestart(accountId: Long, forward: Intent?) {
         cacheUpdater.stop()
         accountManager.setActiveAccount(accountId)
-        val intent = MainActivityIntent(this)
+        val intent = MainActivityIntent(this, accountId)
         intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
         if (forward != null) {
             intent.type = forward.type
@@ -1039,12 +1060,10 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
                     binding.composeButton.hide()
 
                     lifecycleScope.launch {
-                        val otherAccountAvailable = logout.invoke()
-                        val intent = if (otherAccountAvailable) {
-                            MainActivityIntent(this@MainActivity)
-                        } else {
-                            LoginActivityIntent(this@MainActivity, LoginMode.DEFAULT)
-                        }
+                        val nextAccount = logout.invoke()
+                        val intent = nextAccount?.let {
+                            MainActivityIntent(this@MainActivity, it.id)
+                        } ?: LoginActivityIntent(this@MainActivity, LoginMode.DEFAULT)
                         startActivity(intent)
                         finish()
                     }
@@ -1227,6 +1246,9 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
     companion object {
         private const val DRAWER_ITEM_ADD_ACCOUNT: Long = -13
         private const val DRAWER_ITEM_ANNOUNCEMENTS: Long = 14
+
+        /** Drawer identifier for the "Lists" section header. */
+        private const val DRAWER_ITEM_LISTS: Long = 15
     }
 }
 

--- a/app/src/main/java/app/pachli/TabPreferenceActivity.kt
+++ b/app/src/main/java/app/pachli/TabPreferenceActivity.kt
@@ -48,7 +48,8 @@ import app.pachli.core.data.repository.ListsRepository
 import app.pachli.core.data.repository.ListsRepository.Companion.compareByListTitle
 import app.pachli.core.designsystem.R as DR
 import app.pachli.core.model.Timeline
-import app.pachli.core.navigation.ListActivityIntent
+import app.pachli.core.navigation.ListsActivityIntent
+import app.pachli.core.navigation.pachliAccountId
 import app.pachli.core.network.model.MastoList
 import app.pachli.core.network.retrofit.MastodonApi
 import app.pachli.databinding.ActivityTabPreferenceBinding
@@ -110,7 +111,7 @@ class TabPreferenceActivity : BaseActivity(), ItemInteractionListener {
             setDisplayShowHomeEnabled(true)
         }
 
-        currentTabs = accountManager.activeAccount?.tabPreferences.orEmpty().map { TabViewData.from(it) }.toMutableList()
+        currentTabs = accountManager.activeAccount?.tabPreferences.orEmpty().map { TabViewData.from(accountManager.activeAccount!!.id, it) }.toMutableList()
         currentTabsAdapter = TabAdapter(currentTabs, false, this)
         binding.currentTabsRecyclerView.adapter = currentTabsAdapter
         binding.currentTabsRecyclerView.layoutManager = LinearLayoutManager(this)
@@ -118,7 +119,7 @@ class TabPreferenceActivity : BaseActivity(), ItemInteractionListener {
             MaterialDividerItemDecoration(this, MaterialDividerItemDecoration.VERTICAL),
         )
 
-        addTabAdapter = TabAdapter(listOf(TabViewData.from(Timeline.Conversations)), true, this)
+        addTabAdapter = TabAdapter(listOf(TabViewData.from(intent.pachliAccountId, Timeline.Conversations)), true, this)
         binding.addTabRecyclerView.adapter = addTabAdapter
         binding.addTabRecyclerView.layoutManager = LinearLayoutManager(this)
 
@@ -251,7 +252,10 @@ class TabPreferenceActivity : BaseActivity(), ItemInteractionListener {
             .setPositiveButton(R.string.action_save) { _, _ ->
                 val input = editText.text.toString().trim()
                 if (timeline == null) {
-                    val newTab = TabViewData.from(Timeline.Hashtags(listOf(input)))
+                    val newTab = TabViewData.from(
+                        intent.pachliAccountId,
+                        Timeline.Hashtags(listOf(input)),
+                    )
                     currentTabs.add(newTab)
                     currentTabsAdapter.notifyItemInserted(currentTabs.size - 1)
                 } else {
@@ -294,7 +298,10 @@ class TabPreferenceActivity : BaseActivity(), ItemInteractionListener {
             .setView(selectListBinding.root)
             .setAdapter(adapter) { _, position ->
                 adapter.getItem(position)?.let { item ->
-                    val newTab = TabViewData.from(Timeline.UserList(item.id, item.title))
+                    val newTab = TabViewData.from(
+                        intent.pachliAccountId,
+                        Timeline.UserList(item.id, item.title),
+                    )
                     currentTabs.add(newTab)
                     currentTabsAdapter.notifyItemInserted(currentTabs.size - 1)
                     updateAvailableTabs()
@@ -310,7 +317,7 @@ class TabPreferenceActivity : BaseActivity(), ItemInteractionListener {
         dialog.setOnShowListener {
             val button = dialog.getButton(AlertDialog.BUTTON_NEUTRAL)
             button.setOnClickListener {
-                startActivity(ListActivityIntent(applicationContext))
+                startActivity(ListsActivityIntent(applicationContext, intent.pachliAccountId))
             }
         }
 
@@ -342,51 +349,52 @@ class TabPreferenceActivity : BaseActivity(), ItemInteractionListener {
     }
 
     private fun updateAvailableTabs() {
+        val activeAccountId = intent.pachliAccountId
         val addableTabs: MutableList<TabViewData> = mutableListOf()
 
-        val homeTab = TabViewData.from(Timeline.Home)
+        val homeTab = TabViewData.from(activeAccountId, Timeline.Home)
         if (!currentTabs.contains(homeTab)) {
             addableTabs.add(homeTab)
         }
-        val notificationTab = TabViewData.from(Timeline.Notifications)
+        val notificationTab = TabViewData.from(activeAccountId, Timeline.Notifications)
         if (!currentTabs.contains(notificationTab)) {
             addableTabs.add(notificationTab)
         }
-        val localTab = TabViewData.from(Timeline.PublicLocal)
+        val localTab = TabViewData.from(activeAccountId, Timeline.PublicLocal)
         if (!currentTabs.contains(localTab)) {
             addableTabs.add(localTab)
         }
-        val federatedTab = TabViewData.from(Timeline.PublicFederated)
+        val federatedTab = TabViewData.from(activeAccountId, Timeline.PublicFederated)
         if (!currentTabs.contains(federatedTab)) {
             addableTabs.add(federatedTab)
         }
-        val directMessagesTab = TabViewData.from(Timeline.Conversations)
+        val directMessagesTab = TabViewData.from(activeAccountId, Timeline.Conversations)
         if (!currentTabs.contains(directMessagesTab)) {
             addableTabs.add(directMessagesTab)
         }
-        val bookmarksTab = TabViewData.from(Timeline.Bookmarks)
+        val bookmarksTab = TabViewData.from(activeAccountId, Timeline.Bookmarks)
         if (!currentTabs.contains(bookmarksTab)) {
             addableTabs.add(bookmarksTab)
         }
-        val favouritesTab = TabViewData.from(Timeline.Favourites)
+        val favouritesTab = TabViewData.from(activeAccountId, Timeline.Favourites)
         if (!currentTabs.contains(favouritesTab)) {
             addableTabs.add(favouritesTab)
         }
-        val trendingTagsTab = TabViewData.from(Timeline.TrendingHashtags)
+        val trendingTagsTab = TabViewData.from(activeAccountId, Timeline.TrendingHashtags)
         if (!currentTabs.contains(trendingTagsTab)) {
             addableTabs.add(trendingTagsTab)
         }
-        val trendingLinksTab = TabViewData.from(Timeline.TrendingLinks)
+        val trendingLinksTab = TabViewData.from(activeAccountId, Timeline.TrendingLinks)
         if (!currentTabs.contains(trendingLinksTab)) {
             addableTabs.add(trendingLinksTab)
         }
-        val trendingStatusesTab = TabViewData.from(Timeline.TrendingStatuses)
+        val trendingStatusesTab = TabViewData.from(activeAccountId, Timeline.TrendingStatuses)
         if (!currentTabs.contains(trendingStatusesTab)) {
             addableTabs.add(trendingStatusesTab)
         }
 
-        addableTabs.add(TabViewData.from(Timeline.Hashtags(emptyList())))
-        addableTabs.add(TabViewData.from(Timeline.UserList("", "")))
+        addableTabs.add(TabViewData.from(activeAccountId, Timeline.Hashtags(emptyList())))
+        addableTabs.add(TabViewData.from(activeAccountId, Timeline.UserList("", "")))
 
         addTabAdapter.updateData(addableTabs)
     }

--- a/app/src/main/java/app/pachli/TabViewData.kt
+++ b/app/src/main/java/app/pachli/TabViewData.kt
@@ -66,36 +66,36 @@ data class TabViewData(
     override fun hashCode() = timeline.hashCode()
 
     companion object {
-        fun from(timeline: Timeline) = when (timeline) {
+        fun from(pachliAccountId: Long, timeline: Timeline) = when (timeline) {
             Timeline.Home -> TabViewData(
                 timeline = timeline,
                 text = R.string.title_home,
                 icon = R.drawable.ic_home_24dp,
-                fragment = { TimelineFragment.newInstance(timeline) },
+                fragment = { TimelineFragment.newInstance(pachliAccountId, timeline) },
             )
             Timeline.Notifications -> TabViewData(
                 timeline = timeline,
                 text = R.string.title_notifications,
                 icon = R.drawable.ic_notifications_24dp,
-                fragment = { NotificationsFragment.newInstance() },
+                fragment = { NotificationsFragment.newInstance(pachliAccountId) },
             )
             Timeline.PublicLocal -> TabViewData(
                 timeline = timeline,
                 text = R.string.title_public_local,
                 icon = R.drawable.ic_local_24dp,
-                fragment = { TimelineFragment.newInstance(timeline) },
+                fragment = { TimelineFragment.newInstance(pachliAccountId, timeline) },
             )
             Timeline.PublicFederated -> TabViewData(
                 timeline = timeline,
                 text = R.string.title_public_federated,
                 icon = R.drawable.ic_public_24dp,
-                fragment = { TimelineFragment.newInstance(timeline) },
+                fragment = { TimelineFragment.newInstance(pachliAccountId, timeline) },
             )
             Timeline.Conversations -> TabViewData(
                 timeline = timeline,
                 text = R.string.title_direct_messages,
                 icon = R.drawable.ic_reblog_direct_24dp,
-                fragment = { ConversationsFragment.newInstance() },
+                fragment = { ConversationsFragment.newInstance(pachliAccountId) },
             ) {
                 ComposeActivityIntent(
                     it,
@@ -106,26 +106,26 @@ data class TabViewData(
                 timeline = timeline,
                 text = R.string.title_public_trending_hashtags,
                 icon = R.drawable.ic_trending_up_24px,
-                fragment = { TrendingTagsFragment.newInstance() },
+                fragment = { TrendingTagsFragment.newInstance(pachliAccountId) },
                 composeIntent = null,
             )
             Timeline.TrendingLinks -> TabViewData(
                 timeline = timeline,
                 text = R.string.title_public_trending_links,
                 icon = R.drawable.ic_newspaper_24,
-                fragment = { TrendingLinksFragment.newInstance() },
+                fragment = { TrendingLinksFragment.newInstance(pachliAccountId) },
             )
             Timeline.TrendingStatuses -> TabViewData(
                 timeline = timeline,
                 text = R.string.title_public_trending_statuses,
                 icon = R.drawable.ic_whatshot_24,
-                fragment = { TimelineFragment.newInstance(timeline) },
+                fragment = { TimelineFragment.newInstance(pachliAccountId, timeline) },
             )
             is Timeline.Hashtags -> TabViewData(
                 timeline = timeline,
                 text = R.string.hashtags,
                 icon = R.drawable.ic_hashtag,
-                fragment = { TimelineFragment.newInstance(timeline) },
+                fragment = { TimelineFragment.newInstance(pachliAccountId, timeline) },
                 title = { context ->
                     timeline.tags.joinToString(separator = " ") {
                         context.getString(R.string.title_tag, it)
@@ -146,20 +146,20 @@ data class TabViewData(
                 timeline = timeline,
                 text = R.string.list,
                 icon = app.pachli.core.ui.R.drawable.ic_list,
-                fragment = { TimelineFragment.newInstance(timeline) },
+                fragment = { TimelineFragment.newInstance(pachliAccountId, timeline) },
                 title = { timeline.title },
             )
             Timeline.Bookmarks -> TabViewData(
                 timeline = timeline,
                 text = R.string.title_bookmarks,
                 icon = R.drawable.ic_bookmark_active_24dp,
-                fragment = { TimelineFragment.newInstance(timeline) },
+                fragment = { TimelineFragment.newInstance(pachliAccountId, timeline) },
             )
             Timeline.Favourites -> TabViewData(
                 timeline = timeline,
                 text = R.string.title_favourites,
                 icon = R.drawable.ic_favourite_filled_24dp,
-                fragment = { TimelineFragment.newInstance(timeline) },
+                fragment = { TimelineFragment.newInstance(pachliAccountId, timeline) },
             )
             is Timeline.User.Pinned -> throw IllegalArgumentException("can't add to tab: $timeline")
             is Timeline.User.Posts -> throw IllegalArgumentException("can't add to tab: $timeline")

--- a/app/src/main/java/app/pachli/TimelineActivity.kt
+++ b/app/src/main/java/app/pachli/TimelineActivity.kt
@@ -40,6 +40,7 @@ import app.pachli.core.model.NewContentFilter
 import app.pachli.core.model.NewContentFilterKeyword
 import app.pachli.core.model.Timeline
 import app.pachli.core.navigation.TimelineActivityIntent
+import app.pachli.core.navigation.pachliAccountId
 import app.pachli.databinding.ActivityTimelineBinding
 import app.pachli.interfaces.ActionButtonActivity
 import app.pachli.interfaces.AppBarLayoutHost
@@ -52,6 +53,7 @@ import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -98,7 +100,7 @@ class TimelineActivity : BottomSheetActivity(), AppBarLayoutHost, ActionButtonAc
         timeline = TimelineActivityIntent.getTimeline(intent)
         hashtag = (timeline as? Timeline.Hashtags)?.tags?.firstOrNull()
 
-        val viewData = TabViewData.from(timeline)
+        val viewData = TabViewData.from(intent.pachliAccountId, timeline)
 
         supportActionBar?.run {
             title = viewData.title(this@TimelineActivity)

--- a/app/src/main/java/app/pachli/ViewMediaActivity.kt
+++ b/app/src/main/java/app/pachli/ViewMediaActivity.kt
@@ -52,6 +52,7 @@ import app.pachli.core.domain.DownloadUrlUseCase
 import app.pachli.core.navigation.AttachmentViewData
 import app.pachli.core.navigation.ViewMediaActivityIntent
 import app.pachli.core.navigation.ViewThreadActivityIntent
+import app.pachli.core.navigation.pachliAccountId
 import app.pachli.databinding.ActivityViewMediaBinding
 import app.pachli.fragment.MediaActionsListener
 import app.pachli.pager.ImagePagerAdapter
@@ -254,7 +255,7 @@ class ViewMediaActivity : BaseActivity(), MediaActionsListener {
 
     private fun onOpenStatus() {
         val attach = attachmentViewData!![binding.viewPager.currentItem]
-        startActivityWithDefaultTransition(ViewThreadActivityIntent(this, attach.statusId, attach.statusUrl))
+        startActivityWithDefaultTransition(ViewThreadActivityIntent(this, intent.pachliAccountId, attach.statusId, attach.statusUrl))
     }
 
     private fun copyLink() {

--- a/app/src/main/java/app/pachli/adapter/FilterableStatusViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/FilterableStatusViewHolder.kt
@@ -29,8 +29,9 @@ import app.pachli.interfaces.StatusActionListener
 import app.pachli.viewdata.IStatusViewData
 
 open class FilterableStatusViewHolder<T : IStatusViewData>(
+    private val pachliAccountId: Long,
     private val binding: ItemStatusWrapperBinding,
-) : StatusViewHolder<T>(binding.statusContainer, binding.root) {
+) : StatusViewHolder<T>(pachliAccountId, binding.statusContainer, binding.root) {
     /** The filter that matched the status, null if the status is not being filtered. */
     var matchedFilter: Filter? = null
 
@@ -72,7 +73,7 @@ open class FilterableStatusViewHolder<T : IStatusViewData>(
                 listener.clearWarningAction(status)
             }
             binding.statusFilteredPlaceholder.statusFilterEditFilter.setOnClickListener {
-                listener.onEditFilterById(result.filter.id)
+                listener.onEditFilterById(pachliAccountId, result.filter.id)
             }
         } ?: {
             matchedFilter = null

--- a/app/src/main/java/app/pachli/adapter/StatusBaseViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/StatusBaseViewHolder.kt
@@ -63,7 +63,10 @@ import com.mikepenz.iconics.typeface.library.googlematerial.GoogleMaterial
 import java.text.NumberFormat
 import java.util.Date
 
-abstract class StatusBaseViewHolder<T : IStatusViewData> protected constructor(itemView: View) :
+abstract class StatusBaseViewHolder<T : IStatusViewData> protected constructor(
+    private val pachliAccountId: Long,
+    itemView: View,
+) :
     RecyclerView.ViewHolder(itemView) {
     object Key {
         const val KEY_CREATED = "created"
@@ -883,13 +886,13 @@ abstract class StatusBaseViewHolder<T : IStatusViewData> protected constructor(i
             cardView.bind(card, viewData.actionable.sensitive, statusDisplayOptions) { card, target ->
                 if (target == PreviewCardView.Target.BYLINE) {
                     card.authors?.firstOrNull()?.account?.id?.let {
-                        context.startActivity(AccountActivityIntent(context, it))
+                        context.startActivity(AccountActivityIntent(context, pachliAccountId, it))
                     }
                     return@bind
                 }
 
                 if (card.kind == PreviewCardKind.PHOTO && card.embedUrl.isNotEmpty() && target == PreviewCardView.Target.IMAGE) {
-                    context.startActivity(ViewMediaActivityIntent(context, viewData.actionable.account.username, card.embedUrl))
+                    context.startActivity(ViewMediaActivityIntent(context, pachliAccountId, viewData.actionable.account.username, card.embedUrl))
                     return@bind
                 }
 

--- a/app/src/main/java/app/pachli/adapter/StatusDetailedViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/StatusDetailedViewHolder.kt
@@ -23,8 +23,9 @@ import java.text.DateFormat
 import java.util.Locale
 
 class StatusDetailedViewHolder(
+    pachliAccountId: Long,
     private val binding: ItemStatusDetailedBinding,
-) : StatusBaseViewHolder<StatusViewData>(binding.root) {
+) : StatusBaseViewHolder<StatusViewData>(pachliAccountId, binding.root) {
 
     override fun setMetaData(
         viewData: StatusViewData,

--- a/app/src/main/java/app/pachli/adapter/StatusViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/StatusViewHolder.kt
@@ -36,9 +36,10 @@ import app.pachli.viewdata.IStatusViewData
 import at.connyduck.sparkbutton.helpers.Utils
 
 open class StatusViewHolder<T : IStatusViewData>(
+    pachliAccountId: Long,
     private val binding: ItemStatusBinding,
     root: View? = null,
-) : StatusBaseViewHolder<T>(root ?: binding.root) {
+) : StatusBaseViewHolder<T>(pachliAccountId, root ?: binding.root) {
 
     override fun setupWithStatus(
         viewData: T,

--- a/app/src/main/java/app/pachli/components/account/AccountPagerAdapter.kt
+++ b/app/src/main/java/app/pachli/components/account/AccountPagerAdapter.kt
@@ -26,6 +26,7 @@ import app.pachli.core.model.Timeline
 
 class AccountPagerAdapter(
     activity: FragmentActivity,
+    private val pachliAccountId: Long,
     private val accountId: String,
 ) : CustomFragmentStateAdapter(activity) {
 
@@ -33,10 +34,10 @@ class AccountPagerAdapter(
 
     override fun createFragment(position: Int): Fragment {
         return when (position) {
-            0 -> TimelineFragment.newInstance(Timeline.User.Posts(accountId), false)
-            1 -> TimelineFragment.newInstance(Timeline.User.Replies(accountId), false)
-            2 -> TimelineFragment.newInstance(Timeline.User.Pinned(accountId), false)
-            3 -> AccountMediaFragment.newInstance(accountId)
+            0 -> TimelineFragment.newInstance(pachliAccountId, Timeline.User.Posts(accountId), false)
+            1 -> TimelineFragment.newInstance(pachliAccountId, Timeline.User.Replies(accountId), false)
+            2 -> TimelineFragment.newInstance(pachliAccountId, Timeline.User.Pinned(accountId), false)
+            3 -> AccountMediaFragment.newInstance(pachliAccountId, accountId)
             else -> throw AssertionError("Page $position is out of AccountPagerAdapter bounds")
         }
     }

--- a/app/src/main/java/app/pachli/components/account/media/AccountMediaFragment.kt
+++ b/app/src/main/java/app/pachli/components/account/media/AccountMediaFragment.kt
@@ -50,6 +50,7 @@ import com.mikepenz.iconics.typeface.library.googlematerial.GoogleMaterial
 import com.mikepenz.iconics.utils.colorInt
 import com.mikepenz.iconics.utils.sizeDp
 import dagger.hilt.android.AndroidEntryPoint
+import kotlin.properties.Delegates
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
@@ -69,9 +70,12 @@ class AccountMediaFragment :
 
     private lateinit var adapter: AccountMediaGridAdapter
 
+    private var pachliAccountId by Delegates.notNull<Long>()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        viewModel.accountId = arguments?.getString(ACCOUNT_ID_ARG)!!
+        pachliAccountId = requireArguments().getLong(ARG_PACHLI_ACCOUNT_ID)
+        viewModel.accountId = arguments?.getString(ARG_ACCOUNT_ID)!!
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -165,7 +169,7 @@ class AccountMediaFragment :
             Attachment.Type.VIDEO,
             Attachment.Type.AUDIO,
             -> {
-                val intent = ViewMediaActivityIntent(requireContext(), selected.username, attachmentsFromSameStatus, currentIndex)
+                val intent = ViewMediaActivityIntent(requireContext(), pachliAccountId, selected.username, attachmentsFromSameStatus, currentIndex)
                 if (activity != null) {
                     val url = selected.attachment.url
                     ViewCompat.setTransitionName(view, url)
@@ -197,14 +201,16 @@ class AccountMediaFragment :
     }
 
     companion object {
-        fun newInstance(accountId: String): AccountMediaFragment {
+        private const val ARG_PACHLI_ACCOUNT_ID = "app.pachli.ARG_PACHLI_ACCOUNT_ID"
+        private const val ARG_ACCOUNT_ID = "app.pachli.ARG_ACCOUNT_ID"
+
+        fun newInstance(pachliAccountId: Long, accountId: String): AccountMediaFragment {
             val fragment = AccountMediaFragment()
-            val args = Bundle(1)
-            args.putString(ACCOUNT_ID_ARG, accountId)
-            fragment.arguments = args
+            fragment.arguments = Bundle(2).apply {
+                putLong(ARG_PACHLI_ACCOUNT_ID, pachliAccountId)
+                putString(ARG_ACCOUNT_ID, accountId)
+            }
             return fragment
         }
-
-        private const val ACCOUNT_ID_ARG = "account_id"
     }
 }

--- a/app/src/main/java/app/pachli/components/accountlist/AccountListActivity.kt
+++ b/app/src/main/java/app/pachli/components/accountlist/AccountListActivity.kt
@@ -29,6 +29,7 @@ import app.pachli.core.navigation.AccountListActivityIntent.Kind.FOLLOWS
 import app.pachli.core.navigation.AccountListActivityIntent.Kind.FOLLOW_REQUESTS
 import app.pachli.core.navigation.AccountListActivityIntent.Kind.MUTES
 import app.pachli.core.navigation.AccountListActivityIntent.Kind.REBLOGGED
+import app.pachli.core.navigation.pachliAccountId
 import app.pachli.databinding.ActivityAccountListBinding
 import app.pachli.interfaces.AppBarLayoutHost
 import com.google.android.material.appbar.AppBarLayout
@@ -67,7 +68,7 @@ class AccountListActivity : BottomSheetActivity(), AppBarLayoutHost {
         }
 
         supportFragmentManager.commit {
-            replace(R.id.fragment_container, AccountListFragment.newInstance(kind, id))
+            replace(R.id.fragment_container, AccountListFragment.newInstance(intent.pachliAccountId, kind, id))
         }
     }
 }

--- a/app/src/main/java/app/pachli/components/accountlist/AccountListFragment.kt
+++ b/app/src/main/java/app/pachli/components/accountlist/AccountListFragment.kt
@@ -68,6 +68,7 @@ import com.google.android.material.divider.MaterialDividerItemDecoration
 import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
+import kotlin.properties.Delegates
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -96,8 +97,11 @@ class AccountListFragment :
     private var fetching = false
     private var bottomId: String? = null
 
+    private var pachliAccountId by Delegates.notNull<Long>()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        pachliAccountId = requireArguments().getLong(ARG_PACHLI_ACCOUNT_ID)
         kind = requireArguments().getSerializable(ARG_KIND) as Kind
         id = requireArguments().getString(ARG_ID)
     }
@@ -158,15 +162,19 @@ class AccountListFragment :
     }
 
     override fun onViewTag(tag: String) {
-        activity?.startActivityWithDefaultTransition(TimelineActivityIntent.hashtag(requireContext(), tag))
+        activity?.startActivityWithDefaultTransition(
+            TimelineActivityIntent.hashtag(requireContext(), pachliAccountId, tag),
+        )
     }
 
     override fun onViewAccount(id: String) {
-        activity?.startActivityWithDefaultTransition(AccountActivityIntent(requireContext(), id))
+        activity?.startActivityWithDefaultTransition(
+            AccountActivityIntent(requireContext(), pachliAccountId, id),
+        )
     }
 
     override fun onViewUrl(url: String) {
-        (activity as? BottomSheetActivity)?.viewUrl(url, PostLookupFallbackBehavior.OPEN_IN_BROWSER)
+        (activity as? BottomSheetActivity)?.viewUrl(pachliAccountId, url, PostLookupFallbackBehavior.OPEN_IN_BROWSER)
     }
 
     override fun onMute(mute: Boolean, id: String, position: Int, notifications: Boolean) {
@@ -399,12 +407,14 @@ class AccountListFragment :
     }
 
     companion object {
-        private const val ARG_KIND = "kind"
-        private const val ARG_ID = "id"
+        private const val ARG_PACHLI_ACCOUNT_ID = "app.pachli.ARG_PACHLI_ACCOUNT_ID"
+        private const val ARG_KIND = "app.pachli.ARG_KIND"
+        private const val ARG_ID = "app.pachli.ARG_ID"
 
-        fun newInstance(kind: Kind, id: String? = null): AccountListFragment {
+        fun newInstance(pachliAccountId: Long, kind: Kind, id: String? = null): AccountListFragment {
             return AccountListFragment().apply {
                 arguments = Bundle(3).apply {
+                    putLong(ARG_PACHLI_ACCOUNT_ID, pachliAccountId)
                     putSerializable(ARG_KIND, kind)
                     putString(ARG_ID, id)
                 }

--- a/app/src/main/java/app/pachli/components/announcements/AnnouncementsActivity.kt
+++ b/app/src/main/java/app/pachli/components/announcements/AnnouncementsActivity.kt
@@ -35,6 +35,7 @@ import app.pachli.core.common.extensions.show
 import app.pachli.core.common.extensions.viewBinding
 import app.pachli.core.common.util.unsafeLazy
 import app.pachli.core.navigation.TimelineActivityIntent
+import app.pachli.core.navigation.pachliAccountId
 import app.pachli.core.preferences.PrefKeys
 import app.pachli.core.ui.BackgroundMessage
 import app.pachli.databinding.ActivityAnnouncementsBinding
@@ -187,15 +188,15 @@ class AnnouncementsActivity :
     }
 
     override fun onViewTag(tag: String) {
-        val intent = TimelineActivityIntent.hashtag(this, tag)
+        val intent = TimelineActivityIntent.hashtag(this, intent.pachliAccountId, tag)
         startActivityWithDefaultTransition(intent)
     }
 
     override fun onViewAccount(id: String) {
-        viewAccount(id)
+        viewAccount(intent.pachliAccountId, id)
     }
 
     override fun onViewUrl(url: String) {
-        viewUrl(url)
+        viewUrl(intent.pachliAccountId, url)
     }
 }

--- a/app/src/main/java/app/pachli/components/compose/ComposeViewModel.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeViewModel.kt
@@ -396,7 +396,7 @@ class ComposeViewModel @Inject constructor(
 
         draftHelper.saveDraft(
             draftId = draftId,
-            accountId = accountManager.activeAccount?.id!!,
+            pachliAccountId = accountManager.activeAccount?.id!!,
             inReplyToId = inReplyToId,
             content = content,
             contentWarning = contentWarning,
@@ -421,7 +421,7 @@ class ComposeViewModel @Inject constructor(
     suspend fun sendStatus(
         content: String,
         spoilerText: String,
-        accountId: Long,
+        pachliAccountId: Long,
     ) {
         if (!scheduledTootId.isNullOrEmpty()) {
             api.deleteScheduledStatus(scheduledTootId!!)
@@ -448,7 +448,7 @@ class ComposeViewModel @Inject constructor(
             poll = poll.value,
             replyingStatusContent = null,
             replyingStatusAuthorUsername = null,
-            accountId = accountId,
+            pachliAccountId = pachliAccountId,
             draftId = draftId,
             idempotencyKey = randomAlphanumericString(16),
             retries = 0,

--- a/app/src/main/java/app/pachli/components/conversation/ConversationAdapter.kt
+++ b/app/src/main/java/app/pachli/components/conversation/ConversationAdapter.kt
@@ -26,6 +26,7 @@ import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.interfaces.StatusActionListener
 
 class ConversationAdapter(
+    private val pachliAccountId: Long,
     private var statusDisplayOptions: StatusDisplayOptions,
     private val listener: StatusActionListener<ConversationViewData>,
 ) : PagingDataAdapter<ConversationViewData, ConversationViewHolder>(CONVERSATION_COMPARATOR) {
@@ -40,7 +41,7 @@ class ConversationAdapter(
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ConversationViewHolder {
         val view = LayoutInflater.from(parent.context).inflate(R.layout.item_conversation, parent, false)
-        return ConversationViewHolder(view, statusDisplayOptions, listener)
+        return ConversationViewHolder(pachliAccountId, view, statusDisplayOptions, listener)
     }
 
     override fun onBindViewHolder(holder: ConversationViewHolder, position: Int) {

--- a/app/src/main/java/app/pachli/components/conversation/ConversationViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/conversation/ConversationViewHolder.kt
@@ -33,10 +33,11 @@ import app.pachli.interfaces.StatusActionListener
 import app.pachli.util.SmartLengthInputFilter
 
 class ConversationViewHolder internal constructor(
+    pachliAccountId: Long,
     itemView: View,
     private val statusDisplayOptions: StatusDisplayOptions,
     private val listener: StatusActionListener<ConversationViewData>,
-) : StatusBaseViewHolder<ConversationViewData>(itemView) {
+) : StatusBaseViewHolder<ConversationViewData>(pachliAccountId, itemView) {
     private val conversationNameTextView: TextView = itemView.findViewById(R.id.conversation_name)
     private val contentCollapseButton: Button = itemView.findViewById(R.id.button_toggle_content)
     private val avatars: Array<ImageView> = arrayOf(

--- a/app/src/main/java/app/pachli/components/drafts/DraftHelper.kt
+++ b/app/src/main/java/app/pachli/components/drafts/DraftHelper.kt
@@ -51,7 +51,7 @@ class DraftHelper @Inject constructor(
 ) {
     suspend fun saveDraft(
         draftId: Int,
-        accountId: Long,
+        pachliAccountId: Long,
         inReplyToId: String?,
         content: String?,
         contentWarning: String?,
@@ -114,7 +114,7 @@ class DraftHelper @Inject constructor(
 
         val draft = DraftEntity(
             id = draftId,
-            accountId = accountId,
+            accountId = pachliAccountId,
             inReplyToId = inReplyToId,
             content = content,
             contentWarning = contentWarning,
@@ -144,8 +144,8 @@ class DraftHelper @Inject constructor(
         draftDao.delete(draft.id)
     }
 
-    suspend fun deleteAllDraftsAndAttachmentsForAccount(accountId: Long) {
-        draftDao.loadDrafts(accountId).forEach { draft ->
+    suspend fun deleteAllDraftsAndAttachmentsForAccount(pachliAccountId: Long) {
+        draftDao.loadDrafts(pachliAccountId).forEach { draft ->
             deleteDraftAndAttachments(draft)
         }
     }

--- a/app/src/main/java/app/pachli/components/filters/ContentFiltersActivity.kt
+++ b/app/src/main/java/app/pachli/components/filters/ContentFiltersActivity.kt
@@ -14,6 +14,7 @@ import app.pachli.core.common.extensions.viewBinding
 import app.pachli.core.common.extensions.visible
 import app.pachli.core.model.ContentFilter
 import app.pachli.core.navigation.EditContentFilterActivityIntent
+import app.pachli.core.navigation.pachliAccountId
 import app.pachli.core.ui.BackgroundMessage
 import app.pachli.databinding.ActivityContentFiltersBinding
 import com.google.android.material.color.MaterialColors
@@ -97,8 +98,8 @@ class ContentFiltersActivity : BaseActivity(), ContentFiltersListener {
 
     private fun launchEditContentFilterActivity(contentFilter: ContentFilter? = null) {
         val intent = contentFilter?.let {
-            EditContentFilterActivityIntent.edit(this, contentFilter)
-        } ?: EditContentFilterActivityIntent(this)
+            EditContentFilterActivityIntent.edit(this, intent.pachliAccountId, contentFilter)
+        } ?: EditContentFilterActivityIntent(this, intent.pachliAccountId)
         startActivityWithTransition(intent, TransitionKind.SLIDE_FROM_END)
     }
 

--- a/app/src/main/java/app/pachli/components/followedtags/FollowedTagsActivity.kt
+++ b/app/src/main/java/app/pachli/components/followedtags/FollowedTagsActivity.kt
@@ -22,6 +22,7 @@ import app.pachli.core.common.extensions.show
 import app.pachli.core.common.extensions.viewBinding
 import app.pachli.core.common.extensions.visible
 import app.pachli.core.navigation.TimelineActivityIntent
+import app.pachli.core.navigation.pachliAccountId
 import app.pachli.core.network.retrofit.MastodonApi
 import app.pachli.core.ui.ActionButtonScrollListener
 import app.pachli.databinding.ActivityFollowedTagsBinding
@@ -173,7 +174,7 @@ class FollowedTagsActivity :
     }
 
     override fun onViewTag(tag: String) {
-        startActivityWithDefaultTransition(TimelineActivityIntent.hashtag(this, tag))
+        startActivityWithDefaultTransition(TimelineActivityIntent.hashtag(this, intent.pachliAccountId, tag))
     }
 
     override suspend fun search(token: String): List<ComposeAutoCompleteAdapter.AutocompleteResult> {

--- a/app/src/main/java/app/pachli/components/notifications/NotificationFetcher.kt
+++ b/app/src/main/java/app/pachli/components/notifications/NotificationFetcher.kt
@@ -56,14 +56,14 @@ class NotificationFetcher @Inject constructor(
     private val accountManager: AccountManager,
     @ApplicationContext private val context: Context,
 ) {
-    suspend fun fetchAndShow(accountId: Long) {
+    suspend fun fetchAndShow(pachliAccountId: Long) {
         Timber.d("NotificationFetcher.fetchAndShow() started")
 
         val accounts = buildList {
-            if (accountId == NotificationWorker.ALL_ACCOUNTS) {
+            if (pachliAccountId == NotificationWorker.ALL_ACCOUNTS) {
                 addAll(accountManager.getAllAccountsOrderedByActive())
             } else {
-                accountManager.getAccountById(accountId)?.let { add(it) }
+                accountManager.getAccountById(pachliAccountId)?.let { add(it) }
             }
         }
 

--- a/app/src/main/java/app/pachli/components/notifications/NotificationsPagingAdapter.kt
+++ b/app/src/main/java/app/pachli/components/notifications/NotificationsPagingAdapter.kt
@@ -110,6 +110,7 @@ interface NotificationActionListener {
 
 class NotificationsPagingAdapter(
     diffCallback: DiffUtil.ItemCallback<NotificationViewData>,
+    private val pachliAccountId: Long,
     /** ID of the the account that notifications are being displayed for */
     private val accountId: String,
     private val statusActionListener: StatusActionListener<NotificationViewData>,
@@ -145,6 +146,7 @@ class NotificationsPagingAdapter(
         return when (NotificationViewKind.entries[viewType]) {
             NotificationViewKind.STATUS -> {
                 StatusViewHolder(
+                    pachliAccountId,
                     ItemStatusBinding.inflate(inflater, parent, false),
                     statusActionListener,
                     accountId,
@@ -152,6 +154,7 @@ class NotificationsPagingAdapter(
             }
             NotificationViewKind.STATUS_FILTERED -> {
                 FilterableStatusViewHolder(
+                    pachliAccountId,
                     ItemStatusWrapperBinding.inflate(inflater, parent, false),
                     statusActionListener,
                     accountId,

--- a/app/src/main/java/app/pachli/components/notifications/StatusViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/notifications/StatusViewHolder.kt
@@ -27,10 +27,11 @@ import app.pachli.interfaces.StatusActionListener
 import app.pachli.viewdata.NotificationViewData
 
 internal class StatusViewHolder(
+    pachliAccountId: Long,
     binding: ItemStatusBinding,
     private val statusActionListener: StatusActionListener<NotificationViewData>,
     private val accountId: String,
-) : NotificationsPagingAdapter.ViewHolder, StatusViewHolder<NotificationViewData>(binding) {
+) : NotificationsPagingAdapter.ViewHolder, StatusViewHolder<NotificationViewData>(pachliAccountId, binding) {
 
     override fun bind(
         viewData: NotificationViewData,
@@ -62,10 +63,11 @@ internal class StatusViewHolder(
 }
 
 class FilterableStatusViewHolder(
+    private val pachliAccountId: Long,
     binding: ItemStatusWrapperBinding,
     private val statusActionListener: StatusActionListener<NotificationViewData>,
     private val accountId: String,
-) : NotificationsPagingAdapter.ViewHolder, FilterableStatusViewHolder<NotificationViewData>(binding) {
+) : NotificationsPagingAdapter.ViewHolder, FilterableStatusViewHolder<NotificationViewData>(pachliAccountId, binding) {
     // Note: Identical to bind() in StatusViewHolder above
     override fun bind(
         viewData: NotificationViewData,

--- a/app/src/main/java/app/pachli/components/preference/PreferencesActivity.kt
+++ b/app/src/main/java/app/pachli/components/preference/PreferencesActivity.kt
@@ -33,6 +33,7 @@ import app.pachli.core.activity.extensions.startActivityWithDefaultTransition
 import app.pachli.core.navigation.MainActivityIntent
 import app.pachli.core.navigation.PreferencesActivityIntent
 import app.pachli.core.navigation.PreferencesActivityIntent.PreferenceScreen
+import app.pachli.core.navigation.pachliAccountId
 import app.pachli.core.preferences.PrefKeys
 import app.pachli.core.preferences.PrefKeys.APP_THEME
 import app.pachli.databinding.ActivityPreferencesBinding
@@ -60,7 +61,7 @@ class PreferencesActivity :
              * Either the back stack activities need to all be recreated, or do the easier thing, which
              * is hijack the back button press and use it to launch a new MainActivity and clear the
              * back stack. */
-            val intent = MainActivityIntent(this@PreferencesActivity)
+            val intent = MainActivityIntent(this@PreferencesActivity, intent.pachliAccountId)
             intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
             startActivityWithDefaultTransition(intent)
         }
@@ -85,7 +86,7 @@ class PreferencesActivity :
         val fragment: Fragment = supportFragmentManager.findFragmentByTag(fragmentTag)
             ?: when (preferenceType) {
                 PreferenceScreen.GENERAL -> PreferencesFragment.newInstance()
-                PreferenceScreen.ACCOUNT -> AccountPreferencesFragment.newInstance()
+                PreferenceScreen.ACCOUNT -> AccountPreferencesFragment.newInstance(intent.pachliAccountId)
                 PreferenceScreen.NOTIFICATION -> NotificationPreferencesFragment.newInstance()
                 else -> throw IllegalArgumentException("preferenceType not known")
             }

--- a/app/src/main/java/app/pachli/components/report/ReportActivity.kt
+++ b/app/src/main/java/app/pachli/components/report/ReportActivity.kt
@@ -23,6 +23,7 @@ import app.pachli.components.report.adapter.ReportPagerAdapter
 import app.pachli.core.activity.BottomSheetActivity
 import app.pachli.core.common.extensions.viewBinding
 import app.pachli.core.navigation.ReportActivityIntent
+import app.pachli.core.navigation.pachliAccountId
 import app.pachli.databinding.ActivityReportBinding
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -70,7 +71,7 @@ class ReportActivity : BottomSheetActivity() {
         //   (unfixed old bug: https://github.com/material-components/material-components-android/issues/500)
         binding.wizard.offscreenPageLimit = 1
 
-        binding.wizard.adapter = ReportPagerAdapter(this)
+        binding.wizard.adapter = ReportPagerAdapter(this, intent.pachliAccountId)
     }
 
     private fun subscribeObservables() {
@@ -90,7 +91,7 @@ class ReportActivity : BottomSheetActivity() {
         viewModel.checkUrl.observe(this) {
             if (!it.isNullOrBlank()) {
                 viewModel.urlChecked()
-                viewUrl(it)
+                viewUrl(intent.pachliAccountId, it)
             }
         }
     }

--- a/app/src/main/java/app/pachli/components/report/adapter/ReportPagerAdapter.kt
+++ b/app/src/main/java/app/pachli/components/report/adapter/ReportPagerAdapter.kt
@@ -23,10 +23,10 @@ import app.pachli.components.report.fragments.ReportDoneFragment
 import app.pachli.components.report.fragments.ReportNoteFragment
 import app.pachli.components.report.fragments.ReportStatusesFragment
 
-class ReportPagerAdapter(activity: FragmentActivity) : FragmentStateAdapter(activity) {
+class ReportPagerAdapter(activity: FragmentActivity, private val pachliAccountId: Long) : FragmentStateAdapter(activity) {
     override fun createFragment(position: Int): Fragment {
         return when (position) {
-            0 -> ReportStatusesFragment.newInstance()
+            0 -> ReportStatusesFragment.newInstance(pachliAccountId)
             1 -> ReportNoteFragment.newInstance()
             2 -> ReportDoneFragment.newInstance()
             else -> throw IllegalArgumentException("Unknown page index: $position")

--- a/app/src/main/java/app/pachli/components/report/fragments/ReportStatusesFragment.kt
+++ b/app/src/main/java/app/pachli/components/report/fragments/ReportStatusesFragment.kt
@@ -56,6 +56,7 @@ import com.mikepenz.iconics.utils.colorInt
 import com.mikepenz.iconics.utils.sizeDp
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
+import kotlin.properties.Delegates
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
@@ -77,12 +78,25 @@ class ReportStatusesFragment :
 
     private var snackbarErrorRetry: Snackbar? = null
 
+    private var pachliAccountId by Delegates.notNull<Long>()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        pachliAccountId = requireArguments().getLong(ARG_PACHLI_ACCOUNT_ID)
+    }
+
     override fun showMedia(v: View?, status: Status?, idx: Int) {
         status?.actionableStatus?.let { actionable ->
             when (actionable.attachments[idx].type) {
                 Attachment.Type.GIFV, Attachment.Type.VIDEO, Attachment.Type.IMAGE, Attachment.Type.AUDIO -> {
                     val attachments = AttachmentViewData.list(actionable)
-                    val intent = ViewMediaActivityIntent(requireContext(), actionable.account.username, attachments, idx)
+                    val intent = ViewMediaActivityIntent(
+                        requireContext(),
+                        pachliAccountId,
+                        actionable.account.username,
+                        attachments,
+                        idx,
+                    )
                     if (v != null) {
                         val url = actionable.attachments[idx].url
                         ViewCompat.setTransitionName(v, url)
@@ -209,13 +223,25 @@ class ReportStatusesFragment :
         return viewModel.isStatusChecked(id)
     }
 
-    override fun onViewAccount(id: String) = startActivity(AccountActivityIntent(requireContext(), id))
+    override fun onViewAccount(id: String) = startActivity(
+        AccountActivityIntent(requireContext(), pachliAccountId, id),
+    )
 
-    override fun onViewTag(tag: String) = startActivity(TimelineActivityIntent.hashtag(requireContext(), tag))
+    override fun onViewTag(tag: String) = startActivity(
+        TimelineActivityIntent.hashtag(requireContext(), pachliAccountId, tag),
+    )
 
     override fun onViewUrl(url: String) = viewModel.checkClickedUrl(url)
 
     companion object {
-        fun newInstance() = ReportStatusesFragment()
+        private const val ARG_PACHLI_ACCOUNT_ID = "app.pachli.ARG_PACHLI_ACCOUNT_ID"
+
+        fun newInstance(pachliAccountId: Long): ReportStatusesFragment {
+            val fragment = ReportStatusesFragment()
+            fragment.arguments = Bundle(1).apply {
+                putLong(ARG_PACHLI_ACCOUNT_ID, pachliAccountId)
+            }
+            return fragment
+        }
     }
 }

--- a/app/src/main/java/app/pachli/components/search/SearchActivity.kt
+++ b/app/src/main/java/app/pachli/components/search/SearchActivity.kt
@@ -88,6 +88,7 @@ import app.pachli.core.model.ServerOperation.ORG_JOINMASTODON_SEARCH_QUERY_IN_PU
 import app.pachli.core.model.ServerOperation.ORG_JOINMASTODON_SEARCH_QUERY_IS_REPLY
 import app.pachli.core.model.ServerOperation.ORG_JOINMASTODON_SEARCH_QUERY_IS_SENSITIVE
 import app.pachli.core.model.ServerOperation.ORG_JOINMASTODON_SEARCH_QUERY_LANGUAGE
+import app.pachli.core.navigation.pachliAccountId
 import app.pachli.core.network.Server
 import app.pachli.core.preferences.PrefKeys
 import app.pachli.core.ui.extensions.await
@@ -151,7 +152,7 @@ class SearchActivity :
 
     private fun setupPages() {
         binding.pages.reduceSwipeSensitivity()
-        binding.pages.adapter = SearchPagerAdapter(this)
+        binding.pages.adapter = SearchPagerAdapter(this, intent.pachliAccountId)
 
         val enableSwipeForTabs = sharedPreferencesRepository.getBoolean(PrefKeys.ENABLE_SWIPE_FOR_TABS, true)
         binding.pages.isUserInputEnabled = enableSwipeForTabs

--- a/app/src/main/java/app/pachli/components/search/adapter/SearchPagerAdapter.kt
+++ b/app/src/main/java/app/pachli/components/search/adapter/SearchPagerAdapter.kt
@@ -23,13 +23,16 @@ import app.pachli.components.search.fragments.SearchAccountsFragment
 import app.pachli.components.search.fragments.SearchHashtagsFragment
 import app.pachli.components.search.fragments.SearchStatusesFragment
 
-class SearchPagerAdapter(activity: FragmentActivity) : FragmentStateAdapter(activity) {
+class SearchPagerAdapter(
+    activity: FragmentActivity,
+    private val pachliAccountId: Long,
+) : FragmentStateAdapter(activity) {
 
     override fun createFragment(position: Int): Fragment {
         return when (position) {
-            0 -> SearchStatusesFragment.newInstance()
-            1 -> SearchAccountsFragment.newInstance()
-            2 -> SearchHashtagsFragment.newInstance()
+            0 -> SearchStatusesFragment.newInstance(pachliAccountId)
+            1 -> SearchAccountsFragment.newInstance(pachliAccountId)
+            2 -> SearchHashtagsFragment.newInstance(pachliAccountId)
             else -> throw IllegalArgumentException("Unknown page index: $position")
         }
     }

--- a/app/src/main/java/app/pachli/components/search/adapter/SearchStatusesAdapter.kt
+++ b/app/src/main/java/app/pachli/components/search/adapter/SearchStatusesAdapter.kt
@@ -27,12 +27,14 @@ import app.pachli.interfaces.StatusActionListener
 import app.pachli.viewdata.StatusViewData
 
 class SearchStatusesAdapter(
+    private val pachliAccountId: Long,
     private val statusDisplayOptions: StatusDisplayOptions,
     private val statusListener: StatusActionListener<StatusViewData>,
 ) : PagingDataAdapter<StatusViewData, StatusViewHolder<StatusViewData>>(STATUS_COMPARATOR) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): StatusViewHolder<StatusViewData> {
         return StatusViewHolder(
+            pachliAccountId,
             ItemStatusBinding.inflate(LayoutInflater.from(parent.context), parent, false),
         )
     }

--- a/app/src/main/java/app/pachli/components/search/fragments/SearchAccountsFragment.kt
+++ b/app/src/main/java/app/pachli/components/search/fragments/SearchAccountsFragment.kt
@@ -54,6 +54,8 @@ class SearchAccountsFragment : SearchFragment<TimelineAccount>() {
         get() = viewModel.accountsFlow
 
     companion object {
-        fun newInstance() = SearchAccountsFragment()
+        fun newInstance(pachliAccountId: Long): SearchAccountsFragment {
+            return SearchFragment.newInstance(pachliAccountId)
+        }
     }
 }

--- a/app/src/main/java/app/pachli/components/search/fragments/SearchFragment.kt
+++ b/app/src/main/java/app/pachli/components/search/fragments/SearchFragment.kt
@@ -34,6 +34,7 @@ import com.mikepenz.iconics.typeface.library.googlematerial.GoogleMaterial
 import com.mikepenz.iconics.utils.colorInt
 import com.mikepenz.iconics.utils.sizeDp
 import javax.inject.Inject
+import kotlin.properties.Delegates
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -59,6 +60,13 @@ abstract class SearchFragment<T : Any> :
     protected lateinit var adapter: PagingDataAdapter<T, *>
 
     private var currentQuery: String = ""
+
+    protected var pachliAccountId by Delegates.notNull<Long>()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        pachliAccountId = requireArguments().getLong(ARG_PACHLI_ACCOUNT_ID)
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         initAdapter()
@@ -145,15 +153,19 @@ abstract class SearchFragment<T : Any> :
     }
 
     override fun onViewAccount(id: String) {
-        bottomSheetActivity?.startActivityWithDefaultTransition(AccountActivityIntent(requireContext(), id))
+        bottomSheetActivity?.startActivityWithDefaultTransition(
+            AccountActivityIntent(requireContext(), pachliAccountId, id),
+        )
     }
 
     override fun onViewTag(tag: String) {
-        bottomSheetActivity?.startActivityWithDefaultTransition(TimelineActivityIntent.hashtag(requireContext(), tag))
+        bottomSheetActivity?.startActivityWithDefaultTransition(
+            TimelineActivityIntent.hashtag(requireContext(), pachliAccountId, tag),
+        )
     }
 
     override fun onViewUrl(url: String) {
-        bottomSheetActivity?.viewUrl(url)
+        bottomSheetActivity?.viewUrl(pachliAccountId, url)
     }
 
     protected val bottomSheetActivity
@@ -161,5 +173,17 @@ abstract class SearchFragment<T : Any> :
 
     override fun onRefresh() {
         adapter.refresh()
+    }
+
+    companion object {
+        const val ARG_PACHLI_ACCOUNT_ID = "app.pachli.ARG_PACHLI_ACCOUNT_ID"
+
+        inline fun <reified T : SearchFragment<*>> newInstance(pachliAccountId: Long): T {
+            val fragment = T::class.java.getDeclaredConstructor().newInstance()
+            fragment.arguments = Bundle(1).apply {
+                putLong(ARG_PACHLI_ACCOUNT_ID, pachliAccountId)
+            }
+            return fragment
+        }
     }
 }

--- a/app/src/main/java/app/pachli/components/search/fragments/SearchHashtagsFragment.kt
+++ b/app/src/main/java/app/pachli/components/search/fragments/SearchHashtagsFragment.kt
@@ -42,6 +42,8 @@ class SearchHashtagsFragment : SearchFragment<HashTag>() {
     override fun createAdapter(): PagingDataAdapter<HashTag, *> = SearchHashtagsAdapter(this)
 
     companion object {
-        fun newInstance() = SearchHashtagsFragment()
+        fun newInstance(pachliAccountId: Long): SearchHashtagsFragment {
+            return SearchFragment.newInstance(pachliAccountId)
+        }
     }
 }

--- a/app/src/main/java/app/pachli/components/search/fragments/SearchStatusesFragment.kt
+++ b/app/src/main/java/app/pachli/components/search/fragments/SearchStatusesFragment.kt
@@ -85,7 +85,7 @@ class SearchStatusesFragment : SearchFragment<StatusViewData>(), StatusActionLis
             MaterialDividerItemDecoration(requireContext(), MaterialDividerItemDecoration.VERTICAL),
         )
         binding.searchRecyclerView.layoutManager = LinearLayoutManager(binding.searchRecyclerView.context)
-        return SearchStatusesAdapter(statusDisplayOptions, this)
+        return SearchStatusesAdapter(viewModel.activeAccount!!.id, statusDisplayOptions, this)
     }
 
     override fun onContentHiddenChange(viewData: StatusViewData, isShowing: Boolean) {
@@ -115,6 +115,7 @@ class SearchStatusesFragment : SearchFragment<StatusViewData>(), StatusActionLis
                 val attachments = AttachmentViewData.list(actionable)
                 val intent = ViewMediaActivityIntent(
                     requireContext(),
+                    pachliAccountId,
                     actionable.account.username,
                     attachments,
                     attachmentIndex,
@@ -140,11 +141,11 @@ class SearchStatusesFragment : SearchFragment<StatusViewData>(), StatusActionLis
 
     override fun onViewThread(status: Status) {
         val actionableStatus = status.actionableStatus
-        bottomSheetActivity?.viewThread(actionableStatus.id, actionableStatus.url)
+        bottomSheetActivity?.viewThread(pachliAccountId, actionableStatus.id, actionableStatus.url)
     }
 
     override fun onOpenReblog(status: Status) {
-        bottomSheetActivity?.viewAccount(status.account.id)
+        bottomSheetActivity?.viewAccount(pachliAccountId, status.account.id)
     }
 
     override fun onExpandedChange(viewData: StatusViewData, expanded: Boolean) {
@@ -165,15 +166,11 @@ class SearchStatusesFragment : SearchFragment<StatusViewData>(), StatusActionLis
         viewModel.reblog(viewData, reblog)
     }
 
-    override fun onEditFilterById(filterId: String) {
+    override fun onEditFilterById(pachliAccountId: Long, filterId: String) {
         requireActivity().startActivityWithTransition(
-            EditContentFilterActivityIntent.edit(requireContext(), filterId),
+            EditContentFilterActivityIntent.edit(requireContext(), pachliAccountId, filterId),
             TransitionKind.SLIDE_FROM_END,
         )
-    }
-
-    companion object {
-        fun newInstance() = SearchStatusesFragment()
     }
 
     private fun reply(status: StatusViewData) {
@@ -399,7 +396,7 @@ class SearchStatusesFragment : SearchFragment<StatusViewData>(), StatusActionLis
     }
 
     private fun openReportPage(accountId: String, accountUsername: String, statusId: String) {
-        startActivity(ReportActivityIntent(requireContext(), accountId, accountUsername, statusId))
+        startActivity(ReportActivityIntent(requireContext(), this.pachliAccountId, accountUsername, statusId))
     }
 
     // TODO: Identical to the same function in SFragment.kt
@@ -487,6 +484,12 @@ class SearchStatusesFragment : SearchFragment<StatusViewData>(), StatusActionLis
                     ).show()
                 },
             )
+        }
+    }
+
+    companion object {
+        fun newInstance(pachliAccountId: Long): SearchStatusesFragment {
+            return SearchFragment.newInstance(pachliAccountId)
         }
     }
 }

--- a/app/src/main/java/app/pachli/components/timeline/CachedTimelineRepository.kt
+++ b/app/src/main/java/app/pachli/components/timeline/CachedTimelineRepository.kt
@@ -113,7 +113,7 @@ class CachedTimelineRepository @Inject constructor(
                 remoteMediator = CachedTimelineRemoteMediator(
                     initialKey,
                     mastodonApi,
-                    accountManager,
+                    activeAccount!!.id,
                     factory!!,
                     transactionProvider,
                     timelineDao,

--- a/app/src/main/java/app/pachli/components/timeline/TimelinePagingAdapter.kt
+++ b/app/src/main/java/app/pachli/components/timeline/TimelinePagingAdapter.kt
@@ -33,6 +33,7 @@ import app.pachli.interfaces.StatusActionListener
 import app.pachli.viewdata.StatusViewData
 
 class TimelinePagingAdapter(
+    private val pachliAccountId: Long,
     private val statusListener: StatusActionListener<StatusViewData>,
     var statusDisplayOptions: StatusDisplayOptions,
 ) : PagingDataAdapter<StatusViewData, RecyclerView.ViewHolder>(TimelineDifferCallback) {
@@ -40,10 +41,10 @@ class TimelinePagingAdapter(
         val inflater = LayoutInflater.from(viewGroup.context)
         return when (viewType) {
             VIEW_TYPE_STATUS_FILTERED -> {
-                FilterableStatusViewHolder<StatusViewData>(ItemStatusWrapperBinding.inflate(inflater, viewGroup, false))
+                FilterableStatusViewHolder<StatusViewData>(pachliAccountId, ItemStatusWrapperBinding.inflate(inflater, viewGroup, false))
             }
             VIEW_TYPE_STATUS -> {
-                StatusViewHolder<StatusViewData>(ItemStatusBinding.inflate(inflater, viewGroup, false))
+                StatusViewHolder<StatusViewData>(pachliAccountId, ItemStatusBinding.inflate(inflater, viewGroup, false))
             }
             else -> return object : RecyclerView.ViewHolder(inflater.inflate(R.layout.item_placeholder, viewGroup, false)) {}
         }

--- a/app/src/main/java/app/pachli/components/trending/TrendingActivity.kt
+++ b/app/src/main/java/app/pachli/components/trending/TrendingActivity.kt
@@ -33,6 +33,7 @@ import app.pachli.core.activity.BottomSheetActivity
 import app.pachli.core.activity.ReselectableFragment
 import app.pachli.core.common.extensions.viewBinding
 import app.pachli.core.model.Timeline
+import app.pachli.core.navigation.pachliAccountId
 import app.pachli.core.ui.extensions.reduceSwipeSensitivity
 import app.pachli.databinding.ActivityTrendingBinding
 import app.pachli.interfaces.AppBarLayoutHost
@@ -77,11 +78,13 @@ class TrendingActivity : BottomSheetActivity(), AppBarLayoutHost, MenuProvider {
             setDisplayShowHomeEnabled(true)
         }
 
+        val pachliAccountId = intent.pachliAccountId
+
         adapter = MainPagerAdapter(
             listOf(
-                TabViewData.from(Timeline.TrendingHashtags),
-                TabViewData.from(Timeline.TrendingLinks),
-                TabViewData.from(Timeline.TrendingStatuses),
+                TabViewData.from(pachliAccountId, Timeline.TrendingHashtags),
+                TabViewData.from(pachliAccountId, Timeline.TrendingLinks),
+                TabViewData.from(pachliAccountId, Timeline.TrendingStatuses),
             ),
             this,
         )

--- a/app/src/main/java/app/pachli/components/trending/TrendingLinksFragment.kt
+++ b/app/src/main/java/app/pachli/components/trending/TrendingLinksFragment.kt
@@ -60,6 +60,7 @@ import com.mikepenz.iconics.typeface.library.googlematerial.GoogleMaterial
 import com.mikepenz.iconics.utils.colorInt
 import com.mikepenz.iconics.utils.sizeDp
 import dagger.hilt.android.AndroidEntryPoint
+import kotlin.properties.Delegates
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import retrofit2.HttpException
@@ -80,6 +81,13 @@ class TrendingLinksFragment :
     private lateinit var trendingLinksAdapter: TrendingLinksAdapter
 
     private var talkBackWasEnabled = false
+
+    private var pachliAccountId by Delegates.notNull<Long>()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        pachliAccountId = requireArguments().getLong(ARG_PACHLI_ACCOUNT_ID)
+    }
 
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
@@ -232,7 +240,7 @@ class TrendingLinksFragment :
     private fun onOpenLink(card: PreviewCard, target: Target) {
         if (target == Target.BYLINE) {
             card.authors?.firstOrNull()?.account?.id?.let {
-                startActivity(AccountActivityIntent(requireContext(), it))
+                startActivity(AccountActivityIntent(requireContext(), pachliAccountId, it))
             }
             return
         }
@@ -256,6 +264,14 @@ class TrendingLinksFragment :
     }
 
     companion object {
-        fun newInstance() = TrendingLinksFragment()
+        private const val ARG_PACHLI_ACCOUNT_ID = "app.pachli.ARG_PACHLI_ACCOUNT_ID"
+
+        fun newInstance(pachliAccountId: Long): TrendingLinksFragment {
+            val fragment = TrendingLinksFragment()
+            fragment.arguments = Bundle(1).apply {
+                putLong(ARG_PACHLI_ACCOUNT_ID, pachliAccountId)
+            }
+            return fragment
+        }
     }
 }

--- a/app/src/main/java/app/pachli/components/trending/TrendingTagsFragment.kt
+++ b/app/src/main/java/app/pachli/components/trending/TrendingTagsFragment.kt
@@ -57,6 +57,7 @@ import com.mikepenz.iconics.typeface.library.googlematerial.GoogleMaterial
 import com.mikepenz.iconics.utils.colorInt
 import com.mikepenz.iconics.utils.sizeDp
 import dagger.hilt.android.AndroidEntryPoint
+import kotlin.properties.Delegates
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -74,6 +75,13 @@ class TrendingTagsFragment :
     private val binding by viewBinding(FragmentTrendingTagsBinding::bind)
 
     private val adapter = TrendingTagsAdapter(::onViewTag)
+
+    private var pachliAccountId by Delegates.notNull<Long>()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        pachliAccountId = requireArguments().getLong(ARG_PACHLI_ACCOUNT_ID)
+    }
 
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
@@ -176,6 +184,7 @@ class TrendingTagsFragment :
         activity?.startActivityWithDefaultTransition(
             TimelineActivityIntent.hashtag(
                 requireContext(),
+                pachliAccountId,
                 tag,
             ),
         )
@@ -281,6 +290,14 @@ class TrendingTagsFragment :
     }
 
     companion object {
-        fun newInstance() = TrendingTagsFragment()
+        private const val ARG_PACHLI_ACCOUNT_ID = "app.pachli.ARG_PACHLI_ACCOUNT_ID"
+
+        fun newInstance(pachliAccountId: Long): TrendingTagsFragment {
+            val fragment = TrendingTagsFragment()
+            fragment.arguments = Bundle(1).apply {
+                putLong(ARG_PACHLI_ACCOUNT_ID, pachliAccountId)
+            }
+            return fragment
+        }
     }
 }

--- a/app/src/main/java/app/pachli/components/viewthread/ThreadAdapter.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/ThreadAdapter.kt
@@ -33,6 +33,7 @@ import app.pachli.interfaces.StatusActionListener
 import app.pachli.viewdata.StatusViewData
 
 class ThreadAdapter(
+    private val pachliAccountId: Long,
     private val statusDisplayOptions: StatusDisplayOptions,
     private val statusActionListener: StatusActionListener<StatusViewData>,
 ) : ListAdapter<StatusViewData, StatusBaseViewHolder<StatusViewData>>(ThreadDifferCallback) {
@@ -41,13 +42,13 @@ class ThreadAdapter(
         val inflater = LayoutInflater.from(parent.context)
         return when (viewType) {
             VIEW_TYPE_STATUS -> {
-                StatusViewHolder(ItemStatusBinding.inflate(inflater, parent, false))
+                StatusViewHolder(pachliAccountId, ItemStatusBinding.inflate(inflater, parent, false))
             }
             VIEW_TYPE_STATUS_FILTERED -> {
-                FilterableStatusViewHolder(ItemStatusWrapperBinding.inflate(inflater, parent, false))
+                FilterableStatusViewHolder(pachliAccountId, ItemStatusWrapperBinding.inflate(inflater, parent, false))
             }
             VIEW_TYPE_STATUS_DETAILED -> {
-                StatusDetailedViewHolder(ItemStatusDetailedBinding.inflate(inflater, parent, false))
+                StatusDetailedViewHolder(pachliAccountId, ItemStatusDetailedBinding.inflate(inflater, parent, false))
             }
             else -> error("Unknown item type: $viewType")
         }

--- a/app/src/main/java/app/pachli/components/viewthread/ViewThreadActivity.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/ViewThreadActivity.kt
@@ -22,6 +22,7 @@ import app.pachli.R
 import app.pachli.core.activity.BottomSheetActivity
 import app.pachli.core.common.extensions.viewBinding
 import app.pachli.core.navigation.ViewThreadActivityIntent
+import app.pachli.core.navigation.pachliAccountId
 import app.pachli.databinding.ActivityViewThreadBinding
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -45,7 +46,7 @@ class ViewThreadActivity : BottomSheetActivity() {
         val url = ViewThreadActivityIntent.getUrl(intent)
         val fragment =
             supportFragmentManager.findFragmentByTag(FRAGMENT_TAG + id) as ViewThreadFragment?
-                ?: ViewThreadFragment.newInstance(id, url)
+                ?: ViewThreadFragment.newInstance(intent.pachliAccountId, id, url)
 
         supportFragmentManager.commit {
             replace(R.id.fragment_container, fragment, FRAGMENT_TAG + id)

--- a/app/src/main/java/app/pachli/components/viewthread/edits/ViewEditsFragment.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/edits/ViewEditsFragment.kt
@@ -54,6 +54,7 @@ import com.mikepenz.iconics.utils.colorInt
 import com.mikepenz.iconics.utils.sizeDp
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
+import kotlin.properties.Delegates
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -73,6 +74,13 @@ class ViewEditsFragment :
 
     private lateinit var statusId: String
 
+    private var pachliAccountId by Delegates.notNull<Long>()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        pachliAccountId = requireArguments().getLong(ARG_PACHLI_ACCOUNT_ID)
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
 
@@ -87,7 +95,7 @@ class ViewEditsFragment :
         )
         (binding.recyclerView.itemAnimator as SimpleItemAnimator).supportsChangeAnimations = false
 
-        statusId = requireArguments().getString(STATUS_ID_EXTRA)!!
+        statusId = requireArguments().getString(ARG_STATUS_ID)!!
 
         val animateAvatars = sharedPreferencesRepository.getBoolean(PrefKeys.ANIMATE_GIF_AVATARS, false)
         val animateEmojis = sharedPreferencesRepository.getBoolean(PrefKeys.ANIMATE_CUSTOM_EMOJIS, false)
@@ -183,28 +191,34 @@ class ViewEditsFragment :
     }
 
     override fun onViewAccount(id: String) {
-        bottomSheetActivity?.startActivityWithDefaultTransition(AccountActivityIntent(requireContext(), id))
+        bottomSheetActivity?.startActivityWithDefaultTransition(
+            AccountActivityIntent(requireContext(), pachliAccountId, id),
+        )
     }
 
     override fun onViewTag(tag: String) {
-        bottomSheetActivity?.startActivityWithDefaultTransition(TimelineActivityIntent.hashtag(requireContext(), tag))
+        bottomSheetActivity?.startActivityWithDefaultTransition(
+            TimelineActivityIntent.hashtag(requireContext(), pachliAccountId, tag),
+        )
     }
 
     override fun onViewUrl(url: String) {
-        bottomSheetActivity?.viewUrl(url)
+        bottomSheetActivity?.viewUrl(pachliAccountId, url)
     }
 
     private val bottomSheetActivity
         get() = (activity as? BottomSheetActivity)
 
     companion object {
-        private const val STATUS_ID_EXTRA = "id"
+        private const val ARG_PACHLI_ACCOUNT_ID = "app.pachli.ARG_PACHLI_ACCOUNT_ID"
+        private const val ARG_STATUS_ID = "app.pachli.ARG_STATUS_ID"
 
-        fun newInstance(statusId: String): ViewEditsFragment {
-            val arguments = Bundle(1)
+        fun newInstance(pachliAccountId: Long, statusId: String): ViewEditsFragment {
             val fragment = ViewEditsFragment()
-            arguments.putString(STATUS_ID_EXTRA, statusId)
-            fragment.arguments = arguments
+            fragment.arguments = Bundle(2).apply {
+                putLong(ARG_PACHLI_ACCOUNT_ID, pachliAccountId)
+                putString(ARG_STATUS_ID, statusId)
+            }
             return fragment
         }
     }

--- a/app/src/main/java/app/pachli/db/DraftsAlert.kt
+++ b/app/src/main/java/app/pachli/db/DraftsAlert.kt
@@ -66,7 +66,7 @@ class DraftsAlert @Inject constructor(private val draftDao: DraftDao) {
                             .setPositiveButton(R.string.action_post_failed_show_drafts) { _: DialogInterface?, _: Int ->
                                 clearDraftsAlert(coroutineScope, activeAccountId) // User looked at drafts
 
-                                val intent = DraftsActivityIntent(context)
+                                val intent = DraftsActivityIntent(context, activeAccountId)
                                 context.startActivity(intent)
                             }
                             .setNegativeButton(R.string.action_post_failed_do_nothing) { _: DialogInterface?, _: Int ->

--- a/app/src/main/java/app/pachli/fragment/SFragment.kt
+++ b/app/src/main/java/app/pachli/fragment/SFragment.kt
@@ -97,6 +97,8 @@ abstract class SFragment<T : IStatusViewData> : Fragment(), StatusActionListener
 
     private var serverCanTranslate = false
 
+    protected abstract var pachliAccountId: Long
+
     override fun startActivity(intent: Intent) {
         if (intent.component?.className?.startsWith("app.pachli.") == true) {
             requireActivity().startActivityWithDefaultTransition(intent)
@@ -122,7 +124,7 @@ abstract class SFragment<T : IStatusViewData> : Fragment(), StatusActionListener
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 serverRepository.flow.collect { result ->
                     result.onSuccess {
-                        serverCanTranslate = it?.can(
+                        serverCanTranslate = it.can(
                             operation = ORG_JOINMASTODON_STATUSES_TRANSLATE,
                             constraint = ">=1.0".toConstraint(),
                         ) ?: false
@@ -153,19 +155,19 @@ abstract class SFragment<T : IStatusViewData> : Fragment(), StatusActionListener
 
     protected fun openReblog(status: Status?) {
         if (status == null) return
-        bottomSheetActivity.viewAccount(status.account.id)
+        bottomSheetActivity.viewAccount(pachliAccountId, status.account.id)
     }
 
     protected fun viewThread(statusId: String?, statusUrl: String?) {
-        bottomSheetActivity.viewThread(statusId!!, statusUrl)
+        bottomSheetActivity.viewThread(pachliAccountId, statusId!!, statusUrl)
     }
 
     protected fun viewAccount(accountId: String?) {
-        bottomSheetActivity.viewAccount(accountId!!)
+        bottomSheetActivity.viewAccount(pachliAccountId, accountId!!)
     }
 
     override fun onViewUrl(url: String) {
-        bottomSheetActivity.viewUrl(url, PostLookupFallbackBehavior.OPEN_IN_BROWSER)
+        bottomSheetActivity.viewUrl(pachliAccountId, url, PostLookupFallbackBehavior.OPEN_IN_BROWSER)
     }
 
     protected fun reply(status: Status) {
@@ -409,7 +411,7 @@ abstract class SFragment<T : IStatusViewData> : Fragment(), StatusActionListener
         val attachment = attachments[urlIndex].attachment
         when (attachment.type) {
             Attachment.Type.GIFV, Attachment.Type.VIDEO, Attachment.Type.IMAGE, Attachment.Type.AUDIO -> {
-                val intent = ViewMediaActivityIntent(requireContext(), owningUsername, attachments, urlIndex)
+                val intent = ViewMediaActivityIntent(requireContext(), pachliAccountId, owningUsername, attachments, urlIndex)
                 if (view != null) {
                     val url = attachment.url
                     ViewCompat.setTransitionName(view, url)
@@ -430,11 +432,11 @@ abstract class SFragment<T : IStatusViewData> : Fragment(), StatusActionListener
     }
 
     protected fun viewTag(tag: String) {
-        startActivity(TimelineActivityIntent.hashtag(requireContext(), tag))
+        startActivity(TimelineActivityIntent.hashtag(requireContext(), pachliAccountId, tag))
     }
 
     private fun openReportPage(accountId: String, accountUsername: String, statusId: String) {
-        startActivity(ReportActivityIntent(requireContext(), accountId, accountUsername, statusId))
+        startActivity(ReportActivityIntent(requireContext(), pachliAccountId, accountId, accountUsername, statusId))
     }
 
     private fun showConfirmDeleteDialog(viewData: T) {

--- a/app/src/main/java/app/pachli/interfaces/StatusActionListener.kt
+++ b/app/src/main/java/app/pachli/interfaces/StatusActionListener.kt
@@ -61,5 +61,5 @@ interface StatusActionListener<T : IStatusViewData> : LinkListener {
     fun clearWarningAction(viewData: T)
 
     /** Edit the filter that matched this status. */
-    fun onEditFilterById(filterId: String)
+    fun onEditFilterById(pachliAccountId: Long, filterId: String)
 }

--- a/app/src/main/java/app/pachli/receiver/SendStatusBroadcastReceiver.kt
+++ b/app/src/main/java/app/pachli/receiver/SendStatusBroadcastReceiver.kt
@@ -108,7 +108,7 @@ class SendStatusBroadcastReceiver : BroadcastReceiver() {
                         poll = null,
                         replyingStatusContent = null,
                         replyingStatusAuthorUsername = null,
-                        accountId = account.id,
+                        pachliAccountId = account.id,
                         draftId = -1,
                         idempotencyKey = randomAlphanumericString(16),
                         retries = 0,

--- a/app/src/main/java/app/pachli/service/PachliTileService.kt
+++ b/app/src/main/java/app/pachli/service/PachliTileService.kt
@@ -30,7 +30,8 @@ import app.pachli.core.navigation.MainActivityIntent
 @TargetApi(24)
 class PachliTileService : TileService() {
     override fun onClick() {
-        val intent = MainActivityIntent.openCompose(this, ComposeOptions())
+        // XXX: -1L here needs handling properly.
+        val intent = MainActivityIntent.openCompose(this, ComposeOptions(), -1L)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
             val pendingIntent = PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_IMMUTABLE)
             startActivityAndCollapse(pendingIntent)

--- a/app/src/main/java/app/pachli/service/SendStatusService.kt
+++ b/app/src/main/java/app/pachli/service/SendStatusService.kt
@@ -129,7 +129,7 @@ class SendStatusService : Service() {
         val statusToSend = statusesToSend[statusId] ?: return
 
         // when account == null, user has logged out, cancel sending
-        val account = accountManager.getAccountById(statusToSend.accountId)
+        val account = accountManager.getAccountById(statusToSend.pachliAccountId)
 
         if (account == null) {
             statusesToSend.remove(statusId)
@@ -326,7 +326,7 @@ class SendStatusService : Service() {
             val notification = buildDraftNotification(
                 R.string.send_post_notification_error_title,
                 R.string.send_post_notification_saved_content,
-                failedStatus.accountId,
+                failedStatus.pachliAccountId,
                 statusId,
             )
 
@@ -351,7 +351,7 @@ class SendStatusService : Service() {
             val notification = buildDraftNotification(
                 R.string.send_post_notification_cancel_title,
                 R.string.send_post_notification_saved_content,
-                statusToCancel.accountId,
+                statusToCancel.pachliAccountId,
                 statusId,
             )
 
@@ -366,7 +366,7 @@ class SendStatusService : Service() {
     private suspend fun saveStatusToDrafts(status: StatusToSend, failedToSendAlert: Boolean) {
         draftHelper.saveDraft(
             draftId = status.draftId,
-            accountId = status.accountId,
+            pachliAccountId = status.pachliAccountId,
             inReplyToId = status.inReplyToId,
             content = status.text,
             contentWarning = status.warningText,
@@ -480,7 +480,7 @@ data class StatusToSend(
     val poll: NewPoll?,
     val replyingStatusContent: String?,
     val replyingStatusAuthorUsername: String?,
-    val accountId: Long,
+    val pachliAccountId: Long,
     val draftId: Int,
     val idempotencyKey: String,
     var retries: Int,

--- a/app/src/main/java/app/pachli/util/ListStatusAccessibilityDelegate.kt
+++ b/app/src/main/java/app/pachli/util/ListStatusAccessibilityDelegate.kt
@@ -31,6 +31,7 @@ fun interface StatusProvider<T> {
 }
 
 class ListStatusAccessibilityDelegate<T : IStatusViewData>(
+    private val pachliAccountId: Long,
     private val recyclerView: RecyclerView,
     private val statusActionListener: StatusActionListener<T>,
     private val statusProvider: StatusProvider<T>,
@@ -194,7 +195,7 @@ class ListStatusAccessibilityDelegate<T : IStatusViewData>(
                 app.pachli.core.ui.R.id.action_show_anyway -> statusActionListener.clearWarningAction(status)
                 app.pachli.core.ui.R.id.action_edit_filter -> {
                     (recyclerView.findContainingViewHolder(host) as? FilterableStatusViewHolder<*>)?.matchedFilter?.let {
-                        statusActionListener.onEditFilterById(it.id)
+                        statusActionListener.onEditFilterById(pachliAccountId, it.id)
                         return@let true
                     } ?: false
                 }

--- a/app/src/main/java/app/pachli/util/ShareShortcutHelper.kt
+++ b/app/src/main/java/app/pachli/util/ShareShortcutHelper.kt
@@ -77,7 +77,7 @@ suspend fun updateShortcuts(context: Context, accountManager: AccountManager) = 
             .build()
 
         // This intent will be sent when the user clicks on one of the launcher shortcuts. Intent from share sheet will be different
-        val intent = MainActivityIntent(context).apply {
+        val intent = MainActivityIntent(context, account.id).apply {
             action = Intent.ACTION_SEND
             type = "text/plain"
             putExtra(ShortcutManagerCompat.EXTRA_SHORTCUT_ID, account.id.toString())

--- a/app/src/test/java/app/pachli/components/timeline/CachedTimelineRemoteMediatorTest.kt
+++ b/app/src/test/java/app/pachli/components/timeline/CachedTimelineRemoteMediatorTest.kt
@@ -12,7 +12,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import app.pachli.components.timeline.viewmodel.CachedTimelineRemoteMediator
 import app.pachli.components.timeline.viewmodel.CachedTimelineRemoteMediator.Companion.TIMELINE_ID
-import app.pachli.core.data.repository.AccountManager
 import app.pachli.core.database.AppDatabase
 import app.pachli.core.database.Converters
 import app.pachli.core.database.di.TransactionProvider
@@ -49,16 +48,14 @@ import retrofit2.Response
 @RunWith(AndroidJUnit4::class)
 class CachedTimelineRemoteMediatorTest {
 
-    private val accountManager: AccountManager = mock {
-        on { activeAccount } doReturn AccountEntity(
-            id = 1,
-            domain = "mastodon.example",
-            accessToken = "token",
-            clientId = "id",
-            clientSecret = "secret",
-            isActive = true,
-        )
-    }
+    private val activeAccount = AccountEntity(
+        id = 1,
+        domain = "mastodon.example",
+        accessToken = "token",
+        clientId = "id",
+        clientSecret = "secret",
+        isActive = true,
+    )
 
     private lateinit var db: AppDatabase
     private lateinit var transactionProvider: TransactionProvider
@@ -95,7 +92,7 @@ class CachedTimelineRemoteMediatorTest {
     fun `should return error when network call returns error code`() {
         val remoteMediator = CachedTimelineRemoteMediator(
             initialKey = null,
-            accountManager = accountManager,
+            pachliAccountId = activeAccount.id,
             api = mock {
                 onBlocking { homeTimeline(anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull()) } doReturn Response.error(500, "".toResponseBody())
             },
@@ -118,7 +115,7 @@ class CachedTimelineRemoteMediatorTest {
     fun `should return error when network call fails`() {
         val remoteMediator = CachedTimelineRemoteMediator(
             initialKey = null,
-            accountManager = accountManager,
+            pachliAccountId = activeAccount.id,
             api = mock {
                 onBlocking { homeTimeline(anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull()) } doThrow IOException()
             },
@@ -140,7 +137,7 @@ class CachedTimelineRemoteMediatorTest {
     fun `should not prepend statuses`() {
         val remoteMediator = CachedTimelineRemoteMediator(
             initialKey = null,
-            accountManager = accountManager,
+            pachliAccountId = activeAccount.id,
             api = mock(),
             factory = pagingSourceFactory,
             transactionProvider = transactionProvider,
@@ -172,7 +169,7 @@ class CachedTimelineRemoteMediatorTest {
     fun `should not try to refresh already cached statuses when db is empty`() {
         val remoteMediator = CachedTimelineRemoteMediator(
             initialKey = null,
-            accountManager = accountManager,
+            pachliAccountId = activeAccount.id,
             api = mock {
                 onBlocking { homeTimeline(limit = 20) } doReturn Response.success(
                     listOf(
@@ -227,7 +224,7 @@ class CachedTimelineRemoteMediatorTest {
 
         val remoteMediator = CachedTimelineRemoteMediator(
             initialKey = null,
-            accountManager = accountManager,
+            pachliAccountId = activeAccount.id,
             api = mock {
                 onBlocking { homeTimeline(limit = 20) } doReturn Response.success(
                     listOf(
@@ -284,7 +281,7 @@ class CachedTimelineRemoteMediatorTest {
 
         val remoteMediator = CachedTimelineRemoteMediator(
             initialKey = null,
-            accountManager = accountManager,
+            pachliAccountId = activeAccount.id,
             api = mock {
                 onBlocking { homeTimeline(maxId = "5", limit = 20) } doReturn Response.success(
                     listOf(

--- a/core/activity/src/test/kotlin/app/pachli/core/activity/BottomSheetActivityTest.kt
+++ b/core/activity/src/test/kotlin/app/pachli/core/activity/BottomSheetActivityTest.kt
@@ -58,6 +58,8 @@ class BottomSheetActivityTest {
         SearchResult(emptyList(), emptyList(), emptyList()),
     )
 
+    private val pachliAccountId = 0L
+
     private val account = TimelineAccount(
         id = "1",
         localUsername = "admin",
@@ -166,21 +168,23 @@ class BottomSheetActivityTest {
 
     @Test
     fun search_inIdealConditions_returnsRequestedResults_forAccount() = runTest {
-        activity.viewUrl(accountQuery)
+        activity.viewUrl(pachliAccountId, accountQuery)
         advanceUntilIdle()
+        assertEquals(pachliAccountId, activity.pachliAccountId)
         assertEquals(account.id, activity.accountId)
     }
 
     @Test
     fun search_inIdealConditions_returnsRequestedResults_forStatus() = runTest {
-        activity.viewUrl(statusQuery)
+        activity.viewUrl(pachliAccountId, statusQuery)
         advanceUntilIdle()
+        assertEquals(pachliAccountId, activity.pachliAccountId)
         assertEquals(status.id, activity.statusId)
     }
 
     @Test
     fun search_inIdealConditions_returnsRequestedResults_forNonMastodonURL() = runTest {
-        activity.viewUrl(nonMastodonQuery)
+        activity.viewUrl(pachliAccountId, nonMastodonQuery)
         advanceUntilIdle()
         assertEquals(nonMastodonQuery, activity.link)
     }
@@ -188,7 +192,7 @@ class BottomSheetActivityTest {
     @Test
     fun search_withNoResults_appliesRequestedFallbackBehavior() = runTest {
         for (fallbackBehavior in listOf(PostLookupFallbackBehavior.OPEN_IN_BROWSER, PostLookupFallbackBehavior.DISPLAY_ERROR)) {
-            activity.viewUrl(nonMastodonQuery, fallbackBehavior)
+            activity.viewUrl(pachliAccountId, nonMastodonQuery, fallbackBehavior)
             advanceUntilIdle()
             assertEquals(nonMastodonQuery, activity.link)
             assertEquals(fallbackBehavior, activity.fallbackBehavior)
@@ -197,15 +201,14 @@ class BottomSheetActivityTest {
 
     @Test
     fun search_doesNotRespectUnrelatedResult() = runTest {
-        activity.viewUrl(nonexistentStatusQuery)
+        activity.viewUrl(pachliAccountId, nonexistentStatusQuery)
         advanceUntilIdle()
-        assertEquals(nonexistentStatusQuery, activity.link)
         assertEquals(null, activity.accountId)
     }
 
     @Test
     fun search_withCancellation_doesNotLoadUrl_forAccount() = runTest {
-        activity.viewUrl(accountQuery)
+        activity.viewUrl(pachliAccountId, accountQuery)
         assertTrue(activity.isSearching())
         activity.cancelActiveSearch()
         assertFalse(activity.isSearching())
@@ -214,14 +217,14 @@ class BottomSheetActivityTest {
 
     @Test
     fun search_withCancellation_doesNotLoadUrl_forStatus() = runTest {
-        activity.viewUrl(accountQuery)
+        activity.viewUrl(pachliAccountId, accountQuery)
         activity.cancelActiveSearch()
         assertEquals(null, activity.accountId)
     }
 
     @Test
     fun search_withCancellation_doesNotLoadUrl_forNonMastodonURL() = runTest {
-        activity.viewUrl(nonMastodonQuery)
+        activity.viewUrl(pachliAccountId, nonMastodonQuery)
         activity.cancelActiveSearch()
         assertEquals(null, activity.searchUrl)
     }
@@ -229,11 +232,11 @@ class BottomSheetActivityTest {
     @Test
     fun search_withPreviousCancellation_completes() = runTest {
         // begin/cancel account search
-        activity.viewUrl(accountQuery)
+        activity.viewUrl(pachliAccountId, accountQuery)
         activity.cancelActiveSearch()
 
         // begin status search
-        activity.viewUrl(statusQuery)
+        activity.viewUrl(pachliAccountId, statusQuery)
 
         // ensure that search is still ongoing
         assertTrue(activity.isSearching())
@@ -243,12 +246,14 @@ class BottomSheetActivityTest {
 
         // ensure that the result of the status search was recorded
         // and the account search wasn't
+        assertEquals(pachliAccountId, activity.pachliAccountId)
         assertEquals(status.id, activity.statusId)
         assertEquals(null, activity.accountId)
     }
 
     class FakeBottomSheetActivity(api: MastodonApi) : BottomSheetActivity() {
 
+        var pachliAccountId: Long? = null
         var statusId: String? = null
         var accountId: String? = null
         var link: String? = null
@@ -263,11 +268,13 @@ class BottomSheetActivityTest {
             this.link = url
         }
 
-        override fun viewAccount(id: String) {
+        override fun viewAccount(pachliAccountId: Long, id: String) {
+            this.pachliAccountId = pachliAccountId
             this.accountId = id
         }
 
-        override fun viewThread(statusId: String, url: String?) {
+        override fun viewThread(pachliAccountId: Long, statusId: String, url: String?) {
+            this.pachliAccountId = pachliAccountId
             this.statusId = statusId
         }
 

--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/AccountManager.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/AccountManager.kt
@@ -86,7 +86,7 @@ class AccountManager @Inject constructor(
         clientSecret: String,
         oauthScopes: String,
         newAccount: Account,
-    ) {
+    ): Long {
         activeAccount?.let {
             it.isActive = false
             Timber.d("addAccount: saving account with id %d", it.id)
@@ -122,6 +122,7 @@ class AccountManager @Inject constructor(
 
         activeAccount = newAccountEntity
         updateActiveAccount(newAccount)
+        return newAccountEntity.id
     }
 
     /**

--- a/core/navigation/src/main/kotlin/app/pachli/core/navigation/Navigation.kt
+++ b/core/navigation/src/main/kotlin/app/pachli/core/navigation/Navigation.kt
@@ -21,6 +21,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Parcelable
 import androidx.core.content.IntentCompat
+import androidx.core.content.pm.ShortcutManagerCompat
 import app.pachli.core.database.model.DraftAttachment
 import app.pachli.core.model.ContentFilter
 import app.pachli.core.model.Timeline
@@ -39,33 +40,50 @@ import app.pachli.core.network.model.Status
 import com.gaelmarhic.quadrant.QuadrantConstants
 import kotlinx.parcelize.Parcelize
 
+private const val EXTRA_PACHLI_ACCOUNT_ID = "app.pachli.EXTRA_PACHLI_ACCOUNT_ID"
+
+/**
+ * The Pachli Account ID passed to this intent. This is the
+ * [id][app.pachli.core.database.model.AccountEntity.id] of the account that is
+ * "active" for the purposes of this activity.
+ */
+var Intent.pachliAccountId: Long
+    get() = getLongExtra(EXTRA_PACHLI_ACCOUNT_ID, -1L)
+    set(value) {
+        putExtra(EXTRA_PACHLI_ACCOUNT_ID, value)
+        return
+    }
+
 /**
  * @param context
- * @param accountId Server ID of the account to view
+ * @param pachliAccountId See [pachliAccountId][Intent.pachliAccountId].
+ * @param accountId Server ID of the account to view.
  * @see [app.pachli.components.account.AccountActivity]
  */
-class AccountActivityIntent(context: Context, accountId: String) : Intent() {
+class AccountActivityIntent(context: Context, pachliAccountId: Long, accountId: String) : Intent() {
     init {
         setClassName(context, QuadrantConstants.ACCOUNT_ACTIVITY)
-        putExtra(EXTRA_KEY_ACCOUNT_ID, accountId)
+        this.pachliAccountId = pachliAccountId
+        putExtra(EXTRA_ACCOUNT_ID, accountId)
     }
 
     companion object {
-        private const val EXTRA_KEY_ACCOUNT_ID = "id"
+        private const val EXTRA_ACCOUNT_ID = "app.pachli.EXTRA_KEY_ACCOUNT_ID"
 
         /** @return the account ID passed in this intent */
-        fun getAccountId(intent: Intent) = intent.getStringExtra(EXTRA_KEY_ACCOUNT_ID)!!
+        fun getAccountId(intent: Intent) = intent.getStringExtra(EXTRA_ACCOUNT_ID)!!
     }
 }
 
 /**
  * @param context
+ * @param pachliAccountId
  * @param kind The kind of accounts to show
  * @param id Optional ID. Sometimes an account ID, sometimes a status ID, and
  *     sometimes ignored. See [Kind] for details of how `id` is interpreted.
  * @see [app.pachli.components.accountlist.AccountListActivity]
  */
-class AccountListActivityIntent(context: Context, kind: Kind, id: String? = null) : Intent() {
+class AccountListActivityIntent(context: Context, pachliAccountId: Long, kind: Kind, id: String? = null) : Intent() {
     enum class Kind {
         /** Show the accounts the account with `id` is following */
         FOLLOWS,
@@ -91,13 +109,14 @@ class AccountListActivityIntent(context: Context, kind: Kind, id: String? = null
 
     init {
         setClassName(context, QuadrantConstants.ACCOUNT_LIST_ACTIVITY)
+        this.pachliAccountId = pachliAccountId
         putExtra(EXTRA_KIND, kind)
         putExtra(EXTRA_ID, id)
     }
 
     companion object {
-        private const val EXTRA_KIND = "kind"
-        private const val EXTRA_ID = "id"
+        private const val EXTRA_KIND = "app.pachli.EXTRA_KIND"
+        private const val EXTRA_ID = "app.pachli.EXTRA_ID"
 
         /** @return The [Kind] passed in this intent */
         fun getKind(intent: Intent) = intent.getSerializableExtra(EXTRA_KIND) as Kind
@@ -182,7 +201,7 @@ class ComposeActivityIntent(context: Context) : Intent() {
     }
 
     companion object {
-        private const val EXTRA_COMPOSE_OPTIONS = "composeOptions"
+        private const val EXTRA_COMPOSE_OPTIONS = "app.pachli.EXTRA_COMPOSE_OPTIONS"
 
         /** @return the [ComposeOptions] passed in this intent, or null */
         fun getOptions(intent: Intent) = IntentCompat.getParcelableExtra(intent, EXTRA_COMPOSE_OPTIONS, ComposeOptions::class.java)
@@ -193,38 +212,44 @@ class ComposeActivityIntent(context: Context) : Intent() {
  * Launch with an empty content filter to edit.
  *
  * @param context
+ * @param pachliAccountId The account that will own the filter
  * @see [app.pachli.components.filters.EditContentFilterActivity]
  */
-class EditContentFilterActivityIntent(context: Context) : Intent() {
+class EditContentFilterActivityIntent(context: Context, pachliAccountId: Long) : Intent() {
     init {
         setClassName(context, QuadrantConstants.EDIT_CONTENT_FILTER_ACTIVITY)
+        this.pachliAccountId = pachliAccountId
     }
 
     companion object {
-        private const val EXTRA_CONTENT_FILTER_TO_EDIT = "contentFilterToEdit"
-        private const val EXTRA_CONTENT_FILTER_ID_TO_LOAD = "contentFilterIdToLoad"
+        private const val EXTRA_CONTENT_FILTER_TO_EDIT = "app.pachli.EXTRA_CONTENT_FILTER_TO_EDIT"
+        private const val EXTRA_CONTENT_FILTER_ID_TO_LOAD =
+            "app.pachli.EXTRA_CONTENT_FILTER_ID_TO_LOAD"
 
         /**
          * Launch with [contentFilter] displayed, ready to edit.
          *
          * @param context
          * @param contentFilter Content filter to edit
+         * @param accountId The account that owns the filter
          * @see [app.pachli.components.filters.EditContentFilterActivity]
          */
-        fun edit(context: Context, contentFilter: ContentFilter) = EditContentFilterActivityIntent(context).apply {
+        fun edit(context: Context, accountId: Long, contentFilter: ContentFilter) = EditContentFilterActivityIntent(context, accountId).apply {
             putExtra(EXTRA_CONTENT_FILTER_TO_EDIT, contentFilter)
         }
 
         /**
-         * Launch and load [filterId], display it ready to edit.
+         * Launch and load [contentFilterId], display it ready to edit.
          *
          * @param context
-         * @param filterId ID of the content filter to load
+         * @param accountId The account that owns the filter
+         * @param contentFilterId ID of the content filter to load
          * @see [app.pachli.components.filters.EditContentFilterActivity]
          */
-        fun edit(context: Context, filterId: String) = EditContentFilterActivityIntent(context).apply {
-            putExtra(EXTRA_CONTENT_FILTER_ID_TO_LOAD, filterId)
-        }
+        fun edit(context: Context, accountId: Long, contentFilterId: String) =
+            EditContentFilterActivityIntent(context, accountId).apply {
+                putExtra(EXTRA_CONTENT_FILTER_ID_TO_LOAD, contentFilterId)
+            }
 
         /** @return the [ContentFilter] passed in this intent, or null */
         fun getContentFilter(intent: Intent) = IntentCompat.getParcelableExtra(intent, EXTRA_CONTENT_FILTER_TO_EDIT, ContentFilter::class.java)
@@ -257,72 +282,70 @@ class LoginActivityIntent(context: Context, loginMode: LoginMode = LoginMode.DEF
     }
 
     companion object {
-        private const val EXTRA_LOGIN_MODE = "loginMode"
+        private const val EXTRA_LOGIN_MODE = "app.pachli.EXTRA_LOGIN_MODE"
 
         /** @return the `loginMode` passed to this intent */
         fun getLoginMode(intent: Intent) = intent.getSerializableExtra(EXTRA_LOGIN_MODE)!! as LoginMode
     }
 }
 
-class MainActivityIntent(context: Context) : Intent() {
+class MainActivityIntent constructor(context: Context, pachliAccountId: Long) : Intent() {
     init {
         setClassName(context, QuadrantConstants.MAIN_ACTIVITY)
+        this.pachliAccountId = pachliAccountId
     }
 
     companion object {
-        private const val EXTRA_PACHLI_ACCOUNT_ID = "pachliAccountId"
-        private const val EXTRA_NOTIFICATION_TYPE = "notificationType"
-        private const val EXTRA_COMPOSE_OPTIONS = "composeOptions"
-        private const val EXTRA_NOTIFICATION_TAG = "notificationTag"
-        private const val EXTRA_NOTIFICATION_ID = "notificationId"
-        private const val EXTRA_REDIRECT_URL = "redirectUrl"
-        private const val EXTRA_OPEN_DRAFTS = "openDrafts"
+        private const val EXTRA_NOTIFICATION_TYPE = "app.pachli.EXTRA_NOTIFICATION_TYPE"
+        private const val EXTRA_COMPOSE_OPTIONS = "app.pachli.EXTRA_COMPOSE_OPTIONS"
+        private const val EXTRA_NOTIFICATION_TAG = "app.pachli.EXTRA_NOTIFICATION_TAG"
+        private const val EXTRA_NOTIFICATION_ID = "app.pachli.EXTRA_NOTIFICATION_ID"
+        private const val EXTRA_REDIRECT_URL = "app.pachli.EXTRA_REDIRECT_URL"
+        private const val EXTRA_OPEN_DRAFTS = "app.pachli.EXTRA_OPEN_DRAFTS"
 
         fun hasComposeOptions(intent: Intent) = intent.hasExtra(EXTRA_COMPOSE_OPTIONS)
         fun hasNotificationType(intent: Intent) = intent.hasExtra(EXTRA_NOTIFICATION_TYPE)
 
-        fun getPachliAccountId(intent: Intent) = intent.getLongExtra(EXTRA_PACHLI_ACCOUNT_ID, -1)
         fun getNotificationType(intent: Intent) = intent.getSerializableExtra(EXTRA_NOTIFICATION_TYPE) as Notification.Type
         fun getNotificationTag(intent: Intent) = intent.getStringExtra(EXTRA_NOTIFICATION_TAG)
         fun getNotificationId(intent: Intent) = intent.getIntExtra(EXTRA_NOTIFICATION_ID, -1)
         fun getRedirectUrl(intent: Intent) = intent.getStringExtra(EXTRA_REDIRECT_URL)
         fun getOpenDrafts(intent: Intent) = intent.getBooleanExtra(EXTRA_OPEN_DRAFTS, false)
 
-        fun setPachliAccountId(intent: Intent, pachliAccountId: Long) {
-            intent.putExtra(EXTRA_PACHLI_ACCOUNT_ID, pachliAccountId)
-        }
-
         /**
-         * Switches the active account to the provided accountId and then stays on MainActivity
+         *
          */
-        private fun switchAccount(context: Context, pachliAccountId: Long) = MainActivityIntent(context).apply {
-            putExtra(EXTRA_PACHLI_ACCOUNT_ID, pachliAccountId)
+        fun withShortCut(context: Context, pachliAccountId: Long) = MainActivityIntent(context, pachliAccountId).apply {
+            action = ACTION_SEND
+            type = "text/plain"
+            putExtra(ShortcutManagerCompat.EXTRA_SHORTCUT_ID, pachliAccountId.toString())
         }
 
         /**
-         * Switches the active account to the accountId and takes the user to the correct place according to the notification they clicked
+         * Switches the active account to the accountId and takes the user to the correct place
+         * according to the notification they clicked
          */
         fun openNotification(
             context: Context,
             pachliAccountId: Long,
             type: Notification.Type,
-        ) = switchAccount(context, pachliAccountId).apply {
+        ) = MainActivityIntent(context, pachliAccountId).apply {
             putExtra(EXTRA_NOTIFICATION_TYPE, type)
         }
 
         /**
          * Switches the active account to the accountId and then opens ComposeActivity with the provided options
-         * @param pachliAccountId the id of the Pachli account to open the screen with. Set to -1 for current account.
+         * @param pachliAccountId the id of the Pachli account to open the screen with.
          * @param notificationId optional id of the notification that should be cancelled when this intent is opened
          * @param notificationTag optional tag of the notification that should be cancelled when this intent is opened
          */
         fun openCompose(
             context: Context,
             options: ComposeActivityIntent.ComposeOptions,
-            pachliAccountId: Long = -1,
+            pachliAccountId: Long,
             notificationTag: String? = null,
             notificationId: Int = -1,
-        ) = switchAccount(context, pachliAccountId).apply {
+        ) = MainActivityIntent(context, pachliAccountId).apply {
             action = ACTION_SEND
             putExtra(EXTRA_COMPOSE_OPTIONS, options)
             putExtra(EXTRA_NOTIFICATION_TAG, notificationTag)
@@ -331,13 +354,14 @@ class MainActivityIntent(context: Context) : Intent() {
         }
 
         /**
-         * switches the active account to the accountId and then tries to resolve and show the provided url
+         * Switches the active account to [pachliAccountId] and then tries to resolve and
+         * show the provided url
          */
         fun redirect(
             context: Context,
             pachliAccountId: Long,
             url: String,
-        ) = switchAccount(context, pachliAccountId).apply {
+        ) = MainActivityIntent(context, pachliAccountId).apply {
             putExtra(EXTRA_REDIRECT_URL, url)
             flags = FLAG_ACTIVITY_NEW_TASK or FLAG_ACTIVITY_CLEAR_TASK
         }
@@ -345,7 +369,7 @@ class MainActivityIntent(context: Context) : Intent() {
         /**
          * switches the active account to the provided accountId and then opens drafts
          */
-        fun openDrafts(context: Context, pachliAccountId: Long) = switchAccount(context, pachliAccountId).apply {
+        fun openDrafts(context: Context, pachliAccountId: Long) = MainActivityIntent(context, pachliAccountId).apply {
             putExtra(EXTRA_OPEN_DRAFTS, true)
         }
     }
@@ -356,7 +380,7 @@ class MainActivityIntent(context: Context) : Intent() {
  * @param screen The preference screen to show
  * @see [app.pachli.components.preference.PreferencesActivity]
  */
-class PreferencesActivityIntent(context: Context, screen: PreferenceScreen) : Intent() {
+class PreferencesActivityIntent(context: Context, pachliAccountId: Long, screen: PreferenceScreen) : Intent() {
     /** A specific preference screen */
     enum class PreferenceScreen {
         /** General preferences */
@@ -368,13 +392,15 @@ class PreferencesActivityIntent(context: Context, screen: PreferenceScreen) : In
         /** Notification preferences */
         NOTIFICATION,
     }
+
     init {
         setClassName(context, QuadrantConstants.PREFERENCES_ACTIVITY)
+        this.pachliAccountId = pachliAccountId
         putExtra(EXTRA_PREFERENCE_SCREEN, screen)
     }
 
     companion object {
-        private const val EXTRA_PREFERENCE_SCREEN = "preferenceScreen"
+        private const val EXTRA_PREFERENCE_SCREEN = "app.pachli.EXTRA_PREFERENCE_SCREEN"
 
         /** @return the `screen` passed to this intent */
         fun getPreferenceType(intent: Intent) = intent.getSerializableExtra(EXTRA_PREFERENCE_SCREEN)!! as PreferenceScreen
@@ -388,18 +414,19 @@ class PreferencesActivityIntent(context: Context, screen: PreferenceScreen) : In
  * @param statusId Optional ID of a status to include in the report
  * @see [app.pachli.components.report.ReportActivity]
  */
-class ReportActivityIntent(context: Context, accountId: String, userName: String, statusId: String? = null) : Intent() {
+class ReportActivityIntent(context: Context, pachliAccountId: Long, accountId: String, userName: String, statusId: String? = null) : Intent() {
     init {
         setClassName(context, QuadrantConstants.REPORT_ACTIVITY)
+        this.pachliAccountId = pachliAccountId
         putExtra(EXTRA_ACCOUNT_ID, accountId)
         putExtra(EXTRA_ACCOUNT_USERNAME, userName)
         putExtra(EXTRA_STATUS_ID, statusId)
     }
 
     companion object {
-        private const val EXTRA_ACCOUNT_ID = "accountId"
-        private const val EXTRA_ACCOUNT_USERNAME = "accountUsername"
-        private const val EXTRA_STATUS_ID = "statusId"
+        private const val EXTRA_ACCOUNT_ID = "app.pachli.EXTRA_ACCOUNT_ID"
+        private const val EXTRA_ACCOUNT_USERNAME = "app.pachli.EXTRA_ACCOUNT_USERNAME"
+        private const val EXTRA_STATUS_ID = "app.pachli.EXTRA_STATUS_ID"
 
         /** @return the `accountId` passed to this intent */
         fun getAccountId(intent: Intent) = intent.getStringExtra(EXTRA_ACCOUNT_ID)!!
@@ -416,20 +443,21 @@ class ReportActivityIntent(context: Context, accountId: String, userName: String
  * Use one of [bookmarks], [conversations], [favourites], [hashtag], [list], [publicFederated],
  * or [publicLocal] to construct.
  */
-class TimelineActivityIntent private constructor(context: Context) : Intent() {
+class TimelineActivityIntent private constructor(context: Context, pachliAccountId: Long) : Intent() {
     init {
         setClassName(context, QuadrantConstants.TIMELINE_ACTIVITY)
+        this.pachliAccountId = pachliAccountId
     }
 
     companion object {
-        private const val EXTRA_TIMELINE = "timeline"
+        private const val EXTRA_TIMELINE = "app.pachli.EXTRA_TIMELINE"
 
         /**
          * Show the user's bookmarks.
          *
          * @param context
          */
-        fun bookmarks(context: Context) = TimelineActivityIntent(context).apply {
+        fun bookmarks(context: Context, pachliAccountId: Long) = TimelineActivityIntent(context, pachliAccountId).apply {
             putExtra(EXTRA_TIMELINE, Timeline.Bookmarks)
         }
 
@@ -438,7 +466,7 @@ class TimelineActivityIntent private constructor(context: Context) : Intent() {
          *
          * @param context
          */
-        fun conversations(context: Context) = TimelineActivityIntent(context).apply {
+        fun conversations(context: Context, pachliAccountId: Long) = TimelineActivityIntent(context, pachliAccountId).apply {
             putExtra(EXTRA_TIMELINE, Timeline.Conversations)
         }
 
@@ -447,7 +475,7 @@ class TimelineActivityIntent private constructor(context: Context) : Intent() {
          *
          * @param context
          */
-        fun favourites(context: Context) = TimelineActivityIntent(context).apply {
+        fun favourites(context: Context, pachliAccountId: Long) = TimelineActivityIntent(context, pachliAccountId).apply {
             putExtra(EXTRA_TIMELINE, Timeline.Favourites)
         }
 
@@ -457,7 +485,7 @@ class TimelineActivityIntent private constructor(context: Context) : Intent() {
          * @param context
          * @param hashtag The hashtag to show, without the leading "`#`"
          */
-        fun hashtag(context: Context, hashtag: String) = TimelineActivityIntent(context).apply {
+        fun hashtag(context: Context, pachliAccountId: Long, hashtag: String) = TimelineActivityIntent(context, pachliAccountId).apply {
             putExtra(EXTRA_TIMELINE, Timeline.Hashtags(listOf(hashtag)))
         }
 
@@ -468,7 +496,7 @@ class TimelineActivityIntent private constructor(context: Context) : Intent() {
          * @param listId ID of the list to show
          * @param title The title to display
          */
-        fun list(context: Context, listId: String, title: String) = TimelineActivityIntent(context).apply {
+        fun list(context: Context, pachliAccountId: Long, listId: String, title: String) = TimelineActivityIntent(context, pachliAccountId).apply {
             putExtra(EXTRA_TIMELINE, Timeline.UserList(listId, title))
         }
 
@@ -477,7 +505,7 @@ class TimelineActivityIntent private constructor(context: Context) : Intent() {
          *
          * @param context
          */
-        fun publicFederated(context: Context) = TimelineActivityIntent(context).apply {
+        fun publicFederated(context: Context, pachliAccountId: Long) = TimelineActivityIntent(context, pachliAccountId).apply {
             putExtra(EXTRA_TIMELINE, Timeline.PublicFederated)
         }
 
@@ -486,7 +514,7 @@ class TimelineActivityIntent private constructor(context: Context) : Intent() {
          *
          * @param context
          */
-        fun publicLocal(context: Context) = TimelineActivityIntent(context).apply {
+        fun publicLocal(context: Context, pachliAccountId: Long) = TimelineActivityIntent(context, pachliAccountId).apply {
             putExtra(EXTRA_TIMELINE, Timeline.PublicLocal)
         }
 
@@ -495,7 +523,7 @@ class TimelineActivityIntent private constructor(context: Context) : Intent() {
          *
          * @param context
          */
-        fun notifications(context: Context) = TimelineActivityIntent(context).apply {
+        fun notifications(context: Context, pachliAccountId: Long) = TimelineActivityIntent(context, pachliAccountId).apply {
             putExtra(EXTRA_TIMELINE, Timeline.Notifications)
         }
 
@@ -504,21 +532,23 @@ class TimelineActivityIntent private constructor(context: Context) : Intent() {
     }
 }
 
-class ViewMediaActivityIntent private constructor(context: Context) : Intent() {
+class ViewMediaActivityIntent private constructor(context: Context, accountId: Long) : Intent() {
     init {
         setClassName(context, QuadrantConstants.VIEW_MEDIA_ACTIVITY)
+        pachliAccountId = accountId
     }
 
     /**
      * Show a collection of media attachments.
      *
      * @param context
+     * @param accountId ID of the Pachli account viewing the media
      * @param owningUsername The username that owns the media. See
      * [SFragment.viewMedia][app.pachli.fragment.SFragment.viewMedia].
      * @param attachments The attachments to show
      * @param index The index of the attachment in [attachments] to focus on
      */
-    constructor(context: Context, owningUsername: String, attachments: List<AttachmentViewData>, index: Int) : this(context) {
+    constructor(context: Context, accountId: Long, owningUsername: String, attachments: List<AttachmentViewData>, index: Int) : this(context, accountId) {
         putExtra(EXTRA_OWNING_USERNAME, owningUsername)
         putParcelableArrayListExtra(EXTRA_ATTACHMENTS, ArrayList(attachments))
         putExtra(EXTRA_ATTACHMENT_INDEX, index)
@@ -528,20 +558,21 @@ class ViewMediaActivityIntent private constructor(context: Context) : Intent() {
      * Show a single image identified by a URL
      *
      * @param context
+     * @param accountId ID of the Pachli account viewing the media
      * @param owningUsername The username that owns the media. See
      * [SFragment.viewMedia][app.pachli.fragment.SFragment.viewMedia].
      * @param url The URL of the image
      */
-    constructor(context: Context, owningUsername: String, url: String) : this(context) {
+    constructor(context: Context, accountId: Long, owningUsername: String, url: String) : this(context, accountId) {
         putExtra(EXTRA_OWNING_USERNAME, owningUsername)
         putExtra(EXTRA_SINGLE_IMAGE_URL, url)
     }
 
     companion object {
-        private const val EXTRA_OWNING_USERNAME = "owningUsername"
-        private const val EXTRA_ATTACHMENTS = "attachments"
-        private const val EXTRA_ATTACHMENT_INDEX = "index"
-        private const val EXTRA_SINGLE_IMAGE_URL = "singleImage"
+        private const val EXTRA_OWNING_USERNAME = "app.pachli.EXTRA_OWNING_USERNAME"
+        private const val EXTRA_ATTACHMENTS = "app.pachli.EXTRA_ATTACHMENTS"
+        private const val EXTRA_ATTACHMENT_INDEX = "app.pachli.EXTRA_ATTACHMENT_INDEX"
+        private const val EXTRA_SINGLE_IMAGE_URL = "app.pachli.EXTRA_SINGLE_IMAGE_URL"
 
         /** @return the owningUsername passed in this intent. */
         fun getOwningUsername(intent: Intent): String = intent.getStringExtra(EXTRA_OWNING_USERNAME)!!
@@ -559,20 +590,22 @@ class ViewMediaActivityIntent private constructor(context: Context) : Intent() {
 
 /**
  * @param context
+ * @param accountId ID of the Pachli account viewing the thread
  * @param statusId ID of the status to start from (may be in the middle of the thread)
  * @param statusUrl Optional URL of the status in `statusId`
  * @see [app.pachli.components.viewthread.ViewThreadActivity]
  */
-class ViewThreadActivityIntent(context: Context, statusId: String, statusUrl: String? = null) : Intent() {
+class ViewThreadActivityIntent(context: Context, accountId: Long, statusId: String, statusUrl: String? = null) : Intent() {
     init {
         setClassName(context, QuadrantConstants.VIEW_THREAD_ACTIVITY)
+        pachliAccountId = accountId
         putExtra(EXTRA_STATUS_ID, statusId)
         putExtra(EXTRA_STATUS_URL, statusUrl)
     }
 
     companion object {
-        private const val EXTRA_STATUS_ID = "id"
-        private const val EXTRA_STATUS_URL = "url"
+        private const val EXTRA_STATUS_ID = "app.pachli.EXTRA_STATUS_ID"
+        private const val EXTRA_STATUS_URL = "app.pachli.EXTRA_STATUS_URL"
 
         /** @return the `statusId` passed to this intent */
         fun getStatusId(intent: Intent) = intent.getStringExtra(EXTRA_STATUS_ID)!!
@@ -588,33 +621,38 @@ class AboutActivityIntent(context: Context) : Intent() {
     }
 }
 
-class AnnouncementsActivityIntent(context: Context) : Intent() {
+class AnnouncementsActivityIntent(context: Context, pachliAccountId: Long) : Intent() {
     init {
         setClassName(context, QuadrantConstants.ANNOUNCEMENTS_ACTIVITY)
+        this.pachliAccountId = pachliAccountId
     }
 }
 
-class DraftsActivityIntent(context: Context) : Intent() {
+class DraftsActivityIntent(context: Context, pachliAccountId: Long) : Intent() {
     init {
         setClassName(context, QuadrantConstants.DRAFTS_ACTIVITY)
+        this.pachliAccountId = pachliAccountId
     }
 }
 
-class EditProfileActivityIntent(context: Context) : Intent() {
+class EditProfileActivityIntent(context: Context, pachliAccountId: Long) : Intent() {
     init {
         setClassName(context, QuadrantConstants.EDIT_PROFILE_ACTIVITY)
+        this.pachliAccountId = pachliAccountId
     }
 }
 
-class ContentFiltersActivityIntent(context: Context) : Intent() {
+class ContentFiltersActivityIntent(context: Context, pachliAccountId: Long) : Intent() {
     init {
         setClassName(context, QuadrantConstants.CONTENT_FILTERS_ACTIVITY)
+        this.pachliAccountId = pachliAccountId
     }
 }
 
-class FollowedTagsActivityIntent(context: Context) : Intent() {
+class FollowedTagsActivityIntent(context: Context, pachliAccountId: Long) : Intent() {
     init {
         setClassName(context, QuadrantConstants.FOLLOWED_TAGS_ACTIVITY)
+        this.pachliAccountId = pachliAccountId
     }
 }
 
@@ -624,9 +662,10 @@ class InstanceListActivityIntent(context: Context) : Intent() {
     }
 }
 
-class ListActivityIntent(context: Context) : Intent() {
+class ListActivityIntent(context: Context, pachliAccountId: Long) : Intent() {
     init {
         setClassName(context, QuadrantConstants.LISTS_ACTIVITY)
+        this.pachliAccountId = pachliAccountId
     }
 }
 
@@ -636,32 +675,37 @@ class LoginWebViewActivityIntent(context: Context) : Intent() {
     }
 }
 
-class ScheduledStatusActivityIntent(context: Context) : Intent() {
+class ScheduledStatusActivityIntent(context: Context, pachliAccountId: Long) : Intent() {
     init {
         setClassName(context, QuadrantConstants.SCHEDULED_STATUS_ACTIVITY)
+        this.pachliAccountId = pachliAccountId
     }
 }
 
-class SearchActivityIntent(context: Context) : Intent() {
+class SearchActivityIntent(context: Context, pachliAccountId: Long) : Intent() {
     init {
         setClassName(context, QuadrantConstants.SEARCH_ACTIVITY)
+        this.pachliAccountId = pachliAccountId
     }
 }
 
-class SuggestionsActivityIntent(context: Context) : Intent() {
+class SuggestionsActivityIntent(context: Context, pachliAccountId: Long) : Intent() {
     init {
         setClassName(context, QuadrantConstants.SUGGESTIONS_ACTIVITY)
+        this.pachliAccountId = pachliAccountId
     }
 }
 
-class TabPreferenceActivityIntent(context: Context) : Intent() {
+class TabPreferenceActivityIntent(context: Context, pachliAccountId: Long) : Intent() {
     init {
         setClassName(context, QuadrantConstants.TAB_PREFERENCE_ACTIVITY)
+        this.pachliAccountId = pachliAccountId
     }
 }
 
-class TrendingActivityIntent(context: Context) : Intent() {
+class TrendingActivityIntent(context: Context, accountId: Long) : Intent() {
     init {
         setClassName(context, QuadrantConstants.TRENDING_ACTIVITY)
+        pachliAccountId = accountId
     }
 }

--- a/core/navigation/src/main/kotlin/app/pachli/core/navigation/Navigation.kt
+++ b/core/navigation/src/main/kotlin/app/pachli/core/navigation/Navigation.kt
@@ -662,7 +662,7 @@ class InstanceListActivityIntent(context: Context) : Intent() {
     }
 }
 
-class ListActivityIntent(context: Context, pachliAccountId: Long) : Intent() {
+class ListsActivityIntent(context: Context, pachliAccountId: Long) : Intent() {
     init {
         setClassName(context, QuadrantConstants.LISTS_ACTIVITY)
         this.pachliAccountId = pachliAccountId

--- a/feature/about/src/main/kotlin/app/pachli/feature/about/AboutFragment.kt
+++ b/feature/about/src/main/kotlin/app/pachli/feature/about/AboutFragment.kt
@@ -34,7 +34,7 @@ import androidx.core.content.ContextCompat.getSystemService
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
-import app.pachli.core.activity.BottomSheetActivity
+import app.pachli.core.activity.openLink
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
 import app.pachli.core.common.extensions.viewBinding
@@ -95,7 +95,7 @@ class AboutFragment : Fragment(R.layout.fragment_about) {
         binding.aboutBugsFeaturesInfoTextView.setClickableTextWithoutUnderlines(R.string.about_bug_feature_request_site)
 
         binding.appProfileButton.setOnClickListener {
-            (activity as? BottomSheetActivity)?.viewUrl(BuildConfig.SUPPORT_ACCOUNT_URL)
+            requireActivity().openLink(BuildConfig.SUPPORT_ACCOUNT_URL)
         }
 
         binding.copyDeviceInfo.setOnClickListener {

--- a/feature/lists/src/main/kotlin/app/pachli/feature/lists/ListsActivity.kt
+++ b/feature/lists/src/main/kotlin/app/pachli/feature/lists/ListsActivity.kt
@@ -47,6 +47,7 @@ import app.pachli.core.data.repository.Lists
 import app.pachli.core.data.repository.ListsError
 import app.pachli.core.data.repository.ListsRepository.Companion.compareByListTitle
 import app.pachli.core.navigation.TimelineActivityIntent
+import app.pachli.core.navigation.pachliAccountId
 import app.pachli.core.network.model.MastoList
 import app.pachli.core.network.model.UserListRepliesPolicy
 import app.pachli.core.ui.BackgroundMessage
@@ -238,7 +239,7 @@ class ListsActivity : BaseActivity(), MenuProvider {
 
     private fun onListSelected(listId: String, listTitle: String) {
         startActivityWithDefaultTransition(
-            TimelineActivityIntent.list(this, listId, listTitle),
+            TimelineActivityIntent.list(this, intent.pachliAccountId, listId, listTitle),
         )
     }
 

--- a/feature/lists/src/main/kotlin/app/pachli/feature/lists/ListsForAccountFragment.kt
+++ b/feature/lists/src/main/kotlin/app/pachli/feature/lists/ListsForAccountFragment.kt
@@ -57,7 +57,9 @@ class ListsForAccountFragment : DialogFragment() {
     private val viewModel: ListsForAccountViewModel by viewModels(
         extrasProducer = {
             defaultViewModelCreationExtras.withCreationCallback<ListsForAccountViewModel.Factory> { factory ->
-                factory.create(requireArguments().getString(ARG_ACCOUNT_ID)!!)
+                factory.create(
+                    requireArguments().getString(ARG_ACCOUNT_ID)!!,
+                )
             }
         },
     )
@@ -209,11 +211,14 @@ class ListsForAccountFragment : DialogFragment() {
     }
 
     companion object {
-        /** The ID of the account to add/remove the lists */
-        private const val ARG_ACCOUNT_ID = "accountId"
+        private const val ARG_PACHLI_ACCOUNT_ID = "app.pachli.ARG_PACHLI_ACCOUNT_ID"
 
-        fun newInstance(accountId: String): ListsForAccountFragment {
+        /** The ID of the account to add/remove the lists */
+        private const val ARG_ACCOUNT_ID = "app.pachli.ARG_ACCOUNT_ID"
+
+        fun newInstance(pachliAccountId: Long, accountId: String): ListsForAccountFragment {
             val args = Bundle().apply {
+                putLong(ARG_PACHLI_ACCOUNT_ID, pachliAccountId)
                 putString(ARG_ACCOUNT_ID, accountId)
             }
             return ListsForAccountFragment().apply { arguments = args }

--- a/feature/login/src/main/kotlin/app/pachli/feature/login/LoginActivity.kt
+++ b/feature/login/src/main/kotlin/app/pachli/feature/login/LoginActivity.kt
@@ -88,7 +88,8 @@ class LoginActivity : BaseActivity() {
 
         if (savedInstanceState == null &&
             BuildConfig.CUSTOM_INSTANCE.isNotBlank() &&
-            !isAdditionalLogin() && !isAccountMigration()
+            !isAdditionalLogin() &&
+            !isAccountMigration()
         ) {
             binding.domainEditText.setText(BuildConfig.CUSTOM_INSTANCE)
             binding.domainEditText.setSelection(BuildConfig.CUSTOM_INSTANCE.length)
@@ -309,27 +310,30 @@ class LoginActivity : BaseActivity() {
         mastodonApi.accountVerifyCredentials(
             domain = domain,
             auth = "Bearer ${accessToken.accessToken}",
-        ).fold({ newAccount ->
-            accountManager.addAccount(
-                accessToken = accessToken.accessToken,
-                domain = domain,
-                clientId = clientId,
-                clientSecret = clientSecret,
-                oauthScopes = OAUTH_SCOPES,
-                newAccount = newAccount,
-            )
+        ).fold(
+            { newAccount ->
+                val pachliAccountId = accountManager.addAccount(
+                    accessToken = accessToken.accessToken,
+                    domain = domain,
+                    clientId = clientId,
+                    clientSecret = clientSecret,
+                    oauthScopes = OAUTH_SCOPES,
+                    newAccount = newAccount,
+                )
 
-            val intent = MainActivityIntent(this)
-            intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-            startActivityWithTransition(intent, TransitionKind.EXPLODE)
-            finishAffinity()
-            setCloseTransition(TransitionKind.EXPLODE)
-        }, { e ->
-            setLoading(false)
-            binding.domainTextInputLayout.error =
-                getString(R.string.error_loading_account_details)
-            Timber.e(e, getString(R.string.error_loading_account_details))
-        })
+                val intent = MainActivityIntent(this, pachliAccountId)
+                intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                startActivityWithTransition(intent, TransitionKind.EXPLODE)
+                finishAffinity()
+                setCloseTransition(TransitionKind.EXPLODE)
+            },
+            { e ->
+                setLoading(false)
+                binding.domainTextInputLayout.error =
+                    getString(R.string.error_loading_account_details)
+                Timber.e(e, getString(R.string.error_loading_account_details))
+            },
+        )
     }
 
     private fun setLoading(loadingState: Boolean) {

--- a/feature/suggestions/src/main/kotlin/app/pachli/feature/suggestions/SuggestionsActivity.kt
+++ b/feature/suggestions/src/main/kotlin/app/pachli/feature/suggestions/SuggestionsActivity.kt
@@ -18,9 +18,11 @@
 package app.pachli.feature.suggestions
 
 import android.os.Bundle
+import androidx.fragment.app.commit
 import app.pachli.core.activity.BottomSheetActivity
 import app.pachli.core.activity.ReselectableFragment
 import app.pachli.core.common.extensions.viewBinding
+import app.pachli.core.navigation.pachliAccountId
 import app.pachli.feature.suggestions.databinding.ActivitySuggestionsBinding
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -46,5 +48,19 @@ class SuggestionsActivity : BottomSheetActivity() {
         binding.toolbar.setOnClickListener {
             (binding.fragmentContainer.getFragment<SuggestionsFragment>() as? ReselectableFragment)?.onReselect()
         }
+
+        val pachliAccountId = intent.pachliAccountId
+
+        val fragment =
+            supportFragmentManager.findFragmentByTag(FRAGMENT_TAG + pachliAccountId) as SuggestionsFragment?
+                ?: SuggestionsFragment.newInstance(pachliAccountId)
+
+        supportFragmentManager.commit {
+            replace(R.id.fragment_container, fragment, FRAGMENT_TAG + pachliAccountId)
+        }
+    }
+
+    companion object {
+        private const val FRAGMENT_TAG = "SuggestionsFragment_"
     }
 }

--- a/feature/suggestions/src/main/kotlin/app/pachli/feature/suggestions/SuggestionsFragment.kt
+++ b/feature/suggestions/src/main/kotlin/app/pachli/feature/suggestions/SuggestionsFragment.kt
@@ -67,6 +67,7 @@ import com.google.android.material.divider.MaterialDividerItemDecoration
 import com.google.android.material.snackbar.Snackbar
 import com.mikepenz.iconics.typeface.library.googlematerial.GoogleMaterial
 import dagger.hilt.android.AndroidEntryPoint
+import kotlin.properties.Delegates
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -103,9 +104,16 @@ class SuggestionsFragment :
     /** The active snackbar */
     private var snackbar: Snackbar? = null
 
+    private var pachliAccountId by Delegates.notNull<Long>()
+
     override fun onAttach(context: Context) {
         super.onAttach(context)
         bottomSheetActivity = (context as? BottomSheetActivity) ?: throw IllegalStateException("Fragment must be attached to a BottomSheetActivity")
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        pachliAccountId = requireArguments().getLong(ARG_PACHLI_ACCOUNT_ID)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -169,9 +177,25 @@ class SuggestionsFragment :
         when (uiAction) {
             is NavigationAction -> {
                 when (uiAction) {
-                    is NavigationAction.ViewAccount -> requireActivity().startActivityWithTransition(AccountActivityIntent(requireContext(), uiAction.accountId), TransitionKind.SLIDE_FROM_END)
-                    is NavigationAction.ViewHashtag -> requireActivity().startActivityWithTransition(TimelineActivityIntent.hashtag(requireContext(), uiAction.hashtag), TransitionKind.SLIDE_FROM_END)
-                    is NavigationAction.ViewUrl -> bottomSheetActivity.viewUrl(uiAction.url, PostLookupFallbackBehavior.OPEN_IN_BROWSER)
+                    is NavigationAction.ViewAccount -> requireActivity().startActivityWithTransition(
+                        AccountActivityIntent(requireContext(), pachliAccountId, uiAction.accountId),
+                        TransitionKind.SLIDE_FROM_END,
+                    )
+
+                    is NavigationAction.ViewHashtag -> requireActivity().startActivityWithTransition(
+                        TimelineActivityIntent.hashtag(
+                            requireContext(),
+                            pachliAccountId,
+                            uiAction.hashtag,
+                        ),
+                        TransitionKind.SLIDE_FROM_END,
+                    )
+
+                    is NavigationAction.ViewUrl -> bottomSheetActivity.viewUrl(
+                        pachliAccountId,
+                        uiAction.url,
+                        PostLookupFallbackBehavior.OPEN_IN_BROWSER,
+                    )
                 }
             }
             else -> {
@@ -271,7 +295,15 @@ class SuggestionsFragment :
     }
 
     companion object {
-        fun newInstance() = SuggestionsFragment()
+        private const val ARG_PACHLI_ACCOUNT_ID = "app.pachli.ARG_PACHLI_ACCOUNT_ID"
+
+        fun newInstance(pachliAccountId: Long): SuggestionsFragment {
+            val fragment = SuggestionsFragment()
+            fragment.arguments = Bundle(1).apply {
+                putLong(ARG_PACHLI_ACCOUNT_ID, pachliAccountId)
+            }
+            return fragment
+        }
     }
 }
 

--- a/feature/suggestions/src/main/res/layout/activity_suggestions.xml
+++ b/feature/suggestions/src/main/res/layout/activity_suggestions.xml
@@ -44,7 +44,6 @@
         android:id="@+id/fragment_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:name="app.pachli.feature.suggestions.SuggestionsFragment"
         app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
     <include layout="@layout/item_status_bottom_sheet"/>


### PR DESCRIPTION
Previous code assumed the active account could always be determined from
the account manager.

This causes a few problems.

1. The account manager has to handle the case where there is no active
account (e.g., the user is logging out of the last account). This meant
the `activeAccount` property had to be nullable, so every consumer of
that property either used it with a `let` or `!!` expression.

2. The active account can change over the life of the UI component, for
example, when the user is switching accounts. There's a theoretical race
condition where the UI component has started an operation for one
account, then the account changes and the network authentication code
uses the new account.

3. All operations assume they operate on whatever the active account is,
making it difficult to provide any features that allow the user to
temporarily operate as another account ("Boost as...", etc).

This "ambient account" was effectively global mutable state, with all
the problems that can cause.

Start to fix this. The changes in this commit do not fix the problem
completely, but they are some progress.

Each activity (except LoginActivity) is expected to be launched with an
intent that includes the ID of the Pachli account it defaults to
operating with. This is `pachliAccountId`, and is the *database ID*
(not the server ID) of the account. This is non-null, which removes one
class of bugs.

This account is passed to each fragment and any piece of code that has
to perform an operation on behalf of this account. It's not used in
most of those places yet, that will be done over a number of followup
PRs as part of modernising each module.