### PR TITLE
refactor: Use pachliAccountId in EditProfileActivity

### DIFF
--- a/app/src/main/java/app/pachli/EditProfileActivity.kt
+++ b/app/src/main/java/app/pachli/EditProfileActivity.kt
@@ -40,6 +40,7 @@ import app.pachli.core.common.extensions.show
 import app.pachli.core.common.extensions.viewBinding
 import app.pachli.core.data.model.InstanceInfo.Companion.DEFAULT_MAX_ACCOUNT_FIELDS
 import app.pachli.core.designsystem.R as DR
+import app.pachli.core.navigation.pachliAccountId
 import app.pachli.core.ui.extensions.await
 import app.pachli.core.ui.extensions.getErrorString
 import app.pachli.databinding.ActivityEditProfileBinding
@@ -155,7 +156,7 @@ class EditProfileActivity : BaseActivity() {
             }
         }
 
-        viewModel.obtainProfile()
+        viewModel.obtainProfile(intent.pachliAccountId)
 
         viewModel.profileData.observe(this) { profileRes ->
             when (profileRes) {
@@ -191,7 +192,7 @@ class EditProfileActivity : BaseActivity() {
                 is Error -> {
                     Snackbar.make(binding.avatarButton, app.pachli.core.ui.R.string.error_generic, Snackbar.LENGTH_LONG)
                         .setAction(app.pachli.core.ui.R.string.action_retry) {
-                            viewModel.obtainProfile()
+                            viewModel.obtainProfile(intent.pachliAccountId)
                         }
                         .show()
                 }

--- a/app/src/main/java/app/pachli/viewmodel/EditProfileViewModel.kt
+++ b/app/src/main/java/app/pachli/viewmodel/EditProfileViewModel.kt
@@ -37,6 +37,7 @@ import at.connyduck.calladapter.networkresult.fold
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.io.File
 import javax.inject.Inject
+import kotlin.properties.Delegates
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
@@ -77,7 +78,11 @@ class EditProfileViewModel @Inject constructor(
     /** True if the user has made unsaved changes to the profile */
     val isDirty = _isDirty.asStateFlow()
 
-    fun obtainProfile() = viewModelScope.launch {
+    var pachliAccountId by Delegates.notNull<Long>()
+
+    fun obtainProfile(pachliAccountId: Long) = viewModelScope.launch {
+        this@EditProfileViewModel.pachliAccountId = pachliAccountId
+
         if (profileData.value == null || profileData.value is Error) {
             profileData.postValue(Loading())
 
@@ -86,9 +91,7 @@ class EditProfileViewModel @Inject constructor(
                     apiProfileAccount = profile
                     profileData.postValue(Success(profile))
                 },
-                {
-                    profileData.postValue(Error())
-                },
+                { profileData.postValue(Error()) },
             )
         }
     }
@@ -242,8 +245,14 @@ class EditProfileViewModel @Inject constructor(
         val headerFile: File?,
         val avatarFile: File?,
     ) {
-        fun hasChanges() = displayName != null || note != null || locked != null ||
-            avatarFile != null || headerFile != null || field1 != null || field2 != null ||
-            field3 != null || field4 != null
+        fun hasChanges() = displayName != null ||
+            note != null ||
+            locked != null ||
+            avatarFile != null ||
+            headerFile != null ||
+            field1 != null ||
+            field2 != null ||
+            field3 != null ||
+            field4 != null
     }
 }


### PR DESCRIPTION
Pass the value to EditProfileViewModel. It's not used yet, but this minimises diffs an upcoming large refactor.