### PR TITLE
fix: Remove the "Liimt timeline notifications" preference

### DIFF
--- a/app/src/main/java/app/pachli/PachliApplication.kt
+++ b/app/src/main/java/app/pachli/PachliApplication.kt
@@ -150,8 +150,12 @@ class PachliApplication : Application() {
         // General usage is:
         //
         // if (oldVersion < ...) {
-        //     ... use editor modify the preferences ...
+        //     ... use `editor` to modify the preferences ...
         // }
+
+        if (oldVersion < 2024101701) {
+            editor.remove(PrefKeys.Deprecated.WELLBEING_LIMITED_NOTIFICATIONS)
+        }
 
         editor.putInt(PrefKeys.SCHEMA_VERSION, newVersion)
         editor.apply()

--- a/app/src/main/java/app/pachli/components/preference/PreferencesFragment.kt
+++ b/app/src/main/java/app/pachli/components/preference/PreferencesFragment.kt
@@ -49,7 +49,6 @@ import app.pachli.core.common.util.unsafeLazy
 import app.pachli.core.data.repository.AccountManager
 import app.pachli.core.database.model.AccountEntity
 import app.pachli.core.designsystem.R as DR
-import app.pachli.core.network.model.Notification
 import app.pachli.core.preferences.AppTheme
 import app.pachli.core.preferences.DownloadLocation
 import app.pachli.core.preferences.MainNavigationPosition
@@ -73,8 +72,6 @@ import app.pachli.updatecheck.UpdateCheck
 import app.pachli.updatecheck.UpdateCheckResult.AT_LATEST
 import app.pachli.updatecheck.UpdateNotificationFrequency
 import app.pachli.util.LocaleManager
-import app.pachli.util.deserialize
-import app.pachli.util.serialize
 import app.pachli.view.FontFamilyDialogFragment
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
@@ -449,31 +446,6 @@ class PreferencesFragment : PreferenceFragmentCompat() {
             }
 
             preferenceCategory(R.string.pref_title_wellbeing_mode) {
-                switchPreference {
-                    title = getString(R.string.limit_notifications)
-                    setDefaultValue(false)
-                    key = PrefKeys.WELLBEING_LIMITED_NOTIFICATIONS
-                    setOnPreferenceChangeListener { _, value ->
-                        for (account in accountManager.accounts) {
-                            val notificationFilter = deserialize(account.notificationsFilter).toMutableSet()
-
-                            if (value == true) {
-                                notificationFilter.add(Notification.Type.FAVOURITE)
-                                notificationFilter.add(Notification.Type.FOLLOW)
-                                notificationFilter.add(Notification.Type.REBLOG)
-                            } else {
-                                notificationFilter.remove(Notification.Type.FAVOURITE)
-                                notificationFilter.remove(Notification.Type.FOLLOW)
-                                notificationFilter.remove(Notification.Type.REBLOG)
-                            }
-
-                            account.notificationsFilter = serialize(notificationFilter)
-                            accountManager.saveAccount(account)
-                        }
-                        true
-                    }
-                }
-
                 switchPreference {
                     title = getString(R.string.wellbeing_hide_stats_posts)
                     setDefaultValue(false)

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -464,7 +464,6 @@
     <string name="pref_title_confirm_favourites">أظهر نافذة لطلب التأكيد قبل الإضافة إلى المفضلة</string>
     <string name="drafts_failed_loading_reply">فشل في تحميل معلومات الرد</string>
     <string name="duration_indefinite">غير محددة</string>
-    <string name="limit_notifications">وضع حد لإشعارات الخيط الزمني</string>
     <string name="duration_14_days">14 يومًا</string>
     <string name="duration_30_days">30 يومًا</string>
     <string name="duration_60_days">60 يومًا</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -509,7 +509,6 @@
         <item quantity="many">Вы не можаце запампаваць больш за %1$d медыя далучэнняў.</item>
         <item quantity="other">Вы не можаце запампаваць больш за %1$d медыя далучэнняў.</item>
     </plurals>
-    <string name="limit_notifications">Абмежаванне апавяшчэнняў у стужцы</string>
     <string name="wellbeing_hide_stats_posts">Схаваць колькасную статыстыку допісаў</string>
     <string name="wellbeing_hide_stats_profile">Схаваць колькасную статыстыку профіляў</string>
     <string name="report_category_violation">Парушэнне правіла</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -360,7 +360,6 @@
     </plurals>
     <string name="wellbeing_hide_stats_profile">Скриване на количествена статистика на профили</string>
     <string name="wellbeing_hide_stats_posts">Скриване на количествена статистика на публикации</string>
-    <string name="limit_notifications">Ограничаване на известия от емисия</string>
     <string name="review_notifications">Преглед на известията</string>
     <string name="wellbeing_mode_notice">Част от информацията, която може да повлияе на вашето психично състояние, ще бъде скрита. Това включва:
 \n

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -365,7 +365,6 @@
     <string name="account_note_saved">সংরক্ষিত!</string>
     <string name="wellbeing_hide_stats_profile">অবতারে পরিসংখ্যান লুকাও</string>
     <string name="wellbeing_hide_stats_posts">ছাপার পরিসংখ্যান লুকাও</string>
-    <string name="limit_notifications">সময়কাল বিজ্ঞপ্তি সীমাবদ্ধ করো</string>
     <string name="wellbeing_mode_notice">তোমার মানসিক স্বাস্থে নেতিবাচক প্রভাব ফেলতে পারে এমন জিনিসগুলো লুকানো আছে। যেমন:
 \n
 \n - পছন্দ/বুস্ট/অনুসরণ বিজ্ঞপ্তি

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -415,7 +415,6 @@
     </plurals>
     <string name="wellbeing_hide_stats_profile">Amaga les estadístiques quantitatives dels perfils</string>
     <string name="wellbeing_hide_stats_posts">Amaga les estadístiques quantitatives de les publicacions</string>
-    <string name="limit_notifications">Limita les notificacions de la cronologia</string>
     <string name="filter_expiration_format">%s (%s)</string>
     <string name="dialog_delete_conversation_warning">Vols suprimir aquesta conversa\?</string>
     <string name="error_image_edit_failed">La imatge no s\'ha pogut editar.</string>

--- a/app/src/main/res/values-ckb/strings.xml
+++ b/app/src/main/res/values-ckb/strings.xml
@@ -198,7 +198,6 @@
     </plurals>
     <string name="wellbeing_hide_stats_profile">شاردنەوەی زانیاری چەندێتی لەسەر پرۆفایلەکان</string>
     <string name="wellbeing_hide_stats_posts">شاردنەوەی زانیاری چەندێتی لە بابەتەکان</string>
-    <string name="limit_notifications">سنووردارکردنی ئاگانامەکانی تایم لاین</string>
     <string name="review_notifications">پێداچوونەوەی ئاگانامەکان</string>
     <string name="wellbeing_mode_notice">هەندێک زانیاری کە لەوانەیە کاریگەری لەسەر باشبوونی دەروونیت دروست بکات دەشاردرێنەوە. ئەمە پێکدێت لە:
 \n

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -469,7 +469,6 @@
     <string name="account_note_saved">Uloženo!</string>
     <string name="pref_title_wellbeing_mode">Pohoda</string>
     <string name="review_notifications">Zkontrolovat oznámení</string>
-    <string name="limit_notifications">Omezit upozornění na časové ose</string>
     <string name="wellbeing_hide_stats_posts">Skrýt kvantitativní statistiky příspěvků</string>
     <string name="account_date_joined">Připojil/a se %1$s</string>
     <string name="saving_draft">Koncept se ukládá…</string>

--- a/app/src/main/res/values-cy/strings.xml
+++ b/app/src/main/res/values-cy/strings.xml
@@ -413,7 +413,6 @@
     <string name="description_post_bookmarked">Tudalnodiwyd</string>
     <string name="select_list_title">Dewiswch restr</string>
     <string name="report_sent_success">Wedi adrodd ar @%s yn llwyddiannus</string>
-    <string name="limit_notifications">Cyfyngu ar hysbysiadau ffrydiau</string>
     <string name="pref_title_show_self_username">Dangos enw defnyddiwr mewn bariau offer</string>
     <string name="pref_title_confirm_favourites">Dangos cadarnhad cyn hoffi</string>
     <string name="pref_title_hide_top_toolbar">Cuddio teitl y bar offer uchaf</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -426,7 +426,6 @@
     <string name="follow_requests_info">Auch wenn dein Konto öffentlich bzw. nicht geschützt ist, haben die Admins von %1$s gedacht, dass du diesen Follower lieber manuell bestätigen solltest.</string>
     <string name="wellbeing_hide_stats_profile">Statistiken auf Profilen ausblenden</string>
     <string name="wellbeing_hide_stats_posts">Statistiken in Beiträgen ausblenden</string>
-    <string name="limit_notifications">Timeline-Benachrichtigungen einschränken</string>
     <string name="action_subscribe_account">Abonnieren</string>
     <string name="action_unsubscribe_account">Deabonnieren</string>
     <string name="abbreviated_in_minutes">in %d Min.</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -438,7 +438,6 @@
 \n
 \n Sciigoj ne estos influitaj, sed vi povas kontroli viajn agordojn pri sciigojn permane.</string>
     <string name="review_notifications">Kontroli la sciigojn</string>
-    <string name="limit_notifications">Limigi sciigojn pri tempolinio</string>
     <string name="drafts_post_reply_removed">La mesaĝo, al kiu tiu ĉi malneto respondas, estis forigita</string>
     <string name="notification_sign_up_format">%s registriĝis</string>
     <string name="pref_title_notification_filter_sign_ups">iu registriĝis</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -435,7 +435,6 @@
     <string name="label_duration">Duración</string>
     <string name="post_media_attachments">Adjuntos</string>
     <string name="post_media_audio">Audio</string>
-    <string name="limit_notifications">Limitar cronología de notificaciones</string>
     <string name="action_unbookmark">Quitar marcador</string>
     <string name="follow_requests_info">Aunque tu cuenta no está bloqueada, el personal de %1$s pensó que podrías querer revisar las solicitudes de seguimiento de estas cuentas manualmente.</string>
     <string name="action_subscribe_account">Suscribir</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -406,7 +406,6 @@
         <item quantity="one">Ezin duzu multimedia eranskin %1$d baino gehiago kargatu.</item>
         <item quantity="other">Ezin dituzu %1$d multimedia eranskin baino gehiago kargatu.</item>
     </plurals>
-    <string name="limit_notifications">Denbora-lerroaren jakinarazpenak mugatu</string>
     <string name="label_duration">Iraupena</string>
     <string name="duration_indefinite">Zehaztugabea</string>
     <string name="action_unsubscribe_account">Harpidetza kendu</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -402,7 +402,6 @@
     <string name="drafts_post_failed_to_send">فرستادن این فرسته شکست خورد!</string>
     <string name="wellbeing_hide_stats_profile">نهفتن آمار کمی روی نمایه‌ها</string>
     <string name="wellbeing_hide_stats_posts">نهفتن آمار کمی روی فرسته‌ها</string>
-    <string name="limit_notifications">محدود کردن آگاهی‌های خط‌زمانی</string>
     <string name="review_notifications">بازبینی آگاهی‌ها</string>
     <string name="pref_title_wellbeing_mode">سلامتی</string>
     <string name="label_duration">طول</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -465,7 +465,6 @@
     <string name="report_category_violation">Sääntörikkomus</string>
     <string name="label_filter_keywords">Avainsanat tai jonot jotka suodatetaan</string>
     <string name="drafts_post_reply_removed">Julkaisu, johon olit kirjoittanut vastausluonnoksen, on poistettu</string>
-    <string name="limit_notifications">Rajoita aikajanan ilmoituksia</string>
     <string name="account_date_joined">Liittyi %1$s</string>
     <string name="ui_error_filter_v1_load_fmt">Suodattimien lataaminen epäonnistui: %1$s</string>
     <string name="announcement_date_updated">(Päivitetty: %1$s)</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -427,7 +427,6 @@
     </plurals>
     <string name="pref_title_wellbeing_mode">Bien-être</string>
     <string name="notification_subscription_description">Notifications quand quelqu’un que vous suivez publie un nouveau message</string>
-    <string name="limit_notifications">Limiter les notifications du fil</string>
     <string name="wellbeing_hide_stats_profile">Cacher les statistiques quantitatives sur les profils</string>
     <string name="wellbeing_hide_stats_posts">Cacher les statistiques quantitatives sur les messages</string>
     <string name="action_unbookmark">Supprimer le signet</string>

--- a/app/src/main/res/values-gd/strings.xml
+++ b/app/src/main/res/values-gd/strings.xml
@@ -69,7 +69,6 @@
     </plurals>
     <string name="wellbeing_hide_stats_profile">Falaich an stadastaireachd àireamhail air pròifilean</string>
     <string name="wellbeing_hide_stats_posts">Falaich an stadastaireachd àireamhail air postaichean</string>
-    <string name="limit_notifications">Cuingich na brathan mun loidhne-ama</string>
     <string name="review_notifications">Thoir sùil air na brathan</string>
     <string name="wellbeing_mode_notice">Thèid cuid a dh’fhiosrachadh a dh’fhaodadh droch-bhuaidh a thoirt air d’ shlàinte-inntinn fhalach. Tha seo a’ gabhail a-staigh:
 \n

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -368,7 +368,6 @@
     </plurals>
     <string name="wellbeing_hide_stats_profile">Agochar estatísticas cuantitativas nos perfís</string>
     <string name="wellbeing_hide_stats_posts">Agochar estatísticas cuantitativas nas publicacións</string>
-    <string name="limit_notifications">Limitar notificacións da cronoloxía</string>
     <string name="review_notifications">Revisar Notificacións</string>
     <string name="wellbeing_mode_notice">Agocharemos algunha información que podería afectar ao teu benestar mental. Esto inclúe:
 \n

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -407,7 +407,6 @@
     </plurals>
     <string name="wellbeing_hide_stats_profile">Profilok mérőszámainak elrejtése</string>
     <string name="wellbeing_hide_stats_posts">Bejegyzések mérőszámainak elrejtése</string>
-    <string name="limit_notifications">Idővonali értesítések korlátozása</string>
     <string name="review_notifications">Értesítések Áttekintése</string>
     <string name="wellbeing_mode_notice">Pár információ, ami befolyásolhatja a mentális jóllétedet rejtve marad. Ilyenek pl.:
 \n

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -414,7 +414,6 @@
     </plurals>
     <string name="wellbeing_hide_stats_profile">Fela magntölfræði notendasniða</string>
     <string name="wellbeing_hide_stats_posts">Fela magntölfræði færslna</string>
-    <string name="limit_notifications">Takmarka tilkynningar á tímalínu</string>
     <string name="review_notifications">Yfirfara tilkynningar</string>
     <string name="pref_title_wellbeing_mode">Vellíðan</string>
     <string name="notification_subscription_description">Tilkynningar þegar einhver sem þú ert áskrifandi að hefur birt nýja færslu</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -427,7 +427,6 @@
     <string name="pref_title_notification_filter_follow_requests">mi viene richiesto di seguirmi</string>
     <string name="wellbeing_hide_stats_profile">Nascondi le statistiche sui profili</string>
     <string name="wellbeing_hide_stats_posts">Nascondi le statistiche sui post</string>
-    <string name="limit_notifications">Limita le notifiche della timeline</string>
     <string name="review_notifications">Rivedi le notifiche</string>
     <string name="pref_title_wellbeing_mode">Benessere</string>
     <string name="notification_subscription_description">Notifiche di nuovi messaggi di qualcuno a cui sei iscritto</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -400,7 +400,6 @@
     <string name="duration_90_days">90日間</string>
     <string name="duration_180_days">180日間</string>
     <string name="duration_365_days">365日間</string>
-    <string name="limit_notifications">タイムライン通知を制限する</string>
     <string name="wellbeing_hide_stats_posts">投稿上の数値的な統計情報を隠す</string>
     <string name="failed_to_pin">ピン留めに失敗しました</string>
     <string name="failed_to_unpin">ピン留めの解除に失敗しました</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -363,7 +363,6 @@
     <string name="notification_poll_description">Paziņojumi par pabeigtajām aptaujām</string>
     <string name="notification_subscription_description">Paziņojumi par jauniem ierakstiem no kāda, kura ierakstus esi abonējis</string>
     <string name="notification_sign_up_description">Paziņojumi par jauniem lietotājiem</string>
-    <string name="limit_notifications">Ierobežot laika līnijas paziņojumus</string>
     <string name="wellbeing_hide_stats_profile">Slēpt profilu kvantitatīvo statistiku</string>
     <string name="wellbeing_hide_stats_posts">Slēpt ierakstu kvantitatīvo statistiku</string>
     <string name="drafts_failed_loading_reply">Neizdevās ielādēt atbildes informāciju</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -394,7 +394,6 @@
     <string name="title_announcements">Kunngjøringer</string>
     <string name="wellbeing_hide_stats_profile">Skjul kvantitativ informasjon på profiler</string>
     <string name="wellbeing_hide_stats_posts">Skjul kvantitativ statistikk på innleggene</string>
-    <string name="limit_notifications">Begrens tidslinjevarsler</string>
     <string name="review_notifications">Se over varsler</string>
     <string name="wellbeing_mode_notice">Informasjon som kan påvirke ditt mentale velvære vil bli skjult. Dette inkluderer:
 \n

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -382,7 +382,6 @@
         <item quantity="one">Je kan niet meer dan %1$d mediabijlage uploaden.</item>
         <item quantity="other">Je kan niet meer dan %1$d mediabijlagen uploaden.</item>
     </plurals>
-    <string name="limit_notifications">Meldingen op tijdlijn beperken</string>
     <string name="account_note_saved">Opgeslagen!</string>
     <string name="account_note_hint">Jouw eigen opmerking over dit account</string>
     <string name="pref_title_wellbeing_mode">Welzijn</string>

--- a/app/src/main/res/values-oc/strings.xml
+++ b/app/src/main/res/values-oc/strings.xml
@@ -417,7 +417,6 @@
     </plurals>
     <string name="wellbeing_hide_stats_profile">Amagar las estatisticas dels perfils</string>
     <string name="wellbeing_hide_stats_posts">Amagar las estatisticas dels tuts</string>
-    <string name="limit_notifications">Limitar las notificacions de la cronologia</string>
     <string name="pref_title_hide_top_toolbar">Amagar lo títol ennaut de la barra</string>
     <string name="pref_title_confirm_reblogs">Afichar una confirmacion abans de partejar</string>
     <string name="action_unbookmark">Tirar dels marcapaginas</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -420,7 +420,6 @@
     <string name="drafts_failed_loading_reply">Nie udało się załadować informacji o odpowiedzi</string>
     <string name="drafts_post_failed_to_send">Przesłanie wpisu nie powiodło się!</string>
     <string name="no_announcements">Nie ma ogłoszeń.</string>
-    <string name="limit_notifications">Ogranicz liczbę powiadomień o zmianach na osi czasu</string>
     <string name="label_duration">Czas trwania</string>
     <string name="notification_subscription_name">Nowe wpisy</string>
     <string name="wellbeing_mode_notice">Niektóre informacje, które mogą wpływać na Twój dobrostan psychiczny zostaną ukryte. W ich skład wchodzą:

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -416,7 +416,6 @@
     </plurals>
     <string name="wellbeing_hide_stats_profile">Ocultar estatísticas numéricas dos perfis</string>
     <string name="wellbeing_hide_stats_posts">Ocultar estatísticas numéricas dos Toots</string>
-    <string name="limit_notifications">Limitar notificações da linha do tempo</string>
     <string name="review_notifications">Revisar notificações</string>
     <string name="wellbeing_mode_notice">Algumas informações que podem afetar teu bem-estar serão ocultadas. Isso inclui:
 \n

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -428,7 +428,6 @@
 \n
 \nNotificações push não serão afetadas, mas é possível rever as configurações das notificações manualmente.</string>
     <string name="review_notifications">Rever Notificações</string>
-    <string name="limit_notifications">Limitar notificações da timeline</string>
     <string name="no_announcements">Sem anúncios.</string>
     <string name="warning_scheduling_interval">O Mastodon tem um intervalo mínimo de agendamento de 5 minutos.</string>
     <string name="pref_title_show_cards_in_timelines">Mostrar pré-visualização de hiperligações nas timelines</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -441,7 +441,6 @@
     <string name="draft_deleted">Черновик удалён</string>
     <string name="drafts_post_failed_to_send">Этот гудок не удалось отправить!</string>
     <string name="wellbeing_hide_stats_profile">Скрыть количественную статистику по профилям пользователей</string>
-    <string name="limit_notifications">Ограничение уведомлений в ленте</string>
     <string name="review_notifications">Просмотр уведомлений</string>
     <string name="notification_subscription_description">Уведомления, когда кто-то, на кого вы подписаны, опубликовал новую запись</string>
     <string name="notification_subscription_name">Новые гудки</string>

--- a/app/src/main/res/values-sa/strings.xml
+++ b/app/src/main/res/values-sa/strings.xml
@@ -461,7 +461,6 @@
     <string name="title_migration_relogin">पुनःसम्प्रवेशाय विज्ञापन-ज्ञापनसूचनाः</string>
     <string name="dialog_follow_hashtag_hint">#निश्रेणिचिह्नशीर्षकः</string>
     <string name="dialog_follow_hashtag_title">व्यक्तित्वविवरणलेखा अनुसरतु</string>
-    <string name="limit_notifications">कालानुक्रमपङ्क्त्याः सूचनाः परिमिताः कुरुताम्</string>
     <string name="notification_report_description">परिमितावेदनानि प्रति ज्ञापनसूचनाः</string>
     <string name="unsaved_changes">भवतः अरक्षितानि परिवर्तनानि सन्ति।</string>
     <string name="pref_title_notification_filter_reports">नूतनम् आवेदनमस्ति</string>

--- a/app/src/main/res/values-si/strings.xml
+++ b/app/src/main/res/values-si/strings.xml
@@ -127,7 +127,6 @@
     <string name="title_public_local">ස්ථානීය</string>
     <string name="action_view_favourites">ප්‍රියතමයන්</string>
     <string name="label_quick_reply">පිළිතුරු…</string>
-    <string name="limit_notifications">කාලරේඛා දැනුම්දීම් සීමාකරන්න</string>
     <string name="send_post_notification_error_title">ටූට් යැවීමේ දෝෂයකි</string>
     <string name="filter_addition_title">පෙරහන එකතු කරන්න</string>
     <string name="pref_default_media_sensitivity">සැමවිටම මාධ්‍ය සංවේදී ලෙස සලකුණු කරන්න</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -409,7 +409,6 @@
     <string name="notification_subscription_format">%s skrev precis</string>
     <string name="wellbeing_hide_stats_profile">Dölj kvantitativ information på profiler</string>
     <string name="wellbeing_hide_stats_posts">Dölj kvantitativ information på inlägg</string>
-    <string name="limit_notifications">Begränsa tidslinje aviseringar</string>
     <string name="review_notifications">Revidera aviseringar</string>
     <string name="wellbeing_mode_notice">Information som kan påverka ditt välmående kommer att döljas. Detta inkluderar:
 \n

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -385,7 +385,6 @@
 \n- สถิติ ผู้ติดตาม/โพสต์ ในโปรไฟล์
 \n
 \n การแจ้งเตือนแบบพุชจะไม่ได้รับผลกระทบ แต่คุณสามารถตรวจสอบการตั้งค่าการแจ้งเตือนได้ด้วยตนเอง</string>
-    <string name="limit_notifications">แจ้งเตือน Limit timeline</string>
     <string name="review_notifications">แจ้งเตือน Review</string>
     <string name="pref_title_notification_filter_subscriptions">ใครบางคนที่ฉันได้ติดตาม ได้เผยแพร่โพสต์ใหม่</string>
     <string name="wellbeing_hide_stats_profile">ซ่อนสถิติเชิงปริมาณในโปรไฟล์</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -460,7 +460,6 @@
     <string name="failed_to_pin">Sabitleme Başarısız</string>
     <string name="failed_to_unpin">Açılamadı</string>
     <string name="drafts_post_failed_to_send">Bu yayın gönderilemedi!</string>
-    <string name="limit_notifications">Ağ akışı bildirimlerini sınırla</string>
     <string name="wellbeing_hide_stats_posts">Yayınların niceliksel istatistikleri gizle</string>
     <string name="status_created_at_now">şimdi</string>
     <string name="drafts_post_reply_removed">Yanıt yazdığınız yayın kaldırıldı</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -395,7 +395,6 @@
     </plurals>
     <string name="wellbeing_hide_stats_profile">Приховати кількісну статистику профілів</string>
     <string name="wellbeing_hide_stats_posts">Приховати кількісну статистику дописів</string>
-    <string name="limit_notifications">Обмеження сповіщень стрічки</string>
     <string name="review_notifications">Переглянути сповіщення</string>
     <string name="account_note_hint">Ваша особиста примітка про цей обліковий запис</string>
     <string name="pref_title_wellbeing_mode">Добробут</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -383,7 +383,6 @@
     <string name="title_announcements">Có gì mới\?</string>
     <string name="wellbeing_hide_stats_profile">Ẩn số liệu trên trang hồ sơ</string>
     <string name="wellbeing_hide_stats_posts">Ẩn số liệu trên tút</string>
-    <string name="limit_notifications">Giảm bớt thông báo</string>
     <string name="review_notifications">Chọn loại thông báo</string>
     <string name="wellbeing_mode_notice">Các thông tin ảnh hưởng tới tâm lý hành vi của bạn sẽ bị ẩn. Bao gồm:
 \n

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -404,7 +404,6 @@
     <string name="wellbeing_hide_stats_profile">隐藏账号的统计信息</string>
     <string name="review_notifications">反馈通知</string>
     <string name="wellbeing_hide_stats_posts">隐藏嘟文的统计信息</string>
-    <string name="limit_notifications">限制时间线通知</string>
     <string name="wellbeing_mode_notice">一些可能影响你精神状态的信息将被隐藏，包括：
 \n
 \n - 喜欢、转发、关注通知

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -356,7 +356,6 @@
     <string name="title_bookmarks">書籤</string>
     <string name="wellbeing_hide_stats_profile">隱藏個人頁面中的狀態數量資訊</string>
     <string name="wellbeing_hide_stats_posts">隱藏貼文上的狀態數量資訊</string>
-    <string name="limit_notifications">限制時間軸通知</string>
     <string name="review_notifications">檢查通知設定</string>
     <string name="wellbeing_mode_notice">有些資訊可能會影響你的心理健康將會被隱藏。包括：
 \n

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -583,7 +583,6 @@
         Push-notifications will not be affected, but you can review your notification preferences manually.
     </string>
     <string name="review_notifications">Review Notifications</string>
-    <string name="limit_notifications">Limit timeline notifications</string>
     <string name="wellbeing_hide_stats_posts">Hide quantitative stats on posts</string>
     <string name="wellbeing_hide_stats_profile">Hide quantitative stats on profiles</string>
     <plurals name="error_upload_max_media_reached">

--- a/core/preferences/src/main/kotlin/app/pachli/core/preferences/SettingsConstants.kt
+++ b/core/preferences/src/main/kotlin/app/pachli/core/preferences/SettingsConstants.kt
@@ -29,7 +29,7 @@ package app.pachli.core.preferences
  *
  * - Adding a new preference that does not change the interpretation of an existing preference
  */
-const val SCHEMA_VERSION = 2023090201
+const val SCHEMA_VERSION = 2024101701
 
 /** The schema version for fresh installs */
 const val NEW_INSTALL_SCHEMA_VERSION = 0
@@ -59,7 +59,6 @@ object PrefKeys {
     const val SHOW_STATS_INLINE = "showStatsInline"
 
     const val CUSTOM_TABS = "customTabs"
-    const val WELLBEING_LIMITED_NOTIFICATIONS = "wellbeingModeLimitedNotifications"
     const val WELLBEING_HIDE_STATS_POSTS = "wellbeingHideStatsPosts"
     const val WELLBEING_HIDE_STATS_PROFILE = "wellbeingHideStatsProfile"
 
@@ -114,6 +113,6 @@ object PrefKeys {
 
     /** Keys that are no longer used (e.g., the preference has been removed */
     object Deprecated {
-        // Empty at this time
+        const val WELLBEING_LIMITED_NOTIFICATIONS = "wellbeingModeLimitedNotifications"
     }
 }


### PR DESCRIPTION
This wasn't acting as a preference.

It presented as a switch. If the user toggled it some notification settings were changed for all accounts.

It wasn't clear what was changed, and if the user changed some of those settings back the switch position did not change (it couldn't, you couldn't meaningfully represent a partial change using a single switch).

Since the user has full control over the notification filters on a per-account basis remove this "preference" to reduce confusion.

Fixes #935