### PR TITLE
feat: Show link title when viewing posts about a trending link

### DIFF
--- a/app/src/main/java/app/pachli/TabViewData.kt
+++ b/app/src/main/java/app/pachli/TabViewData.kt
@@ -161,7 +161,13 @@ data class TabViewData(
                 icon = R.drawable.ic_favourite_filled_24dp,
                 fragment = { TimelineFragment.newInstance(pachliAccountId, timeline) },
             )
-            is Timeline.Link -> throw IllegalArgumentException("can't add to tab: $timeline")
+            is Timeline.Link -> TabViewData(
+                timeline = timeline,
+                text = -1,
+                icon = R.drawable.ic_newspaper_24,
+                fragment = {TimelineFragment.newInstance(pachliAccountId, timeline) },
+                title = { timeline.title }
+            )
             is Timeline.User.Pinned -> throw IllegalArgumentException("can't add to tab: $timeline")
             is Timeline.User.Posts -> throw IllegalArgumentException("can't add to tab: $timeline")
             is Timeline.User.Replies -> throw IllegalArgumentException("can't add to tab: $timeline")

--- a/app/src/main/java/app/pachli/TimelineActivity.kt
+++ b/app/src/main/java/app/pachli/TimelineActivity.kt
@@ -101,23 +101,23 @@ class TimelineActivity : BottomSheetActivity(), AppBarLayoutHost, ActionButtonAc
         timeline = TimelineActivityIntent.getTimeline(intent)
         hashtag = (timeline as? Timeline.Hashtags)?.tags?.firstOrNull()
 
-        val viewData = TabViewData.from(intent.pachliAccountId, timeline)
+        val tabViewData = TabViewData.from(intent.pachliAccountId, timeline)
 
         supportActionBar?.run {
-            title = viewData.title(this@TimelineActivity)
+            title = tabViewData.title(this@TimelineActivity)
             setDisplayHomeAsUpEnabled(true)
             setDisplayShowHomeEnabled(true)
         }
 
         if (supportFragmentManager.findFragmentById(R.id.fragmentContainer) == null) {
             supportFragmentManager.commit {
-                val fragment = viewData.fragment()
+                val fragment = tabViewData.fragment()
                 replace(R.id.fragmentContainer, fragment)
                 binding.composeButton.show()
             }
         }
 
-        viewData.composeIntent?.let { intent ->
+        tabViewData.composeIntent?.let { intent ->
             binding.composeButton.setOnClickListener {
                 startActivity(
                     intent(
@@ -158,8 +158,10 @@ class TimelineActivity : BottomSheetActivity(), AppBarLayoutHost, ActionButtonAc
 
     override fun onPrepareMenu(menu: Menu) {
         // Check if this timeline is in a tab; if not, enable the add_to_tab menu item
+        // Timeline.Link (all posts about a specific link) is special-cased to not be
+        // addable to a tab)
         val currentTabs = accountManager.activeAccount?.tabPreferences.orEmpty()
-        val hideMenu = currentTabs.contains(timeline)
+        val hideMenu = timeline is Timeline.Link || currentTabs.contains(timeline)
         menu.findItem(R.id.action_add_to_tab)?.setVisible(!hideMenu)
     }
 

--- a/app/src/main/java/app/pachli/components/trending/TrendingLinksFragment.kt
+++ b/app/src/main/java/app/pachli/components/trending/TrendingLinksFragment.kt
@@ -279,6 +279,7 @@ class TrendingLinksFragment :
                     requireContext(),
                     pachliAccountId,
                     card.url,
+                    card.title
                 )
                 startActivity(intent)
             }

--- a/core/model/src/main/kotlin/app/pachli/core/model/Timeline.kt
+++ b/core/model/src/main/kotlin/app/pachli/core/model/Timeline.kt
@@ -112,11 +112,11 @@ sealed interface Timeline : Parcelable {
     @TypeLabel("trending_statuses")
     data object TrendingStatuses : Timeline
 
-    /** Timeline of statuses that mention [url]. */
+    /** Timeline of statuses that mention [url] (which has [title]). */
     @Parcelize
     @TypeLabel("link")
     @JsonClass(generateAdapter = true)
-    data class Link(val url: String) : Timeline
+    data class Link(val url: String, val title: String) : Timeline
 
     // TODO: DRAFTS
 

--- a/core/navigation/src/main/kotlin/app/pachli/core/navigation/Navigation.kt
+++ b/core/navigation/src/main/kotlin/app/pachli/core/navigation/Navigation.kt
@@ -589,10 +589,11 @@ class TimelineActivityIntent private constructor(context: Context, pachliAccount
          * Show statuses that reference a trending link.
          *
          * @param context
-         *
+         * @param url URL of trending link.
+         * @param title URL's title.
          */
-        fun link(context: Context, pachliAccountId: Long, url: String) = TimelineActivityIntent(context, pachliAccountId).apply {
-            putExtra(EXTRA_TIMELINE, Timeline.Link(url))
+        fun link(context: Context, pachliAccountId: Long, url: String,title: String) = TimelineActivityIntent(context, pachliAccountId).apply {
+            putExtra(EXTRA_TIMELINE, Timeline.Link(url, title))
         }
 
         /**


### PR DESCRIPTION
Previous code inadvertently crashed when the user clicekd on a trending link count to see statuses about the link.

Don't do that. Instead, show the statuses that mention the link, and show the link's title in the actionbar to make it more explicit for the user.

Special-case this timeline type in TimelineActivity so it can't be added to a tab (it would be difficult to distinguish it amongst tabs as they would have the same icon).