### PR TITLE
fix: Set the jvmToolChain version for the checks module

### DIFF
--- a/checks/build.gradle.kts
+++ b/checks/build.gradle.kts
@@ -26,6 +26,10 @@ java {
     targetCompatibility = JavaVersion.VERSION_17
 }
 
+kotlin {
+    jvmToolchain(17)
+}
+
 tasks.jar {
     manifest {
         attributes["Lint-Registry-v2"] = "app.pachli.lint.checks.LintRegistry"


### PR DESCRIPTION
Prevents compilation errors complaining that the Java JVM version and Kotlin JVM version are different.