### PR TITLE
fix: Show bold text correctly in many locales

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -312,20 +312,20 @@
     <string name="poll_ended_created">لقد انتهى استطلاع رأي قمتَ بإنشائه</string>
     <string name="pref_title_notification_filter_poll">تنتهي استطلاعات الرأي</string>
     <plurals name="favs">
-        <item quantity="zero"><b>%1$s</b> مفضلة</item>
-        <item quantity="one"><b>%1$s</b> مفضلة</item>
-        <item quantity="two"><b>%1$s</b> مفضلتين</item>
-        <item quantity="few"><b>%1$s</b> مفضلة</item>
-        <item quantity="many"><b>%1$s</b> مفضلات</item>
-        <item quantity="other"><b>%1$s</b> مفضلات</item>
+        <item quantity="zero">&lt;b>%1$s&lt;/b> مفضلة</item>
+        <item quantity="one">&lt;b>%1$s&lt;/b> مفضلة</item>
+        <item quantity="two">&lt;b>%1$s&lt;/b> مفضلتين</item>
+        <item quantity="few">&lt;b>%1$s&lt;/b> مفضلة</item>
+        <item quantity="many">&lt;b>%1$s&lt;/b> مفضلات</item>
+        <item quantity="other">&lt;b>%1$s&lt;/b> مفضلات</item>
     </plurals>
     <plurals name="reblogs">
-        <item quantity="zero"><b>%s</b> مشاركة</item>
-        <item quantity="one"><b>%s</b> مشاركة</item>
-        <item quantity="two"><b>%s</b> مشاركتين</item>
-        <item quantity="few"><b>%s</b> مشاركات</item>
-        <item quantity="many"><b>%s</b> مشاركات</item>
-        <item quantity="other"><b>%s</b> مشاركات</item>
+        <item quantity="zero">&lt;b>%s&lt;/b> مشاركة</item>
+        <item quantity="one">&lt;b>%s&lt;/b> مشاركة</item>
+        <item quantity="two">&lt;b>%s&lt;/b> مشاركتين</item>
+        <item quantity="few">&lt;b>%s&lt;/b> مشاركات</item>
+        <item quantity="many">&lt;b>%s&lt;/b> مشاركات</item>
+        <item quantity="other">&lt;b>%s&lt;/b> مشاركات</item>
     </plurals>
     <string name="pref_title_bot_overlay">إظهار علامة البوتات</string>
     <plurals name="poll_timespan_days">

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -320,10 +320,10 @@
     <string name="send_post_notification_channel_name">Дасыланне допісаў</string>
     <string name="later">Пазней</string>
     <plurals name="favs">
-        <item quantity="one"><b>%1$s</b> абраны</item>
-        <item quantity="few"><b>%1$s</b> абраныя</item>
-        <item quantity="many"><b>%1$s</b> абраных</item>
-        <item quantity="other"><b>%1$s</b> абраных</item>
+        <item quantity="one">&lt;b>%1$s&lt;/b> абраны</item>
+        <item quantity="few">&lt;b>%1$s&lt;/b> абраныя</item>
+        <item quantity="many">&lt;b>%1$s&lt;/b> абраных</item>
+        <item quantity="other">&lt;b>%1$s&lt;/b> абраных</item>
     </plurals>
     <string name="title_reblogged_by">Пашырылі</string>
     <string name="profile_metadata_label">Метазвесткі профілю</string>
@@ -349,10 +349,10 @@
     <string name="pref_title_absolute_time">Паказваць абсалютны час</string>
     <string name="label_remote_account">Інфармацыя ніжэй можа не паказваць поўны профіль карыстальніка. Націсніце, каб адкрыць поўны профіль у браўзеры.</string>
     <plurals name="reblogs">
-        <item quantity="one"><b>%s</b> пашыраны</item>
-        <item quantity="few"><b>%s</b> пашырана</item>
-        <item quantity="many"><b>%s</b> пашыраных</item>
-        <item quantity="other"><b>%s</b> пашыраных</item>
+        <item quantity="one">&lt;b>%s&lt;/b> пашыраны</item>
+        <item quantity="few">&lt;b>%s&lt;/b> пашырана</item>
+        <item quantity="many">&lt;b>%s&lt;/b> пашыраных</item>
+        <item quantity="other">&lt;b>%s&lt;/b> пашыраных</item>
     </plurals>
     <string name="unsaved_changes">У Вас засталіся незахаваныя змены.</string>
     <string name="expand_collapse_all_posts">Разгарнуць/згарнуць допісы</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -337,8 +337,8 @@
     <string name="error_no_web_browser_found">ব্যবহার করার জন্য একটি ওয়েব ব্রাউজার খুঁজে পাওয়া যায়নি।</string>
     <string name="error_empty">এই জায়গা খালি হতে পারে না।</string>
     <plurals name="favs">
-        <item quantity="one"><b>%1$s</b>টি পছন্দ</item>
-        <item quantity="other"><b>%1$s</b>টি পছন্দ</item>
+        <item quantity="one">&lt;b>%1$s&lt;/b>টি পছন্দ</item>
+        <item quantity="other">&lt;b>%1$s&lt;/b>টি পছন্দ</item>
     </plurals>
     <string name="confirmation_domain_unmuted">%s দৃশ্যমান</string>
     <string name="notification_subscription_format">%s পোস্ট করেছে</string>
@@ -407,8 +407,8 @@
     <string name="action_subscribe_account">সদস্যতা</string>
     <string name="action_unsubscribe_account">সদস্যতা বাতিল</string>
     <plurals name="reblogs">
-        <item quantity="one"><b>%s</b> বুস্ট</item>
-        <item quantity="other"><b>%s</b> বুস্ট</item>
+        <item quantity="one">&lt;b>%s&lt;/b> বুস্ট</item>
+        <item quantity="other">&lt;b>%s&lt;/b> বুস্ট</item>
     </plurals>
     <string name="account_moved_description">%1$s স্থানান্তরিত হয়েছে এখানে:</string>
     <string name="post_media_attachments">সংযুক্তি</string>

--- a/app/src/main/res/values-bn-rIN/strings.xml
+++ b/app/src/main/res/values-bn-rIN/strings.xml
@@ -265,12 +265,12 @@
     <string name="unpin_action">আনপিন</string>
     <string name="pin_action">পিন</string>
     <plurals name="favs">
-        <item quantity="one"><b>%1$s</b> প্রিয়</item>
-        <item quantity="other"><b>%1$s</b> পছন্দসই</item>
+        <item quantity="one">&lt;b>%1$s&lt;/b> প্রিয়</item>
+        <item quantity="other">&lt;b>%1$s&lt;/b> পছন্দসই</item>
     </plurals>
     <plurals name="reblogs">
-        <item quantity="one"><b>%s</b> বুস্ট</item>
-        <item quantity="other"><b>%s</b> বুস্ট</item>
+        <item quantity="one">&lt;b>%s&lt;/b> বুস্ট</item>
+        <item quantity="other">&lt;b>%s&lt;/b> বুস্ট</item>
     </plurals>
     <string name="title_reblogged_by">দ্বারা সর্মথন</string>
     <string name="title_favourited_by">দ্বারা পছন্দ</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -259,12 +259,12 @@
     <string name="pref_title_absolute_time">Utilitzar el temps absolut</string>
     <string name="label_remote_account">La informació de sota pot mostrar el perfil incomplert de l\'usuari. Clica per obrir el perfil complert al navegador.</string>
     <plurals name="favs">
-        <item quantity="one"><b>%1$s</b> Favorit</item>
-        <item quantity="other"><b>%1$s</b> Favorits</item>
+        <item quantity="one">&lt;b>%1$s&lt;/b> Favorit</item>
+        <item quantity="other">&lt;b>%1$s&lt;/b> Favorits</item>
     </plurals>
     <plurals name="reblogs">
-        <item quantity="one"><b>%s</b> impuls</item>
-        <item quantity="other"><b>%s</b> impulsos</item>
+        <item quantity="one">&lt;b>%s&lt;/b> impuls</item>
+        <item quantity="other">&lt;b>%s&lt;/b> impulsos</item>
     </plurals>
     <string name="title_reblogged_by">Impulsat per</string>
     <string name="title_favourited_by">Marcat favorit per</string>

--- a/app/src/main/res/values-ckb/strings.xml
+++ b/app/src/main/res/values-ckb/strings.xml
@@ -287,12 +287,12 @@
     <string name="title_favourited_by">پەسەندکراوە لەلایەن</string>
     <string name="title_reblogged_by">پۆست کراوەتەوە لەلایەن</string>
     <plurals name="reblogs">
-        <item quantity="one"><b>%s</b> پۆستکردنەوە</item>
-        <item quantity="other"><b>%s</b> پۆستکردنەوە</item>
+        <item quantity="one">&lt;b>%s&lt;/b> پۆستکردنەوە</item>
+        <item quantity="other">&lt;b>%s&lt;/b> پۆستکردنەوە</item>
     </plurals>
     <plurals name="favs">
-        <item quantity="one"><b>%1$s</b> دڵخواز</item>
-        <item quantity="other"><b>%1$s</b> دڵخواز</item>
+        <item quantity="one">&lt;b>%1$s&lt;/b> دڵخواز</item>
+        <item quantity="other">&lt;b>%1$s&lt;/b> دڵخواز</item>
     </plurals>
     <string name="pin_action">Pin</string>
     <string name="unpin_action">لابردن</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -264,14 +264,14 @@
     <string name="unpin_action">Odepnout</string>
     <string name="pin_action">Připnout</string>
     <plurals name="favs">
-        <item quantity="one"><b>%1$s</b> oblíbení</item>
-        <item quantity="few"><b>%1$s</b> oblíbení</item>
-        <item quantity="other"><b>%1$s</b> oblíbení</item>
+        <item quantity="one">&lt;b>%1$s&lt;/b> oblíbení</item>
+        <item quantity="few">&lt;b>%1$s&lt;/b> oblíbení</item>
+        <item quantity="other">&lt;b>%1$s&lt;/b> oblíbení</item>
     </plurals>
     <plurals name="reblogs">
-        <item quantity="one"><b>%s</b> boost</item>
-        <item quantity="few"><b>%s</b> boosty</item>
-        <item quantity="other"><b>%s</b> boostů</item>
+        <item quantity="one">&lt;b>%s&lt;/b> boost</item>
+        <item quantity="few">&lt;b>%s&lt;/b> boosty</item>
+        <item quantity="other">&lt;b>%s&lt;/b> boostů</item>
     </plurals>
     <string name="title_reblogged_by">Boostnuto uživatelem</string>
     <string name="title_favourited_by">Oblíbeno uživatelem</string>

--- a/app/src/main/res/values-cy/strings.xml
+++ b/app/src/main/res/values-cy/strings.xml
@@ -384,12 +384,12 @@
     <string name="mute_domain_warning">Ydych chi\'n siŵr yr hoffech chi flocio %s gyfan\? Fyddwch chi ddim yn gweld dim cynnwys o\'r parth hwnnw mewn unrhyw ffrwd gyhoeddus na chwaith yn eich hysbysiadau. Bydd eich dilynwyr o\'r parth hwnnw yn cael eu dileu.</string>
     <string name="duration_indefinite">Dim diwedd</string>
     <plurals name="favs">
