### PR TITLE
fix: Ensure clientId and clientSecret are non null during db migration

### DIFF
--- a/core/database/src/main/kotlin/app/pachli/core/database/di/DatabaseModule.kt
+++ b/core/database/src/main/kotlin/app/pachli/core/database/di/DatabaseModule.kt
@@ -22,6 +22,7 @@ import androidx.room.Room
 import androidx.room.withTransaction
 import app.pachli.core.database.AppDatabase
 import app.pachli.core.database.Converters
+import app.pachli.core.database.MIGRATE_8_9
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -41,6 +42,7 @@ object DatabaseModule {
         return Room.databaseBuilder(appContext, AppDatabase::class.java, "pachliDB")
             .addTypeConverter(converters)
             .allowMainThreadQueries()
+            .addMigrations(MIGRATE_8_9)
             .build()
     }
 


### PR DESCRIPTION
Previous migration code could crash if the `clientId` or `clientSecret` columns were null during the migration (unclear how that could happen but there's at least one user report of this crash).

Re-write the migration to set these columns to the empty string if NULL first.