### PR TITLE
fix: Don't crash when using active acccount before SetActiveAccount c…

### DIFF
--- a/app/src/main/java/app/pachli/MainActivity.kt
+++ b/app/src/main/java/app/pachli/MainActivity.kt
@@ -175,7 +175,6 @@ import dagger.hilt.android.AndroidEntryPoint
 import de.c1710.filemojicompat_ui.helpers.EMOJI_PREFERENCE
 import javax.inject.Inject
 import kotlin.math.max
-import kotlin.properties.Delegates
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChangedBy
@@ -254,8 +253,6 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
      * the account has no lists.
      */
     private val listDrawerItems = mutableListOf<PrimaryDrawerItem>()
-
-    private var pachliAccountId by Delegates.notNull<Long>()
 
     /** Mutex to protect modifications to the drawer's items. */
     private val drawerMutex = Mutex()
@@ -496,7 +493,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
         super.onMenuItemSelected(menuItem)
         return when (menuItem.itemId) {
             R.id.action_search -> {
-                startActivity(SearchActivityIntent(this@MainActivity, pachliAccountId))
+                startActivity(SearchActivityIntent(this@MainActivity, intent.pachliAccountId))
                 true
             }
             R.id.action_remove_tab -> {
@@ -505,7 +502,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
                 true
             }
             R.id.action_tab_preferences -> {
-                startActivity(TabPreferenceActivityIntent(this, pachliAccountId))
+                startActivity(TabPreferenceActivityIntent(this, intent.pachliAccountId))
                 true
             }
             else -> super.onOptionsItemSelected(menuItem)
@@ -548,7 +545,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
             }
             KeyEvent.KEYCODE_SEARCH -> {
                 startActivityWithDefaultTransition(
-                    SearchActivityIntent(this, pachliAccountId),
+                    SearchActivityIntent(this, intent.pachliAccountId),
                 )
                 return true
             }
@@ -558,7 +555,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
             when (keyCode) {
                 KeyEvent.KEYCODE_N -> {
                     // open compose activity by pressing SHIFT + N (or CTRL + N)
-                    val composeIntent = ComposeActivityIntent(applicationContext, pachliAccountId)
+                    val composeIntent = ComposeActivityIntent(applicationContext, intent.pachliAccountId)
                     startActivity(composeIntent)
                     return true
                 }
@@ -703,11 +700,9 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
         }
         uiResult.onSuccess { uiSuccess ->
             when (uiSuccess) {
-                is UiSuccess.RefreshAccount -> {
-                    /* do nothing */
-                }
+                is UiSuccess.RefreshAccount -> { /* do nothing */ }
 
-                is UiSuccess.SetActiveAccount -> pachliAccountId = uiSuccess.accountEntity.id
+                is UiSuccess.SetActiveAccount -> { /* nothing */ }
             }
         }
     }
@@ -1120,13 +1115,13 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
                     0 -> {
                         Timber.d("Clearing home timeline cache")
                         lifecycleScope.launch {
-                            developerToolsUseCase.clearHomeTimelineCache(pachliAccountId)
+                            developerToolsUseCase.clearHomeTimelineCache(intent.pachliAccountId)
                         }
                     }
                     1 -> {
                         Timber.d("Removing most recent 40 statuses")
                         lifecycleScope.launch {
-                            developerToolsUseCase.deleteFirstKStatuses(pachliAccountId, 40)
+                            developerToolsUseCase.deleteFirstKStatuses(intent.pachliAccountId, 40)
                         }
                     }
                 }
@@ -1279,7 +1274,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
     private fun refreshComposeButtonState(tabViewData: TabViewData) {
         tabViewData.composeIntent?.let { intent ->
             binding.composeButton.setOnClickListener {
-                startActivity(intent(applicationContext, pachliAccountId))
+                startActivity(intent(applicationContext, this.intent.pachliAccountId))
             }
             binding.composeButton.show()
         } ?: binding.composeButton.hide()


### PR DESCRIPTION
Previous code used `intent.pachliAccountId` and the response from the `SetActiveAccount` action (which might be null if the response hadn't been received).

Since these are identical, and only `intent.pachliAccountId` can never be null, use `intent.pachliAccountId`.