-        <item quantity="zero"><b>%1$s</b> Ffefryn</item>
-        <item quantity="one"><b>%1$s</b> Ffefryn</item>
-        <item quantity="two"><b>%1$s</b> Ffefryn</item>
-        <item quantity="few"><b>%1$s</b> Ffefryn</item>
-        <item quantity="many"><b>%1$s</b> Ffefryn</item>
-        <item quantity="other"><b>%1$s</b> Ffefryn</item>
+        <item quantity="zero">&lt;b>%1$s&lt;/b> Ffefryn</item>
+        <item quantity="one">&lt;b>%1$s&lt;/b> Ffefryn</item>
+        <item quantity="two">&lt;b>%1$s&lt;/b> Ffefryn</item>
+        <item quantity="few">&lt;b>%1$s&lt;/b> Ffefryn</item>
+        <item quantity="many">&lt;b>%1$s&lt;/b> Ffefryn</item>
+        <item quantity="other">&lt;b>%1$s&lt;/b> Ffefryn</item>
     </plurals>
     <string name="description_visibility_direct">Uniongyrchol</string>
     <string name="compose_save_draft_loses_media">Cadw drafft? (Bydd atodiadau\'n cael eu lanlwytho eto pan fyddwch chi\'n adfer y drafft.)</string>
@@ -425,12 +425,12 @@
     <string name="notification_report_name">Adroddiadau</string>
     <string name="label_remote_account">Gall y wybodaeth isod adlewyrchu proffil y defnyddiwr yn anghyflawn. Pwyswch i agor proffil llawn yn y porwr.</string>
     <plurals name="reblogs">
-        <item quantity="zero"><b>%s</b> Hybiau</item>
-        <item quantity="one"><b>%s</b> Hwb</item>
-        <item quantity="two"><b>%s</b> Hwb</item>
-        <item quantity="few"><b>%s</b> Hwb</item>
-        <item quantity="many"><b>%s</b> Hwb</item>
-        <item quantity="other"><b>%s</b> Hwb</item>
+        <item quantity="zero">&lt;b>%s&lt;/b> Hybiau</item>
+        <item quantity="one">&lt;b>%s&lt;/b> Hwb</item>
+        <item quantity="two">&lt;b>%s&lt;/b> Hwb</item>
+        <item quantity="few">&lt;b>%s&lt;/b> Hwb</item>
+        <item quantity="many">&lt;b>%s&lt;/b> Hwb</item>
+        <item quantity="other">&lt;b>%s&lt;/b> Hwb</item>
     </plurals>
     <string name="conversation_1_recipients">%1$s</string>
     <string name="description_post_edited">Golygwyd</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -261,8 +261,8 @@
     <string name="action_open_reblogger">Autor*in des geteilten Beitrags öffnen</string>
     <string name="pref_title_public_filter_keywords">Öffentliche Timelines</string>
     <plurals name="favs">
-        <item quantity="one"><b>%1$s</b> Favorit</item>
-        <item quantity="other"><b>%1$s</b> Favoriten</item>
+        <item quantity="one">&lt;b>%1$s&lt;/b> Favorit</item>
+        <item quantity="other">&lt;b>%1$s&lt;/b> Favoriten</item>
     </plurals>
     <string name="title_reblogged_by">Geteilt von</string>
     <string name="description_post_media">Medien: %s</string>
@@ -380,8 +380,8 @@
     <string name="pref_title_gradient_for_media">Farbverlauf für verborgene Medien anzeigen</string>
     <string name="action_unmute_domain">%s nicht mehr stummschalten</string>
     <plurals name="reblogs">
-        <item quantity="one"><b>%s</b>-mal geteilt</item>
-        <item quantity="other"><b>%s</b>-mal geteilt</item>
+        <item quantity="one">&lt;b>%s&lt;/b>-mal geteilt</item>
+        <item quantity="other">&lt;b>%s&lt;/b>-mal geteilt</item>
     </plurals>
     <string name="pref_main_nav_position">Position der Hauptnavigation</string>
     <string name="dialog_mute_hide_notifications">Benachrichtigungen ausblenden</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -244,14 +244,14 @@
     <string name="unpin_action">No fijar</string>
     <string name="pin_action">Fijar</string>
     <plurals name="favs">
-        <item quantity="one"><b>%1$s</b> Favorito</item>
-        <item quantity="many"><b>%1$s</b> Favoritos</item>
-        <item quantity="other"><b>%1$s</b> Favoritos</item>
+        <item quantity="one">&lt;b>%1$s&lt;/b> Favorito</item>
+        <item quantity="many">&lt;b>%1$s&lt;/b> Favoritos</item>
+        <item quantity="other">&lt;b>%1$s&lt;/b> Favoritos</item>
     </plurals>
     <plurals name="reblogs">
-        <item quantity="one"><b>%s</b> Impulso</item>
-        <item quantity="many"><b>%s</b> Impulsos</item>
-        <item quantity="other"><b>%s</b> Impulsos</item>
+        <item quantity="one">&lt;b>%s&lt;/b> Impulso</item>
+        <item quantity="many">&lt;b>%s&lt;/b> Impulsos</item>
+        <item quantity="other">&lt;b>%s&lt;/b> Impulsos</item>
     </plurals>
     <string name="title_reblogged_by">Impulsado por</string>
     <string name="title_favourited_by">Marcado como favorito por</string>
@@ -623,7 +623,7 @@
     <string name="notification_severed_relationships_user_domain_block_body">Bloqueaste el dominio</string>
     <string name="notification_severed_relationships_account_suspension_body">Un moderador suspendió la cuenta</string>
     <string name="notification_severed_relationships_unknown_body">Motivo desconocido</string>
-    <string name="notification_severed_relationships_format">Se rompió la relación con <b>%1$s</b></string>
+    <string name="notification_severed_relationships_format">Se rompió la relación con &lt;b>%1$s&lt;/b></string>
     <string name="notification_severed_relationships_name">Relaciones rotas</string>
     <string name="notification_severed_relationships_description">Notificaciones de relaciones rotas</string>
     <string name="poll_show_votes">Mostrar votos</string>
@@ -638,7 +638,7 @@
     <string name="error_media_uploader_upload_not_found_fmt">no se encontró la subida de medios con ID de %1$s</string>
     <string name="error_prepare_media_unknown_file_size">no se pudo determinar el tamaño del archivo</string>
     <string name="error_prepare_media_unknown_mime_type">se desconoce el tipo de archivo</string>
-    <string name="preview_card_byline_fediverse_account_fmt">Por <b>%1$s</b>. Ver más publicaciones</string>
+    <string name="preview_card_byline_fediverse_account_fmt">Por &lt;b>%1$s&lt;/b>. Ver más publicaciones</string>
     <string name="action_open_byline_account">Mostrar el perfil del autor del artículo</string>
     <string name="action_open_link">Abrir enlace</string>
     <string name="compose_warn_language_dialog_title">Comprueba el idioma de la publicación</string>
@@ -800,19 +800,19 @@
     <string name="pref_account_notification_filters_label_not_followed">… que no sigues</string>
     <string name="pref_account_notification_filters_label_younger_30d">… creadas en los últimos 30 días</string>
     <string name="pref_account_notification_filters_label_limited_by_server">… limitadas por tus moderadores</string>
-    <string name="account_filter_placeholder_type_favourite_fmt">Un usuario de <b>%1s</b> marcó como favorita tu publicación</string>
-    <string name="account_filter_placeholder_type_follow_request_fmt">Solicitud de seguimiento de un usuario de <b>%1s</b></string>
-    <string name="account_filter_placeholder_type_mention_fmt">Un usuario de <b>%1s</b> te mencionó</string>
-    <string name="account_filter_placeholder_type_reblog_fmt">Un usuario de <b>%1s</b> impulsó tu publicación</string>
-    <string name="account_filter_placeholder_label_domain">De un usuario de <b>%1s</b></string>
-    <string name="account_filter_placeholder_type_follow_fmt">Un usuario de <b>%1s</b> te siguió</string>
-    <string name="account_filter_placeholder_label_not_following">Filtrado porque: <b>no le sigues</b></string>
+    <string name="account_filter_placeholder_type_favourite_fmt">Un usuario de &lt;b>%1s&lt;/b> marcó como favorita tu publicación</string>
+    <string name="account_filter_placeholder_type_follow_request_fmt">Solicitud de seguimiento de un usuario de &lt;b>%1s&lt;/b></string>
+    <string name="account_filter_placeholder_type_mention_fmt">Un usuario de &lt;b>%1s&lt;/b> te mencionó</string>
+    <string name="account_filter_placeholder_type_reblog_fmt">Un usuario de &lt;b>%1s&lt;/b> impulsó tu publicación</string>
+    <string name="account_filter_placeholder_label_domain">De un usuario de &lt;b>%1s&lt;/b></string>
+    <string name="account_filter_placeholder_type_follow_fmt">Un usuario de &lt;b>%1s&lt;/b> te siguió</string>
+    <string name="account_filter_placeholder_label_not_following">Filtrado porque: &lt;b>no le sigues&lt;/b></string>
     <string name="notification_unknown">Tipo de notificación desconocido</string>
     <string name="pref_account_notification_filters_subtitle">Qué debería ocurrir con las notificaciones de cuentas…</string>
     <string name="pref_title_account_notification_filters">Filtros de notificaciones</string>
-    <string name="preview_card_byline_name_only_fmt">Por <b>%1$s</b></string>
+    <string name="preview_card_byline_name_only_fmt">Por &lt;b>%1$s&lt;/b></string>
     <string name="action_timeline_link">Publicaciones acerca de este enlace</string>
-    <string name="account_filter_placeholder_label_younger_30d">Filtrado porque: <b>creada en los últimos 30 días</b></string>
-    <string name="account_filter_placeholder_label_limited_by_server">Filtrado porque: <b>limitada por tus moderadores</b></string>
-    <string name="preview_card_timeline_link_fmt">Ver <b>%1$s</b> publicaciones sobre este enlace</string>
+    <string name="account_filter_placeholder_label_younger_30d">Filtrado porque: &lt;b>creada en los últimos 30 días&lt;/b></string>
+    <string name="account_filter_placeholder_label_limited_by_server">Filtrado porque: &lt;b>limitada por tus moderadores&lt;/b></string>
+    <string name="preview_card_timeline_link_fmt">Ver &lt;b>%1$s&lt;/b> publicaciones sobre este enlace</string>
 </resources>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -278,12 +278,12 @@
     <string name="filter_dialog_whole_word_description">Gako-hitza edo esaldia alfanumerikoa denean bakarrik, hitz osoarekin bat datorrenean bakarrik aplikatuko da</string>
     <string name="filter_add_description">Iragazteko esaldia</string>
     <plurals name="favs">
-        <item quantity="one">Gogoko <b>%1$s</b></item>
-        <item quantity="other"><b>%1$s</b> Gogoko</item>
+        <item quantity="one">Gogoko &lt;b>%1$s&lt;/b></item>
+        <item quantity="other">&lt;b>%1$s&lt;/b> Gogoko</item>
     </plurals>
     <plurals name="reblogs">
-        <item quantity="one">Bultzada <b>%s</b></item>
-        <item quantity="other"><b>%s</b> Bultzada</item>
+        <item quantity="one">Bultzada &lt;b>%s&lt;/b></item>
+        <item quantity="other">&lt;b>%s&lt;/b> Bultzada</item>
     </plurals>
     <string name="title_reblogged_by">Bultzatuta</string>
     <string name="title_favourited_by">Gogokoa</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -272,12 +272,12 @@
     <string name="filter_dialog_update_button">به‌روز رسانی</string>
     <string name="filter_dialog_whole_word">تمام واژه</string>
     <plurals name="favs">
-        <item quantity="one"><b>%1$s</b> برگزیدن</item>
-        <item quantity="other"><b>%1$s</b> برگزیدن</item>
+        <item quantity="one">&lt;b>%1$s&lt;/b> برگزیدن</item>
+        <item quantity="other">&lt;b>%1$s&lt;/b> برگزیدن</item>
     </plurals>
     <plurals name="reblogs">
-        <item quantity="one"><b>%s</b> تقویت</item>
-        <item quantity="other"><b>%s</b> تقویت</item>
+        <item quantity="one">&lt;b>%s&lt;/b> تقویت</item>
+        <item quantity="other">&lt;b>%s&lt;/b> تقویت</item>
     </plurals>
     <string name="title_reblogged_by">تقویت‌شده به دست</string>
     <string name="title_favourited_by">برگزیده به دست</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -526,8 +526,8 @@
     <string name="description_browser_login">Saattaa tukea muita tunnistautumistapoja, mutta vaatii tuetun verkkoselaimen.</string>
     <string name="report_description_1">Raportti lähetetään palvelimesi moderaattorille. Alla voit selittää miksi raportoit tämän tilin:</string>
     <plurals name="reblogs">
-        <item quantity="one"><b>%s</b> Tehostus</item>
-        <item quantity="other"><b>%s</b> Tehostusta</item>
+        <item quantity="one">&lt;b>%s&lt;/b> Tehostus</item>
+        <item quantity="other">&lt;b>%s&lt;/b> Tehostusta</item>
     </plurals>
     <string name="failed_report">Raportointi epäonnistui</string>
     <string name="description_login">Toimii yleensä. Dataa ei vuoda muihin sovelluksiin.</string>
@@ -587,8 +587,8 @@
     <string name="poll_ended_created">Kysely jonka olet luonut on päättynyt</string>
     <string name="description_post_bookmarked">Kirjanmerkki lisätty</string>
     <plurals name="favs">
-        <item quantity="one"><b>%1$s</b> Tykkäys</item>
-        <item quantity="other"><b>%1$s</b> Tykkäystä</item>
+        <item quantity="one">&lt;b>%1$s&lt;/b> Tykkäys</item>
+        <item quantity="other">&lt;b>%1$s&lt;/b> Tykkäystä</item>
     </plurals>
     <string name="description_poll">Kysely jossa vaihtoehdot: %1$s, %2$s, %3$s, %4$s, %5$s</string>
     <string name="duration_no_change">(Ei muutosta)</string>
@@ -608,7 +608,7 @@
     <string name="action_manage_tabs">Hallinnoi välilehtiä</string>
     <string name="action_remove_tab">Poista välilehti</string>
     <string name="notification_severed_relationships_domain_block_body">Moderaattori esti verkkotunnuksen</string>
-    <string name="notification_severed_relationships_format">Yhteys katkaistu: <b>%1$s </b></string>
+    <string name="notification_severed_relationships_format">Yhteys katkaistu: &lt;b>%1$s&lt;/b></string>
     <string name="notification_severed_relationships_user_domain_block_body">Estit verkkotunnuksen</string>
     <string name="notification_severed_relationships_account_suspension_body">Moderaattori esti tilin</string>
     <string name="notification_severed_relationships_unknown_body">Tuntematon syy</string>
@@ -628,7 +628,7 @@
     <string name="error_prepare_media_content_resolver_unsupported_scheme_fmt">sisältöselvittäjä-URI:n kaavaa ei tueta: %1$s</string>
     <string name="error_prepare_media_unknown_mime_type">tuntematon tiedostotyyppi</string>
     <string name="error_pick_media_fmt">Julkaisuun ei voitu liittää tiedostoa: %1$s</string>
-    <string name="preview_card_byline_fediverse_account_fmt">Teki <b>%1$s</b>. Katso lisää julkaisuja</string>
+    <string name="preview_card_byline_fediverse_account_fmt">Teki &lt;b>%1$s&lt;/b>. Katso lisää julkaisuja</string>
     <string name="action_open_byline_account">Näytä julkaisun tekijän profiili</string>
     <string name="action_open_link">Avaa linkki</string>
     <string name="error_prepare_media_unknown_file_size">tiedoston kokoa ei voitu määrittää</string>
@@ -764,9 +764,9 @@
     <string name="conversation_0_recipients">Ei muita osanottajia</string>
     <string name="compose_warn_language_dialog_accept_and_dont_ask_fmt">Julkaise muutoksetta (%1$s) äläkä kysy uudelleen</string>
     <string name="pref_title_confirm_status_language">Tarkasta julkaisun kieli ennen julkaisemista</string>
-    <string name="account_filter_placeholder_type_favourite_fmt">Käyttäjä @<b>%1s</b> merkitsi julkaisusi suosikiksi</string>
-    <string name="account_filter_placeholder_type_mention_fmt">Käyttäjä @<b>%1s</b> mainitsi sinut</string>
-    <string name="account_filter_placeholder_type_follow_request_fmt">Käyttäjä @<b>%1s</b> pyytää seuraamista</string>
+    <string name="account_filter_placeholder_type_favourite_fmt">Käyttäjä @&lt;b>%1s&lt;/b> merkitsi julkaisusi suosikiksi</string>
+    <string name="account_filter_placeholder_type_mention_fmt">Käyttäjä @&lt;b>%1s&lt;/b> mainitsi sinut</string>
+    <string name="account_filter_placeholder_type_follow_request_fmt">Käyttäjä @&lt;b>%1s&lt;/b> pyytää seuraamista</string>
     <string name="filter_action_none">Näytä</string>
     <string name="filter_description_none">Näytä kuten tavallisesti</string>
     <string name="pref_title_account_notification_filters">Ilmoitusten suodattimet</string>
@@ -774,9 +774,9 @@
     <string name="pref_account_notification_filters_label_not_followed">… joita et seuraa</string>
     <string name="pref_account_notification_filters_label_younger_30d">… jotka on luotu viimeisten 30 päivän aikana</string>
     <string name="pref_account_notification_filters_label_limited_by_server">… jotka moderaattorisi on rajoittanut</string>
-    <string name="account_filter_placeholder_type_follow_fmt">Käyttäjä @<b>%1s</b> seurasi sinua</string>
-    <string name="account_filter_placeholder_type_reblog_fmt">Käyttäjä @<b>%1s</b> tehosti julkaisuasi</string>
-    <string name="account_filter_placeholder_label_domain">Käyttäjältä @<b>%1s</b></string>
+    <string name="account_filter_placeholder_type_follow_fmt">Käyttäjä @&lt;b>%1s&lt;/b> seurasi sinua</string>
+    <string name="account_filter_placeholder_type_reblog_fmt">Käyttäjä @&lt;b>%1s&lt;/b> tehosti julkaisuasi</string>
+    <string name="account_filter_placeholder_label_domain">Käyttäjältä @&lt;b>%1s&lt;/b></string>
     <string name="account_filter_placeholder_label_not_following">Suodatettu koska: <b>et seuraa käyttäjää</b></string>
     <string name="account_filter_placeholder_label_younger_30d">Suodatettu koska: <b>luotu viimeisten 30 päivän aikana</b></string>
     <string name="account_filter_placeholder_label_limited_by_server">Suodatettu koska: <b>moderaattorisi rajoittama</b></string>
@@ -794,7 +794,7 @@
     <string name="action_relogin">Kirjaudu uudestaan</string>
     <string name="upload_failed_modify_attachment">Muokkaa liitettä</string>
     <string name="notification_unknown">Tuntematon ilmoitustyyppi</string>
-    <string name="preview_card_timeline_link_fmt">Katso <b>%1$s</b> julkaisua tästä linkistä</string>
+    <string name="preview_card_timeline_link_fmt">Katso &lt;b>%1$s&lt;/b> julkaisua tästä linkistä</string>
     <string name="action_timeline_link">Julkaisuja tästä linkistä</string>
-    <string name="preview_card_byline_name_only_fmt">Tehnyt <b>%1$s</b></string>
+    <string name="preview_card_byline_name_only_fmt">Tehnyt &lt;b>%1$s&lt;/b></string>
 </resources>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -353,7 +353,7 @@
     <string name="send_post_notification_error_title">Julkaisun lähettäminen epäonnistui</string>
     <string name="pref_title_notification_filter_follow_requests">seuraamista pyydetty</string>
     <string name="pref_title_notification_filters">Ilmoita kun</string>
-    <string name="status_filter_placeholder_label_format">Suodatettu: &lt;b&gt;%1$s&lt;/b&gt;</string>
+    <string name="status_filter_placeholder_label_format">Suodatettu: &lt;b>%1$s&lt;/b></string>
     <string name="pref_title_notification_filter_poll">päättyneet äänestykset</string>
     <string name="abbreviated_in_seconds">%ds</string>
     <string name="failed_to_unpin">Irrottaminen epäonnistui</string>
@@ -777,9 +777,9 @@
     <string name="account_filter_placeholder_type_follow_fmt">Käyttäjä @&lt;b>%1s&lt;/b> seurasi sinua</string>
     <string name="account_filter_placeholder_type_reblog_fmt">Käyttäjä @&lt;b>%1s&lt;/b> tehosti julkaisuasi</string>
     <string name="account_filter_placeholder_label_domain">Käyttäjältä @&lt;b>%1s&lt;/b></string>
-    <string name="account_filter_placeholder_label_not_following">Suodatettu koska: <b>et seuraa käyttäjää</b></string>
-    <string name="account_filter_placeholder_label_younger_30d">Suodatettu koska: <b>luotu viimeisten 30 päivän aikana</b></string>
-    <string name="account_filter_placeholder_label_limited_by_server">Suodatettu koska: <b>moderaattorisi rajoittama</b></string>
+    <string name="account_filter_placeholder_label_not_following">Suodatettu koska: &lt;b>et seuraa käyttäjää&lt;/b></string>
+    <string name="account_filter_placeholder_label_younger_30d">Suodatettu koska: &lt;b>luotu viimeisten 30 päivän aikana&lt;/b></string>
+    <string name="account_filter_placeholder_label_limited_by_server">Suodatettu koska: &lt;b>moderaattorisi rajoittama&lt;/b></string>
     <plurals name="notification_severed_relationships_summary_followers_fmt">
         <item quantity="one">%1$s seuraaja poistettu</item>
         <item quantity="other">%1$s seuraajaa poistettu</item>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -261,14 +261,14 @@
     <string name="unpin_action">Détacher</string>
     <string name="pin_action">Épingler</string>
     <plurals name="favs">
-        <item quantity="one"><b>%1$s</b> Favori</item>
-        <item quantity="many"><b>%1$s</b> de favoris</item>
-        <item quantity="other"><b>%1$s</b> Favoris</item>
+        <item quantity="one">&lt;b>%1$s&lt;/b> Favori</item>
+        <item quantity="many">&lt;b>%1$s&lt;/b> de favoris</item>
+        <item quantity="other">&lt;b>%1$s&lt;/b> Favoris</item>
     </plurals>
     <plurals name="reblogs">
-        <item quantity="one"><b>%s</b> Partage</item>
-        <item quantity="many"><b>%s</b> de partages</item>
-        <item quantity="other"><b>%s</b> Partages</item>
+        <item quantity="one">&lt;b>%s&lt;/b> Partage</item>
+        <item quantity="many">&lt;b>%s&lt;/b> de partages</item>
+        <item quantity="other">&lt;b>%s&lt;/b> Partages</item>
     </plurals>
     <string name="title_reblogged_by">Partagé par</string>
     <string name="title_favourited_by">Mis en favoris par</string>

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -817,8 +817,8 @@
     <string name="account_filter_placeholder_label_younger_30d">Scagtha toisc: &lt;b>cruthaithe le 30 lá anuas&lt;/b></string>
     <string name="account_filter_placeholder_type_reblog_fmt">Chuir úsáideoir @&lt;b>%1s&lt;/b> do phostáil chun cinn</string>
     <string name="account_filter_placeholder_label_domain">Ó úsáideoir @&lt;b>%1s&lt;/b></string>
-    <string name="account_filter_placeholder_label_not_following">Scagtha toisc: <b>ní leanann tú iad</b></string>
-    <string name="account_filter_placeholder_label_limited_by_server">Scagtha toisc: <b>teoranta ag do mhodhnóirí</b></string>
+    <string name="account_filter_placeholder_label_not_following">Scagtha toisc: &lt;b>ní leanann tú iad&lt;/b></string>
+    <string name="account_filter_placeholder_label_limited_by_server">Scagtha toisc: &lt;b>teoranta ag do mhodhnóirí&lt;/b></string>
     <string name="account_filter_placeholder_type_mention_fmt">Luaigh úsáideoir @ &lt;b>%1s&lt;/b> tú</string>
     <string name="pref_account_notification_filters_label_limited_by_server">… teoranta ag do mhodhnóirí</string>
     <string name="filter_action_none">Taispeáin</string>

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -292,18 +292,18 @@
     <string name="pref_title_absolute_time">Úsáid am iomlán</string>
     <string name="pin_action">Bioráin</string>
     <plurals name="favs">
-        <item quantity="one"><b>%1$s </b> Togha</item>
-        <item quantity="two"><b>%1$s</b> Toghanna</item>
-        <item quantity="few"><b>%1$s</b> Toghanna</item>
-        <item quantity="many"><b>%1$s</b> Toghanna</item>
-        <item quantity="other"><b>%1$s</b> Toghanna</item>
+        <item quantity="one">&lt;b>%1$s&lt;/b> Togha</item>
+        <item quantity="two">&lt;b>%1$s&lt;/b> Toghanna</item>
+        <item quantity="few">&lt;b>%1$s&lt;/b> Toghanna</item>
+        <item quantity="many">&lt;b>%1$s&lt;/b> Toghanna</item>
+        <item quantity="other">&lt;b>%1$s&lt;/b> Toghanna</item>
     </plurals>
     <plurals name="reblogs">
-        <item quantity="one"><b>%s</b> athchraoladh</item>
-        <item quantity="two"><b>%s</b> athchraolta</item>
-        <item quantity="few"><b>%s</b> athchraolta</item>
-        <item quantity="many"><b>%s</b> athchraolta</item>
-        <item quantity="other"><b>%s</b> athchraolta</item>
+        <item quantity="one">&lt;b>%s&lt;/b> athchraoladh</item>
+        <item quantity="two">&lt;b>%s&lt;/b> athchraolta</item>
+        <item quantity="few">&lt;b>%s&lt;/b> athchraolta</item>
+        <item quantity="many">&lt;b>%s&lt;/b> athchraolta</item>
+        <item quantity="other">&lt;b>%s&lt;/b> athchraolta</item>
     </plurals>
     <string name="title_reblogged_by">Athchraolta ag</string>
     <string name="title_favourited_by">Tofa ag</string>
@@ -642,7 +642,7 @@
     <string name="notification_listenable_worker_description">Fógraí nuair atá Pachli ag obair sa chúlra</string>
     <string name="post_media_audio">Fuaim</string>
     <string name="post_media_attachments">Ceangaltáin</string>
-    <string name="status_filter_placeholder_label_format">Scagtha: <b>%1$s</b></string>
+    <string name="status_filter_placeholder_label_format">Scagtha: &lt;b>%1$s&lt;/b></string>
     <string name="compose_save_draft_loses_media">Uaslódálfar ceangaltáin arís nuair a chuirfidh tú an dréacht ar ais.</string>
     <string name="update_dialog_title">Tá nuashonrú ar fáil</string>
     <string name="update_dialog_neutral">Ná cuir an leagan seo i gcuimhne dom</string>
@@ -665,7 +665,7 @@
     <string name="search_operator_where_dialog_public_hint">Poist phoiblí, inchuardaithe ar a dtugtar an freastalaí</string>
     <string name="pref_update_notification_frequency_once_per_version">Uair amháin in aghaidh an leagain</string>
     <string name="pref_update_notification_frequency_always">I gcónaí</string>
-    <string name="notification_severed_relationships_format">Scaradh an gaol le <b>%1$s</b></string>
+    <string name="notification_severed_relationships_format">Scaradh an gaol le &lt;b>%1$s&lt;/b></string>
     <string name="action_share_account_link">Comhroinn nasc chuig an gcuntas</string>
     <string name="pref_title_show_self_boosts_description">Duine éigin ag cur lena bpost féin</string>
     <string name="notification_prune_cache">Cothabháil taisce…</string>
@@ -812,17 +812,17 @@
     <string name="pref_title_account_notification_filters">Scagairí fógra</string>
     <string name="pref_account_notification_filters_subtitle">Cad ba cheart a tharlú d\'fhógraí ó chuntais…</string>
     <string name="pref_account_notification_filters_label_younger_30d">… a cruthaíodh le 30 lá anuas</string>
-    <string name="account_filter_placeholder_type_favourite_fmt">B\'fhearr le húsáideoir @<b>%1s</b> do phostáil</string>
-    <string name="account_filter_placeholder_type_follow_request_fmt">Lean iarratas ó úsáideoir @<b>%1s</b></string>
-    <string name="account_filter_placeholder_label_younger_30d">Scagtha toisc: <b>cruthaithe le 30 lá anuas</b></string>
-    <string name="account_filter_placeholder_type_reblog_fmt">Chuir úsáideoir @<b>%1s</b> do phostáil chun cinn</string>
-    <string name="account_filter_placeholder_label_domain">Ó úsáideoir @<b>%1s</b></string>
+    <string name="account_filter_placeholder_type_favourite_fmt">B\'fhearr le húsáideoir @&lt;b>%1s&lt;/b> do phostáil</string>
+    <string name="account_filter_placeholder_type_follow_request_fmt">Lean iarratas ó úsáideoir @&lt;b>%1s&lt;/b></string>
+    <string name="account_filter_placeholder_label_younger_30d">Scagtha toisc: &lt;b>cruthaithe le 30 lá anuas&lt;/b></string>
+    <string name="account_filter_placeholder_type_reblog_fmt">Chuir úsáideoir @&lt;b>%1s&lt;/b> do phostáil chun cinn</string>
+    <string name="account_filter_placeholder_label_domain">Ó úsáideoir @&lt;b>%1s&lt;/b></string>
     <string name="account_filter_placeholder_label_not_following">Scagtha toisc: <b>ní leanann tú iad</b></string>
     <string name="account_filter_placeholder_label_limited_by_server">Scagtha toisc: <b>teoranta ag do mhodhnóirí</b></string>
-    <string name="account_filter_placeholder_type_mention_fmt">Luaigh úsáideoir @ <b>%1s</b> tú</string>
+    <string name="account_filter_placeholder_type_mention_fmt">Luaigh úsáideoir @ &lt;b>%1s&lt;/b> tú</string>
     <string name="pref_account_notification_filters_label_limited_by_server">… teoranta ag do mhodhnóirí</string>
     <string name="filter_action_none">Taispeáin</string>
     <string name="pref_account_notification_filters_label_not_followed">… ní leanann tú</string>
-    <string name="account_filter_placeholder_type_follow_fmt">Lean úsáideoir @<b>%1s</b> tú</string>
+    <string name="account_filter_placeholder_type_follow_fmt">Lean úsáideoir @&lt;b>%1s&lt;/b> tú</string>
     <string name="notification_unknown">Cineál fógra anaithnid</string>
 </resources>

--- a/app/src/main/res/values-gd/strings.xml
+++ b/app/src/main/res/values-gd/strings.xml
@@ -174,16 +174,16 @@
     <string name="title_favourited_by">’Na annsachd aig</string>
     <string name="title_reblogged_by">’Ga brosnachadh le</string>
     <plurals name="reblogs">
-        <item quantity="one"><b>%s</b> bhrosnachadh</item>
-        <item quantity="two"><b>%s</b> bhrosnachadh</item>
-        <item quantity="few"><b>%s</b> brosnachaidhean</item>
-        <item quantity="other"><b>%s</b> brosnachadh</item>
+        <item quantity="one">&lt;b>%s&lt;/b> bhrosnachadh</item>
+        <item quantity="two">&lt;b>%s&lt;/b> bhrosnachadh</item>
+        <item quantity="few">&lt;b>%s&lt;/b> brosnachaidhean</item>
+        <item quantity="other">&lt;b>%s&lt;/b> brosnachadh</item>
     </plurals>
     <plurals name="favs">
-        <item quantity="one"><b>%1$s</b> annsachd</item>
-        <item quantity="two"><b>%1$s</b> annsachd</item>
-        <item quantity="few"><b>%1$s</b> annsachdan</item>
-        <item quantity="other"><b>%1$s</b> annsachd</item>
+        <item quantity="one">&lt;b>%1$s&lt;/b> annsachd</item>
+        <item quantity="two">&lt;b>%1$s&lt;/b> annsachd</item>
+        <item quantity="few">&lt;b>%1$s&lt;/b> annsachdan</item>
+        <item quantity="other">&lt;b>%1$s&lt;/b> annsachd</item>
     </plurals>
     <string name="pin_action">Prìnich</string>
     <string name="unpin_action">Dì-phrìnich</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -182,12 +182,12 @@
     <string name="title_favourited_by">Favorecido por</string>
     <string name="title_reblogged_by">Promovido por</string>
     <plurals name="reblogs">
-        <item quantity="one"><b>%s</b> Promoción</item>
-        <item quantity="other"><b>%s</b> Promocións</item>
+        <item quantity="one">&lt;b>%s&lt;/b> Promoción</item>
+        <item quantity="other">&lt;b>%s&lt;/b> Promocións</item>
     </plurals>
     <plurals name="favs">
-        <item quantity="one"><b>%1$s</b> Favorito</item>
-        <item quantity="other"><b>%1$s</b> Favoritos</item>
+        <item quantity="one">&lt;b>%1$s&lt;/b> Favorito</item>
+        <item quantity="other">&lt;b>%1$s&lt;/b> Favoritos</item>
     </plurals>
     <string name="pin_action">Fixar</string>
     <string name="unpin_action">Desafixar</string>
@@ -570,7 +570,7 @@
     <string name="action_suggestions">Contas suxeridas</string>
     <string name="title_public_trending">En voga</string>
     <string name="title_public_trending_links">Ligazóns populares</string>
-    <string name="notification_severed_relationships_format">Cortouse a relación con <b>%1$s</b></string>
+    <string name="notification_severed_relationships_format">Cortouse a relación con &lt;b>%1$s&lt;/b></string>
     <string name="notification_severed_relationships_domain_block_body">A moderación suspendeu o dominio</string>
     <string name="notification_severed_relationships_unknown_body">Razón descoñecida</string>
     <string name="action_translate">Traducir</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -236,8 +236,8 @@
     <string name="conversation_2_recipients">%1$s तथा %2$s</string>
     <string name="conversation_1_recipients">%1$s</string>
     <plurals name="reblogs">
-        <item quantity="one"><b>%s</b> ने बढ़ावा दिया</item>
-        <item quantity="other"><b>%s</b> ने बढ़ावा दिया</item>
+        <item quantity="one">&lt;b>%s&lt;/b> ने बढ़ावा दिया</item>
+        <item quantity="other">&lt;b>%s&lt;/b> ने बढ़ावा दिया</item>
     </plurals>
     <string name="pin_action">पिन</string>
     <string name="unpin_action">अनपिन</string>
@@ -327,8 +327,8 @@
     <string name="pref_title_show_boosts">बूस्ट दिखाएं</string>
     <string name="action_open_reblogged_by">बूस्ट दिखाएं</string>
     <plurals name="favs">
-        <item quantity="one"><b>%1$s</b> ने पसंद किया</item>
-        <item quantity="other"><b>%1$s</b> ने पसंद किया</item>
+        <item quantity="one">&lt;b>%1$s&lt;/b> ने पसंद किया</item>
+        <item quantity="other">&lt;b>%1$s&lt;/b> ने पसंद किया</item>
     </plurals>
     <plurals name="poll_timespan_seconds">
         <item quantity="one">%d सेकेंड शेष</item>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -280,8 +280,8 @@
     <string name="unpin_action">Kitűzés eltávolítása</string>
     <string name="pin_action">Kitűzés</string>
     <plurals name="favs">
-        <item quantity="one"><b>%1$s</b> Kedvenc</item>
-        <item quantity="other"><b>%1$s</b> Kedvenc</item>
+        <item quantity="one">&lt;b>%1$s&lt;/b> Kedvenc</item>
+        <item quantity="other">&lt;b>%1$s&lt;/b> Kedvenc</item>
     </plurals>
     <plurals name="reblogs">
         <item quantity="one">&lt;b&gt;%s&lt;/b&gt; Megtolás</item>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -341,12 +341,12 @@
     <string name="notification_follow_request_name">Fylgjendabeiðnir</string>
     <string name="hashtags">Myllumerki</string>
     <plurals name="favs">
-        <item quantity="one"><b>%1$s</b> eftirlæti</item>
-        <item quantity="other"><b>%1$s</b> eftirlæti</item>
+        <item quantity="one">&lt;b>%1$s&lt;/b> eftirlæti</item>
+        <item quantity="other">&lt;b>%1$s&lt;/b> eftirlæti</item>
     </plurals>
     <plurals name="reblogs">
-        <item quantity="one"><b>%s</b> Endurbirting</item>
-        <item quantity="other"><b>%s</b> Endurbirtingar</item>
+        <item quantity="one">&lt;b>%s&lt;/b> Endurbirting</item>
+        <item quantity="other">&lt;b>%s&lt;/b> Endurbirtingar</item>
     </plurals>
     <plurals name="poll_timespan_seconds">
         <item quantity="one">%d sekúnda eftir</item>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -277,14 +277,14 @@
     <string name="unpin_action">Non fissare in cima</string>
     <string name="pin_action">Fissa</string>
     <plurals name="favs">
-        <item quantity="one"><b>%1$s</b> Preferito</item>
-        <item quantity="many"><b>%1$s</b> Preferiti</item>
-        <item quantity="other"><b>%1$s</b> Preferiti</item>
+        <item quantity="one">&lt;b>%1$s&lt;/b> Preferito</item>
+        <item quantity="many">&lt;b>%1$s&lt;/b> Preferiti</item>
+        <item quantity="other">&lt;b>%1$s&lt;/b> Preferiti</item>
     </plurals>
     <plurals name="reblogs">
-        <item quantity="one"><b>%s</b> ricondivisione</item>
-        <item quantity="many"><b>%s</b> ricondivisioni</item>
-        <item quantity="other"><b>%s</b> ricondivisioni</item>
+        <item quantity="one">&lt;b>%s&lt;/b> ricondivisione</item>
+        <item quantity="many">&lt;b>%s&lt;/b> ricondivisioni</item>
+        <item quantity="other">&lt;b>%s&lt;/b> ricondivisioni</item>
     </plurals>
     <string name="title_reblogged_by">Condiviso da</string>
     <string name="title_favourited_by">Aggiunto ai post apprezzati da</string>

--- a/app/src/main/res/values-kab/strings.xml
+++ b/app/src/main/res/values-kab/strings.xml
@@ -34,8 +34,8 @@
     <string name="action_open_faved_by">Sken-d ismenyifen</string>
     <string name="notification_favourite_name">Ismenyifen</string>
     <plurals name="favs">
-        <item quantity="one"><b>%1$s</b> n usmenyaf</item>
-        <item quantity="other"><b>%1$s</b> n ismenyifen</item>
+        <item quantity="one">&lt;b>%1$s&lt;/b> n usmenyaf</item>
+        <item quantity="other">&lt;b>%1$s&lt;/b> n ismenyifen</item>
     </plurals>
     <string name="no_drafts">Ur tesɛiḍ ara irewwayen.</string>
     <string name="title_notifications">Tilɣa</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -273,7 +273,7 @@
     <string name="unpin_action">고정 해제</string>
     <string name="pin_action">고정</string>
     <plurals name="favs">
-        <item quantity="other"><b>%1$s</b> 좋아요</item>
+        <item quantity="other">&lt;b>%1$s&lt;/b> 좋아요</item>
     </plurals>
     <plurals name="reblogs">
         <item quantity="other">&lt;b&gt;%s&lt;/b&gt; 부스트</item>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -402,9 +402,9 @@
     <string name="lock_account_label_description">Prasa manuāli apstiprināt sekotājus</string>
     <string name="title_reblogged_by">Pastiprināja</string>
     <plurals name="reblogs">
-        <item quantity="zero"><b>%s</b> pastiprinājumi</item>
-        <item quantity="one"><b>%s</b> pastiprinājums</item>
-        <item quantity="other"><b>%s</b> pastiprinājumi</item>
+        <item quantity="zero">&lt;b>%s&lt;/b> pastiprinājumi</item>
+        <item quantity="one">&lt;b>%s&lt;/b> pastiprinājums</item>
+        <item quantity="other">&lt;b>%s&lt;/b> pastiprinājumi</item>
     </plurals>
     <string name="title_favourites">Izlases</string>
     <string name="notification_favourite_format">%s pievienoja tavu ierakstu izlasei</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -250,8 +250,8 @@
         <item quantity="other">&lt;b&gt;%1$s&lt;/b&gt; Favoritter</item>
     </plurals>
     <plurals name="reblogs">
-        <item quantity="one">Delt <b>%s</b> gang</item>
-        <item quantity="other">Delt <b>%s</b> ganger</item>
+        <item quantity="one">Delt &lt;b>%s&lt;/b> gang</item>
+        <item quantity="other">Delt &lt;b>%s&lt;/b> ganger</item>
     </plurals>
     <string name="title_reblogged_by">Delt av</string>
     <string name="title_favourited_by">Favorisert av</string>
@@ -602,7 +602,7 @@
     <string name="title_public_trending">Trendende</string>
     <string name="title_public_trending_statuses">Trendende innlegg</string>
     <string name="title_tab_public_trending_statuses">Innlegg</string>
-    <string name="notification_severed_relationships_format">Brøt forholdet med <b>%1$s</b></string>
+    <string name="notification_severed_relationships_format">Brøt forholdet med &lt;b>%1$s&lt;/b></string>
     <string name="notification_severed_relationships_unknown_body">Ukjent årsak</string>
     <string name="label_image">Bild</string>
     <string name="pref_title_font_family">Skriftfamilie</string>
@@ -784,17 +784,17 @@
     <string name="pref_account_notification_filters_label_not_followed">…du ikke følger</string>
     <string name="pref_account_notification_filters_label_younger_30d">…ble opprettet på de siste 30 dagene</string>
     <string name="pref_account_notification_filters_label_limited_by_server">…er begrenset av moderatorene dine</string>
-    <string name="account_filter_placeholder_type_favourite_fmt">En bruker (@<b>%1s</b>) favoriserte innlegget ditt</string>
+    <string name="account_filter_placeholder_type_favourite_fmt">En bruker (@&lt;b>%1s&lt;/b>) favoriserte innlegget ditt</string>
     <string name="account_filter_placeholder_label_younger_30d">Filtrert fordi: <b>kontoen ble opprettet på de siste 30 dagene</b></string>
     <string name="account_filter_placeholder_label_limited_by_server">Filtrert fordi: <b>kontoen er begrenset av moderatorene dine</b></string>
     <string name="notification_unknown">Ukjent varseltype</string>
     <string name="account_filter_placeholder_label_not_following">Filtrert fordi: <b>du følger hen ikke</b></string>
-    <string name="account_filter_placeholder_type_mention_fmt">En bruker (@<b>%1s</b>) nevnte deg</string>
-    <string name="account_filter_placeholder_type_reblog_fmt">En bruker (@<b>%1s</b>) delte innlegget ditt</string>
-    <string name="account_filter_placeholder_label_domain">Fra en bruker (@<b>%1s</b>)</string>
-    <string name="preview_card_timeline_link_fmt">Vis <b>%1$s</b> innlegg om denne lenken</string>
-    <string name="account_filter_placeholder_type_follow_fmt">En bruker (@<b>%1s</b>) fulgte deg</string>
-    <string name="account_filter_placeholder_type_follow_request_fmt">Følgeforespørsel fra en bruker (@<b>%1s</b>)</string>
-    <string name="preview_card_byline_name_only_fmt">Av <b>%1$s</b></string>
+    <string name="account_filter_placeholder_type_mention_fmt">En bruker (@&lt;b>%1s&lt;/b>) nevnte deg</string>
+    <string name="account_filter_placeholder_type_reblog_fmt">En bruker (@&lt;b>%1s&lt;/b>) delte innlegget ditt</string>
+    <string name="account_filter_placeholder_label_domain">Fra en bruker (@&lt;b>%1s&lt;/b>)</string>
+    <string name="preview_card_timeline_link_fmt">Vis &lt;b>%1$s&lt;/b> innlegg om denne lenken</string>
+    <string name="account_filter_placeholder_type_follow_fmt">En bruker (@&lt;b>%1s&lt;/b>) fulgte deg</string>
+    <string name="account_filter_placeholder_type_follow_request_fmt">Følgeforespørsel fra en bruker (@&lt;b>%1s&lt;/b>)</string>
+    <string name="preview_card_byline_name_only_fmt">Av &lt;b>%1$s&lt;/b></string>
     <string name="action_timeline_link">Innlegg om denne lenken</string>
 </resources>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -785,10 +785,10 @@
     <string name="pref_account_notification_filters_label_younger_30d">…ble opprettet på de siste 30 dagene</string>
     <string name="pref_account_notification_filters_label_limited_by_server">…er begrenset av moderatorene dine</string>
     <string name="account_filter_placeholder_type_favourite_fmt">En bruker (@&lt;b>%1s&lt;/b>) favoriserte innlegget ditt</string>
-    <string name="account_filter_placeholder_label_younger_30d">Filtrert fordi: <b>kontoen ble opprettet på de siste 30 dagene</b></string>
-    <string name="account_filter_placeholder_label_limited_by_server">Filtrert fordi: <b>kontoen er begrenset av moderatorene dine</b></string>
+    <string name="account_filter_placeholder_label_younger_30d">Filtrert fordi: &lt;b>kontoen ble opprettet på de siste 30 dagene&lt;/b></string>
+    <string name="account_filter_placeholder_label_limited_by_server">Filtrert fordi: &lt;b>kontoen er begrenset av moderatorene dine&lt;/b></string>
     <string name="notification_unknown">Ukjent varseltype</string>
-    <string name="account_filter_placeholder_label_not_following">Filtrert fordi: <b>du følger hen ikke</b></string>
+    <string name="account_filter_placeholder_label_not_following">Filtrert fordi: &lt;b>du følger hen ikke&lt;/b></string>
     <string name="account_filter_placeholder_type_mention_fmt">En bruker (@&lt;b>%1s&lt;/b>) nevnte deg</string>
     <string name="account_filter_placeholder_type_reblog_fmt">En bruker (@&lt;b>%1s&lt;/b>) delte innlegget ditt</string>
     <string name="account_filter_placeholder_label_domain">Fra en bruker (@&lt;b>%1s&lt;/b>)</string>

--- a/app/src/main/res/values-nn/strings.xml
+++ b/app/src/main/res/values-nn/strings.xml
@@ -68,7 +68,7 @@
     </plurals>
     <string name="notification_update_format">%s redigerte innlegget sitt</string>
     <string name="notification_report_format">Ny rapport på %s</string>
-    <string name="notification_severed_relationships_format">Braut forholdet med <b>%1$s</b></string>
+    <string name="notification_severed_relationships_format">Braut forholdet med &lt;b>%1$s&lt;/b></string>
     <string name="notification_severed_relationships_domain_block_body">Ein moderator suspenderte instansen</string>
     <string name="notification_severed_relationships_account_suspension_body">Ein moderator suspenderte kontoen</string>
     <string name="notification_severed_relationships_unknown_body">Ukjend årsak</string>
@@ -241,7 +241,7 @@
     <string name="status_count_one_plus">1+</string>
     <string name="status_created_at_now">no</string>
     <string name="status_filtered_show_anyway">Syn likevel</string>
-    <string name="status_filter_placeholder_label_format">Filtrert: <b>%1$s</b></string>
+    <string name="status_filter_placeholder_label_format">Filtrert: &lt;b>%1$s&lt;/b></string>
     <string name="state_follow_requested">Fylgjeførespurnad sende</string>
     <string name="abbreviated_in_years">om %då</string>
     <string name="abbreviated_in_days">om %dd</string>
@@ -406,12 +406,12 @@
     <string name="failed_to_pin">Festing mislykkast</string>
     <string name="failed_to_unpin">Lausning mislykkast</string>
     <plurals name="favs">
-        <item quantity="one"><b>%1$s</b> favorittmerking</item>
-        <item quantity="other"><b>%1$s</b> favorittmerkingar</item>
+        <item quantity="one">&lt;b>%1$s&lt;/b> favorittmerking</item>
+        <item quantity="other">&lt;b>%1$s&lt;/b> favorittmerkingar</item>
     </plurals>
     <plurals name="reblogs">
-        <item quantity="one"><b>%s</b> deling</item>
-        <item quantity="other"><b>%s</b> delingar</item>
+        <item quantity="one">&lt;b>%s&lt;/b> deling</item>
+        <item quantity="other">&lt;b>%s&lt;/b> delingar</item>
     </plurals>
     <string name="title_reblogged_by">Delt av</string>
     <string name="title_favourited_by">Favorittmerka av</string>
@@ -650,9 +650,9 @@
     <string name="error_prepare_media_content_resolver_unsupported_scheme_fmt">Innhaldsoppløser-URI har ustøtta skjema: %1$s</string>
     <string name="search_operator_attachment_none">Ingen</string>
     <string name="report_category_violation">Regelbrot</string>
-    <string name="preview_card_byline_fediverse_account_fmt">Av <b>%1$s</b>. Sjå fleire innlegg</string>
-    <string name="preview_card_byline_name_only_fmt">Av <b>%1$s</b></string>
-    <string name="preview_card_timeline_link_fmt">Syn <b>%1$s</b> innlegg om denne lenkja</string>
+    <string name="preview_card_byline_fediverse_account_fmt">Av &lt;b>%1$s&lt;/b>. Sjå fleire innlegg</string>
+    <string name="preview_card_byline_name_only_fmt">Av &lt;b>%1$s&lt;/b></string>
+    <string name="preview_card_timeline_link_fmt">Syn &lt;b>%1$s&lt;/b> innlegg om denne lenkja</string>
     <string name="action_timeline_link">Innlegg om denne lenkja</string>
     <string name="search_operator_from_me">Kun mine innlegg</string>
     <string name="search_operator_from_dialog_all">Alle kontoar</string>
@@ -759,16 +759,16 @@
     <string name="pref_account_notification_filters_label_not_followed">…du ikkje fylgjer</string>
     <string name="pref_account_notification_filters_label_younger_30d">…vart oppretta på dei siste 30 dagane</string>
     <string name="pref_account_notification_filters_label_limited_by_server">…er avgrensa av moderatorane dine</string>
-    <string name="account_filter_placeholder_type_follow_fmt">Ein brukar (@<b>%1s</b>) fylgde deg</string>
-    <string name="account_filter_placeholder_type_follow_request_fmt">Fylgjeførespurnad frå ein brukar (@<b>%1s</b>)</string>
-    <string name="account_filter_placeholder_type_mention_fmt">Ein brukar (@<b>%1s</b>) nemnde deg</string>
-    <string name="account_filter_placeholder_label_domain">Frå ein brukar (@<b>%1s</b>)</string>
+    <string name="account_filter_placeholder_type_follow_fmt">Ein brukar (@&lt;b>%1s&lt;/b>) fylgde deg</string>
+    <string name="account_filter_placeholder_type_follow_request_fmt">Fylgjeførespurnad frå ein brukar (@&lt;b>%1s&lt;/b>)</string>
+    <string name="account_filter_placeholder_type_mention_fmt">Ein brukar (@&lt;b>%1s&lt;/b>) nemnde deg</string>
+    <string name="account_filter_placeholder_label_domain">Frå ein brukar (@&lt;b>%1s&lt;/b>)</string>
     <string name="account_filter_placeholder_label_not_following">Filtrert fordi: <b>du fylgjer hen ikkje</b></string>
     <string name="account_filter_placeholder_label_younger_30d">Filtrert fordi: <b>kontoen vart oppretta på dei siste 30 dagane</b></string>
     <string name="account_filter_placeholder_label_limited_by_server">Filtrert fordi: <b>kontoen er avgrensa av moderatorane dine</b></string>
     <string name="search_operator_from_dialog_other_account">Kun innlegg frå denne kontoen</string>
-    <string name="account_filter_placeholder_type_favourite_fmt">Ein brukar (@<b>%1s</b>) favorittmerka innlegget ditt</string>
-    <string name="account_filter_placeholder_type_reblog_fmt">Ein brukar (@<b>%1s</b>) delte innlegget ditt</string>
+    <string name="account_filter_placeholder_type_favourite_fmt">Ein brukar (@&lt;b>%1s&lt;/b>) favorittmerka innlegget ditt</string>
+    <string name="account_filter_placeholder_type_reblog_fmt">Ein brukar (@&lt;b>%1s&lt;/b>) delte innlegget ditt</string>
     <string name="pref_account_notification_filters_subtitle">Kva burde skje til varsel frå kontoar som…</string>
     <string name="search_operator_where_dialog_title">Avgrens til…</string>
     <string name="search_operator_where_dialog_all">Alle innlegg</string>

--- a/app/src/main/res/values-nn/strings.xml
+++ b/app/src/main/res/values-nn/strings.xml
@@ -763,9 +763,9 @@
     <string name="account_filter_placeholder_type_follow_request_fmt">Fylgjeførespurnad frå ein brukar (@&lt;b>%1s&lt;/b>)</string>
     <string name="account_filter_placeholder_type_mention_fmt">Ein brukar (@&lt;b>%1s&lt;/b>) nemnde deg</string>
     <string name="account_filter_placeholder_label_domain">Frå ein brukar (@&lt;b>%1s&lt;/b>)</string>
-    <string name="account_filter_placeholder_label_not_following">Filtrert fordi: <b>du fylgjer hen ikkje</b></string>
-    <string name="account_filter_placeholder_label_younger_30d">Filtrert fordi: <b>kontoen vart oppretta på dei siste 30 dagane</b></string>
-    <string name="account_filter_placeholder_label_limited_by_server">Filtrert fordi: <b>kontoen er avgrensa av moderatorane dine</b></string>
+    <string name="account_filter_placeholder_label_not_following">Filtrert fordi: &lt;b>du fylgjer hen ikkje&lt;/b></string>
+    <string name="account_filter_placeholder_label_younger_30d">Filtrert fordi: &lt;b>kontoen vart oppretta på dei siste 30 dagane&lt;/b></string>
+    <string name="account_filter_placeholder_label_limited_by_server">Filtrert fordi: &lt;b>kontoen er avgrensa av moderatorane dine&lt;/b></string>
     <string name="search_operator_from_dialog_other_account">Kun innlegg frå denne kontoen</string>
     <string name="account_filter_placeholder_type_favourite_fmt">Ein brukar (@&lt;b>%1s&lt;/b>) favorittmerka innlegget ditt</string>
     <string name="account_filter_placeholder_type_reblog_fmt">Ein brukar (@&lt;b>%1s&lt;/b>) delte innlegget ditt</string>

--- a/app/src/main/res/values-oc/strings.xml
+++ b/app/src/main/res/values-oc/strings.xml
@@ -259,12 +259,12 @@
         <item quantity="other">Descriure los contenguts pels mal vesents (%d caractèrs maximum)</item>
     </plurals>
     <plurals name="favs">
-        <item quantity="one"><b>%1$s</b> Favorit</item>
-        <item quantity="other"><b>%1$s</b> Favorits</item>
+        <item quantity="one">&lt;b>%1$s&lt;/b> Favorit</item>
+        <item quantity="other">&lt;b>%1$s&lt;/b> Favorits</item>
     </plurals>
     <plurals name="reblogs">
-        <item quantity="one"><b>%s</b> Partatge</item>
-        <item quantity="other"><b>%s</b> Partatges</item>
+        <item quantity="one">&lt;b>%s&lt;/b> Partatge</item>
+        <item quantity="other">&lt;b>%s&lt;/b> Partatges</item>
     </plurals>
     <string name="title_reblogged_by">Partejat per</string>
     <string name="title_favourited_by">Aimat per</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -284,10 +284,10 @@
     <string name="unpin_action">Odepnij z profilu</string>
     <string name="pin_action">Przypnij do profilu</string>
     <plurals name="favs">
-        <item quantity="one"><b>%1$s</b> polubienie</item>
-        <item quantity="few"><b>%1$s</b> polubienia</item>
-        <item quantity="many"><b>%1$s</b> polubień</item>
-        <item quantity="other"><b>%1$s</b> polubień</item>
+        <item quantity="one">&lt;b>%1$s&lt;/b> polubienie</item>
+        <item quantity="few">&lt;b>%1$s&lt;/b> polubienia</item>
+        <item quantity="many">&lt;b>%1$s&lt;/b> polubień</item>
+        <item quantity="other">&lt;b>%1$s&lt;/b> polubień</item>
     </plurals>
     <plurals name="reblogs">
         <item quantity="one">&lt;b&gt;%s&lt;/b&gt; podbicie</item>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -270,14 +270,14 @@
     <string name="unpin_action">Desafixar</string>
     <string name="pin_action">Fixar</string>
     <plurals name="favs">
-        <item quantity="one"><b>%1$s</b> Favorito</item>
-        <item quantity="many"><b>%1$s</b> Favoritos</item>
-        <item quantity="other"><b>%1$s</b> Favoritos</item>
+        <item quantity="one">&lt;b>%1$s&lt;/b> Favorito</item>
+        <item quantity="many">&lt;b>%1$s&lt;/b> Favoritos</item>
+        <item quantity="other">&lt;b>%1$s&lt;/b> Favoritos</item>
     </plurals>
     <plurals name="reblogs">
-        <item quantity="one"><b>%s</b> Boost</item>
-        <item quantity="many"><b>%s</b> Boosts</item>
-        <item quantity="other"><b>%s</b> Boosts</item>
+        <item quantity="one">&lt;b>%s&lt;/b> Boost</item>
+        <item quantity="many">&lt;b>%s&lt;/b> Boosts</item>
+        <item quantity="other">&lt;b>%s&lt;/b> Boosts</item>
     </plurals>
     <string name="conversation_1_recipients">%1$s</string>
     <string name="conversation_2_recipients">%1$s e %2$s</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -312,14 +312,14 @@
     <string name="label_remote_account">As informações abaixo podem refletir, de forma incompleta, o perfil do utilizador. Toque aqui para abrir o perfil completo no navegador.</string>
     <string name="pin_action">Fixar</string>
     <plurals name="favs">
-        <item quantity="one"><b>%1$s</b> Favorito</item>
-        <item quantity="many"><b>%1$s</b> Favoritos</item>
-        <item quantity="other"><b>%1$s</b> Favoritos</item>
+        <item quantity="one">&lt;b>%1$s&lt;/b> Favorito</item>
+        <item quantity="many">&lt;b>%1$s&lt;/b> Favoritos</item>
+        <item quantity="other">&lt;b>%1$s&lt;/b> Favoritos</item>
     </plurals>
     <plurals name="reblogs">
-        <item quantity="one"><b>%s</b> Boost</item>
-        <item quantity="many"><b>%s</b> Boosts</item>
-        <item quantity="other"><b>%s</b> Boosts</item>
+        <item quantity="one">&lt;b>%s&lt;/b> Boost</item>
+        <item quantity="many">&lt;b>%s&lt;/b> Boosts</item>
+        <item quantity="other">&lt;b>%s&lt;/b> Boosts</item>
     </plurals>
     <string name="title_reblogged_by">Boost dado por</string>
     <string name="title_favourited_by">Adicionado aos favoritos por</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -281,10 +281,10 @@
     <string name="unpin_action">Открепить</string>
     <string name="pin_action">Закрепить</string>
     <plurals name="favs">
-        <item quantity="one"><b>%1$s</b> Понравился</item>
-        <item quantity="few"><b>%1$s</b> Понравилось</item>
-        <item quantity="many"><b>%1$s</b> Понравилось</item>
-        <item quantity="other"><b>%1$s</b> Понравилось</item>
+        <item quantity="one">&lt;b>%1$s&lt;/b> Понравился</item>
+        <item quantity="few">&lt;b>%1$s&lt;/b> Понравилось</item>
+        <item quantity="many">&lt;b>%1$s&lt;/b> Понравилось</item>
+        <item quantity="other">&lt;b>%1$s&lt;/b> Понравилось</item>
     </plurals>
     <plurals name="reblogs">
         <item quantity="one">&lt;b&gt;%s&lt;/b&gt; Продвинул(а)</item>

--- a/app/src/main/res/values-sa/strings.xml
+++ b/app/src/main/res/values-sa/strings.xml
@@ -378,12 +378,12 @@
     <string name="title_favourited_by">निम्नमित्रस्य प्रीतिः</string>
     <string name="title_reblogged_by">निम्नमित्रेण प्रकाशितम्</string>
     <plurals name="reblogs">
-        <item quantity="one"><b>%s</b> प्रकाशनम्</item>
-        <item quantity="other"><b>%s</b> प्रकाशने</item>
+        <item quantity="one">&lt;b>%s&lt;/b> प्रकाशनम्</item>
+        <item quantity="other">&lt;b>%s&lt;/b> प्रकाशने</item>
     </plurals>
     <plurals name="favs">
-        <item quantity="one"><b>%1$s</b> प्रियम्</item>
-        <item quantity="other"><b>%1$s</b> प्रिये</item>
+        <item quantity="one">&lt;b>%1$s&lt;/b> प्रियम्</item>
+        <item quantity="other">&lt;b>%1$s&lt;/b> प्रिये</item>
     </plurals>
     <string name="total_usage">समस्त-उपयोगः</string>
     <string name="total_accounts">सकललेखाः</string>

--- a/app/src/main/res/values-si/strings.xml
+++ b/app/src/main/res/values-si/strings.xml
@@ -207,8 +207,8 @@
     <string name="poll_ended_created">ඔබ සෑදූ මත විමසුම නිම වී ඇත</string>
     <string name="pref_title_bot_overlay">ස්වයංක්‍රමලේඛ සඳහා දර්ශකය පෙන්වන්න</string>
     <plurals name="favs">
-        <item quantity="one">ප්‍රියතමයන් <b>%1$s</b></item>
-        <item quantity="other">ප්‍රියතමයන් <b>%1$s</b></item>
+        <item quantity="one">ප්‍රියතමයන් &lt;b>%1$s&lt;/b></item>
+        <item quantity="other">ප්‍රියතමයන් &lt;b>%1$s&lt;/b></item>
     </plurals>
     <string name="action_favourite">ප්‍රියතම</string>
     <string name="filter_dialog_update_button">යාවත්කාල</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -363,9 +363,9 @@
     <string name="hashtags">Ključniki</string>
     <string name="notification_follow_request_name">Zahteve za Sledenje</string>
     <plurals name="favs">
-        <item quantity="one"><b>%1$s</b> Priljubljena</item>
-        <item quantity="two"><b>%1$s</b> Priljubljeni</item>
-        <item quantity="few"><b>%1$s</b> Priljubljene</item>
-        <item quantity="other"><b>%1$s</b> Priljubljenih</item>
+        <item quantity="one">&lt;b>%1$s&lt;/b> Priljubljena</item>
+        <item quantity="two">&lt;b>%1$s&lt;/b> Priljubljeni</item>
+        <item quantity="few">&lt;b>%1$s&lt;/b> Priljubljene</item>
+        <item quantity="other">&lt;b>%1$s&lt;/b> Priljubljenih</item>
     </plurals>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -261,8 +261,8 @@
         <item quantity="other">&lt;b&gt;%1$s&lt;/b&gt; Favoriter</item>
     </plurals>
     <plurals name="reblogs">
-        <item quantity="one"><b>%s</b> Knuff</item>
-        <item quantity="other"><b>%s</b> Knuffar</item>
+        <item quantity="one">&lt;b>%s&lt;/b> Knuff</item>
+        <item quantity="other">&lt;b>%s&lt;/b> Knuffar</item>
     </plurals>
     <string name="title_reblogged_by">Knuffad av</string>
     <string name="title_favourited_by">Favoritmarkerad av</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -240,12 +240,12 @@
     <string name="unpin_action">Sabitlemeyi kaldır</string>
     <string name="pin_action">Sabitle</string>
     <plurals name="favs">
-        <item quantity="one"><b>%1$s</b> Gözde</item>
-        <item quantity="other"><b>%1$s</b> Gözdeler</item>
+        <item quantity="one">&lt;b>%1$s&lt;/b> Gözde</item>
+        <item quantity="other">&lt;b>%1$s&lt;/b> Gözdeler</item>
     </plurals>
     <plurals name="reblogs">
-        <item quantity="one"><b>%s</b> Yeniden Paylaşan</item>
-        <item quantity="other"><b>%s</b> Yeniden Paylaşanlar</item>
+        <item quantity="one">&lt;b>%s&lt;/b> Yeniden Paylaşan</item>
+        <item quantity="other">&lt;b>%s&lt;/b> Yeniden Paylaşanlar</item>
     </plurals>
     <string name="title_reblogged_by">tarafından paylaşıldı</string>
     <string name="title_favourited_by">Tarafından gözdelendi</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -135,10 +135,10 @@
     <string name="description_post_favourited">Уподобано</string>
     <string name="title_favourited_by">Вподобали</string>
     <plurals name="favs">
-        <item quantity="one"><b>%1$s</b> вподобання</item>
-        <item quantity="few"><b>%1$s</b> вподобання</item>
-        <item quantity="many"><b>%1$s</b> вподобань</item>
-        <item quantity="other"><b>%1$s</b> вподобань</item>
+        <item quantity="one">&lt;b>%1$s&lt;/b> вподобання</item>
+        <item quantity="few">&lt;b>%1$s&lt;/b> вподобання</item>
+        <item quantity="many">&lt;b>%1$s&lt;/b> вподобань</item>
+        <item quantity="other">&lt;b>%1$s&lt;/b> вподобань</item>
     </plurals>
     <string name="notification_favourite_description">Сповіщати про вподобання кимось дописів</string>
     <string name="pref_title_notification_filter_favourites">мої дописи вподобано</string>
@@ -425,10 +425,10 @@
     <string name="description_post_bookmarked">Додано до закладок</string>
     <string name="description_post_reblogged">Поширено</string>
     <plurals name="reblogs">
-        <item quantity="one"><b>%s</b> поширення</item>
-        <item quantity="few"><b>%s</b> поширення</item>
-        <item quantity="many"><b>%s</b> поширень</item>
-        <item quantity="other"><b>%s</b> поширень</item>
+        <item quantity="one">&lt;b>%s&lt;/b> поширення</item>
+        <item quantity="few">&lt;b>%s&lt;/b> поширення</item>
+        <item quantity="many">&lt;b>%s&lt;/b> поширень</item>
+        <item quantity="other">&lt;b>%s&lt;/b> поширень</item>
     </plurals>
     <string name="pin_action">Прикріпити</string>
     <string name="unpin_action">Відкріпити</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -330,10 +330,10 @@
     <string name="title_favourited_by">Lượt thích tút này</string>
     <string name="title_reblogged_by">Lượt đăng lại tút này</string>
     <plurals name="reblogs">
-        <item quantity="other"><b>%s</b> Đăng lại</item>
+        <item quantity="other">&lt;b>%s&lt;/b> Đăng lại</item>
     </plurals>
     <plurals name="favs">
-        <item quantity="other"><b>%1$s</b> Thích</item>
+        <item quantity="other">&lt;b>%1$s&lt;/b> Thích</item>
     </plurals>
     <string name="pin_action">Ghim</string>
     <string name="unpin_action">Gỡ ghim</string>

--- a/app/src/main/res/values-zh-rSG/strings.xml
+++ b/app/src/main/res/values-zh-rSG/strings.xml
@@ -263,7 +263,7 @@
     <string name="unpin_action">取消置顶</string>
     <string name="pin_action">置顶</string>
     <plurals name="favs">
-        <item quantity="other"><b>%1$s</b> 次喜欢</item>
+        <item quantity="other">&lt;b>%1$s&lt;/b> 次喜欢</item>
     </plurals>
     <plurals name="reblogs">
         <item quantity="other">&lt;b&gt;%s&lt;/b&gt; 次转嘟</item>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -262,7 +262,7 @@
     <string name="unpin_action">取消置頂</string>
     <string name="pin_action">置頂</string>
     <plurals name="favs">
-        <item quantity="other"><b>%1$s</b> 次最愛</item>
+        <item quantity="other">&lt;b>%1$s&lt;/b> 次最愛</item>
     </plurals>
     <plurals name="reblogs">
         <item quantity="other">&lt;b&gt;%s&lt;/b&gt; 次轉嘟</item>

--- a/feature/suggestions/src/main/res/values-es/strings.xml
+++ b/feature/suggestions/src/main/res/values-es/strings.xml
@@ -12,9 +12,9 @@
     <string name="action_dismiss_follow_suggestion">Descartar</string>
     <string name="ui_error_delete_suggestion_fmt">Fallo al descartar la sugerencia para %1$s: %2$s</string>
     <string name="ui_error_follow_account_fmt">Fallo al seguir a %1$s: %2$s</string>
-    <string name="follower_count_fmt"><b>%1$s</b> seguidores</string>
-    <string name="follows_count_fmt"><b>%1$s</b> siguiendo</string>
-    <string name="statuses_count_fmt"><b>%1$s</b> publicaciones</string>
-    <string name="statuses_count_per_week_fmt"><b>%1$s</b> publicaciones (<b>%2$d</b> por semana)</string>
-    <string name="statuses_count_per_week_last_fmt"><b>%1$s</b> publicaciones (<b>%2$d</b> por semana; última: <b>%3$s</b>)</string>
+    <string name="follower_count_fmt">&lt;b>%1$s&lt;/b> seguidores</string>
+    <string name="follows_count_fmt">&lt;b>%1$s&lt;/b> siguiendo</string>
+    <string name="statuses_count_fmt">&lt;b>%1$s&lt;/b> publicaciones</string>
+    <string name="statuses_count_per_week_fmt">&lt;b>%1$s&lt;/b> publicaciones (&lt;b>%2$d&lt;/b> por semana)</string>
+    <string name="statuses_count_per_week_last_fmt">&lt;b>%1$s&lt;/b> publicaciones (&lt;b>%2$d&lt;/b> por semana; última: &lt;b>%3$s&lt;/b>)</string>
 </resources>

--- a/feature/suggestions/src/main/res/values-fi/strings.xml
+++ b/feature/suggestions/src/main/res/values-fi/strings.xml
@@ -7,14 +7,14 @@
     <string name="sources_most_followed">Palvelimesi eniten seurattuja</string>
     <string name="sources_featured">Palvelimesi ylläpitäjien ehdotuksia</string>
     <string name="sources_similar_to_recently_followed">Muistuttaa äskettäin seuraamiasi tilejä</string>
-    <string name="follower_count_fmt"><b>%1$s</b> seuraajaa</string>
-    <string name="follows_count_fmt"><b>%1$s</b> seuraa</string>
-    <string name="statuses_count_per_week_last_fmt"><b>%1$s</b> julkaisua <b>%2$d</b> viikossa, uusin <b>%3$s</b>)</string>
+    <string name="follower_count_fmt">&lt;b>%1$s&lt;/b> seuraajaa</string>
+    <string name="follows_count_fmt">&lt;b>%1$s&lt;/b> seuraa</string>
+    <string name="statuses_count_per_week_last_fmt">&lt;b>%1$s&lt;/b> julkaisua &lt;b>%2$d&lt;/b> viikossa, uusin &lt;b>%3$s&lt;/b>)</string>
     <string name="source_unknown">(palvelimen vastauksessa tunnistamaton lähde)</string>
     <string name="action_follow_account">Seuraa</string>
     <string name="action_dismiss_follow_suggestion">Hylkää</string>
     <string name="ui_error_delete_suggestion_fmt">Ehdotuksen %1$s hylkääminen epäonnistui: %2$s</string>
     <string name="ui_error_follow_account_fmt">Tilin %1$s seuraaminen epäonnistui: %2$s</string>
