### PR TITLE
refactor: Create StatusDao for operations that act on individual statuses

### DIFF
--- a/app/src/main/java/app/pachli/appstore/CacheUpdater.kt
+++ b/app/src/main/java/app/pachli/appstore/CacheUpdater.kt
@@ -1,6 +1,7 @@
 package app.pachli.appstore
 
 import app.pachli.core.data.repository.AccountManager
+import app.pachli.core.database.dao.StatusDao
 import app.pachli.core.database.dao.TimelineDao
 import app.pachli.core.eventhub.BookmarkEvent
 import app.pachli.core.eventhub.EventHub
@@ -21,6 +22,7 @@ class CacheUpdater @Inject constructor(
     eventHub: EventHub,
     accountManager: AccountManager,
     timelineDao: TimelineDao,
+    statusDao: StatusDao,
 ) {
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
@@ -30,20 +32,20 @@ class CacheUpdater @Inject constructor(
                 val accountId = accountManager.activeAccount?.id ?: return@collect
                 when (event) {
                     is FavoriteEvent ->
-                        timelineDao.setFavourited(accountId, event.statusId, event.favourite)
+                        statusDao.setFavourited(accountId, event.statusId, event.favourite)
                     is ReblogEvent ->
-                        timelineDao.setReblogged(accountId, event.statusId, event.reblog)
+                        statusDao.setReblogged(accountId, event.statusId, event.reblog)
                     is BookmarkEvent ->
-                        timelineDao.setBookmarked(accountId, event.statusId, event.bookmark)
+                        statusDao.setBookmarked(accountId, event.statusId, event.bookmark)
                     is UnfollowEvent ->
                         timelineDao.removeAllByUser(accountId, event.accountId)
                     is StatusDeletedEvent ->
-                        timelineDao.delete(accountId, event.statusId)
+                        statusDao.delete(accountId, event.statusId)
                     is PollVoteEvent -> {
-                        timelineDao.setVoted(accountId, event.statusId, event.poll)
+                        statusDao.setVoted(accountId, event.statusId, event.poll)
                     }
                     is PinEvent ->
-                        timelineDao.setPinned(accountId, event.statusId, event.pinned)
+                        statusDao.setPinned(accountId, event.statusId, event.pinned)
                 }
             }
         }

--- a/app/src/main/java/app/pachli/components/timeline/CachedTimelineRepository.kt
+++ b/app/src/main/java/app/pachli/components/timeline/CachedTimelineRepository.kt
@@ -28,6 +28,7 @@ import app.pachli.components.timeline.viewmodel.CachedTimelineRemoteMediator.Com
 import app.pachli.core.common.di.ApplicationScope
 import app.pachli.core.data.model.StatusViewData
 import app.pachli.core.database.dao.RemoteKeyDao
+import app.pachli.core.database.dao.StatusDao
 import app.pachli.core.database.dao.TimelineDao
 import app.pachli.core.database.dao.TranslatedStatusDao
 import app.pachli.core.database.di.TransactionProvider
@@ -66,6 +67,7 @@ class CachedTimelineRepository @Inject constructor(
     val timelineDao: TimelineDao,
     private val remoteKeyDao: RemoteKeyDao,
     private val translatedStatusDao: TranslatedStatusDao,
+    private val statusDao: StatusDao,
     @ApplicationScope private val externalScope: CoroutineScope,
 ) : TimelineRepository<TimelineStatusWithAccount> {
     private var factory: InvalidatingPagingSourceFactory<Int, TimelineStatusWithAccount>? = null
@@ -97,6 +99,7 @@ class CachedTimelineRepository @Inject constructor(
                 transactionProvider,
                 timelineDao,
                 remoteKeyDao,
+                statusDao,
             ),
             pagingSourceFactory = factory!!,
         ).flow
