### PR TITLE
test: Fix ViewThreadViewModel flakiness

### DIFF
--- a/app/src/test/java/app/pachli/components/viewthread/ViewThreadViewModelTest.kt
+++ b/app/src/test/java/app/pachli/components/viewthread/ViewThreadViewModelTest.kt
@@ -178,7 +178,7 @@ class ViewThreadViewModelTest {
 
             do {
                 item = awaitItem()
-            } while (item is ThreadUiState.Loading)
+            } while (item !is ThreadUiState.Success)
 
             assertEquals(
                 ThreadUiState.Success(
@@ -219,7 +219,7 @@ class ViewThreadViewModelTest {
 
             do {
                 item = awaitItem()
-            } while (item is ThreadUiState.Loading)
+            } while (item !is ThreadUiState.Success)
 
             assertEquals(
                 ThreadUiState.Success(
@@ -252,7 +252,7 @@ class ViewThreadViewModelTest {
 
             do {
                 item = awaitItem()
-            } while (item is ThreadUiState.Loading)
+            } while (item !is ThreadUiState.Error)
 
             assertEquals(
                 ThreadUiState.Error::class.java,
@@ -279,7 +279,7 @@ class ViewThreadViewModelTest {
 
             do {
                 item = awaitItem()
-            } while (item is ThreadUiState.Loading)
+            } while (item !is ThreadUiState.Error)
 
             assertEquals(
                 ThreadUiState.Error::class.java,


### PR DESCRIPTION
Some tests were assuming the uiState would transition from .Loading to .Success, without considering there might be a .LoadingThread intermediate step. Cater for that to prevent test flakes.