-    <string name="statuses_count_fmt"><b>%1$s</b> julkaisua</string>
-    <string name="statuses_count_per_week_fmt"><b>%1$s</b> julkaisua (<b>%2$d</b> viikossa)</string>
+    <string name="statuses_count_fmt">&lt;b>%1$s&lt;/b> julkaisua</string>
+    <string name="statuses_count_per_week_fmt">&lt;b>%1$s&lt;/b> julkaisua (&lt;b>%2$d&lt;/b> viikossa)</string>
 </resources>

--- a/feature/suggestions/src/main/res/values-ga/strings.xml
+++ b/feature/suggestions/src/main/res/values-ga/strings.xml
@@ -10,11 +10,11 @@
     <string name="action_follow_account">Lean</string>
     <string name="action_dismiss_follow_suggestion">Díbhe</string>
     <string name="ui_error_delete_suggestion_fmt">Theip ar mholadh le haghaidh %1$s a dhíbhe: %2$s</string>
-    <string name="follower_count_fmt"><b>%1$s</b> leantóir</string>
-    <string name="follows_count_fmt"><b>%1$s</b> ina dhiaidh</string>
-    <string name="statuses_count_fmt"><b>%1$s</b> postáil</string>
-    <string name="statuses_count_per_week_fmt"><b>%1$s</b> postáil (<b>%2$d</b> in aghaidh na seachtaine)</string>
-    <string name="statuses_count_per_week_last_fmt"><b>%1$s</b> postáil (<b>%2$d</b> sa tseachtain, an <b>%3$s</b> deireanach)</string>
+    <string name="follower_count_fmt">&lt;b>%1$s&lt;/b> leantóir</string>
+    <string name="follows_count_fmt">&lt;b>%1$s&lt;/b> ina dhiaidh</string>
+    <string name="statuses_count_fmt">&lt;b>%1$s&lt;/b> postáil</string>
+    <string name="statuses_count_per_week_fmt">&lt;b>%1$s&lt;/b> postáil (&lt;b>%2$d&lt;/b> in aghaidh na seachtaine)</string>
+    <string name="statuses_count_per_week_last_fmt">&lt;b>%1$s&lt;/b> postáil (&lt;b>%2$d&lt;/b> sa tseachtain, an &lt;b>%3$s&lt;/b> deireanach)</string>
     <string name="sources_similar_to_recently_followed">Cosúil le cuntais a lean tú le déanaí</string>
     <string name="ui_error_follow_account_fmt">Theip ar %1$s a leanúint: %2$s</string>
 </resources>

