### PR TITLE
fix: Retain task state for MainActivity and ComposeActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -51,6 +51,7 @@
         <activity
             android:name=".MainActivity"
             android:configChanges="orientation|screenSize|keyboardHidden|screenLayout|smallestScreenSize"
+            android:alwaysRetainTaskState="true"
             android:exported="true"
             android:theme="@style/SplashTheme">
 
@@ -114,7 +115,8 @@
         <activity
             android:name=".components.compose.ComposeActivity"
             android:theme="@style/AppDialogActivityTheme"
-            android:windowSoftInputMode="stateVisible|adjustResize" />
+            android:windowSoftInputMode="stateVisible|adjustResize"
+            android:alwaysRetainTaskState="true" />
         <activity
             android:name=".components.viewthread.ViewThreadActivity"
             android:configChanges="orientation|screenSize" />


### PR DESCRIPTION
Some users report that returning to the `ComposeActivity` loses content they've entered and returns to `MainActivity`. I can't reproduce this, but it's possible that Android is clearing the task state and returning to the root activity (`MainActivity` in this case).

Set `alwaysRetainTaskState` to true to keep the activity stack, and hopefully prevent this from happening.