### PR TITLE
fix: Update UI on boosts, etc

### DIFF
--- a/app/src/main/java/app/pachli/components/timeline/TimelineFragment.kt
+++ b/app/src/main/java/app/pachli/components/timeline/TimelineFragment.kt
@@ -349,6 +349,7 @@ class TimelineFragment :
                     is StatusActionSuccess.Translate -> statusViewData.status
                 }
                 (indexedViewData.value as StatusViewData).status = status
+                adapter.notifyItemChanged(indexedViewData.index)
             }
 
             // Refresh adapter on mutes and blocks


### PR DESCRIPTION
A previous change inadvertently removed the line that notified the timeline adapter of changes, so the UI wasn't refresh after e.g. boosting or favouriting a post.