### PR TITLE
feat: Add "Don't ask again" option when confirming the posting language

### DIFF
--- a/app/src/main/java/app/pachli/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeActivity.kt
@@ -974,7 +974,7 @@ class ComposeActivity :
     }
 
     private fun onSendClicked() = lifecycleScope.launch {
-        confirmStatusLanguage()
+        if (viewModel.confirmStatusLanguage) confirmStatusLanguage()
 
         if (verifyScheduledTime()) {
             sendStatus()
@@ -1049,6 +1049,7 @@ class ComposeActivity :
             .await(
                 getString(R.string.compose_warn_language_dialog_change_language_fmt, detectedDisplayLang),
                 getString(R.string.compose_warn_language_dialog_accept_language_fmt, currentDisplayLang),
+                getString(R.string.compose_warn_language_dialog_accept_and_dont_ask_fmt, currentDisplayLang),
             )
 
         if (dialog == AlertDialog.BUTTON_POSITIVE) {
@@ -1057,6 +1058,8 @@ class ComposeActivity :
                 binding.composePostLanguageButton.setSelection(it)
             }
         }
+
+        if (dialog == AlertDialog.BUTTON_NEUTRAL) viewModel.confirmStatusLanguage = false
     }
 
     /** This is for the fancy keyboards which can insert images and stuff, and drag&drop etc */

--- a/app/src/main/java/app/pachli/components/compose/ComposeViewModel.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeViewModel.kt
@@ -43,6 +43,7 @@ import app.pachli.core.network.model.Attachment
 import app.pachli.core.network.model.NewPoll
 import app.pachli.core.network.model.Status
 import app.pachli.core.network.retrofit.MastodonApi
+import app.pachli.core.preferences.SharedPreferencesRepository
 import app.pachli.core.ui.MentionSpan
 import app.pachli.service.MediaToSend
 import app.pachli.service.ServiceClient
@@ -80,7 +81,8 @@ class ComposeViewModel @Inject constructor(
     private val serviceClient: ServiceClient,
     private val draftHelper: DraftHelper,
     instanceInfoRepo: InstanceInfoRepository,
-    private val serverRepository: ServerRepository,
+    serverRepository: ServerRepository,
+    private val sharedPreferencesRepository: SharedPreferencesRepository,
 ) : ViewModel() {
 
     /** The current content */
@@ -152,6 +154,17 @@ class ComposeViewModel @Inject constructor(
     val serverCanSchedule = serverRepository.flow.map {
         it.get()?.can(ServerOperation.ORG_JOINMASTODON_STATUSES_SCHEDULED, ">= 1.0.0".toConstraint()) == true
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
+
+    /**
+     * True if the post's language should be checked before posting.
+     *
+     * Modifications are persisted back to shared preferences.
+     */
+    var confirmStatusLanguage: Boolean
+        get() = sharedPreferencesRepository.confirmStatusLanguage
+        set(value) {
+            sharedPreferencesRepository.confirmStatusLanguage = value
+        }
 
     private lateinit var composeKind: ComposeKind
 

--- a/app/src/main/java/app/pachli/components/preference/PreferencesFragment.kt
+++ b/app/src/main/java/app/pachli/components/preference/PreferencesFragment.kt
@@ -278,6 +278,13 @@ class PreferencesFragment : PreferenceFragmentCompat() {
                     setTitle(R.string.pref_title_show_stat_inline)
                     isSingleLineTitle = false
                 }
+
+                switchPreference {
+                    setDefaultValue(true)
+                    key = PrefKeys.CONFIRM_STATUS_LANGUAGE
+                    setTitle(R.string.pref_title_confirm_status_language)
+                    isSingleLineTitle = false
+                }
             }
 
             preferenceCategory(app.pachli.core.preferences.R.string.pref_category_tabs) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -572,6 +572,7 @@
     <string name="pref_title_show_cards_in_timelines">Show link previews in timelines</string>
     <string name="pref_title_confirm_reblogs">Show confirmation before boosting</string>
     <string name="pref_title_confirm_favourites">Show confirmation before favoriting</string>
+    <string name="pref_title_confirm_status_language">Check post\'s language setting before posting</string>
     <string name="pref_title_hide_top_toolbar">Hide the title of the top toolbar</string>
     <string name="pref_title_wellbeing_mode">Wellbeing</string>
     <string name="account_note_hint">Your private note about this account</string>
@@ -717,6 +718,7 @@
     <string name="compose_warn_language_dialog_fmt">The post\'s language is set to %1$s but you might have written it in %2$s.</string>
     <string name="compose_warn_language_dialog_change_language_fmt">Change language to "%1$s" and post</string>
     <string name="compose_warn_language_dialog_accept_language_fmt">Post as-is (%1$s)</string>
+    <string name="compose_warn_language_dialog_accept_and_dont_ask_fmt">Post as-is (%1$s) and don\'t ask again</string>
 
     <string name="error_media_uploader_upload_not_found_fmt">media upload with ID %1$s not found</string>
     <string name="error_media_uploader_throwable_fmt">%1$s</string>

--- a/core/preferences/src/main/kotlin/app/pachli/core/preferences/SettingsConstants.kt
+++ b/core/preferences/src/main/kotlin/app/pachli/core/preferences/SettingsConstants.kt
@@ -125,6 +125,12 @@ object PrefKeys {
     const val DOWNLOAD_LOCATION = "downloadLocation"
     const val TAB_TAP_BEHAVIOUR = "tabTapBehaviour"
 
+    /**
+     * True if the status' language should be checked before posting and the user
+     * should be prompted to confirm if it doesn't match the set language.
+     */
+    const val CONFIRM_STATUS_LANGUAGE = "confirmStatusLanguage"
+
     /** Keys that are no longer used (e.g., the preference has been removed */
     object Deprecated {
         const val WELLBEING_LIMITED_NOTIFICATIONS = "wellbeingModeLimitedNotifications"

--- a/core/preferences/src/main/kotlin/app/pachli/core/preferences/SharedPreferencesRepository.kt
+++ b/core/preferences/src/main/kotlin/app/pachli/core/preferences/SharedPreferencesRepository.kt
@@ -19,6 +19,7 @@ package app.pachli.core.preferences
 
 import android.content.SharedPreferences
 import androidx.annotation.Keep
+import androidx.core.content.edit
 import app.pachli.core.common.di.ApplicationScope
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -56,6 +57,13 @@ class SharedPreferencesRepository @Inject constructor(
     /** True if emojis should be animated. */
     val animateEmojis: Boolean
         get() = getBoolean(PrefKeys.ANIMATE_CUSTOM_EMOJIS, false)
+
+    /** True if the status' language should be checked before sending. */
+    var confirmStatusLanguage: Boolean
+        get() = getBoolean(PrefKeys.CONFIRM_STATUS_LANGUAGE, true)
+        set(value) {
+            edit { putBoolean(PrefKeys.CONFIRM_STATUS_LANGUAGE, value) }
+        }
 
     /** Location of downloaded files. */
     val downloadLocation: DownloadLocation


### PR DESCRIPTION
For some users this feature has too many false positives, particularly when emojis are used.

Provide a preference that enables/disables the feature, default to "enable".

When the user is prompted the dialog has a third "Don't ask again" option. If chosen the preference is set to prevent future prompts and the status is sent as-is.

Fixes #893