### PR TITLE
fix: Don't crash on relationship severance events

### DIFF
--- a/app/src/main/java/app/pachli/components/notifications/SeveredRelationshipsViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/notifications/SeveredRelationshipsViewHolder.kt
@@ -48,10 +48,16 @@ class SeveredRelationshipsViewHolder(
 
             binding.datetime.text = getRelativeTimeSpanString(itemView.context, event.createdAt.time, System.currentTimeMillis())
 
-            binding.notificationSummary.text = itemView.context.resources.getQuantityString(
-                R.plurals.notification_severed_relationships_summary_report_fmt,
-                event.relationshipsCount,
-                event.relationshipsCount,
+            binding.notificationFollowersCount.text = itemView.context.resources.getQuantityString(
+                R.plurals.notification_severed_relationships_summary_followers_fmt,
+                event.followersCount,
+                event.followersCount,
+            )
+
+            binding.notificationFollowingCount.text = itemView.context.resources.getQuantityString(
+                R.plurals.notification_severed_relationships_summary_following_fmt,
+                event.followingCount,
+                event.followingCount,
             )
 
             val resourceId = when (event.type) {

--- a/app/src/main/res/layout/item_severed_relationships.xml
+++ b/app/src/main/res/layout/item_severed_relationships.xml
@@ -63,7 +63,7 @@
         tools:ignore="SelectableText" />
 
     <TextView
-        android:id="@+id/notification_summary"
+        android:id="@+id/notification_followers_count"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
@@ -74,7 +74,22 @@
         android:textSize="?attr/status_text_medium"
         app:layout_constraintStart_toStartOf="@+id/notification_top_text"
         app:layout_constraintTop_toBottomOf="@+id/notification_top_text"
-        tools:text="2 relationships"
+        tools:text="2 followers"
+        tools:ignore="SelectableText" />
+
+    <TextView
+        android:id="@+id/notification_following_count"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:hyphenationFrequency="full"
+        android:importantForAccessibility="no"
+        android:lineSpacingMultiplier="1.1"
+        android:textColor="?android:textColorTertiary"
+        android:textSize="?attr/status_text_medium"
+        app:layout_constraintStart_toStartOf="@+id/notification_top_text"
+        app:layout_constraintTop_toBottomOf="@+id/notification_followers_count"
+        tools:text="2 following"
         tools:ignore="SelectableText" />
 
     <TextView
@@ -88,8 +103,8 @@
         android:paddingBottom="10dp"
         android:textColor="?android:textColorTertiary"
         android:textSize="?attr/status_text_medium"
-        app:layout_constraintStart_toStartOf="@+id/notification_summary"
-        app:layout_constraintTop_toBottomOf="@id/notification_summary"
+        app:layout_constraintStart_toStartOf="@+id/notification_top_text"
+        app:layout_constraintTop_toBottomOf="@id/notification_following_count"
         tools:text="@string/notification_severed_relationships_domain_block_body"
         tools:ignore="SelectableText" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -625,11 +625,6 @@
     <string name="notification_severed_relationships_account_suspension_body">Un moderador suspendió la cuenta</string>
     <string name="notification_severed_relationships_unknown_body">Motivo desconocido</string>
     <string name="notification_severed_relationships_format">Se rompió la relación con <b>%1$s</b></string>
-    <plurals name="notification_severed_relationships_summary_report_fmt">
-        <item quantity="one">Se rompió %1$d relación</item>
-        <item quantity="many">Se rompieron %1$d relaciones</item>
-        <item quantity="other">Se rompieron %1$d relaciones</item>
-    </plurals>
     <string name="notification_severed_relationships_name">Relaciones rotas</string>
     <string name="notification_severed_relationships_description">Notificaciones de relaciones rotas</string>
     <string name="poll_show_votes">Mostrar votos</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -613,10 +613,6 @@
     <string name="notification_severed_relationships_user_domain_block_body">Estit verkkotunnuksen</string>
     <string name="notification_severed_relationships_account_suspension_body">Moderaattori esti tilin</string>
     <string name="notification_severed_relationships_unknown_body">Tuntematon syy</string>
-    <plurals name="notification_severed_relationships_summary_report_fmt">
-        <item quantity="one">%1$d yhteys katkaistu</item>
-        <item quantity="other">%1$d yhteyttä katkaistu</item>
-    </plurals>
     <string name="error_filter_missing_keyword">Tarvitaan vähintään yksi avainsana tai lauseke</string>
     <string name="error_filter_missing_context">Tarvitaan vähintään yksi suodatettava asia</string>
     <string name="error_filter_missing_title">Otsikko vaaditaan</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -604,10 +604,6 @@
     <string name="translation_provider_fmt">%1$s</string>
     <string name="update_dialog_neutral">Non avisarme para esta versión</string>
     <string name="translating">Traducindo…</string>
-    <plurals name="notification_severed_relationships_summary_report_fmt">
-        <item quantity="one">%1$d relación perdida</item>
-        <item quantity="other">%1$d relacións perdidas</item>
-    </plurals>
     <string name="announcement_date">%1$s %2$s</string>
     <string name="load_newest_statuses">Cargar as publicacións máis recentes</string>
     <string name="pref_update_notification_frequency_never">Nunca</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -607,10 +607,6 @@
     <string name="title_tab_public_trending_statuses">Innlegg</string>
     <string name="notification_severed_relationships_format">Brøt forholdet med <b>%1$s</b></string>
     <string name="notification_severed_relationships_unknown_body">Ukjent årsak</string>
-    <plurals name="notification_severed_relationships_summary_report_fmt">
-        <item quantity="one">%1$d forhold brøt</item>
-        <item quantity="other">%1$d forhold brøt</item>
-    </plurals>
     <string name="label_image">Bild</string>
     <string name="pref_title_font_family">Skriftfamilie</string>
     <string name="notification_severed_relationships_name">Brutte forhold</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -92,9 +92,13 @@
     <string name="notification_severed_relationships_user_domain_block_body">You blocked the domain</string>
     <string name="notification_severed_relationships_account_suspension_body">A moderator suspended the account</string>
     <string name="notification_severed_relationships_unknown_body">Unknown reason</string>
-    <plurals name="notification_severed_relationships_summary_report_fmt">
-        <item quantity="one">%1$d relationship severed</item>
-        <item quantity="other">%1$d relationships severed</item>
+    <plurals name="notification_severed_relationships_summary_followers_fmt">
+        <item quantity="one">%1$s follower removed</item>
+        <item quantity="other">%1$s followers removed</item>
+    </plurals>
+    <plurals name="notification_severed_relationships_summary_following_fmt">
+        <item quantity="one">%1$s account you follow removed</item>
+        <item quantity="other">%1$s accounts you follow removed</item>
     </plurals>
     <string name="notification_header_report_format">%s reported %s</string>
     <string name="notification_summary_report_format">%s · %d posts attached</string>

--- a/core/network/src/main/kotlin/app/pachli/core/network/model/Notification.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/Notification.kt
@@ -31,6 +31,7 @@ data class Notification(
     val account: TimelineAccount,
     val status: Status?,
     val report: Report?,
+    @Json(name = "event")
     val relationshipSeveranceEvent: RelationshipSeveranceEvent? = null,
 ) {
 

--- a/core/network/src/main/kotlin/app/pachli/core/network/model/RelationshipSeveranceEvent.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/RelationshipSeveranceEvent.kt
@@ -41,9 +41,17 @@ data class RelationshipSeveranceEvent(
      */
     @Json(name = "target_name")
     val targetName: String,
-    /** Number of follow relationships (in either direction) that were severed. */
-    @Json(name = "relationships_count")
-    val relationshipsCount: Int = 0,
+
+    // Documentation is wrong: https://github.com/mastodon/documentation/issues/1556
+    /** Number of follower accounts removed. */
+    @Json(name = "followers_count")
+    val followersCount: Int = 0,
+
+    // Documentation is wrong: https://github.com/mastodon/documentation/issues/1556
+    /** Number of followed accounts removed. */
+    @Json(name = "following_count")
+    val followingCount: Int = 0,
+
     /** When the event took place. */
     @Json(name = "created_at")
     val createdAt: Date,


### PR DESCRIPTION
Previous code was missing the JSON name of the event, so it wasn't present when it should have been, resulting in a crash.

Also, the Mastodon documentation is incorrect about the relationship count, which is instead represented as two properties, one for followers and one for following. So model that, and display them separately in the UI.

Fixes #1086