### PR TITLE
fix: Prevent crash with Paging IndexOutOfBoundsException

### DIFF
--- a/app/src/main/java/app/pachli/components/timeline/TimelinePagingAdapter.kt
+++ b/app/src/main/java/app/pachli/components/timeline/TimelinePagingAdapter.kt
@@ -79,7 +79,16 @@ class TimelinePagingAdapter(
     }
 
     override fun getItemViewType(position: Int): Int {
-        val viewData = getItem(position) ?: return VIEW_TYPE_PLACEHOLDER
+        // The getItem() call here can occasionally trigger a bug in androidx.paging
+        // where androidx.paging.PageStore.checkIndex(PageStore.kt:56) throws an
+        // IndexOutOfBoundsException. Fall back to returning a placeholder in that
+        // case.
+        val viewData = try {
+            getItem(position) ?: return VIEW_TYPE_PLACEHOLDER
+        } catch (e: IndexOutOfBoundsException) {
+            return VIEW_TYPE_PLACEHOLDER
+        }
+
         return if (viewData.contentFilterAction == FilterAction.WARN) {
             VIEW_TYPE_STATUS_FILTERED
         } else {


### PR DESCRIPTION
getItemViewType is occasionally called with a position that's out of range; trying to get the item at that position throws an `IndexOutOfBoundsException`.

Catch it, and return the placeholder view type.