### PR TITLE
fix: Allow nullable `sensitive` and `spoiler_text` status params

### DIFF
--- a/core/network/src/main/kotlin/app/pachli/core/network/model/StatusParams.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/StatusParams.kt
@@ -23,9 +23,9 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class StatusParams(
     val text: String,
-    val sensitive: Boolean,
+    val sensitive: Boolean?,
     val visibility: Status.Visibility,
-    @Json(name = "spoiler_text") val spoilerText: String,
+    @Json(name = "spoiler_text") val spoilerText: String?,
     @Json(name = "in_reply_to_id") val inReplyToId: String?,
     val poll: NewPoll?,
     val language: String? = null,


### PR DESCRIPTION
This matches the API description and prevents an error when parsing JSON responses.

Fixes #1057