### PR TITLE
fix: Show lists sorted by title

### DIFF
--- a/app/src/main/java/app/pachli/MainActivity.kt
+++ b/app/src/main/java/app/pachli/MainActivity.kt
@@ -75,6 +75,7 @@ import app.pachli.core.common.extensions.show
 import app.pachli.core.common.extensions.viewBinding
 import app.pachli.core.common.util.unsafeLazy
 import app.pachli.core.data.model.MastodonList
+import app.pachli.core.data.repository.ListsRepository.Companion.compareByListTitle
 import app.pachli.core.data.repository.PachliAccount
 import app.pachli.core.data.repository.SetActiveAccountError
 import app.pachli.core.database.model.AccountEntity
@@ -845,7 +846,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
         binding.mainDrawer.removeItems(*listDrawerItems.toTypedArray())
 
         listDrawerItems.clear()
-        lists.forEach { list ->
+        lists.sortedWith(compareByListTitle).forEach { list ->
             listDrawerItems.add(
                 primaryDrawerItem {
                     nameText = list.title

--- a/app/src/main/java/app/pachli/TabPreferenceActivity.kt
+++ b/app/src/main/java/app/pachli/TabPreferenceActivity.kt
@@ -62,6 +62,13 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
+/**
+ * Displays the user's list of tabs, and allows them:
+ *
+ * - Drag/drop tabs to re-order.
+ * - Add new tabs.
+ * - Remove existing tabs.
+ */
 @AndroidEntryPoint
 class TabPreferenceActivity : BaseActivity(), ItemInteractionListener {
     @Inject

--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/ListsRepository.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/ListsRepository.kt
@@ -157,12 +157,15 @@ interface ListsRepository {
     ): Result<Unit, ListsError.DeleteAccounts>
 
     companion object {
+        /** Locale aware collator lists. */
+        val listTitleCollator: Collator = Collator.getInstance().apply { strength = Collator.SECONDARY }
+
         /**
          * Locale-aware comparator for lists. Case-insenstive comparison by
          * the list's title.
          */
-        val compareByListTitle: Comparator<MastodonList> = compareBy(
-            Collator.getInstance().apply { strength = Collator.SECONDARY },
-        ) { it.title }
+        val compareByListTitle: Comparator<MastodonList> = compareBy(listTitleCollator) {
+            it.title
+        }
     }
 }

--- a/feature/lists/src/main/kotlin/app/pachli/feature/lists/ListsForAccountFragment.kt
+++ b/feature/lists/src/main/kotlin/app/pachli/feature/lists/ListsForAccountFragment.kt
@@ -31,6 +31,7 @@ import androidx.recyclerview.widget.ListAdapter
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
 import app.pachli.core.common.extensions.viewBinding
+import app.pachli.core.data.repository.ListsRepository.Companion.listTitleCollator
 import app.pachli.core.designsystem.R as DR
 import app.pachli.core.ui.BackgroundMessage
 import app.pachli.core.ui.BindingHolder
@@ -146,7 +147,7 @@ class ListsForAccountFragment : DialogFragment() {
                         binding.messageView.setup(BackgroundMessage.Empty(R.string.no_lists)) { load() }
                     } else {
                         binding.listsView.show()
-                        adapter.submitList(it.listsWithMembership.values.toList())
+                        adapter.submitList(it.listsWithMembership.values.sortedWith(compareByListWithMembershipTitle))
                     }
                 }
             }
@@ -230,5 +231,13 @@ class ListsForAccountFragment : DialogFragment() {
             }
             return ListsForAccountFragment().apply { arguments = args }
         }
+
+        /**
+         * Locale aware comparator for [ListsWithMembership]. Case-insensitive comparison
+         * by the list's title.
+         */
+        val compareByListWithMembershipTitle: Comparator<ListWithMembership> = compareBy(
+            listTitleCollator,
+        ) { it.list.title }
     }
 }

--- a/feature/lists/src/main/kotlin/app/pachli/feature/lists/ListsForAccountViewModel.kt
+++ b/feature/lists/src/main/kotlin/app/pachli/feature/lists/ListsForAccountViewModel.kt
@@ -23,7 +23,6 @@ import app.pachli.core.data.model.MastodonList
 import app.pachli.core.data.repository.HasListId
 import app.pachli.core.data.repository.ListsError
 import app.pachli.core.data.repository.ListsRepository
-import app.pachli.core.network.model.MastoList
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.mapEither
@@ -46,7 +45,7 @@ sealed interface ListsWithMembership {
 }
 
 /**
- * A [MastoList] with a property for whether [ListsForAccountViewModel.accountId] is a
+ * A [MastodonList] with a property for whether [ListsForAccountViewModel.accountId] is a
  * member of the list.
  *
  * @property list The Mastodon list


### PR DESCRIPTION
Some parts of the UI already showed lists sorted by title, but not all.

The areas fixed are:

- The list of lists in the main drawer (left side navitation)
- The list of lists when adding/removing an account from a list

Fixes #1168