### PR TITLE
fix: Don't clear content when account changes

### DIFF
--- a/app/src/main/java/app/pachli/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeActivity.kt
@@ -132,7 +132,7 @@ import kotlin.math.max
 import kotlin.math.min
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -276,7 +276,7 @@ class ComposeActivity :
         )
 
         lifecycleScope.launch {
-            viewModel.accountFlow.distinctUntilChanged().collect { account ->
+            viewModel.accountFlow.take(1).collect { account ->
                 setupAvatar(account.entity)
 
                 if (viewModel.displaySelfUsername) {


### PR DESCRIPTION
Previous code ran the setup routine whenever the account changed. I think this could result in the content being cleared when a notification arrived (processing the notification updates the marker, which updates the account, which triggers a new collection).

Fix this by only taking the first emission of the account from the flow to do the setup.