### PR TITLE
feat: Show request method and URL in ApiResult errors

### DIFF
--- a/core/network/src/main/kotlin/app/pachli/core/network/retrofit/apiresult/ApiResultCall.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/retrofit/apiresult/ApiResultCall.kt
@@ -34,12 +34,12 @@ internal class ApiResultCall<T : Any>(
             override fun onResponse(call: Call<T>, response: Response<T>) {
                 callback.onResponse(
                     this@ApiResultCall,
-                    Response.success(ApiResult.from(response, successType)),
+                    Response.success(ApiResult.from(call.request(), response, successType)),
                 )
             }
 
             override fun onFailure(call: Call<T>, throwable: Throwable) {
-                val err: ApiResult<T> = Err(ApiError.from(throwable))
+                val err: ApiResult<T> = Err(ApiError.from(call.request(), throwable))
 
                 callback.onResponse(this@ApiResultCall, Response.success(err))
             }

--- a/core/network/src/main/kotlin/app/pachli/core/network/retrofit/apiresult/SyncApiResultCallAdapter.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/retrofit/apiresult/SyncApiResultCallAdapter.kt
@@ -36,9 +36,9 @@ internal class SyncApiResultCallAdapter<T : Any>(
 
     override fun adapt(call: Call<T>): ApiResult<T> {
         return try {
-            ApiResult.from(call.execute(), successType)
+            ApiResult.from(call.request(), call.execute(), successType)
         } catch (e: Exception) {
-            Err(ApiError.from(e))
+            Err(ApiError.from(call.request(), e))
         }
     }
 }

--- a/core/network/src/test/kotlin/app/pachli/core/network/retrofit/apiresult/ApiResultCallAdapterFactoryTest.kt
+++ b/core/network/src/test/kotlin/app/pachli/core/network/retrofit/apiresult/ApiResultCallAdapterFactoryTest.kt
@@ -10,7 +10,7 @@ import retrofit2.Call
 import retrofit2.Retrofit
 
 class ApiResultCallAdapterFactoryTest {
-    private val retrofit = Retrofit.Builder().baseUrl("http://example.com").build()
+    private val retrofit = Retrofit.Builder().baseUrl("https://example.com").build()
 
     @OptIn(ExperimentalStdlibApi::class)
     @Test

--- a/core/network/src/test/kotlin/app/pachli/core/network/retrofit/apiresult/TestCall.kt
+++ b/core/network/src/test/kotlin/app/pachli/core/network/retrofit/apiresult/TestCall.kt
@@ -28,7 +28,7 @@ class TestCall<T> : Call<T> {
     private var executed = false
     private var canceled = false
     private var callback: Callback<T>? = null
-    private var request = Request.Builder().url("http://example.com").build()
+    private var request = Request.Builder().url("https://example.com").build()
 
     fun completeWithException(t: Throwable) {
         synchronized(this) {

--- a/core/testing/src/main/kotlin/app/pachli/core/testing/ApiResult.kt
+++ b/core/testing/src/main/kotlin/app/pachli/core/testing/ApiResult.kt
@@ -25,6 +25,7 @@ import com.github.michaelbull.result.Ok
 import okhttp3.Headers
 import okhttp3.Protocol
 import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.ResponseBody.Companion.toResponseBody
 import retrofit2.HttpException
 import retrofit2.Response
@@ -45,11 +46,30 @@ fun <T> success(data: T, code: Int = 200, vararg headers: String): ApiResult<T> 
  * failure.
  *
  * @param code HTTP failure code.
- * @param body Data to use as the HTTP response body.
+ * @param responseBody Data to use as the HTTP response body.
  * @param message (optional) String to use as the HTTP status message.
+ * @param method (optional) String to use as the request method
+ * @param url (optional) String to use as the request URL
+ * @param requestBody (optional) String to use as the request body
  */
-fun <T> failure(code: Int = 404, body: String = "", message: String = code.httpStatusMessage()): ApiResult<T> =
-    Err(ApiError.from(HttpException(jsonError(code, body, message))))
+fun <T> failure(
+    code: Int = 404,
+    responseBody: String = "",
+    message: String = code.httpStatusMessage(),
+    method: String = "GET",
+    url: String = "https://example.com",
+    requestBody: String? = null,
+): ApiResult<T> {
+    return Err(
+        ApiError.from(
+            Request.Builder()
+                .method(method, requestBody?.toRequestBody())
+                .url(url)
+                .build(),
+            HttpException(jsonError(code, responseBody, message)),
+        ),
+    )
+}
 
 /**
  * Equivalent to [Response.error] with the content-type set to `application/json`.


### PR DESCRIPTION
Append the request method ("GET", etc) and the request URL to error messages in ApiResult errors. This should provide additional inforamtion when debugging issues reported by users.