### PR TITLE
refactor: rename `filterAction` property to `contentFilterAction`

### DIFF
--- a/app/src/main/java/app/pachli/adapter/FilterableStatusViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/FilterableStatusViewHolder.kt
@@ -50,7 +50,7 @@ open class FilterableStatusViewHolder<T : IStatusViewData>(
         status: T,
         listener: StatusActionListener<T>,
     ) {
-        if (status.filterAction !== FilterAction.WARN) {
+        if (status.contentFilterAction !== FilterAction.WARN) {
             matchedFilter = null
             setPlaceholderVisibility(false)
             return

--- a/app/src/main/java/app/pachli/adapter/StatusViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/StatusViewHolder.kt
@@ -52,7 +52,7 @@ open class StatusViewHolder<T : IStatusViewData>(
             val expanded = viewData.isExpanded
             setupCollapsedState(pachliAccountId, viewData, sensitive, expanded, listener)
             val reblogging = viewData.rebloggingStatus
-            if (reblogging == null || viewData.filterAction === FilterAction.WARN) {
+            if (reblogging == null || viewData.contentFilterAction === FilterAction.WARN) {
                 statusInfo.hide()
             } else {
                 val rebloggedByDisplayName = reblogging.account.name

--- a/app/src/main/java/app/pachli/components/notifications/NotificationsFragment.kt
+++ b/app/src/main/java/app/pachli/components/notifications/NotificationsFragment.kt
@@ -636,7 +636,7 @@ class NotificationsFragment :
         adapter.snapshot().withIndex().filter { it.value?.statusViewData?.actionableId == viewData.statusViewData!!.actionableId }
             .map {
                 it.value?.statusViewData = it.value?.statusViewData?.copy(
-                    filterAction = FilterAction.NONE,
+                    contentFilterAction = FilterAction.NONE,
                 )
                 adapter.notifyItemChanged(it.index)
             }

--- a/app/src/main/java/app/pachli/components/notifications/NotificationsPagingAdapter.kt
+++ b/app/src/main/java/app/pachli/components/notifications/NotificationsPagingAdapter.kt
@@ -133,7 +133,7 @@ class NotificationsPagingAdapter(
 
     override fun getItemViewType(position: Int): Int {
         val item = getItem(position)
-        if (item?.statusViewData?.filterAction == FilterAction.WARN) {
+        if (item?.statusViewData?.contentFilterAction == FilterAction.WARN) {
             return NotificationViewKind.STATUS_FILTERED.ordinal
         }
 

--- a/app/src/main/java/app/pachli/components/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/app/pachli/components/notifications/NotificationsViewModel.kt
@@ -537,11 +537,11 @@ class NotificationsViewModel @AssistedInject constructor(
                             !(notification.status?.actionableStatus?.sensitive ?: false),
                         isExpanded = statusDisplayOptions.value.openSpoiler,
                         isCollapsed = true,
-                        filterAction = filterAction,
+                        contentFilterAction = filterAction,
                         isAboutSelf = notification.account.id == accountId,
                     )
                 }.filter {
-                    it.statusViewData?.filterAction != FilterAction.HIDE
+                    it.statusViewData?.contentFilterAction != FilterAction.HIDE
                 }
             }
     }

--- a/app/src/main/java/app/pachli/components/timeline/TimelinePagingAdapter.kt
+++ b/app/src/main/java/app/pachli/components/timeline/TimelinePagingAdapter.kt
@@ -80,7 +80,7 @@ class TimelinePagingAdapter(
 
     override fun getItemViewType(position: Int): Int {
         val viewData = getItem(position) ?: return VIEW_TYPE_PLACEHOLDER
-        return if (viewData.filterAction == FilterAction.WARN) {
+        return if (viewData.contentFilterAction == FilterAction.WARN) {
             VIEW_TYPE_STATUS_FILTERED
         } else {
             VIEW_TYPE_STATUS

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/TimelineViewModel.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/TimelineViewModel.kt
@@ -552,8 +552,8 @@ abstract class TimelineViewModel(
         ) {
             return FilterAction.HIDE
         } else {
-            statusViewData.filterAction = contentFilterModel?.filterActionFor(status.actionableStatus) ?: FilterAction.NONE
-            statusViewData.filterAction
+            statusViewData.contentFilterAction = contentFilterModel?.filterActionFor(status.actionableStatus) ?: FilterAction.NONE
+            statusViewData.contentFilterAction
         }
     }
 

--- a/app/src/main/java/app/pachli/components/viewthread/ThreadAdapter.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/ThreadAdapter.kt
@@ -63,7 +63,7 @@ class ThreadAdapter(
         val viewData = getItem(position)
         return if (viewData.isDetailed) {
             VIEW_TYPE_STATUS_DETAILED
-        } else if (viewData.filterAction == FilterAction.WARN) {
+        } else if (viewData.contentFilterAction == FilterAction.WARN) {
             VIEW_TYPE_STATUS_FILTERED
         } else {
             VIEW_TYPE_STATUS

--- a/app/src/main/java/app/pachli/components/viewthread/ViewThreadViewModel.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/ViewThreadViewModel.kt
@@ -552,8 +552,8 @@ class ViewThreadViewModel @Inject constructor(
             if (status.isDetailed) {
                 true
             } else {
-                status.filterAction = contentFilterModel?.filterActionFor(status.status) ?: FilterAction.NONE
-                status.filterAction != FilterAction.HIDE
+                status.contentFilterAction = contentFilterModel?.filterActionFor(status.status) ?: FilterAction.NONE
+                status.contentFilterAction != FilterAction.HIDE
             }
         }
     }

--- a/app/src/main/java/app/pachli/viewdata/NotificationViewData.kt
+++ b/app/src/main/java/app/pachli/viewdata/NotificationViewData.kt
@@ -60,7 +60,7 @@ data class NotificationViewData(
             isShowingContent: Boolean,
             isExpanded: Boolean,
             isCollapsed: Boolean,
-            filterAction: FilterAction,
+            contentFilterAction: FilterAction,
             isAboutSelf: Boolean,
         ) = NotificationViewData(
             notification.type,
@@ -72,7 +72,7 @@ data class NotificationViewData(
                     isShowingContent,
                     isExpanded,
                     isCollapsed,
-                    filterAction = filterAction,
+                    contentFilterAction = contentFilterAction,
                 )
             },
             notification.report,
@@ -116,10 +116,10 @@ data class NotificationViewData(
         get() = statusViewData?.actionableId ?: throw IllegalStateException()
     override val rebloggingStatus: Status?
         get() = statusViewData?.rebloggingStatus
-    override var filterAction: FilterAction
-        get() = statusViewData?.filterAction ?: throw IllegalStateException()
+    override var contentFilterAction: FilterAction
+        get() = statusViewData?.contentFilterAction ?: throw IllegalStateException()
         set(value) {
-            statusViewData?.filterAction = value
+            statusViewData?.contentFilterAction = value
         }
     override val translationState: TranslationState
         get() = statusViewData?.translationState ?: throw IllegalStateException()

--- a/app/src/main/java/app/pachli/viewdata/StatusViewData.kt
+++ b/app/src/main/java/app/pachli/viewdata/StatusViewData.kt
@@ -107,8 +107,8 @@ interface IStatusViewData {
     // empty (e.g., StatusBaseViewHolder.setupFilterPlaceholder()). It would be better
     // if the Filter.Action class subtypes carried the FilterResult information with them,
     // and it's impossible to construct them with an empty list.
-    /** Whether this status should be filtered, and if so, how */
-    var filterAction: FilterAction
+    /** The [FilterAction] to apply, based on the status' content. */
+    var contentFilterAction: FilterAction
 
     /** The current translation state */
     val translationState: TranslationState
@@ -123,7 +123,7 @@ data class StatusViewData(
     override val isExpanded: Boolean,
     override val isShowingContent: Boolean,
     override val isCollapsed: Boolean,
-    override var filterAction: FilterAction = FilterAction.NONE,
+    override var contentFilterAction: FilterAction = FilterAction.NONE,
     override val translationState: TranslationState,
 
     /**
@@ -202,7 +202,7 @@ data class StatusViewData(
             isExpanded: Boolean,
             isCollapsed: Boolean,
             isDetailed: Boolean = false,
-            filterAction: FilterAction = FilterAction.NONE,
+            contentFilterAction: FilterAction = FilterAction.NONE,
             translationState: TranslationState = TranslationState.SHOW_ORIGINAL,
             translation: TranslatedStatusEntity? = null,
         ): StatusViewData {
@@ -223,7 +223,7 @@ data class StatusViewData(
                 isCollapsed = isCollapsed,
                 isExpanded = isExpanded,
                 isDetailed = isDetailed,
-                filterAction = filterAction,
+                contentFilterAction = contentFilterAction,
                 translationState = translationState,
                 translation = translation,
             )


### PR DESCRIPTION
`IStatusViewData.filterAction` was the `FilterAction` to apply to the status based on the status' content.

As new filter options will apply filters based on the account that sent the status, rename to `contentFilterAction` so it's easy to distinguish between the two.