### PR TITLE
refactor: Convert `AccountSelectionListener` to `fun interface`

### DIFF
--- a/app/src/main/java/app/pachli/MainActivity.kt
+++ b/app/src/main/java/app/pachli/MainActivity.kt
@@ -63,7 +63,6 @@ import app.pachli.components.compose.ComposeActivity.Companion.canHandleMimeType
 import app.pachli.components.notifications.createNotificationChannelsForAccount
 import app.pachli.components.notifications.domain.AndroidNotificationsAreEnabledUseCase
 import app.pachli.components.notifications.domain.EnableAllNotificationsUseCase
-import app.pachli.core.activity.AccountSelectionListener
 import app.pachli.core.activity.BottomSheetActivity
 import app.pachli.core.activity.PostLookupFallbackBehavior
 import app.pachli.core.activity.ReselectableFragment
@@ -269,16 +268,10 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
             val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
             when (val payload = MainActivityIntent.payload(intent)) {
                 is Payload.QuickTile -> {
-                    showAccountChooserDialog(
-                        getString(R.string.action_share_as),
-                        true,
-                        object : AccountSelectionListener {
-                            override fun onAccountSelected(account: AccountEntity) {
-                                val requestedId = account.id
-                                launchComposeActivityAndExit(requestedId)
-                            }
-                        },
-                    )
+                    showAccountChooserDialog(getString(R.string.action_share_as), true) { account ->
+                        val requestedId = account.id
+                        launchComposeActivityAndExit(requestedId)
+                    }
                     return
                 }
 
@@ -330,16 +323,10 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
                     // and start the composer.
                     if (canHandleMimeType(intent.type)) {
                         // Determine the account to use.
-                        showAccountChooserDialog(
-                            getString(R.string.action_share_as),
-                            true,
-                            object : AccountSelectionListener {
-                                override fun onAccountSelected(account: AccountEntity) {
-                                    val requestedId = account.id
-                                    forwardToComposeActivityAndExit(requestedId, intent)
-                                }
-                            },
-                        )
+                        showAccountChooserDialog(getString(R.string.action_share_as), true) { account ->
+                            val requestedId = account.id
+                            forwardToComposeActivityAndExit(requestedId, intent)
+                        }
                     }
                 }
             }

--- a/app/src/main/java/app/pachli/components/account/AccountActivity.kt
+++ b/app/src/main/java/app/pachli/components/account/AccountActivity.kt
@@ -51,7 +51,6 @@ import androidx.core.widget.doAfterTextChanged
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.viewpager2.widget.MarginPageTransformer
 import app.pachli.R
-import app.pachli.core.activity.AccountSelectionListener
 import app.pachli.core.activity.BottomSheetActivity
 import app.pachli.core.activity.ReselectableFragment
 import app.pachli.core.activity.emojify
@@ -64,7 +63,6 @@ import app.pachli.core.common.extensions.show
 import app.pachli.core.common.extensions.viewBinding
 import app.pachli.core.common.extensions.visible
 import app.pachli.core.common.util.unsafeLazy
-import app.pachli.core.database.model.AccountEntity
 import app.pachli.core.designsystem.R as DR
 import app.pachli.core.navigation.AccountActivityIntent
 import app.pachli.core.navigation.AccountListActivityIntent
@@ -997,15 +995,9 @@ class AccountActivity :
             }
             R.id.action_open_as -> {
                 loadedAccount?.let { loadedAccount ->
-                    showAccountChooserDialog(
-                        item.title,
-                        false,
-                        object : AccountSelectionListener {
-                            override fun onAccountSelected(account: AccountEntity) {
-                                openAsAccount(loadedAccount.url, account)
-                            }
-                        },
-                    )
+                    showAccountChooserDialog(item.title, false) { account ->
+                        openAsAccount(loadedAccount.url, account)
+                    }
                 }
             }
             R.id.action_share_account_link -> {

--- a/app/src/main/java/app/pachli/components/search/fragments/SearchStatusesFragment.kt
+++ b/app/src/main/java/app/pachli/components/search/fragments/SearchStatusesFragment.kt
@@ -33,7 +33,6 @@ import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.LinearLayoutManager
 import app.pachli.R
 import app.pachli.components.search.adapter.SearchStatusesAdapter
-import app.pachli.core.activity.AccountSelectionListener
 import app.pachli.core.activity.BaseActivity
 import app.pachli.core.activity.extensions.TransitionKind
 import app.pachli.core.activity.extensions.startActivityWithDefaultTransition
@@ -363,15 +362,9 @@ class SearchStatusesFragment : SearchFragment<StatusViewData>(), StatusActionLis
     }
 
     private fun showOpenAsDialog(statusUrl: String, dialogTitle: CharSequence?) {
-        bottomSheetActivity?.showAccountChooserDialog(
-            dialogTitle,
-            false,
-            object : AccountSelectionListener {
-                override fun onAccountSelected(account: AccountEntity) {
-                    bottomSheetActivity?.openAsAccount(statusUrl, account)
-                }
-            },
-        )
+        bottomSheetActivity?.showAccountChooserDialog(dialogTitle, false) { account ->
+            bottomSheetActivity?.openAsAccount(statusUrl, account)
+        }
     }
 
     private fun downloadAllMedia(status: Status) {

--- a/app/src/main/java/app/pachli/fragment/SFragment.kt
+++ b/app/src/main/java/app/pachli/fragment/SFragment.kt
@@ -36,7 +36,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import app.pachli.R
-import app.pachli.core.activity.AccountSelectionListener
 import app.pachli.core.activity.BaseActivity
 import app.pachli.core.activity.BottomSheetActivity
 import app.pachli.core.activity.PostLookupFallbackBehavior
@@ -538,15 +537,9 @@ abstract class SFragment<T : IStatusViewData> : Fragment(), StatusActionListener
         }
 
         (activity as BaseActivity).apply {
-            showAccountChooserDialog(
-                dialogTitle,
-                false,
-                object : AccountSelectionListener {
-                    override fun onAccountSelected(account: AccountEntity) {
-                        openAsAccount(statusUrl, account)
-                    }
-                },
-            )
+            showAccountChooserDialog(dialogTitle, false) { account ->
+                openAsAccount(statusUrl, account)
+            }
         }
     }
 

--- a/core/activity/src/main/kotlin/app/pachli/core/activity/AccountSelectionListener.kt
+++ b/core/activity/src/main/kotlin/app/pachli/core/activity/AccountSelectionListener.kt
@@ -18,6 +18,6 @@ package app.pachli.core.activity
 
 import app.pachli.core.database.model.AccountEntity
 
-interface AccountSelectionListener {
+fun interface AccountSelectionListener {
     fun onAccountSelected(account: AccountEntity)
 }


### PR DESCRIPTION
`AccountSelectionListener` only has one method; converting to a Kotlin `fun interface` simplifies the calling code.