### PR TITLE
fix: Don't prompt to discard/save unedited scheduled posts

### DIFF
--- a/app/src/main/java/app/pachli/components/scheduled/ScheduledStatusActivity.kt
+++ b/app/src/main/java/app/pachli/components/scheduled/ScheduledStatusActivity.kt
@@ -166,6 +166,7 @@ class ScheduledStatusActivity :
                 sensitive = item.params.sensitive,
                 kind = ComposeOptions.ComposeKind.EDIT_SCHEDULED,
                 poll = item.params.poll,
+                language = item.params.language,
             ),
         )
         startActivity(intent)

--- a/core/network/src/main/kotlin/app/pachli/core/network/model/StatusParams.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/StatusParams.kt
@@ -28,4 +28,5 @@ data class StatusParams(
     @Json(name = "spoiler_text") val spoilerText: String,
     @Json(name = "in_reply_to_id") val inReplyToId: String?,
     val poll: NewPoll?,
+    val language: String? = null,
 )


### PR DESCRIPTION
Previous code didn't send the language to ComposeActivity when editing a scheduled status so it always appeared to be dirty. This prompted the user to save/discard changes when backing out, even if they hadn't made any changes.

Fix this by collecting the language code when fetching scheduled posts and passing it in `ComposeOptions`.