### PR TITLE
build: Add Java toolchain resolver

### DIFF
--- a/plugins/markdown2resource/settings.gradle.kts
+++ b/plugins/markdown2resource/settings.gradle.kts
@@ -27,4 +27,8 @@ dependencyResolutionManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version ("0.8.0")
+}
+
 rootProject.name = "markdown2resource-plugin"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -31,6 +31,7 @@ dependencyResolutionManagement {
 
 plugins {
     id("com.gradle.develocity") version "3.18.2"
+    id("org.gradle.toolchains.foojay-resolver-convention") version("0.8.0")
 }
 
 develocity {


### PR DESCRIPTION
Without this an initial build on a machine with no JDK installed can fail with

```
A problem occurred configuring project ':feature:about'.
> Could not resolve all dependencies for configuration 'classpath'.
   > Could not resolve project :markdown2resource.
     Required by:
         project :feature:about
      > Failed to calculate the value of task ':markdown2resource:compileJava' property 'javaCompiler'.
         > Cannot find a Java installation on your machine matching this tasks requirements: {languageVersion=17, vendor=any vendor, implementation=vendor-specific} for WINDOWS on x86_64.
            > No locally installed toolchains match and toolchain download repositories have not been configured.
```