--- a/feature/suggestions/src/main/res/values-gl/strings.xml
+++ b/feature/suggestions/src/main/res/values-gl/strings.xml
@@ -12,9 +12,9 @@
     <string name="action_dismiss_follow_suggestion">Desbotar</string>
     <string name="ui_error_delete_suggestion_fmt">Fallou o rexeitamento da suxestión %1$s: %2$s</string>
     <string name="ui_error_follow_account_fmt">Fallou o seguimento de %1$s: %2$s</string>
-    <string name="follower_count_fmt"><b>%1$s</b> seguidoras</string>
-    <string name="follows_count_fmt"><b>%1$s</b> seguimentos</string>
-    <string name="statuses_count_fmt"><b>%1$s</b> publicacións</string>
-    <string name="statuses_count_per_week_last_fmt"><b>%1$s</b> publicacións (<b>%2$d</b> por semana, última o <b>%3$s</b>)</string>
-    <string name="statuses_count_per_week_fmt"><b>%1$s</b> publicacións (<b>%2$d</b> por semana)</string>
+    <string name="follower_count_fmt">&lt;b>%1$s&lt;/b> seguidoras</string>
+    <string name="follows_count_fmt">&lt;b>%1$s&lt;/b> seguimentos</string>
+    <string name="statuses_count_fmt">&lt;b>%1$s&lt;/b> publicacións</string>
+    <string name="statuses_count_per_week_last_fmt">&lt;b>%1$s&lt;/b> publicacións (&lt;b>%2$d&lt;/b> por semana, última o &lt;b>%3$s&lt;/b>)</string>
+    <string name="statuses_count_per_week_fmt">&lt;b>%1$s&lt;/b> publicacións (&lt;b>%2$d&lt;/b> por semana)</string>
 </resources>

