### PR TITLE
fix: Show an error message if a Dao error occurs during login

### DIFF
--- a/app/src/main/java/app/pachli/MainActivity.kt
+++ b/app/src/main/java/app/pachli/MainActivity.kt
@@ -660,6 +660,20 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
                             }
                         }
 
+                        // Database errors are not retryable. Display the error, offer to
+                        // switch back to the fall back account.
+                        //
+                        // If these occur it's a bug in Pachli, the database should never
+                        // get to a bad state.
+                        is SetActiveAccountError.Dao -> {
+                            uiError.cause.wantedAccount?.let { builder.setTitle(it.fullName) }
+                            val button = builder.await(android.R.string.ok)
+                            if (button == AlertDialog.BUTTON_POSITIVE && uiError.cause.fallbackAccount != null) {
+                                viewModel.accept(FallibleUiAction.SetActiveAccount(uiError.cause.fallbackAccount!!.id))
+                            }
+                            return
+                        }
+
                         // Other errors are retryable.
                         is SetActiveAccountError.Unexpected -> {
                             builder.setTitle(uiError.cause.wantedAccount.fullName)

--- a/core/data/src/main/res/values/strings.xml
+++ b/core/data/src/main/res/values/strings.xml
@@ -10,5 +10,6 @@
 
     <string name="account_manager_error_account_does_not_exist">Account does not exist in local database. This should never happen. If you see this message please send a bug report.</string>
     <string name="account_manager_error_no_active_account">no account is marked active</string>
+    <string name="account_manager_error_dao">Database error, please report this to team@pachli.app: %1$s</string>
     <string name="account_manager_error_unexpected">unexpected error: %1$s</string>
 </resources>


### PR DESCRIPTION
Previous code would crash on an SQLiteException. Catch it and convert to a specific error.