### PR TITLE
change: Pass desired initialKey row direct to Pager

### DIFF
--- a/app/src/main/java/app/pachli/components/timeline/CachedTimelineRepository.kt
+++ b/app/src/main/java/app/pachli/components/timeline/CachedTimelineRepository.kt
@@ -89,7 +89,7 @@ class CachedTimelineRepository @Inject constructor(
         Timber.d("initialKey: %s is row: %d", initialKey, row)
 
         return Pager(
-            initialKey = row?.let { (row - ((PAGE_SIZE * 3) / 2)).coerceAtLeast(0) },
+            initialKey = row,
             config = PagingConfig(
                 pageSize = PAGE_SIZE,
                 enablePlaceholders = true,

--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/notifications/NotificationsRepository.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/notifications/NotificationsRepository.kt
@@ -76,7 +76,7 @@ class NotificationsRepository @Inject constructor(
         val row = initialKey?.let { notificationDao.getNotificationRowNumber(pachliAccountId, it) }
 
         return Pager(
-            initialKey = row?.let { (row - ((PAGE_SIZE * 3) / 2)).coerceAtLeast(0) },
+            initialKey = row,
             config = PagingConfig(
                 pageSize = PAGE_SIZE,
                 enablePlaceholders = true,


### PR DESCRIPTION
Previous code passed a row some way earlier in the result set so that Room would load that row and content forward of it to "load around" the desired data.

https://issuetracker.google.com/issues/393558969 confirms that Room does this automatically, and the desired row can be passed directly.