### PR TITLE
fix: Prevent FK constraint failures in DB 12->13 migration

### DIFF
--- a/core/database/src/main/kotlin/app/pachli/core/database/di/DatabaseModule.kt
+++ b/core/database/src/main/kotlin/app/pachli/core/database/di/DatabaseModule.kt
@@ -22,6 +22,7 @@ import androidx.room.Room
 import androidx.room.withTransaction
 import app.pachli.core.database.AppDatabase
 import app.pachli.core.database.Converters
+import app.pachli.core.database.MIGRATE_12_13
 import app.pachli.core.database.MIGRATE_8_9
 import dagger.Module
 import dagger.Provides
@@ -43,6 +44,7 @@ object DatabaseModule {
             .addTypeConverter(converters)
             .allowMainThreadQueries()
             .addMigrations(MIGRATE_8_9)
+            .addMigrations(MIGRATE_12_13)
             .build()
     }
 


### PR DESCRIPTION
The default migration code copies existing NotificationEntity rows to the new table. This might fail because of the new FK constraint on TimelineAccountEntity. Fix this by not copying the data over; it's a local cache, so nothing of importance is lost.