### PR TITLE
ci: Add security-events write permission for SARIF upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,9 @@ jobs:
 
   # Android lint is per-variant
   lint:
+    permissions:
+      # Required to upload SARIF files
+      security-events: write
     strategy:
       matrix:
         color: ["orange"]


### PR DESCRIPTION
Required on `main` according to https://github.com/github/codeql-action/issues/2117