@@ -152,7 +155,7 @@ class CachedTimelineRepository @Inject constructor(
 
     /** Clear the warning (remove the "filtered" setting) for the given status, for the active account */
     suspend fun clearStatusWarning(pachliAccountId: Long, statusId: String) = externalScope.launch {
-        timelineDao.clearWarning(pachliAccountId, statusId)
+        statusDao.clearWarning(pachliAccountId, statusId)
     }.join()
 
     suspend fun translate(statusViewData: StatusViewData): NetworkResult<Translation> {

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/CachedTimelineRemoteMediator.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/CachedTimelineRemoteMediator.kt
@@ -22,6 +22,7 @@ import androidx.paging.LoadType
 import androidx.paging.PagingState
 import androidx.paging.RemoteMediator
 import app.pachli.core.database.dao.RemoteKeyDao
+import app.pachli.core.database.dao.StatusDao
 import app.pachli.core.database.dao.TimelineDao
 import app.pachli.core.database.di.TransactionProvider
 import app.pachli.core.database.model.RemoteKeyEntity
@@ -48,6 +49,7 @@ class CachedTimelineRemoteMediator(
     private val transactionProvider: TransactionProvider,
     private val timelineDao: TimelineDao,
     private val remoteKeyDao: RemoteKeyDao,
+    private val statusDao: StatusDao,
 ) : RemoteMediator<Int, TimelineStatusWithAccount>() {
     override suspend fun load(
         loadType: LoadType,
@@ -259,7 +261,7 @@ class CachedTimelineRemoteMediator(
         }
 
         timelineDao.upsertAccounts(accounts.map { TimelineAccountEntity.from(it, pachliAccountId) })
-        timelineDao.upsertStatuses(statuses.map { StatusEntity.from(it, pachliAccountId) })
+        statusDao.upsertStatuses(statuses.map { StatusEntity.from(it, pachliAccountId) })
     }
 
     companion object {

--- a/app/src/test/java/app/pachli/components/timeline/CachedTimelineRemoteMediatorTest.kt
+++ b/app/src/test/java/app/pachli/components/timeline/CachedTimelineRemoteMediatorTest.kt
@@ -103,6 +103,7 @@ class CachedTimelineRemoteMediatorTest {
             transactionProvider = transactionProvider,
             timelineDao = db.timelineDao(),
             remoteKeyDao = db.remoteKeyDao(),
+            statusDao = db.statusDao(),
         )
 
         val result = runBlocking { remoteMediator.load(LoadType.REFRESH, state()) }
@@ -123,6 +124,7 @@ class CachedTimelineRemoteMediatorTest {
             transactionProvider = transactionProvider,
             timelineDao = db.timelineDao(),
             remoteKeyDao = db.remoteKeyDao(),
+            statusDao = db.statusDao(),
         )
 
         val result = runBlocking { remoteMediator.load(LoadType.REFRESH, state()) }
@@ -140,6 +142,7 @@ class CachedTimelineRemoteMediatorTest {
             transactionProvider = transactionProvider,
             timelineDao = db.timelineDao(),
             remoteKeyDao = db.remoteKeyDao(),
+            statusDao = db.statusDao(),
         )
 
         val state = state(
@@ -177,6 +180,7 @@ class CachedTimelineRemoteMediatorTest {
             transactionProvider = transactionProvider,
             timelineDao = db.timelineDao(),
             remoteKeyDao = db.remoteKeyDao(),
+            statusDao = db.statusDao(),
         )
 
         val state = state(
@@ -228,6 +232,7 @@ class CachedTimelineRemoteMediatorTest {
             transactionProvider = transactionProvider,
             timelineDao = db.timelineDao(),
             remoteKeyDao = db.remoteKeyDao(),
+            statusDao = db.statusDao(),
         )
 
         val state = state(
@@ -286,6 +291,7 @@ class CachedTimelineRemoteMediatorTest {
             transactionProvider = transactionProvider,
             timelineDao = db.timelineDao(),
             remoteKeyDao = db.remoteKeyDao(),
+            statusDao = db.statusDao(),
         )
 
         val state = state(
@@ -335,7 +341,7 @@ class CachedTimelineRemoteMediatorTest {
                 statusWithAccount.reblogAccount?.let { account ->
                     timelineDao().insertAccount(account)
                 }
-                timelineDao().insertStatus(statusWithAccount.status)
+                statusDao().insertStatus(statusWithAccount.status)
             }
         }
     }

--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/notifications/NotificationsRemoteMediator.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/notifications/NotificationsRemoteMediator.kt
@@ -24,6 +24,7 @@ import androidx.paging.RemoteMediator
 import app.pachli.core.data.repository.notifications.NotificationsRepository.Companion.RKE_TIMELINE_ID
 import app.pachli.core.database.dao.NotificationDao
 import app.pachli.core.database.dao.RemoteKeyDao
+import app.pachli.core.database.dao.StatusDao
 import app.pachli.core.database.dao.TimelineDao
 import app.pachli.core.database.di.TransactionProvider
 import app.pachli.core.database.model.NotificationData
@@ -59,6 +60,7 @@ class NotificationsRemoteMediator(
     private val timelineDao: TimelineDao,
     private val remoteKeyDao: RemoteKeyDao,
     private val notificationDao: NotificationDao,
+    private val statusDao: StatusDao,
 ) : RemoteMediator<Int, NotificationData>() {
 
     override suspend fun load(loadType: LoadType, state: PagingState<Int, NotificationData>): MediatorResult {
@@ -282,7 +284,7 @@ class NotificationsRemoteMediator(
 
         // Bulk upsert the discovered items.
         timelineDao.upsertAccounts(accounts.map { TimelineAccountEntity.from(it, pachliAccountId) })
-        timelineDao.upsertStatuses(statuses.map { StatusEntity.from(it, pachliAccountId) })
+        statusDao.upsertStatuses(statuses.map { StatusEntity.from(it, pachliAccountId) })
         notificationDao.upsertReports(reports.mapNotNull { NotificationReportEntity.from(pachliAccountId, it) })
         notificationDao.upsertEvents(
             severanceEvents.mapNotNull {

--- a/core/database/src/main/kotlin/app/pachli/core/database/AppDatabase.kt
+++ b/core/database/src/main/kotlin/app/pachli/core/database/AppDatabase.kt
@@ -42,6 +42,7 @@ import app.pachli.core.database.dao.ListsDao
 import app.pachli.core.database.dao.LogEntryDao
 import app.pachli.core.database.dao.NotificationDao
 import app.pachli.core.database.dao.RemoteKeyDao
+import app.pachli.core.database.dao.StatusDao
 import app.pachli.core.database.dao.TimelineDao
 import app.pachli.core.database.dao.TranslatedStatusDao
 import app.pachli.core.database.model.AccountEntity
@@ -125,6 +126,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun announcementsDao(): AnnouncementsDao
     abstract fun followingAccountDao(): FollowingAccountDao
     abstract fun notificationDao(): NotificationDao
+    abstract fun statusDao(): StatusDao
 
     @DeleteColumn("TimelineStatusEntity", "expanded")
     @DeleteColumn("TimelineStatusEntity", "contentCollapsed")

--- a/core/database/src/main/kotlin/app/pachli/core/database/dao/StatusDao.kt
+++ b/core/database/src/main/kotlin/app/pachli/core/database/dao/StatusDao.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2025 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.core.database.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.TypeConverters
+import androidx.room.Upsert
+import app.pachli.core.database.Converters
+import app.pachli.core.database.model.StatusEntity
+import app.pachli.core.network.model.Poll
+
+/**
+ * Operations on individual statuses, irrespective of the timeline they are
+ * part of.
+ */
+@Dao
+@TypeConverters(Converters::class)
+abstract class StatusDao {
+    @Upsert
+    abstract suspend fun upsertStatuses(statuses: Collection<StatusEntity>)
+
+    @Upsert
+    abstract suspend fun insertStatus(statusEntity: StatusEntity): Long
+
+    @Query(
+        """
+UPDATE StatusEntity
+SET
+    favourited = :favourited
+WHERE timelineUserId = :pachliAccountId AND (serverId = :statusId OR reblogServerId = :statusId)
+""",
+    )
+    abstract suspend fun setFavourited(pachliAccountId: Long, statusId: String, favourited: Boolean)
+
+    @Query(
+        """
+UPDATE StatusEntity
+SET
+    bookmarked = :bookmarked
+WHERE timelineUserId = :pachliAccountId AND (serverId = :statusId OR reblogServerId = :statusId)
+""",
+    )
+    abstract suspend fun setBookmarked(pachliAccountId: Long, statusId: String, bookmarked: Boolean)
+
+    @Query(
+        """
+UPDATE StatusEntity
+SET
+    reblogged = :reblogged
+WHERE timelineUserId = :pachliAccountId AND (serverId = :statusId OR reblogServerId = :statusId)
+""",
+    )
+    abstract suspend fun setReblogged(pachliAccountId: Long, statusId: String, reblogged: Boolean)
+
+    @Query(
+        """
+DELETE
+FROM StatusEntity
+WHERE
+    timelineUserId = :accountId
+    AND serverId = :statusId
+""",
+    )
+    abstract suspend fun delete(accountId: Long, statusId: String)
+
+    @Query(
+        """
+UPDATE StatusEntity
+SET
+    poll = :poll
+WHERE timelineUserId = :accountId AND (serverId = :statusId OR reblogServerId = :statusId)
+""",
+    )
+    abstract suspend fun setVoted(accountId: Long, statusId: String, poll: Poll)
+
+    @Query(
+        """
+UPDATE StatusEntity
+SET
+    pinned = :pinned
+WHERE timelineUserId = :accountId AND (serverId = :statusId OR reblogServerId = :statusId)
+""",
+    )
+    abstract suspend fun setPinned(accountId: Long, statusId: String, pinned: Boolean)
+
+    @Query(
+        """
+UPDATE StatusEntity
+SET
+    filtered = NULL
+WHERE timelineUserId = :accountId AND (serverId = :statusId OR reblogServerId = :statusId)
+""",
+    )
+    abstract suspend fun clearWarning(accountId: Long, statusId: String): Int
+}

--- a/core/database/src/main/kotlin/app/pachli/core/database/dao/TimelineDao.kt
+++ b/core/database/src/main/kotlin/app/pachli/core/database/dao/TimelineDao.kt
@@ -31,23 +31,15 @@ import app.pachli.core.database.model.StatusEntity
 import app.pachli.core.database.model.StatusViewDataEntity
 import app.pachli.core.database.model.TimelineAccountEntity
 import app.pachli.core.database.model.TimelineStatusWithAccount
-import app.pachli.core.network.model.Poll
 
 @Dao
 @TypeConverters(Converters::class)
 abstract class TimelineDao {
-
     @Insert(onConflict = REPLACE)
     abstract suspend fun insertAccount(timelineAccountEntity: TimelineAccountEntity): Long
 
     @Upsert
     abstract suspend fun upsertAccounts(accounts: Collection<TimelineAccountEntity>)
-
-    @Upsert
-    abstract suspend fun upsertStatuses(statuses: Collection<StatusEntity>)
-
-    @Upsert
-    abstract suspend fun insertStatus(statusEntity: StatusEntity): Long
 
     @Query(
         """
@@ -263,36 +255,6 @@ WHERE timelineUserId = :accountId
 
     @Query(
         """
-UPDATE StatusEntity
-SET
-    favourited = :favourited
-WHERE timelineUserId = :pachliAccountId AND (serverId = :statusId OR reblogServerId = :statusId)
-""",
-    )
-    abstract suspend fun setFavourited(pachliAccountId: Long, statusId: String, favourited: Boolean)
-
-    @Query(
-        """
-UPDATE StatusEntity
-SET
-    bookmarked = :bookmarked
-WHERE timelineUserId = :pachliAccountId AND (serverId = :statusId OR reblogServerId = :statusId)
-""",
-    )
-    abstract suspend fun setBookmarked(pachliAccountId: Long, statusId: String, bookmarked: Boolean)
-
-    @Query(
-        """
-UPDATE StatusEntity
-SET
-    reblogged = :reblogged
-WHERE timelineUserId = :pachliAccountId AND (serverId = :statusId OR reblogServerId = :statusId)
-""",
-    )
-    abstract suspend fun setReblogged(pachliAccountId: Long, statusId: String, reblogged: Boolean)
-
-    @Query(
-        """
 DELETE
 FROM StatusEntity
 WHERE
@@ -340,17 +302,6 @@ WHERE timelineUserId = :accountId
 """,
     )
     abstract suspend fun removeAllTranslatedStatus(accountId: Long)
-
-    @Query(
-        """
-DELETE
-FROM StatusEntity
-WHERE
-    timelineUserId = :accountId
-    AND serverId = :statusId
-""",
-    )
-    abstract suspend fun delete(accountId: Long, statusId: String)
 
     /**
      * Cleans the StatusEntity and TimelineAccountEntity tables from old entries.
@@ -481,16 +432,6 @@ WHERE
     )
     abstract suspend fun cleanupTranslatedStatus(accountId: Long, limit: Int)
 
-    @Query(
-        """
-UPDATE StatusEntity
-SET
-    poll = :poll
-WHERE timelineUserId = :accountId AND (serverId = :statusId OR reblogServerId = :statusId)
-""",
-    )
-    abstract suspend fun setVoted(accountId: Long, statusId: String, poll: Poll)
-
     @Upsert
     abstract suspend fun upsertStatusViewData(svd: StatusViewDataEntity)
 
@@ -519,16 +460,6 @@ WHERE
 
     @Query(
         """
-UPDATE StatusEntity
-SET
-    pinned = :pinned
-WHERE timelineUserId = :accountId AND (serverId = :statusId OR reblogServerId = :statusId)
-""",
-    )
-    abstract suspend fun setPinned(accountId: Long, statusId: String, pinned: Boolean)
-
-    @Query(
-        """
 DELETE
 FROM StatusEntity
 WHERE timelineUserId = :accountId AND authorServerId IN (
@@ -541,16 +472,6 @@ WHERE timelineUserId = :accountId AND authorServerId IN (
 """,
     )
     abstract suspend fun deleteAllFromInstance(accountId: Long, instanceDomain: String)
-
-    @Query(
-        """
-UPDATE StatusEntity
-SET
-    filtered = NULL
-WHERE timelineUserId = :accountId AND (serverId = :statusId OR reblogServerId = :statusId)
-""",
-    )
-    abstract suspend fun clearWarning(accountId: Long, statusId: String): Int
 
     @Query(
         """

--- a/core/database/src/main/kotlin/app/pachli/core/database/di/DatabaseModule.kt
+++ b/core/database/src/main/kotlin/app/pachli/core/database/di/DatabaseModule.kt
@@ -90,6 +90,9 @@ object DatabaseModule {
 
     @Provides
     fun providesNotificationDao(appDatabase: AppDatabase) = appDatabase.notificationDao()
+
+    @Provides
+    fun providesStatusDao(appDatabase: AppDatabase) = appDatabase.statusDao()
 }
 
 /**

--- a/core/database/src/test/kotlin/app/pachli/core/database/dao/TimelineDaoTest.kt
+++ b/core/database/src/test/kotlin/app/pachli/core/database/dao/TimelineDaoTest.kt
@@ -54,6 +54,9 @@ class TimelineDaoTest {
     @Inject
     lateinit var timelineDao: TimelineDao
 
+    @Inject
+    lateinit var statusDao: StatusDao
+
     @Before
     fun setup() {
         hilt.inject()
@@ -101,7 +104,7 @@ class TimelineDaoTest {
             reblogger?.let {
                 timelineDao.insertAccount(it)
             }
-            timelineDao.insertStatus(status)
+            statusDao.insertStatus(status)
         }
 
         val pagingSource = timelineDao.getStatuses(setOne.first.timelineUserId)
@@ -131,7 +134,7 @@ class TimelineDaoTest {
             reblogAuthor?.let {
                 timelineDao.insertAccount(it)
             }
-            timelineDao.insertStatus(status)
+            statusDao.insertStatus(status)
         }
 
         timelineDao.cleanup(accountId = 1, limit = 3)
@@ -190,7 +193,7 @@ class TimelineDaoTest {
             reblogAuthor?.let {
                 timelineDao.insertAccount(it)
             }
-            timelineDao.insertStatus(status)
+            statusDao.insertStatus(status)
         }
 
         // status 2 gets deleted, newly loaded status contain only 1 + 3
@@ -207,7 +210,7 @@ class TimelineDaoTest {
             reblogAuthor?.let {
                 timelineDao.insertAccount(it)
             }
-            timelineDao.insertStatus(status)
+            statusDao.insertStatus(status)
         }
 
         // make sure status 2 is no longer in db
@@ -240,7 +243,7 @@ class TimelineDaoTest {
             reblogAuthor?.let {
                 timelineDao.insertAccount(it)
             }
-            timelineDao.insertStatus(status)
+            statusDao.insertStatus(status)
         }
 
         assertEquals(3, timelineDao.deleteRange(1, "12", "14"))
@@ -314,7 +317,7 @@ class TimelineDaoTest {
             reblogAuthor?.let {
                 timelineDao.insertAccount(it)
             }
-            timelineDao.insertStatus(status)
+            statusDao.insertStatus(status)
         }
 
         timelineDao.deleteAllFromInstance(1, "mastodon.red")
@@ -339,7 +342,7 @@ class TimelineDaoTest {
             reblogger?.let {
                 timelineDao.insertAccount(it)
             }
-            timelineDao.insertStatus(status)
+            statusDao.insertStatus(status)
         }
 
         val pagingSource = timelineDao.getStatuses(setOne.first.timelineUserId)

--- a/core/testing/src/main/kotlin/app/pachli/core/testing/fakes/FakeDatabaseModule.kt
+++ b/core/testing/src/main/kotlin/app/pachli/core/testing/fakes/FakeDatabaseModule.kt
@@ -88,4 +88,7 @@ object FakeDatabaseModule {
 
     @Provides
     fun providesNotificationDao(appDatabase: AppDatabase) = appDatabase.notificationDao()
+
+    @Provides
+    fun providesStatusDao(appDatabase: AppDatabase) = appDatabase.statusDao()
 }


### PR DESCRIPTION
TimelineDao contained operations on timelines and statuses which made it large and confusing.

Factor out the status-specific operations in to the new StatusDao class to make things more understandable.