### PR TITLE
feat: Show extra a11y actions for trending links and suggested accounts

### DIFF
--- a/app/src/main/java/app/pachli/components/trending/TrendingLinksAccessibilityDelegate.kt
+++ b/app/src/main/java/app/pachli/components/trending/TrendingLinksAccessibilityDelegate.kt
@@ -17,16 +17,19 @@
 
 package app.pachli.components.trending
 
-import android.content.Context
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.os.Build
 import android.os.Bundle
 import android.view.View
-import android.view.accessibility.AccessibilityManager
+import android.widget.Toast
+import androidx.core.content.ContextCompat
 import androidx.core.view.AccessibilityDelegateCompat
 import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
 import androidx.core.view.accessibility.AccessibilityNodeInfoCompat.AccessibilityActionCompat
 import androidx.recyclerview.widget.RecyclerView
-import androidx.recyclerview.widget.RecyclerViewAccessibilityDelegate
 import app.pachli.R
+import app.pachli.core.ui.accessibility.PachliRecyclerViewAccessibilityDelegate
 import app.pachli.view.PreviewCardView
 import app.pachli.view.PreviewCardView.Target
 
@@ -40,15 +43,15 @@ import app.pachli.view.PreviewCardView.Target
 internal class TrendingLinksAccessibilityDelegate(
     private val recyclerView: RecyclerView,
     val listener: PreviewCardView.OnClickListener,
-) : RecyclerViewAccessibilityDelegate(recyclerView) {
-    private val context = recyclerView.context
-
-    private val a11yManager = context.getSystemService(Context.ACCESSIBILITY_SERVICE)
-        as AccessibilityManager
-
+) : PachliRecyclerViewAccessibilityDelegate(recyclerView) {
     private val openLinkAction = AccessibilityActionCompat(
         app.pachli.core.ui.R.id.action_open_link,
         context.getString(R.string.action_open_link),
+    )
+
+    private val copyLinkAction = AccessibilityActionCompat(
+        app.pachli.core.ui.R.id.action_copy_item,
+        context.getString(R.string.action_copy_link),
     )
 
     private val openBylineAccountAction = AccessibilityActionCompat(
@@ -64,6 +67,7 @@ internal class TrendingLinksAccessibilityDelegate(
                 as TrendingLinkViewHolder
 
             info.addAction(openLinkAction)
+            info.addAction(copyLinkAction)
 
             viewHolder.link.authors?.firstOrNull()?.account?.let {
                 info.addAction(openBylineAccountAction)
@@ -80,6 +84,22 @@ internal class TrendingLinksAccessibilityDelegate(
                     listener.onClick(viewHolder.link, Target.CARD)
                     true
                 }
+                app.pachli.core.ui.R.id.action_copy_item -> {
+                    val clipboard = ContextCompat.getSystemService(
+                        context,
+                        ClipboardManager::class.java,
+                    ) as ClipboardManager
+                    val clip = ClipData.newPlainText("", viewHolder.link.url)
+                    clipboard.setPrimaryClip(clip)
+                    if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
+                        Toast.makeText(
+                            context,
+                            context.getString(app.pachli.core.ui.R.string.item_copied),
+                            Toast.LENGTH_SHORT,
+                        ).show()
+                    }
+                    true
+                }
                 app.pachli.core.ui.R.id.action_open_byline_account -> {
                     interrupt()
                     listener.onClick(viewHolder.link, Target.BYLINE)
@@ -89,8 +109,6 @@ internal class TrendingLinksAccessibilityDelegate(
             }
         }
     }
-
-    private fun interrupt() = a11yManager.interrupt()
 
     override fun getItemDelegate(): AccessibilityDelegateCompat = delegate
 }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -91,7 +91,6 @@
     <string name="action_add_tab">إضافة لسان</string>
     <string name="action_open_reblogged_by">اعرض المشاركات</string>
     <string name="action_open_faved_by">اعرض المفضلات</string>
-    <string name="title_mentions_dialog">الإشارات</string>
     <string name="download_image">تنزيل %1$s</string>
     <string name="action_copy_link">إنسخ الرابط</string>
     <string name="action_share_as">شاركه كـ…</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -81,7 +81,6 @@
     <string name="action_open_reblogger">Адкрыць аўтара пашырэння</string>
     <string name="action_open_reblogged_by">Паказаць пашырэнні</string>
     <string name="action_open_faved_by">Паказаць абраныя</string>
-    <string name="title_mentions_dialog">Згадкі</string>
     <string name="action_open_media_n">Адкрыць медыя #%d</string>
     <string name="action_add_reaction">дадаць рэакцыю</string>
     <string name="download_image">Спампоўка %1$s</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -241,7 +241,6 @@
     <string name="action_copy_link">Копиране на връзката</string>
     <string name="download_image">Изтегляне на %1$s</string>
     <string name="action_open_media_n">Отваряне на мултимедия #%d</string>
-    <string name="title_mentions_dialog">Споменавания</string>
     <string name="action_open_faved_by">Показване на любими</string>
     <string name="action_open_reblogged_by">Показване на споделяния</string>
     <string name="action_open_reblogger">Отваряне на споделилия автор</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -164,7 +164,6 @@
     <string name="action_copy_link">লিঙ্ক অনুলিপি করুন</string>
     <string name="download_image">\'%1$s ডাউনলোড হচ্ছে\'</string>
     <string name="action_open_media_n">মিডিয়া খুলুন #%d</string>
-    <string name="title_mentions_dialog">উল্লেখসমূহ</string>
     <string name="action_open_faved_by">প্রিয়গুলি দেখান</string>
     <string name="action_open_reblogged_by">সমর্থন দেখান</string>
     <string name="action_open_reblogger">সমর্থক লেখক খুলুন</string>

--- a/app/src/main/res/values-bn-rIN/strings.xml
+++ b/app/src/main/res/values-bn-rIN/strings.xml
@@ -93,7 +93,6 @@
     <string name="action_open_reblogger">সমর্থক লেখক খুলুন</string>
     <string name="action_open_reblogged_by">সমর্থন দেখান</string>
     <string name="action_open_faved_by">প্রিয়গুলি দেখান</string>
-    <string name="title_mentions_dialog">উল্লেখসমূহ</string>
     <string name="action_open_media_n">মিডিয়া খুলুন #%d</string>
     <string name="download_image">%1$s ডাউনলোড হচ্ছে</string>
     <string name="action_copy_link">লিঙ্ক অনুলিপি করুন</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -176,7 +176,6 @@
     <string name="action_content_warning">Contingut sensible</string>
     <string name="action_add_tab">Afegir una pestanya</string>
     <string name="action_open_faved_by">Mostra els favorits</string>
-    <string name="title_mentions_dialog">Mencions</string>
     <string name="action_share_as">Comparteix com a…</string>
     <string name="download_media">Baixa el fitxer</string>
     <string name="send_media_to">Compartir la imatge a …</string>

--- a/app/src/main/res/values-ckb/strings.xml
+++ b/app/src/main/res/values-ckb/strings.xml
@@ -16,7 +16,6 @@
     <string name="action_copy_link">بەستەرەکە ڕوونوس بکە</string>
     <string name="download_image">داگرتنی %1$s</string>
     <string name="action_open_media_n">کردنەوەی میدیا #%d</string>
-    <string name="title_mentions_dialog">ئاماژەکان</string>
     <string name="action_open_faved_by">پیشاندانی دڵخوازەکان</string>
     <string name="action_open_reblogged_by">پیشاندانی بەهێزکردنەکان</string>
     <string name="action_open_reblogger">پۆستکەرەوەکە ببینە</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -92,7 +92,6 @@
     <string name="action_open_reblogger">Otevřít autora boostu</string>
     <string name="action_open_reblogged_by">Zobrazit boosty</string>
     <string name="action_open_faved_by">Zobrazit oblíbení</string>
-    <string name="title_mentions_dialog">Zmínky</string>
     <string name="action_open_media_n">Otevřít médium #%d</string>
     <string name="download_image">Stahuji %1$s</string>
     <string name="action_copy_link">Zkopírovat odkaz</string>

--- a/app/src/main/res/values-cy/strings.xml
+++ b/app/src/main/res/values-cy/strings.xml
@@ -305,7 +305,6 @@
     <string name="error_image_edit_failed">Methu golygu\'r ddelwedd.</string>
     <string name="description_post_favourited">Hoffwyd</string>
     <string name="saving_draft">Yn cadw drafft…</string>
-    <string name="title_mentions_dialog">Crybwylliadau</string>
     <string name="action_open_media_n">Agor cyfryngau #%d</string>
     <string name="action_share_as">Rhannu fel …</string>
     <string name="downloading_media">Yn llwytho cyfryngau</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -92,7 +92,6 @@
     <string name="action_add_tab">Tab hinzufügen</string>
     <string name="action_open_reblogged_by">Geteilte Beiträge anzeigen</string>
     <string name="action_open_faved_by">Favoriten anzeigen</string>
-    <string name="title_mentions_dialog">Erwähnungen</string>
     <string name="action_open_media_n">Datei #%d öffnen</string>
     <string name="download_image">%1$s heruntergeladen</string>
     <string name="action_copy_link">Link kopieren</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -92,7 +92,6 @@
     <string name="action_open_reblogger">Montri la aŭtoron de la diskonigo</string>
     <string name="action_open_reblogged_by">Montri diskonigojn</string>
     <string name="action_open_faved_by">Montri stelumojn</string>
-    <string name="title_mentions_dialog">Mencioj</string>
     <string name="action_open_media_n">Malfermi aŭdovidaĵon #%d</string>
     <string name="download_image">Elŝutado de %1$s</string>
     <string name="action_copy_link">Kopii la ligilon</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -259,7 +259,6 @@
     <string name="conversation_2_recipients">%1$s y %2$s</string>
     <string name="conversation_more_recipients">%1$s, %2$s y %3$d más</string>
     <string name="action_open_faved_by">Mostrar favoritos</string>
-    <string name="title_mentions_dialog">Menciones</string>
     <string name="download_media">Descargar multimedia</string>
     <string name="pref_title_language">Idioma</string>
     <string name="action_unreblog">Dejar de impulsar</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -249,7 +249,6 @@
     <string name="action_add_tab">Kategoria gehitu</string>
     <string name="action_open_reblogged_by">Bultzadak erakutsi</string>
     <string name="action_open_faved_by">Gogokoak erakutsi</string>
-    <string name="title_mentions_dialog">Aipamenak</string>
     <string name="action_open_media_n">Ireki media #%d</string>
     <string name="action_share_as">… bezala partekatu</string>
     <string name="download_media">Media jaisten</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -243,7 +243,6 @@
     <string name="action_open_reblogger">گشودن تقویت‌کنندهٔ بوق</string>
     <string name="action_open_reblogged_by">نمایش تقویت‌ها</string>
     <string name="action_open_faved_by">نمایش برگزیده‌ها</string>
-    <string name="title_mentions_dialog">اشاره‌ها</string>
     <string name="action_open_media_n">گشودن رسانه #%d</string>
     <string name="action_share_as">هم‌رسانی به عنوان …</string>
     <string name="download_media">بارگیری رسانه</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -102,7 +102,6 @@
     <string name="label_quick_reply">Vastaa…</string>
     <string name="hint_search">Hae…</string>
     <string name="hint_note">Kuvaus</string>
-    <string name="title_mentions_dialog">Maininnat</string>
     <string name="action_reset_schedule">Nollaa</string>
     <string name="action_access_drafts">Luonnokset</string>
     <string name="action_search">Hae</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -92,7 +92,6 @@
     <string name="action_open_reblogger">Afficher l’auteur·rice du partage</string>
     <string name="action_open_reblogged_by">Afficher les partages</string>
     <string name="action_open_faved_by">Montrer les favoris</string>
-    <string name="title_mentions_dialog">Mentions</string>
     <string name="action_open_media_n">Ouvrir le média #%d</string>
     <string name="download_image">Téléchargement de %1$s</string>
     <string name="action_copy_link">Copier le lien</string>

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -205,7 +205,6 @@
     <string name="pref_title_bot_overlay">Taispeáin táscaire do róbónna</string>
     <string name="pref_title_language">Teanga</string>
     <string name="label_avatar">Abhatár</string>
-    <string name="title_mentions_dialog">Tráchtanna</string>
     <string name="action_reblog">Athchraol</string>
     <string name="action_unreblog">Cealaigh athchraoladh</string>
     <string name="action_reply">Freagra</string>

--- a/app/src/main/res/values-gd/strings.xml
+++ b/app/src/main/res/values-gd/strings.xml
@@ -369,7 +369,6 @@
     <string name="action_copy_link">Dèan lethbhreac dhen cheangal</string>
     <string name="download_image">A’ luchdadh a-nuas %1$s</string>
     <string name="action_open_media_n">Fosgail meadhan #%d</string>
-    <string name="title_mentions_dialog">Iomraidhean</string>
     <string name="action_open_faved_by">Seall na h-annsachdan</string>
     <string name="action_open_reblogger">Fosgail ùghdar a’ bhrosnachaidh</string>
     <string name="action_add_tab">Cuir taba ris</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -412,7 +412,6 @@
     <string name="action_copy_link">Copiar ligazón</string>
     <string name="download_image">Descargando %1$s</string>
     <string name="action_open_media_n">Abrir multimedia #%d</string>
-    <string name="title_mentions_dialog">Mencións</string>
     <string name="action_open_faved_by">Mostrar favoritos</string>
     <string name="action_open_reblogged_by">Mostrar promocións</string>
     <string name="action_open_reblogger">Abrir autor da promoción</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -107,7 +107,6 @@
     <string name="download_media">मीडिया डाउनलोड करें</string>
     <string name="action_copy_link">लिंक कॉपी करें</string>
     <string name="action_open_media_n">मीडिया खोलें #%d</string>
-    <string name="title_mentions_dialog">ज़िक्र</string>
     <string name="action_open_faved_by">पसंदीदा दिखाएँ</string>
     <string name="action_add_tab">ऐड टैब</string>
     <string name="action_schedule_post">अनुसूची टूट</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -88,7 +88,6 @@
     <string name="action_emoji_keyboard">Emoji billentyűzet</string>
     <string name="action_add_tab">Fül hozzáadása</string>
     <string name="action_open_faved_by">Kedvencek megjelenítése</string>
-    <string name="title_mentions_dialog">Említések</string>
     <string name="download_image">%1$s letöltése</string>
     <string name="action_copy_link">Link másolása</string>
     <string name="action_share_as">Megosztás mint …</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -240,7 +240,6 @@
     <string name="action_send_public">TOOT!</string>
     <string name="action_translate">Terjemah</string>
     <string name="action_translate_undo">Batalkan terjemahan</string>
-    <string name="title_mentions_dialog">Menyebutkan</string>
     <string name="send_account_link_to">Bagikan URL akun ke…</string>
     <string name="send_account_username_to">Bagikan nama pengguna akun ke…</string>
     <string name="label_image">Gambar</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -105,7 +105,6 @@
     <string name="action_open_reblogger">Opna höfund endurbirtingar</string>
     <string name="action_open_reblogged_by">Sýna endurbirtingar</string>
     <string name="action_open_faved_by">Birta eftirlæti</string>
-    <string name="title_mentions_dialog">Tilvísanir</string>
     <string name="action_open_media_n">Opna myndefni #%d</string>
     <string name="download_image">Sæki %1$s</string>
     <string name="action_copy_link">Afrita tengilinn</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -98,7 +98,6 @@
     <string name="action_open_reblogger">Vai all\'autore della condivisione</string>
     <string name="action_open_reblogged_by">Mostra condivisioni</string>
     <string name="action_open_faved_by">Mostra preferiti</string>
-    <string name="title_mentions_dialog">Menzioni</string>
     <string name="action_open_media_n">Apri media #%d</string>
     <string name="download_image">Scaricando %1$s</string>
     <string name="action_copy_link">Copia collegamento</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -291,7 +291,6 @@
     <string name="notification_poll_description">投票の集計が完了したときの通知</string>
     <string name="pref_title_thread_filter_keywords">スレッド</string>
     <string name="action_add_poll">投票</string>
-    <string name="title_mentions_dialog">返信</string>
     <string name="dialog_redraft_post_warning">この投稿を削除し、下書きに戻しますか？</string>
     <string name="filter_dialog_remove_button">削除</string>
     <string name="filter_dialog_update_button">更新</string>

--- a/app/src/main/res/values-kab/strings.xml
+++ b/app/src/main/res/values-kab/strings.xml
@@ -177,7 +177,6 @@
     <string name="title_follows">Ig ṭṭafar</string>
     <string name="title_followers">Imeḍfaṛen</string>
     <string name="description_visibility_private">Imeḍfaṛen</string>
-    <string name="title_mentions_dialog">Tibdarin</string>
     <string name="confirmation_reported">Yettwaceyyeɛ!</string>
     <string name="post_sent">Yettwaceyyaɛ!</string>
     <string name="search_no_results">Ula d yiwen n ugmuḍ</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -96,7 +96,6 @@
     <string name="action_open_reblogger">부스트한 유저의 프로필로 이동</string>
     <string name="action_open_reblogged_by">부스트 보이기</string>
     <string name="action_open_faved_by">좋아요한 유저 보이기</string>
-    <string name="title_mentions_dialog">멘션</string>
     <string name="action_open_media_n">미디어 #%d 열기</string>
     <string name="download_image">%1$s 다운로드 중</string>
     <string name="action_copy_link">링크 복사</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -64,7 +64,6 @@
     <string name="action_add_tab">Pievienot cilni</string>
     <string name="action_reset_schedule">Atiestatīt</string>
     <string name="download_image">Lejupielādē %1$s</string>
-    <string name="title_mentions_dialog">Pieminējumi</string>
     <string name="confirmation_reported">Nosūtīts!</string>
     <string name="action_copy_link">Nokopēt saiti</string>
     <string name="confirmation_unblocked">Lietotājs atbloķēts</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -109,7 +109,6 @@
     <string name="action_photo_take">ഫോട്ടോ എടുക്കുക</string>
     <string name="hint_search">തിരയുക…</string>
     <string name="post_media_images">ചിത്രങ്ങൾ</string>
-    <string name="title_mentions_dialog">സൂചനകൾ</string>
     <string name="hint_note">ബയോ</string>
     <string name="conversation_1_recipients">%1$s</string>
     <string name="pref_title_thread_filter_keywords">സംഭാഷണങ്ങൾ</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -92,7 +92,6 @@
     <string name="action_open_reblogger">Åpne delerens profil</string>
     <string name="action_open_reblogged_by">Vis delinger</string>
     <string name="action_open_faved_by">Vis favoritter</string>
-    <string name="title_mentions_dialog">Nevnelser</string>
     <string name="action_open_media_n">Åpne media #%d</string>
     <string name="download_image">Laster ned %1$s</string>
     <string name="action_copy_link">Kopier lenken</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -92,7 +92,6 @@
     <string name="action_open_reblogger">Auteur van deze boost openen</string>
     <string name="action_open_reblogged_by">Boosts tonen</string>
     <string name="action_open_faved_by">Favorieten tonen</string>
-    <string name="title_mentions_dialog">Vermeldingen</string>
     <string name="action_open_media_n">Media #%d openen</string>
     <string name="download_image">%1$s aan het downloaden</string>
     <string name="action_copy_link">Link kopiëren</string>

--- a/app/src/main/res/values-oc/strings.xml
+++ b/app/src/main/res/values-oc/strings.xml
@@ -231,7 +231,6 @@
     <string name="action_open_reblogger">Dobrir l’autor del partatge</string>
     <string name="action_open_reblogged_by">Mostrar los retuts</string>
     <string name="action_open_faved_by">Mostrar los favorits</string>
-    <string name="title_mentions_dialog">Mencions</string>
     <string name="action_open_media_n">Dobrir lo mèdia #%d</string>
     <string name="action_share_as">Partejar coma…</string>
     <string name="download_media">Telecargar lo mèdia</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -228,7 +228,6 @@
     <string name="action_delete_and_redraft">Usuń i przeredaguj</string>
     <string name="action_view_account_preferences">Ustawienia konta</string>
     <string name="action_open_faved_by">Pokaż ulubione</string>
-    <string name="title_mentions_dialog">Wzmianki</string>
     <string name="action_share_as">Udostępnij jako …</string>
     <string name="title_tab_preferences">Zakładki</string>
     <string name="title_domain_mutes">Ukryte domeny</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -87,7 +87,6 @@
     <string name="action_add_tab">Adicionar aba</string>
     <string name="action_open_reblogged_by">Mostrar Boosts</string>
     <string name="action_open_faved_by">Mostrar favoritos</string>
-    <string name="title_mentions_dialog">Menções</string>
     <string name="download_image">Baixando %1$s</string>
     <string name="action_copy_link">Copiar URL</string>
     <string name="action_share_as">Compartilhar como…</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -128,7 +128,6 @@
     <string name="action_open_reblogger">Ver autor do boost</string>
     <string name="action_open_reblogged_by">Mostrar boosts</string>
     <string name="action_open_faved_by">Mostrar favoritos</string>
-    <string name="title_mentions_dialog">Menções</string>
     <string name="action_open_media_n">Abrir conteúdo multimédia #%d</string>
     <string name="download_image">A descarregar %1$s</string>
     <string name="action_copy_link">Copiar a hiperligação</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -93,7 +93,6 @@
     <string name="action_open_reblogger">Перейти к автору</string>
     <string name="action_open_reblogged_by">Показывать продвижения</string>
     <string name="action_open_faved_by">Показать избранное</string>
-    <string name="title_mentions_dialog">Упоминания</string>
     <string name="action_open_media_n">Открыть медиафайл #%d</string>
     <string name="download_image">Загрузка %1$s</string>
     <string name="action_copy_link">Копировать ссылку</string>

--- a/app/src/main/res/values-sa/strings.xml
+++ b/app/src/main/res/values-sa/strings.xml
@@ -94,7 +94,6 @@
     <string name="action_copy_link">जालस्थलं प्रतिलिख्यताम्</string>
     <string name="download_image">अवारोप्यमाणम् %1$s</string>
     <string name="action_open_media_n">उद्घाट्यताम् #%d</string>
-    <string name="title_mentions_dialog">उल्लेखाः</string>
     <string name="action_open_faved_by">प्रियाणि दृश्यन्ताम्</string>
     <string name="action_open_reblogged_by">प्रकाशनानि दृश्यन्ताम्</string>
     <string name="action_open_reblogger">प्रकाशनलेखकः उद्घाट्यताम्</string>

--- a/app/src/main/res/values-si/strings.xml
+++ b/app/src/main/res/values-si/strings.xml
@@ -99,7 +99,6 @@
     <string name="downloading_media">මාධ්‍ය බාගත වෙමින්</string>
     <string name="pref_title_show_media_preview">මාධ්‍ය පෙරදසුන් බාගන්න</string>
     <string name="dialog_download_image">බාගන්න</string>
-    <string name="title_mentions_dialog">සඳැහුම්</string>
     <string name="action_reply">පිළිතුර</string>
     <string name="pref_title_edit_notification_settings">දැනුම්දීම්</string>
     <string name="confirmation_unblocked">පරිශීලක අනවහිර කෙරිණි</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -37,7 +37,6 @@
     <string name="action_delete_and_redraft">Vymazať a prepísať</string>
     <string name="action_reset_schedule">Obnoviť</string>
     <string name="action_open_faved_by">Zobraziť obľúbené</string>
-    <string name="title_mentions_dialog">Zmienky</string>
     <string name="action_open_media_n">Otvoriť médium #%d</string>
     <string name="download_image">Sťahovanie %1$s</string>
     <string name="action_copy_link">Kopírovať odkaz</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -89,7 +89,6 @@
     <string name="action_open_reblogger">Odpri spodbujenega avtorja</string>
     <string name="action_open_reblogged_by">Prikaži spodbude</string>
     <string name="action_open_faved_by">Prikaži priljubljene</string>
-    <string name="title_mentions_dialog">Omembe</string>
     <string name="action_open_media_n">Odpri medij #%d</string>
     <string name="download_image">Prejemanje %1$s</string>
     <string name="action_copy_link">Kopiraj povezavo</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -92,7 +92,6 @@
     <string name="action_open_reblogger">Öppna knuff författare</string>
     <string name="action_open_reblogged_by">Visa knuffar</string>
     <string name="action_open_faved_by">Visa favoriter</string>
-    <string name="title_mentions_dialog">Omnämnanden</string>
     <string name="action_open_media_n">Öppna media #%d</string>
     <string name="download_image">Laddar ned %1$s</string>
     <string name="action_copy_link">Kopiera länk</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -254,7 +254,6 @@
     <string name="action_copy_link">คัดลอกลิงก์</string>
     <string name="download_image">กำลังดาวน์โหลด %1$s</string>
     <string name="action_open_media_n">เปิดสื่อ #%d</string>
-    <string name="title_mentions_dialog">โต้ตอบ</string>
     <string name="action_open_faved_by">ดูชื่นชอบ</string>
     <string name="action_open_reblogged_by">ดูบสต์</string>
     <string name="action_open_reblogger">ดูต้นตอบูสต์</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -329,7 +329,6 @@
     <string name="report_description_remote_instance">Hesap başka bir sunucudan. Raporun anonim bir kopyasını da oraya gönderilsin mi\?</string>
     <string name="action_open_reblogger">Gönderi yazanını aç</string>
     <string name="action_open_reblogged_by">Yeniden paylaşımları göster</string>
-    <string name="title_mentions_dialog">Bahsedenler</string>
     <string name="action_open_media_n">#%d medyayı aç</string>
     <string name="title_bookmarks">Yer imleri</string>
     <string name="title_scheduled_posts">Zamanlanmış yayınlar</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -38,7 +38,6 @@
     <string name="action_share_as">Поділитися як …</string>
     <string name="action_copy_link">Копіювати посилання</string>
     <string name="download_image">Завантаження %1$s</string>
-    <string name="title_mentions_dialog">Згадки</string>
     <string name="action_open_faved_by">Показати, хто вподобав</string>
     <string name="action_content_warning">Попередження про вміст</string>
     <string name="action_access_scheduled_posts">Заплановані дописи</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -72,7 +72,6 @@
     <string name="action_copy_link">Chép URL</string>
     <string name="download_image">Đang tải %1$s</string>
     <string name="action_open_media_n">Mở tập tin #%d</string>
-    <string name="title_mentions_dialog">Lượt nhắc tới</string>
     <string name="action_open_faved_by">Xem lượt thích</string>
     <string name="action_open_reblogged_by">Xem lượt đăng lại</string>
     <string name="action_open_reblogger">Xem lượt đăng lại</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -93,7 +93,6 @@
     <string name="action_open_reblogger">打开转嘟用户主页</string>
     <string name="action_open_reblogged_by">显示转嘟</string>
     <string name="action_open_faved_by">显示喜欢</string>
-    <string name="title_mentions_dialog">提及</string>
     <string name="action_open_media_n">打开媒体文件 #%d</string>
     <string name="download_image">下载中 %1$s</string>
     <string name="action_copy_link">复制链接</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -93,7 +93,6 @@
     <string name="action_open_reblogger">打開轉嘟用戶主頁</string>
     <string name="action_open_reblogged_by">顯示轉嘟</string>
     <string name="action_open_faved_by">顯示最愛</string>
-    <string name="title_mentions_dialog">提及</string>
     <string name="action_open_media_n">打開媒體 #%d</string>
     <string name="download_image">正在下載 %1$s</string>
     <string name="action_copy_link">複製連結</string>

--- a/app/src/main/res/values-zh-rMO/strings.xml
+++ b/app/src/main/res/values-zh-rMO/strings.xml
@@ -93,7 +93,6 @@
     <string name="action_open_reblogger">打開轉嘟用戶主頁</string>
     <string name="action_open_reblogged_by">顯示轉嘟</string>
     <string name="action_open_faved_by">顯示收藏</string>
-    <string name="title_mentions_dialog">提及</string>
     <string name="action_open_media_n">打開媒體 #%d</string>
     <string name="download_image">正在下載 %1$s</string>
     <string name="action_copy_link">複製連結</string>

--- a/app/src/main/res/values-zh-rSG/strings.xml
+++ b/app/src/main/res/values-zh-rSG/strings.xml
@@ -93,7 +93,6 @@
     <string name="action_open_reblogger">打开转嘟用户主页</string>
     <string name="action_open_reblogged_by">显示转嘟</string>
     <string name="action_open_faved_by">显示喜欢</string>
-    <string name="title_mentions_dialog">提及</string>
     <string name="action_open_media_n">打开媒体文件 #%d</string>
     <string name="download_image">正在下载 %1$s…</string>
     <string name="action_copy_link">复制链接</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -93,7 +93,6 @@
     <string name="action_open_reblogger">打開轉嘟用戶主頁</string>
     <string name="action_open_reblogged_by">顯示轉嘟</string>
     <string name="action_open_faved_by">顯示最愛</string>
-    <string name="title_mentions_dialog">提及</string>
     <string name="action_open_media_n">打開媒體 #%d</string>
     <string name="download_image">正在下載 %1$s</string>
     <string name="action_copy_link">複製連結</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -186,7 +186,6 @@
     <string name="action_suggestions">Suggested accounts</string>
     <string name="action_translate">Translate</string>
     <string name="action_translate_undo">Undo translate</string>
-    <string name="title_mentions_dialog">Mentions</string>
     <string name="action_open_media_n">Open media #%d</string>
     <string name="download_image">Downloading %1$s</string>
     <string name="action_copy_link">Copy the link</string>

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/accessibility/ArrayAdapterWithCopyButton.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/accessibility/ArrayAdapterWithCopyButton.kt
@@ -15,7 +15,7 @@
  * see <http://www.gnu.org/licenses>.
  */
 
-package app.pachli.core.ui
+package app.pachli.core.ui.accessibility
 
 import android.content.ClipData
 import android.content.ClipboardManager
@@ -27,6 +27,7 @@ import android.view.ViewGroup
 import android.widget.ArrayAdapter
 import android.widget.Toast
 import androidx.core.content.ContextCompat
+import app.pachli.core.ui.R
 import app.pachli.core.ui.databinding.SimpleListItem1CopyButtonBinding
 
 /**

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/accessibility/PachliRecyclerViewAccessibilityDelegate.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/accessibility/PachliRecyclerViewAccessibilityDelegate.kt
@@ -47,6 +47,10 @@ abstract class PachliRecyclerViewAccessibilityDelegate(
      * for assistive technologies to copy the item.
      *
      * Focus is set to the list after showing the dialog.
+     *
+     * @param title String resource to use as the dialog's title.
+     * @param items Items to show in the dialog.
+     * @param listener Callback, called with the position of the clicked item.
      */
     fun showA11yDialogWithCopyButton(@StringRes title: Int, items: List<CharSequence>, listener: ArrayAdapterWithCopyButton.OnClickListener) {
         AlertDialog.Builder(context)

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/accessibility/PachliRecyclerViewAccessibilityDelegate.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/accessibility/PachliRecyclerViewAccessibilityDelegate.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2024 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.core.ui.accessibility
+
+import android.content.Context
+import android.text.Spannable
+import android.text.Spanned
+import android.text.style.CharacterStyle
+import android.text.style.URLSpan
+import android.view.View
+import android.view.accessibility.AccessibilityEvent
+import android.view.accessibility.AccessibilityManager
+import androidx.annotation.StringRes
+import androidx.appcompat.app.AlertDialog
+import androidx.core.text.getSpans
+import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerViewAccessibilityDelegate
+
+/** Base class for Pachli-specific [RecyclerViewAccessibilityDelegate]s. */
+abstract class PachliRecyclerViewAccessibilityDelegate(
+    recyclerView: RecyclerView,
+) : RecyclerViewAccessibilityDelegate(recyclerView) {
+    protected val context: Context = recyclerView.context
+
+    private val a11yManager = context.getSystemService(Context.ACCESSIBILITY_SERVICE)
+        as AccessibilityManager
+
+    /**
+     * Shows a dialog with [title] displaying a list of [items].
+     *
+     * Each row in the list shows the item and a "Copy" button to make it easier
+     * for assistive technologies to copy the item.
+     *
+     * Focus is set to the list after showing the dialog.
+     */
+    fun showA11yDialogWithCopyButton(@StringRes title: Int, items: List<CharSequence>, listener: ArrayAdapterWithCopyButton.OnClickListener) {
+        AlertDialog.Builder(context)
+            .setTitle(title)
+            .setAdapter(ArrayAdapterWithCopyButton(context, items, listener), null)
+            .show()
+            .let { forceFocus(it.listView) }
+    }
+
+    /** Interrupts the accessibility service and sets focus to [view]. */
+    protected fun forceFocus(view: View) {
+        interrupt()
+        view.post {
+            view.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED)
+        }
+    }
+
+    /** Requests feedback interruption from all accessibility services. */
+    protected fun interrupt() = a11yManager.interrupt()
+
+    companion object {
+        /** @return The text enclosed by [span]. */
+        @JvmStatic
+        protected fun Spanned.subSequence(span: CharacterStyle) =
+            subSequence(getSpanStart(span), getSpanEnd(span))
+
+        /** @return Links, excluding any links that are hashtags or @-mentions. */
+        @JvmStatic
+        protected fun Spanned.getLinks(): List<URLSpan> {
+            if (this !is Spannable) return emptyList()
+
+            return getSpans<URLSpan>(0, length)
+                .mapNotNull { span ->
+                    val text = subSequence(span)
+                    if (text.isHashtag() || text.isMention()) null else span
+                }
+        }
+
+        /** @return The text of the linked hashtags (without the leading '#'). */
+        @JvmStatic
+        protected fun Spanned.getHashtags(): List<CharSequence> = getSpans<URLSpan>(0, length)
+            .map { span -> subSequence(span).toString() }
+            .filter { it.isHashtag() }
+            .map { it.removePrefix("\u2068").removePrefix("#") }
+
+        /**
+         * @return True if this is a hashtag (starts with `#` or `#` preceded by
+         * the directional isolate added by [StringUtils.unicodeWrap]).
+         */
+        @JvmStatic
+        protected fun CharSequence.isHashtag() = startsWith("#") ||
+            startsWith("\u2068#")
+
+        /**
+         * @return True if this is a mention (starts with `@` or `@` preceded by
+         * the directional isolate added by [StringUtils.unicodeWrap]).
+         */
+        @JvmStatic
+        protected fun CharSequence.isMention() = startsWith("@") ||
+            startsWith("\u2068@")
+    }
+}

--- a/core/ui/src/main/res/values-ar/strings.xml
+++ b/core/ui/src/main/res/values-ar/strings.xml
@@ -14,4 +14,5 @@
     <string name="action_hashtags">الوسوم</string>
     <string name="title_links_dialog">الروابط</string>
     <string name="title_hashtags_dialog">الوسوم</string>
+    <string name="title_mentions_dialog">الإشارات</string>
 </resources>

--- a/core/ui/src/main/res/values-be/strings.xml
+++ b/core/ui/src/main/res/values-be/strings.xml
@@ -14,4 +14,5 @@
     <string name="action_hashtags">Хэштэгі</string>
     <string name="title_links_dialog">Спасылкі</string>
     <string name="title_hashtags_dialog">Хэштэгі</string>
+    <string name="title_mentions_dialog">Згадкі</string>
 </resources>

--- a/core/ui/src/main/res/values-bg/strings.xml
+++ b/core/ui/src/main/res/values-bg/strings.xml
@@ -12,4 +12,5 @@
     <string name="action_hashtags">Хаштагове</string>
     <string name="title_links_dialog">Връзки</string>
     <string name="title_hashtags_dialog">Хаштагове</string>
+    <string name="title_mentions_dialog">Споменавания</string>
 </resources>

--- a/core/ui/src/main/res/values-bn-rBD/strings.xml
+++ b/core/ui/src/main/res/values-bn-rBD/strings.xml
@@ -12,4 +12,5 @@
     <string name="action_hashtags">হ্যাশট্যাগ</string>
     <string name="title_links_dialog">লিংকসমূহ</string>
     <string name="title_hashtags_dialog">হ্যাশট্যাগ</string>
+    <string name="title_mentions_dialog">উল্লেখসমূহ</string>
 </resources>

--- a/core/ui/src/main/res/values-bn-rIN/strings.xml
+++ b/core/ui/src/main/res/values-bn-rIN/strings.xml
@@ -12,4 +12,5 @@
     <string name="action_hashtags">হ্যাশট্যাগ</string>
     <string name="title_links_dialog">লিংকসমূহ</string>
     <string name="title_hashtags_dialog">হ্যাশট্যাগ</string>
+    <string name="title_mentions_dialog">উল্লেখসমূহ</string>
 </resources>

--- a/core/ui/src/main/res/values-ca/strings.xml
+++ b/core/ui/src/main/res/values-ca/strings.xml
@@ -14,4 +14,5 @@
     <string name="action_hashtags">Hashtags</string>
     <string name="title_links_dialog">Enllaç</string>
     <string name="title_hashtags_dialog">Hashtags</string>
+    <string name="title_mentions_dialog">Mencions</string>
 </resources>

--- a/core/ui/src/main/res/values-ckb/strings.xml
+++ b/core/ui/src/main/res/values-ckb/strings.xml
@@ -12,4 +12,5 @@
     <string name="action_hashtags">هاشتاگ</string>
     <string name="title_links_dialog">بەستەرەکان</string>
     <string name="title_hashtags_dialog">هاشتاگی</string>
+    <string name="title_mentions_dialog">ئاماژەکان</string>
 </resources>

--- a/core/ui/src/main/res/values-cs/strings.xml
+++ b/core/ui/src/main/res/values-cs/strings.xml
@@ -13,4 +13,5 @@
     <string name="action_hashtags">Hashtagy</string>
     <string name="title_links_dialog">Odkazy</string>
     <string name="title_hashtags_dialog">Hashtagy</string>
+    <string name="title_mentions_dialog">Zmínky</string>
 </resources>

--- a/core/ui/src/main/res/values-cy/strings.xml
+++ b/core/ui/src/main/res/values-cy/strings.xml
@@ -14,4 +14,5 @@
     <string name="action_hashtags">Hashnodau</string>
     <string name="title_links_dialog">Dolenni</string>
     <string name="title_hashtags_dialog">Hashnodau</string>
+    <string name="title_mentions_dialog">Crybwylliadau</string>
 </resources>

--- a/core/ui/src/main/res/values-de/strings.xml
+++ b/core/ui/src/main/res/values-de/strings.xml
@@ -14,4 +14,5 @@
     <string name="action_hashtags">Hashtags</string>
     <string name="title_links_dialog">Links</string>
     <string name="title_hashtags_dialog">Hashtags</string>
+    <string name="title_mentions_dialog">Erwähnungen</string>
 </resources>

--- a/core/ui/src/main/res/values-eo/strings.xml
+++ b/core/ui/src/main/res/values-eo/strings.xml
@@ -13,4 +13,5 @@
     <string name="action_hashtags">Kradvortoj</string>
     <string name="title_links_dialog">Ligiloj</string>
     <string name="title_hashtags_dialog">Kradvortoj</string>
+    <string name="title_mentions_dialog">Mencioj</string>
 </resources>

--- a/core/ui/src/main/res/values-es/strings.xml
+++ b/core/ui/src/main/res/values-es/strings.xml
@@ -16,4 +16,5 @@
     <string name="title_hashtags_dialog">Etiquetas</string>
     <string name="item_copied">Texto copiado</string>
     <string name="action_copy_item">Copiar ítem</string>
+    <string name="title_mentions_dialog">Menciones</string>
 </resources>

--- a/core/ui/src/main/res/values-eu/strings.xml
+++ b/core/ui/src/main/res/values-eu/strings.xml
@@ -12,4 +12,5 @@
     <string name="action_hashtags">Traolak</string>
     <string name="title_links_dialog">Estekak</string>
     <string name="title_hashtags_dialog">Traolak</string>
+    <string name="title_mentions_dialog">Aipamenak</string>
 </resources>

--- a/core/ui/src/main/res/values-fa/strings.xml
+++ b/core/ui/src/main/res/values-fa/strings.xml
@@ -14,4 +14,5 @@
     <string name="action_hashtags">برچسب‌ها</string>
     <string name="title_links_dialog">پیوندها</string>
     <string name="title_hashtags_dialog">برچسب‌ها</string>
+    <string name="title_mentions_dialog">اشاره‌ها</string>
 </resources>

--- a/core/ui/src/main/res/values-fi/strings.xml
+++ b/core/ui/src/main/res/values-fi/strings.xml
@@ -16,4 +16,5 @@
     <string name="title_hashtags_dialog">Aihetunnisteet</string>
     <string name="item_copied">Teksti kopioitu</string>
     <string name="action_copy_item">Kopioi kohde</string>
+    <string name="title_mentions_dialog">Maininnat</string>
 </resources>

--- a/core/ui/src/main/res/values-fr/strings.xml
+++ b/core/ui/src/main/res/values-fr/strings.xml
@@ -14,4 +14,5 @@
     <string name="action_hashtags">Hashtags</string>
     <string name="title_links_dialog">Liens</string>
     <string name="title_hashtags_dialog">Hashtags</string>
+    <string name="title_mentions_dialog">Mentions</string>
 </resources>

--- a/core/ui/src/main/res/values-ga/strings.xml
+++ b/core/ui/src/main/res/values-ga/strings.xml
@@ -16,4 +16,5 @@
     <string name="url_domain_notifier">" (🔗 %s)"</string>
     <string name="item_copied">Cóipeáladh téacs</string>
     <string name="action_copy_item">Cóipeáil mír</string>
+    <string name="title_mentions_dialog">Tráchtanna</string>
 </resources>

--- a/core/ui/src/main/res/values-gd/strings.xml
+++ b/core/ui/src/main/res/values-gd/strings.xml
@@ -14,4 +14,5 @@
     <string name="action_hashtags">Tagaichean hais</string>
     <string name="title_links_dialog">Ceanglaichean</string>
     <string name="title_hashtags_dialog">Tagaichean hais</string>
+    <string name="title_mentions_dialog">Iomraidhean</string>
 </resources>

--- a/core/ui/src/main/res/values-gl/strings.xml
+++ b/core/ui/src/main/res/values-gl/strings.xml
@@ -14,4 +14,5 @@
     <string name="action_hashtags">Cancelos</string>
     <string name="title_links_dialog">Ligazóns</string>
     <string name="title_hashtags_dialog">Cancelos</string>
+    <string name="title_mentions_dialog">Mencións</string>
 </resources>

--- a/core/ui/src/main/res/values-hi/strings.xml
+++ b/core/ui/src/main/res/values-hi/strings.xml
@@ -11,4 +11,5 @@
     <string name="action_hashtags">हैशटैग</string>
     <string name="title_links_dialog">लिंक</string>
     <string name="title_hashtags_dialog">हैशटैग</string>
+    <string name="title_mentions_dialog">ज़िक्र</string>
 </resources>

--- a/core/ui/src/main/res/values-hu/strings.xml
+++ b/core/ui/src/main/res/values-hu/strings.xml
@@ -14,4 +14,5 @@
     <string name="action_hashtags">Hashtagek</string>
     <string name="title_links_dialog">Linkek</string>
     <string name="title_hashtags_dialog">Hashtagek</string>
+    <string name="title_mentions_dialog">Említések</string>
 </resources>

--- a/core/ui/src/main/res/values-in/strings.xml
+++ b/core/ui/src/main/res/values-in/strings.xml
@@ -11,4 +11,5 @@
     <string name="action_hashtags">Hashtag</string>
     <string name="title_links_dialog">Tautan</string>
     <string name="title_hashtags_dialog">Hashtag</string>
+    <string name="title_mentions_dialog">Menyebutkan</string>
 </resources>

--- a/core/ui/src/main/res/values-is/strings.xml
+++ b/core/ui/src/main/res/values-is/strings.xml
@@ -14,4 +14,5 @@
     <string name="action_hashtags">Myllumerki</string>
     <string name="title_links_dialog">Tenglar</string>
     <string name="title_hashtags_dialog">Myllumerki</string>
+    <string name="title_mentions_dialog">Tilvísanir</string>
 </resources>

--- a/core/ui/src/main/res/values-it/strings.xml
+++ b/core/ui/src/main/res/values-it/strings.xml
@@ -14,4 +14,5 @@
     <string name="action_hashtags">Hashtag</string>
     <string name="title_links_dialog">Collegamenti</string>
     <string name="title_hashtags_dialog">Hashtag</string>
+    <string name="title_mentions_dialog">Menzioni</string>
 </resources>

--- a/core/ui/src/main/res/values-ja/strings.xml
+++ b/core/ui/src/main/res/values-ja/strings.xml
@@ -14,4 +14,5 @@
     <string name="action_hashtags">ハッシュタグ</string>
     <string name="title_links_dialog">リンク</string>
     <string name="title_hashtags_dialog">ハッシュタグ</string>
+    <string name="title_mentions_dialog">返信</string>
 </resources>

--- a/core/ui/src/main/res/values-kab/strings.xml
+++ b/core/ui/src/main/res/values-kab/strings.xml
@@ -12,4 +12,5 @@
     <string name="action_hashtags">Ihacṭagen</string>
     <string name="title_links_dialog">Iseɣwan</string>
     <string name="title_hashtags_dialog">Ihacṭagen</string>
+    <string name="title_mentions_dialog">Tibdarin</string>
 </resources>

--- a/core/ui/src/main/res/values-ko/strings.xml
+++ b/core/ui/src/main/res/values-ko/strings.xml
@@ -12,4 +12,5 @@
     <string name="action_hashtags">해시태그</string>
     <string name="title_links_dialog">링크</string>
     <string name="title_hashtags_dialog">해시태그</string>
+    <string name="title_mentions_dialog">멘션</string>
 </resources>

--- a/core/ui/src/main/res/values-lv/strings.xml
+++ b/core/ui/src/main/res/values-lv/strings.xml
@@ -14,4 +14,5 @@
     <string name="action_hashtags">Tēmturi</string>
     <string name="title_links_dialog">Saites</string>
     <string name="title_hashtags_dialog">Tēmturi</string>
+    <string name="title_mentions_dialog">Pieminējumi</string>
 </resources>

--- a/core/ui/src/main/res/values-ml/strings.xml
+++ b/core/ui/src/main/res/values-ml/strings.xml
@@ -9,4 +9,5 @@
     <string name="action_links">ലിങ്കുകൾ</string>
     <string name="action_mentions">സൂചനകൾ</string>
     <string name="title_links_dialog">ലിങ്കുകൾ</string>
+    <string name="title_mentions_dialog">സൂചനകൾ</string>
 </resources>

--- a/core/ui/src/main/res/values-nb-rNO/strings.xml
+++ b/core/ui/src/main/res/values-nb-rNO/strings.xml
@@ -14,4 +14,5 @@
     <string name="action_hashtags">Emneknagger</string>
     <string name="title_links_dialog">Lenker</string>
     <string name="title_hashtags_dialog">Stikkord</string>
+    <string name="title_mentions_dialog">Nevnelser</string>
 </resources>

--- a/core/ui/src/main/res/values-nl/strings.xml
+++ b/core/ui/src/main/res/values-nl/strings.xml
@@ -14,4 +14,5 @@
     <string name="action_hashtags">Hashtags</string>
     <string name="title_links_dialog">Links</string>
     <string name="title_hashtags_dialog">Hashtags</string>
+    <string name="title_mentions_dialog">Vermeldingen</string>
 </resources>

--- a/core/ui/src/main/res/values-oc/strings.xml
+++ b/core/ui/src/main/res/values-oc/strings.xml
@@ -14,4 +14,5 @@
     <string name="action_hashtags">Etiquetas</string>
     <string name="title_links_dialog">Ligams</string>
     <string name="title_hashtags_dialog">Etiquetas</string>
+    <string name="title_mentions_dialog">Mencions</string>
 </resources>

--- a/core/ui/src/main/res/values-pl/strings.xml
+++ b/core/ui/src/main/res/values-pl/strings.xml
@@ -14,4 +14,5 @@
     <string name="action_hashtags">Hashtagi</string>
     <string name="title_links_dialog">Linki</string>
     <string name="title_hashtags_dialog">Hashtagi</string>
+    <string name="title_mentions_dialog">Wzmianki</string>
 </resources>

--- a/core/ui/src/main/res/values-pt-rBR/strings.xml
+++ b/core/ui/src/main/res/values-pt-rBR/strings.xml
@@ -14,4 +14,5 @@
     <string name="action_hashtags">Hashtags</string>
     <string name="title_links_dialog">Links</string>
     <string name="title_hashtags_dialog">Hashtags</string>
+    <string name="title_mentions_dialog">Menções</string>
 </resources>

--- a/core/ui/src/main/res/values-pt-rPT/strings.xml
+++ b/core/ui/src/main/res/values-pt-rPT/strings.xml
@@ -13,4 +13,5 @@
     <string name="action_hashtags">Hashtags</string>
     <string name="title_links_dialog">Hiperligações</string>
     <string name="title_hashtags_dialog">Hashtags</string>
+    <string name="title_mentions_dialog">Menções</string>
 </resources>

--- a/core/ui/src/main/res/values-ru/strings.xml
+++ b/core/ui/src/main/res/values-ru/strings.xml
@@ -12,4 +12,5 @@
     <string name="action_hashtags">Хэштеги</string>
     <string name="title_links_dialog">Ссылки</string>
     <string name="title_hashtags_dialog">Хэштеги</string>
+    <string name="title_mentions_dialog">Упоминания</string>
 </resources>

--- a/core/ui/src/main/res/values-sa/strings.xml
+++ b/core/ui/src/main/res/values-sa/strings.xml
@@ -13,4 +13,5 @@
     <string name="action_hashtags">निश्रेणिचिह्नशीर्षकाः</string>
     <string name="title_links_dialog">जालस्थलानि</string>
     <string name="title_hashtags_dialog">निश्रेणिचिह्नशीर्षकाः</string>
+    <string name="title_mentions_dialog">उल्लेखाः</string>
 </resources>

--- a/core/ui/src/main/res/values-si/strings.xml
+++ b/core/ui/src/main/res/values-si/strings.xml
@@ -8,4 +8,5 @@
     <string name="action_links">සබැඳි</string>
     <string name="action_mentions">සඳැහුම්</string>
     <string name="title_links_dialog">සබැඳි</string>
+    <string name="title_mentions_dialog">සඳැහුම්</string>
 </resources>

--- a/core/ui/src/main/res/values-sk/strings.xml
+++ b/core/ui/src/main/res/values-sk/strings.xml
@@ -7,4 +7,5 @@
     <string name="action_hashtags">Hashtagy</string>
     <string name="title_links_dialog">Odkazy</string>
     <string name="title_hashtags_dialog">Hashtagy</string>
+    <string name="title_mentions_dialog">Zmienky</string>
 </resources>

--- a/core/ui/src/main/res/values-sl/strings.xml
+++ b/core/ui/src/main/res/values-sl/strings.xml
@@ -12,4 +12,5 @@
     <string name="action_hashtags">Ključniki</string>
     <string name="title_links_dialog">Povezave</string>
     <string name="title_hashtags_dialog">Ključniki</string>
+    <string name="title_mentions_dialog">Omembe</string>
 </resources>

--- a/core/ui/src/main/res/values-sv/strings.xml
+++ b/core/ui/src/main/res/values-sv/strings.xml
@@ -14,4 +14,5 @@
     <string name="action_hashtags">Hashtaggar</string>
     <string name="title_links_dialog">Länkar</string>
     <string name="title_hashtags_dialog">Hashtaggar</string>
+    <string name="title_mentions_dialog">Omnämnanden</string>
 </resources>

--- a/core/ui/src/main/res/values-th/strings.xml
+++ b/core/ui/src/main/res/values-th/strings.xml
@@ -12,4 +12,5 @@
     <string name="action_hashtags">แฮชแท็ก</string>
     <string name="title_links_dialog">ลิงก์</string>
     <string name="title_hashtags_dialog">แฮชแท็ก</string>
+    <string name="title_mentions_dialog">โต้ตอบ</string>
 </resources>

--- a/core/ui/src/main/res/values-tr/strings.xml
+++ b/core/ui/src/main/res/values-tr/strings.xml
@@ -14,4 +14,5 @@
     <string name="action_hashtags">Etiketler</string>
     <string name="title_links_dialog">Bağlantılar</string>
     <string name="title_hashtags_dialog">Etiketler</string>
+    <string name="title_mentions_dialog">Bahsedenler</string>
 </resources>

--- a/core/ui/src/main/res/values-uk/strings.xml
+++ b/core/ui/src/main/res/values-uk/strings.xml
@@ -14,4 +14,5 @@
     <string name="action_hashtags">Хештеги</string>
     <string name="title_links_dialog">Посилання</string>
     <string name="title_hashtags_dialog">Хештеги</string>
+    <string name="title_mentions_dialog">Згадки</string>
 </resources>

--- a/core/ui/src/main/res/values-vi/strings.xml
+++ b/core/ui/src/main/res/values-vi/strings.xml
@@ -14,4 +14,5 @@
     <string name="action_hashtags">Hashtag</string>
     <string name="title_links_dialog">Links</string>
     <string name="title_hashtags_dialog">Hashtag</string>
+    <string name="title_mentions_dialog">Lượt nhắc tới</string>
 </resources>

--- a/core/ui/src/main/res/values-zh-rCN/strings.xml
+++ b/core/ui/src/main/res/values-zh-rCN/strings.xml
@@ -14,4 +14,5 @@
     <string name="action_hashtags">话题</string>
     <string name="title_links_dialog">链接</string>
     <string name="title_hashtags_dialog">话题</string>
+    <string name="title_mentions_dialog">提及</string>
 </resources>

--- a/core/ui/src/main/res/values-zh-rHK/strings.xml
+++ b/core/ui/src/main/res/values-zh-rHK/strings.xml
@@ -13,4 +13,5 @@
     <string name="title_links_dialog">連結</string>
     <string name="title_hashtags_dialog">話題</string>
     <string name="action_refresh">重新整理</string>
+    <string name="title_mentions_dialog">提及</string>
 </resources>

--- a/core/ui/src/main/res/values-zh-rMO/strings.xml
+++ b/core/ui/src/main/res/values-zh-rMO/strings.xml
@@ -11,4 +11,5 @@
     <string name="action_hashtags">話題</string>
     <string name="title_links_dialog">連結</string>
     <string name="title_hashtags_dialog">話題</string>
+    <string name="title_mentions_dialog">提及</string>
 </resources>

--- a/core/ui/src/main/res/values-zh-rSG/strings.xml
+++ b/core/ui/src/main/res/values-zh-rSG/strings.xml
@@ -11,4 +11,5 @@
     <string name="action_hashtags">话题</string>
     <string name="title_links_dialog">链接</string>
     <string name="title_hashtags_dialog">话题</string>
+    <string name="title_mentions_dialog">提及</string>
 </resources>

--- a/core/ui/src/main/res/values-zh-rTW/strings.xml
+++ b/core/ui/src/main/res/values-zh-rTW/strings.xml
@@ -14,4 +14,5 @@
     <string name="title_links_dialog">連結</string>
     <string name="title_hashtags_dialog">話題</string>
     <string name="action_refresh">重新整理</string>
+    <string name="title_mentions_dialog">提及</string>
 </resources>

--- a/core/ui/src/main/res/values/actions.xml
+++ b/core/ui/src/main/res/values/actions.xml
@@ -42,8 +42,12 @@
 
     <!-- Open the account on a preview card's byline -->
     <item name="action_open_byline_account" type="id" />
+
     <!-- Open the link in a preview card -->
     <item name="action_open_link" type="id" />
+
+    <!-- Copy the item -->
+    <item name="action_copy_item" type="id" />
 
     <item name="action_more" type="id" />
 

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -16,4 +16,5 @@
     <string name="title_hashtags_dialog">Hashtags</string>
     <string name="item_copied">Text copied</string>
     <string name="action_copy_item">Copy item</string>
+    <string name="title_mentions_dialog">Mentions</string>
 </resources>


### PR DESCRIPTION
Extend the "suggested accounts" accessibility actions to include any mentions in the account's bio. Links, mentions, and hashtags are now shown with a button to easily copy them.

Extend the "trending links" accessibility actions with a new "copy link" action.

Consolidate common functionality in to the new
`PachliRecyclerviewAccessibilityDelegate` base class.