### PR TITLE
build: Exclude "generated" field from aboutlibraries metadata

### DIFF
--- a/feature/about/build.gradle.kts
+++ b/feature/about/build.gradle.kts
@@ -37,6 +37,8 @@ aboutLibraries {
     includePlatform = false
     duplicationMode = com.mikepenz.aboutlibraries.plugin.DuplicateMode.MERGE
     prettyPrint = true
+    // The "generated" field contains a timestamp, which breaks reproducible builds.
+    excludeFields = arrayOf("generated")
 }
 
 markdown2resource {


### PR DESCRIPTION
This improves the reproducibility of the build, as the "generated" field contains a timestamp which changes on every build.