### PR TITLE
fix: Always create per-timeline menu

### DIFF
--- a/app/src/main/java/app/pachli/components/timeline/TimelineFragment.kt
+++ b/app/src/main/java/app/pachli/components/timeline/TimelineFragment.kt
@@ -507,8 +507,9 @@ class TimelineFragment :
     }
 
     override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+        menuInflater.inflate(R.menu.fragment_timeline, menu)
+
         if (isSwipeToRefreshEnabled) {
-            menuInflater.inflate(R.menu.fragment_timeline, menu)
             menu.findItem(R.id.action_refresh)?.apply {
                 icon = IconicsDrawable(requireContext(), GoogleMaterial.Icon.gmd_refresh).apply {
                     sizeDp = 20


### PR DESCRIPTION
Previous code only inflated the timeline fragment menu if swipe/refresh was enabled -- a hold over from when "Refresh" was the only menu item.

There are other menu items now, and they were also hidden. Fix this by always inflating the menu.