### PR TITLE
feat: Show "copy" button for links/hashtags/mentions in accessibility dialogs

### DIFF
--- a/app/src/main/res/layout/simple_list_item_1_copy_button.xml
+++ b/app/src/main/res/layout/simple_list_item_1_copy_button.xml
@@ -35,6 +35,7 @@
         android:layout_weight="1"
         android:gravity="center_vertical"
         android:textAppearance="?android:attr/textAppearanceListItemSmall"
+        tools:ignore="SelectableText"
         tools:text="#TestHashTag" />
 
     <ImageButton

--- a/app/src/main/res/layout/simple_list_item_1_copy_button.xml
+++ b/app/src/main/res/layout/simple_list_item_1_copy_button.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2024 Pachli Association
+  ~
+  ~ This file is a part of Pachli.
+  ~
+  ~ This program is free software; you can redistribute it and/or modify it under the terms of the
+  ~ GNU General Public License as published by the Free Software Foundation; either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+  ~ the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+  ~ Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License along with Pachli; if not,
+  ~ see <http://www.gnu.org/licenses>.
+  -->
+
+<!-- Like simple_list_item_1, but includes a button to copy the contents. -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="horizontal"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingStart="?android:attr/listPreferredItemPaddingStart"
+    android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
+    android:minHeight="?android:attr/listPreferredItemHeightSmall">
+
+    <TextView
+        android:id="@android:id/text1"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_gravity="center"
+        android:layout_weight="1"
+        android:gravity="center_vertical"
+        android:textAppearance="?android:attr/textAppearanceListItemSmall"
+        tools:text="#TestHashTag" />
+
+    <ImageButton
+        android:id="@+id/copy"
+        style="@style/AppImageButton"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:contentDescription="@string/action_copy_item"
+        app:srcCompat="@drawable/ic_content_copy_24" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -850,4 +850,7 @@
     <string name="search_operator_where_dialog_library_hint">Your own posts, boosts, favorites, bookmarks, and posts that @mention you</string>
     <string name="search_operator_where_dialog_public">Public posts</string>
     <string name="search_operator_where_dialog_public_hint">Public, searchable posts known by server</string>
+
+    <string name="action_copy_item">Copy item</string>
+    <string name="item_copied">Text copied</string>
 </resources>

--- a/core/network/src/main/kotlin/app/pachli/core/network/model/Status.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/Status.kt
@@ -17,6 +17,7 @@
 
 package app.pachli.core.network.model
 
+import android.app.Application
 import android.text.SpannableStringBuilder
 import android.text.style.URLSpan
 import app.pachli.core.common.extensions.getOrElse
@@ -162,7 +163,9 @@ data class Status(
     data class Mention(
         val id: String,
         val url: String,
+        /** If this is remote then "[localUsername]@server", otherwise [localUsername]. */
         @Json(name = "acct") val username: String,
+        /** The username, without the server part or leading "@". */
         @Json(name = "username") val localUsername: String,
     )
 


### PR DESCRIPTION
Users report that copying items can be difficult using Talkback.

Make this easier in the dialogs that appear for links, mentions, and hashtags by using a dedicated adapter that displays a "Copy" button at the end of each item.

Fixes #1038