### PR TITLE
fix: Load announcements with associated statuses correctly

### DIFF
--- a/core/network/src/main/kotlin/app/pachli/core/network/model/Announcement.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/Announcement.kt
@@ -31,7 +31,7 @@ data class Announcement(
     @Json(name = "updated_at") val updatedAt: Date,
     val read: Boolean,
     val mentions: List<Status.Mention>,
-    val statuses: List<Status>,
+    val statuses: List<AnnouncementStatus>,
     val tags: List<HashTag>,
     val emojis: List<Emoji>,
     val reactions: List<Reaction>,
@@ -56,5 +56,11 @@ data class Announcement(
         val me: Boolean,
         val url: String?,
         @Json(name = "static_url") val staticUrl: String?,
+    )
+
+    @JsonClass(generateAdapter = true)
+    data class AnnouncementStatus(
+        val id: String,
+        val url: String,
     )
 }


### PR DESCRIPTION
The `Status` type associated with an announcement is entirely different to the regular `Status` type, with a different JSON shape. The incorrect type meant a deserialisation error when loading announcements with associated statuses.