### PR TITLE
fix: Make "Open boost author" open the correct profile

### DIFF
--- a/app/src/main/java/app/pachli/util/ListStatusAccessibilityDelegate.kt
+++ b/app/src/main/java/app/pachli/util/ListStatusAccessibilityDelegate.kt
@@ -180,7 +180,7 @@ class ListStatusAccessibilityDelegate<T : IStatusViewData>(
                 app.pachli.core.ui.R.id.action_hashtags -> showHashtagsDialog(host)
                 app.pachli.core.ui.R.id.action_open_reblogger -> {
                     interrupt()
-                    statusActionListener.onOpenReblog(status.actionable)
+                    statusActionListener.onOpenReblog(status.status)
                 }
                 app.pachli.core.ui.R.id.action_open_reblogged_by -> {
                     interrupt()


### PR DESCRIPTION
Previous code passed the actionable status, so "Open boost author" actually opened the account that posted the original status.

Pass the status representing the boost, so the correct account is opened.

Fixes #1042