### PR TITLE
fix: Show top level error message when video playback fails

### DIFF
--- a/app/src/main/java/app/pachli/fragment/ViewVideoFragment.kt
+++ b/app/src/main/java/app/pachli/fragment/ViewVideoFragment.kt
@@ -239,7 +239,7 @@ class ViewVideoFragment : ViewMediaFragment() {
             override fun onPlayerError(error: PlaybackException) {
                 val message = getString(
                     R.string.error_media_playback,
-                    error.cause?.message ?: error.message,
+                    error.message ?: error.cause?.message,
                 )
                 Snackbar.make(binding.root, message, Snackbar.LENGTH_INDEFINITE)
                     .setAction(app.pachli.core.ui.R.string.action_retry) { player?.prepare() }


### PR DESCRIPTION
Previous code showed the error message for the underlying cause, which might be too technical for the user. Prefer to use top level error message; hopefully that is more actionable.

Contributes to #1083