--- a/feature/suggestions/src/main/res/values-lt/strings.xml
+++ b/feature/suggestions/src/main/res/values-lt/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="sources_most_followed">Vienas iš labiausiai sekamų jūsų serveryje</string>
-    <string name="follower_count_fmt"><b>%1$s</b> sekėjai</string>
+    <string name="follower_count_fmt">&lt;b>%1$s&lt;/b> sekėjai</string>
     <string name="action_follow_account">Sekti</string>
     <string name="action_dismiss_follow_suggestion">Atmesti</string>
     <string name="sources_friends_of_friends">Populiarus tarp žmonių, kuriuos sekate</string>
@@ -13,8 +13,8 @@
     <string name="sources_unknown">(serveris grąžino neatpažintus šaltinius)</string>
     <string name="ui_error_delete_suggestion_fmt">Nepavyko atmesti pasiūlymo dėl %1$s: %2$s.</string>
     <string name="ui_error_follow_account_fmt">Nepavyko sekti %1$s: %2$s.</string>
-    <string name="follows_count_fmt"><b>%1$s</b> sekimai</string>
-    <string name="statuses_count_fmt"><b>%1$s</b> įrašai</string>
-    <string name="statuses_count_per_week_fmt"><b>%1$s</b> įrašai (<b>%2$d</b> per savaitę)</string>
-    <string name="statuses_count_per_week_last_fmt"><b>%1$s</b> įrašai (<b>%2$d</b> per savaitę, paskutinis <b>%3$s</b>)</string>
+    <string name="follows_count_fmt">&lt;b>%1$s&lt;/b> sekimai</string>
+    <string name="statuses_count_fmt">&lt;b>%1$s&lt;/b> įrašai</string>
+    <string name="statuses_count_per_week_fmt">&lt;b>%1$s&lt;/b> įrašai (&lt;b>%2$d&lt;/b> per savaitę)</string>
+    <string name="statuses_count_per_week_last_fmt">&lt;b>%1$s&lt;/b> įrašai (&lt;b>%2$d&lt;/b> per savaitę, paskutinis &lt;b>%3$s&lt;/b>)</string>
 </resources>

