### PR TITLE
fix: Parse and restore poll when editing scheduled statuses

### DIFF
--- a/app/src/main/java/app/pachli/components/scheduled/ScheduledStatusActivity.kt
+++ b/app/src/main/java/app/pachli/components/scheduled/ScheduledStatusActivity.kt
@@ -165,6 +165,7 @@ class ScheduledStatusActivity :
                 scheduledAt = item.scheduledAt,
                 sensitive = item.params.sensitive,
                 kind = ComposeOptions.ComposeKind.EDIT_SCHEDULED,
+                poll = item.params.poll,
             ),
         )
         startActivity(intent)

--- a/core/network/src/main/kotlin/app/pachli/core/network/model/StatusParams.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/StatusParams.kt
@@ -27,4 +27,5 @@ data class StatusParams(
     val visibility: Status.Visibility,
     @Json(name = "spoiler_text") val spoilerText: String,
     @Json(name = "in_reply_to_id") val inReplyToId: String?,
+    val poll: NewPoll?,
 )


### PR DESCRIPTION
Previous code didn't deserialise the "poll" attribute so it was never passed to the composer when editing scheduled statuses.

Fixes #991