### PR TITLE
fix: Scroll and restore position correctly in Home and Notifications

### DIFF
--- a/app/src/main/java/app/pachli/components/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/app/pachli/components/notifications/NotificationsViewModel.kt
@@ -76,6 +76,7 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.receiveAsFlow
@@ -372,6 +373,10 @@ class NotificationsViewModel @AssistedInject constructor(
     private val accountFlow = accountManager.getPachliAccountFlow(pachliAccountId)
         .filterNotNull()
         .shareIn(viewModelScope, SharingStarted.WhileSubscribed(5000), replay = 1)
+
+    val initialRefreshKey = accountFlow.flatMapLatest {
+        flow { emit(repository.getRefreshKey(it.id)) }
+    }
 
     /** The account to display notifications for */
     val account: AccountEntity

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/CachedTimelineViewModel.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/CachedTimelineViewModel.kt
@@ -43,6 +43,7 @@ import javax.inject.Inject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -69,6 +70,10 @@ class CachedTimelineViewModel @Inject constructor(
     statusDisplayOptionsRepository,
     sharedPreferencesRepository,
 ) {
+    val initialRefreshKey = accountFlow.flatMapLatest {
+        flow { emit(repository.getRefreshKey(it.data!!.id)) }
+    }
+
     override var statuses = accountFlow.flatMapLatest {
         getStatuses(it.data!!)
     }.cachedIn(viewModelScope)


### PR DESCRIPTION
These are cached timelines, backed by Room. Room **requires** the `PagingConfig` to have `enablePlaceholders = true`. Otherwise the list is corrupted when scrolling down the list and paging in new items.

To restore the user's reading position correctly in the UI, wait for the adapter to emit the very first page. Combine this with the user's refresh key, and the number of placeholders in the page, to scroll the user to the correct place in the list.

To make all this work, ensure that Room loads a large enough page of data around the refresh key (in the `initialKey` calculation).