--- a/feature/suggestions/src/main/res/values-nb-rNO/strings.xml
+++ b/feature/suggestions/src/main/res/values-nb-rNO/strings.xml
@@ -12,9 +12,9 @@
     <string name="sources_friends_of_friends">Populær blant de du følger</string>
     <string name="sources_unknown">(Serveren ga ukjente kilder)</string>
     <string name="action_dismiss_follow_suggestion">Avvis</string>
-    <string name="follower_count_fmt"><b>%1$s</b> følgere</string>
-    <string name="follows_count_fmt">Følger <b>%1$s</b></string>
-    <string name="statuses_count_fmt"><b>%1$s</b> innlegg</string>
-    <string name="statuses_count_per_week_fmt"><b>%1$s</b> innlegg (<b>%2$d</b> om uken)</string>
-    <string name="statuses_count_per_week_last_fmt"><b>%1$s</b> innlegg (<b>%2$d</b> om uken, siste uke <b>%3$s</b>)</string>
+    <string name="follower_count_fmt">&lt;b>%1$s&lt;/b> følgere</string>
+    <string name="follows_count_fmt">Følger &lt;b>%1$s&lt;/b></string>
+    <string name="statuses_count_fmt">&lt;b>%1$s&lt;/b> innlegg</string>
+    <string name="statuses_count_per_week_fmt">&lt;b>%1$s&lt;/b> innlegg (&lt;b>%2$d&lt;/b> om uken)</string>
+    <string name="statuses_count_per_week_last_fmt">&lt;b>%1$s&lt;/b> innlegg (&lt;b>%2$d&lt;/b> om uken, siste uke &lt;b>%3$s&lt;/b>)</string>
 </resources>


### PR DESCRIPTION
Previous translations used `<b>` instead of escaping the opening bracket (`&lt;b>`) so the styling was being lost, per https://developer.android.com/guide/topics/resources/string-resource#StylingWithHTML.