### PR TITLE
fix: Remove "dummy.placeholder" from network error messages

### DIFF
--- a/core/network/src/main/kotlin/app/pachli/core/network/retrofit/apiresult/ApiResult.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/retrofit/apiresult/ApiResult.kt
@@ -66,9 +66,13 @@ sealed class ApiError(
     open val throwable: Throwable,
 ) : PachliError {
     override val formatArgs: Array<out Any>? by lazy {
-        (
-            throwable.getServerErrorMessage() ?: throwable.localizedMessage?.trim()
-            )?.let { arrayOf("$it: ${request.method} ${request.url}") } ?: arrayOf("${request.method} ${request.url}")
+        val pathAndQuery = request.url.encodedQuery?.let { query ->
+            "${request.url.encodedPath}?$query"
+        } ?: request.url.encodedPath
+
+        (throwable.getServerErrorMessage() ?: throwable.localizedMessage?.trim())?.let { msg ->
+            arrayOf("$msg: ${request.method} $pathAndQuery")
+        } ?: arrayOf("${request.method} $pathAndQuery")
     }
     override val cause: PachliError? = null
 


### PR DESCRIPTION
When constructing an ApiError the *original* request is used, because Retrofit cannot access the request after its been through OkHttp interceptors. So Retrofit cannot know the actual domaint the request was sent to, and the "dummy.placeholder" domain is displayed.

To prevent user confusion, and since this can't be corrected, display just the path and query part of the URL in the error message. This is still sufficient to diagnose the precise API call and parameters that resulted in the error.

Fixes #1217