### PR TITLE
fix: Don't crash if foreign key constraint is invalid in transaction

### DIFF
--- a/core/database/src/main/kotlin/app/pachli/core/database/model/TimelineStatusEntity.kt
+++ b/core/database/src/main/kotlin/app/pachli/core/database/model/TimelineStatusEntity.kt
@@ -55,6 +55,7 @@ import java.util.Date
                 entity = TimelineAccountEntity::class,
                 parentColumns = ["serverId", "timelineUserId"],
                 childColumns = ["authorServerId", "timelineUserId"],
+                deferred = true,
             ),
         ]
         ),


### PR DESCRIPTION
ForeignKey constraints can be invalidated in the middle of a transaction even if a later statement in the same transaction will make them valid again. This seems to be causing production crashes.

Defer foreign key constraint checks until the end of the transaction to prevent this.