### PR TITLE
change: Move / rename StatusMocker to core.testing / FakeStatus

### DIFF
--- a/app/src/test/java/app/pachli/components/timeline/CachedTimelineRemoteMediatorTest.kt
+++ b/app/src/test/java/app/pachli/components/timeline/CachedTimelineRemoteMediatorTest.kt
@@ -26,6 +26,8 @@ import app.pachli.core.network.json.Guarded
 import app.pachli.core.network.json.InstantJsonAdapter
 import app.pachli.core.network.json.LenientRfc3339DateJsonAdapter
 import app.pachli.core.testing.failure
+import app.pachli.core.testing.fakes.fakeStatus
+import app.pachli.core.testing.fakes.fakeStatusEntityWithAccount
 import app.pachli.core.testing.success
 import com.google.common.truth.Truth.assertThat
 import com.squareup.moshi.Moshi
@@ -147,7 +149,7 @@ class CachedTimelineRemoteMediatorTest {
             listOf(
                 PagingSource.LoadResult.Page(
                     data = listOf(
-                        mockStatusEntityWithAccount("3"),
+                        fakeStatusEntityWithAccount("3"),
                     ),
                     prevKey = null,
                     nextKey = 1,
@@ -168,9 +170,9 @@ class CachedTimelineRemoteMediatorTest {
             mastodonApi = mock {
                 onBlocking { homeTimeline(limit = 20) } doReturn success(
                     listOf(
-                        mockStatus("5"),
-                        mockStatus("4"),
-                        mockStatus("3"),
+                        fakeStatus("5"),
+                        fakeStatus("4"),
+                        fakeStatus("3"),
                     ),
                 )
             },
@@ -198,9 +200,9 @@ class CachedTimelineRemoteMediatorTest {
 
         db.assertStatuses(
             listOf(
-                mockStatusEntityWithAccount("5"),
-                mockStatusEntityWithAccount("4"),
-                mockStatusEntityWithAccount("3"),
+                fakeStatusEntityWithAccount("5"),
+                fakeStatusEntityWithAccount("4"),
+                fakeStatusEntityWithAccount("3"),
             ),
         )
     }
@@ -210,9 +212,9 @@ class CachedTimelineRemoteMediatorTest {
     fun `should remove deleted status from db and keep state of other cached statuses`() = runTest {
         // Given
         val statusesAlreadyInDb = listOf(
-            mockStatusEntityWithAccount("3", expanded = true),
-            mockStatusEntityWithAccount("2"),
-            mockStatusEntityWithAccount("1", expanded = false),
+            fakeStatusEntityWithAccount("3", expanded = true),
+            fakeStatusEntityWithAccount("2"),
+            fakeStatusEntityWithAccount("1", expanded = false),
         )
 
         db.insert(statusesAlreadyInDb)
@@ -221,8 +223,8 @@ class CachedTimelineRemoteMediatorTest {
             mastodonApi = mock {
                 onBlocking { homeTimeline(limit = 20) } doReturn success(
                     listOf(
-                        mockStatus("3"),
-                        mockStatus("1"),
+                        fakeStatus("3"),
+                        fakeStatus("1"),
                     ),
                 )
             },
@@ -253,8 +255,8 @@ class CachedTimelineRemoteMediatorTest {
             listOf(
                 // id="2" was in the database initially, but not in the results returned
                 // from the API, so it should have been deleted here.
-                mockStatusEntityWithAccount("3", expanded = true),
-                mockStatusEntityWithAccount("1", expanded = false),
+                fakeStatusEntityWithAccount("3", expanded = true),
+                fakeStatusEntityWithAccount("1", expanded = false),
             ),
         )
     }
@@ -263,9 +265,9 @@ class CachedTimelineRemoteMediatorTest {
     @ExperimentalPagingApi
     fun `should append statuses`() = runTest {
         val statusesAlreadyInDb = listOf(
-            mockStatusEntityWithAccount("8"),
-            mockStatusEntityWithAccount("7"),
-            mockStatusEntityWithAccount("5"),
+            fakeStatusEntityWithAccount("8"),
+            fakeStatusEntityWithAccount("7"),
+            fakeStatusEntityWithAccount("5"),
         )
 
         db.insert(statusesAlreadyInDb)
@@ -276,9 +278,9 @@ class CachedTimelineRemoteMediatorTest {
             mastodonApi = mock {
                 onBlocking { homeTimeline(maxId = "5", limit = 20) } doReturn success(
                     listOf(
-                        mockStatus("3"),
-                        mockStatus("2"),
-                        mockStatus("1"),
+                        fakeStatus("3"),
+                        fakeStatus("2"),
+                        fakeStatus("1"),
                     ),
                     headers = arrayOf("Link", "<http://example.com/?min_id=3>; rel=\"prev\", <http://example.com/?max_id=1>; rel=\"next\""),
 
@@ -307,12 +309,12 @@ class CachedTimelineRemoteMediatorTest {
         assertEquals(false, (result as RemoteMediator.MediatorResult.Success).endOfPaginationReached)
         db.assertStatuses(
             listOf(
-                mockStatusEntityWithAccount("8"),
-                mockStatusEntityWithAccount("7"),
-                mockStatusEntityWithAccount("5"),
-                mockStatusEntityWithAccount("3"),
-                mockStatusEntityWithAccount("2"),
-                mockStatusEntityWithAccount("1"),
+                fakeStatusEntityWithAccount("8"),
+                fakeStatusEntityWithAccount("7"),
+                fakeStatusEntityWithAccount("5"),
+                fakeStatusEntityWithAccount("3"),
+                fakeStatusEntityWithAccount("2"),
+                fakeStatusEntityWithAccount("1"),
             ),
         )
     }

--- a/app/src/test/java/app/pachli/components/timeline/NetworkTimelinePagingSourceTest.kt
+++ b/app/src/test/java/app/pachli/components/timeline/NetworkTimelinePagingSourceTest.kt
@@ -25,6 +25,7 @@ import app.pachli.components.timeline.viewmodel.NetworkTimelinePagingSource
 import app.pachli.components.timeline.viewmodel.Page
 import app.pachli.components.timeline.viewmodel.PageCache
 import app.pachli.core.network.model.Status
+import app.pachli.core.testing.fakes.fakeStatus
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -59,9 +60,9 @@ class NetworkTimelinePagingSourceTest {
     fun `load() for an item in a page returns the page containing that item and next, prev keys`() = runTest {
         // Given
         val pages = PageCache().apply {
-            add(Page(data = mutableListOf(mockStatus(id = "3")), nextKey = "1", prevKey = "4"), LoadType.REFRESH)
-            add(Page(data = mutableListOf(mockStatus(id = "1"), mockStatus(id = "2")), nextKey = "0", prevKey = "3"), LoadType.APPEND)
-            add(Page(data = mutableListOf(mockStatus(id = "0")), prevKey = "1"), LoadType.APPEND)
+            add(Page(data = mutableListOf(fakeStatus(id = "3")), nextKey = "1", prevKey = "4"), LoadType.REFRESH)
+            add(Page(data = mutableListOf(fakeStatus(id = "1"), fakeStatus(id = "2")), nextKey = "0", prevKey = "3"), LoadType.APPEND)
+            add(Page(data = mutableListOf(fakeStatus(id = "0")), prevKey = "1"), LoadType.APPEND)
         }
         val pagingSource = NetworkTimelinePagingSource(pages)
 
@@ -73,7 +74,7 @@ class NetworkTimelinePagingSourceTest {
         assertThat((loadResult as? LoadResult.Page))
             .isEqualTo(
                 LoadResult.Page(
-                    data = listOf(mockStatus(id = "1"), mockStatus(id = "2")),
+                    data = listOf(fakeStatus(id = "1"), fakeStatus(id = "2")),
                     prevKey = "3",
                     nextKey = "0",
                     itemsBefore = 1,
@@ -86,9 +87,9 @@ class NetworkTimelinePagingSourceTest {
     fun `append returns the page after`() = runTest {
         // Given
         val pages = PageCache().apply {
-            add(Page(data = mutableListOf(mockStatus(id = "2")), nextKey = "1"), LoadType.REFRESH)
-            add(Page(data = mutableListOf(mockStatus(id = "1")), nextKey = "0", prevKey = "2"), LoadType.APPEND)
-            add(Page(data = mutableListOf(mockStatus(id = "0")), prevKey = "1"), LoadType.APPEND)
+            add(Page(data = mutableListOf(fakeStatus(id = "2")), nextKey = "1"), LoadType.REFRESH)
+            add(Page(data = mutableListOf(fakeStatus(id = "1")), nextKey = "0", prevKey = "2"), LoadType.APPEND)
+            add(Page(data = mutableListOf(fakeStatus(id = "0")), prevKey = "1"), LoadType.APPEND)
         }
         val pagingSource = NetworkTimelinePagingSource(pages)
 
@@ -100,7 +101,7 @@ class NetworkTimelinePagingSourceTest {
         assertThat((loadResult as? LoadResult.Page))
             .isEqualTo(
                 LoadResult.Page(
-                    data = listOf(mockStatus(id = "1")),
+                    data = listOf(fakeStatus(id = "1")),
                     prevKey = "2",
                     nextKey = "0",
                     itemsBefore = 1,
@@ -113,9 +114,9 @@ class NetworkTimelinePagingSourceTest {
     fun `prepend returns the page before`() = runTest {
         // Given
         val pages = PageCache().apply {
-            add(Page(data = mutableListOf(mockStatus(id = "2")), nextKey = "1"), LoadType.REFRESH)
-            add(Page(data = mutableListOf(mockStatus(id = "1")), nextKey = "0", prevKey = "2"), LoadType.APPEND)
-            add(Page(data = mutableListOf(mockStatus(id = "0")), prevKey = "1"), LoadType.APPEND)
+            add(Page(data = mutableListOf(fakeStatus(id = "2")), nextKey = "1"), LoadType.REFRESH)
+            add(Page(data = mutableListOf(fakeStatus(id = "1")), nextKey = "0", prevKey = "2"), LoadType.APPEND)
+            add(Page(data = mutableListOf(fakeStatus(id = "0")), prevKey = "1"), LoadType.APPEND)
         }
         val pagingSource = NetworkTimelinePagingSource(pages)
 
@@ -127,7 +128,7 @@ class NetworkTimelinePagingSourceTest {
         assertThat((loadResult as? LoadResult.Page))
             .isEqualTo(
                 LoadResult.Page(
-                    data = listOf(mockStatus(id = "1")),
+                    data = listOf(fakeStatus(id = "1")),
                     prevKey = "2",
                     nextKey = "0",
                     itemsBefore = 1,
@@ -140,9 +141,9 @@ class NetworkTimelinePagingSourceTest {
     fun `Refresh with null key returns the latest page`() = runTest {
         // Given
         val pages = PageCache().apply {
-            add(Page(data = mutableListOf(mockStatus(id = "2")), nextKey = "1"), LoadType.REFRESH)
-            add(Page(data = mutableListOf(mockStatus(id = "1")), nextKey = "0", prevKey = "2"), LoadType.APPEND)
-            add(Page(data = mutableListOf(mockStatus(id = "0")), prevKey = "1"), LoadType.APPEND)
+            add(Page(data = mutableListOf(fakeStatus(id = "2")), nextKey = "1"), LoadType.REFRESH)
+            add(Page(data = mutableListOf(fakeStatus(id = "1")), nextKey = "0", prevKey = "2"), LoadType.APPEND)
+            add(Page(data = mutableListOf(fakeStatus(id = "0")), prevKey = "1"), LoadType.APPEND)
         }
         val pagingSource = NetworkTimelinePagingSource(pages)
 
@@ -154,7 +155,7 @@ class NetworkTimelinePagingSourceTest {
         assertThat((loadResult as? LoadResult.Page))
             .isEqualTo(
                 LoadResult.Page(
-                    data = listOf(mockStatus(id = "2")),
+                    data = listOf(fakeStatus(id = "2")),
                     prevKey = null,
                     nextKey = "1",
                     itemsBefore = 0,
@@ -167,8 +168,8 @@ class NetworkTimelinePagingSourceTest {
     fun `Append with a too-old key returns empty list`() = runTest {
         // Given
         val pages = PageCache().apply {
-            add(Page(data = mutableListOf(mockStatus(id = "20")), nextKey = "10"), LoadType.REFRESH)
-            add(Page(data = mutableListOf(mockStatus(id = "10")), prevKey = "20"), LoadType.APPEND)
+            add(Page(data = mutableListOf(fakeStatus(id = "20")), nextKey = "10"), LoadType.REFRESH)
+            add(Page(data = mutableListOf(fakeStatus(id = "10")), prevKey = "20"), LoadType.APPEND)
         }
         val pagingSource = NetworkTimelinePagingSource(pages)
 
@@ -194,8 +195,8 @@ class NetworkTimelinePagingSourceTest {
     fun `Prepend with a too-new key returns empty list`() = runTest {
         // Given
         val pages = PageCache().apply {
-            add(Page(data = mutableListOf(mockStatus(id = "20")), nextKey = "10"), LoadType.REFRESH)
-            add(Page(data = mutableListOf(mockStatus(id = "10")), prevKey = "20"), LoadType.APPEND)
+            add(Page(data = mutableListOf(fakeStatus(id = "20")), nextKey = "10"), LoadType.REFRESH)
+            add(Page(data = mutableListOf(fakeStatus(id = "10")), prevKey = "20"), LoadType.APPEND)
         }
         val pagingSource = NetworkTimelinePagingSource(pages)
 

--- a/app/src/test/java/app/pachli/components/timeline/NetworkTimelineRemoteMediatorTest.kt
+++ b/app/src/test/java/app/pachli/components/timeline/NetworkTimelineRemoteMediatorTest.kt
@@ -32,6 +32,7 @@ import app.pachli.core.database.model.AccountEntity
 import app.pachli.core.model.Timeline
 import app.pachli.core.network.model.Status
 import app.pachli.core.testing.failure
+import app.pachli.core.testing.fakes.fakeStatus
 import app.pachli.core.testing.success
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
@@ -114,7 +115,7 @@ class NetworkTimelineRemoteMediatorTest {
         val remoteMediator = NetworkTimelineRemoteMediator(
             api = mock {
                 onBlocking { homeTimeline(maxId = anyOrNull(), minId = anyOrNull(), limit = anyOrNull(), sinceId = anyOrNull()) } doReturn success(
-                    listOf(mockStatus("7"), mockStatus("6"), mockStatus("5")),
+                    listOf(fakeStatus("7"), fakeStatus("6"), fakeStatus("5")),
                     headers = arrayOf(
                         "Link",
                         "<https://mastodon.example/api/v1/timelines/home?max_id=5>; rel=\"next\", <https://mastodon.example/api/v1/timelines/homefavourites?min_id=7>; rel=\"prev\"",
@@ -144,7 +145,7 @@ class NetworkTimelineRemoteMediatorTest {
         val expectedPages = PageCache().apply {
             add(
                 Page(
-                    data = mutableListOf(mockStatus("7"), mockStatus("6"), mockStatus("5")),
+                    data = mutableListOf(fakeStatus("7"), fakeStatus("6"), fakeStatus("5")),
                     prevKey = "7",
                     nextKey = "5",
                 ),
@@ -167,7 +168,7 @@ class NetworkTimelineRemoteMediatorTest {
         val pages = PageCache().apply {
             add(
                 Page(
-                    data = mutableListOf(mockStatus("7"), mockStatus("6"), mockStatus("5")),
+                    data = mutableListOf(fakeStatus("7"), fakeStatus("6"), fakeStatus("5")),
                     prevKey = "7",
                     nextKey = "5",
                 ),
@@ -178,7 +179,7 @@ class NetworkTimelineRemoteMediatorTest {
         val remoteMediator = NetworkTimelineRemoteMediator(
             api = mock {
                 onBlocking { homeTimeline(maxId = anyOrNull(), minId = anyOrNull(), limit = anyOrNull(), sinceId = anyOrNull()) } doReturn success(
-                    listOf(mockStatus("10"), mockStatus("9"), mockStatus("8")),
+                    listOf(fakeStatus("10"), fakeStatus("9"), fakeStatus("8")),
                     headers = arrayOf(
                         "Link",
                         "<https://mastodon.example/api/v1/timelines/home?max_id=8>; rel=\"next\", <https://mastodon.example/api/v1/timelines/homefavourites?min_id=10>; rel=\"prev\"",
@@ -194,7 +195,7 @@ class NetworkTimelineRemoteMediatorTest {
         val state = state(
             listOf(
                 PagingSource.LoadResult.Page(
-                    data = listOf(mockStatus("7"), mockStatus("6"), mockStatus("5")),
+                    data = listOf(fakeStatus("7"), fakeStatus("6"), fakeStatus("5")),
                     prevKey = "7",
                     nextKey = "5",
                 ),
@@ -208,7 +209,7 @@ class NetworkTimelineRemoteMediatorTest {
         val expectedPages = PageCache().apply {
             add(
                 Page(
-                    data = mutableListOf(mockStatus("7"), mockStatus("6"), mockStatus("5")),
+                    data = mutableListOf(fakeStatus("7"), fakeStatus("6"), fakeStatus("5")),
                     prevKey = "7",
                     nextKey = "5",
                 ),
@@ -216,7 +217,7 @@ class NetworkTimelineRemoteMediatorTest {
             )
             add(
                 Page(
-                    data = mutableListOf(mockStatus("10"), mockStatus("9"), mockStatus("8")),
+                    data = mutableListOf(fakeStatus("10"), fakeStatus("9"), fakeStatus("8")),
                     prevKey = "10",
                     nextKey = "8",
                 ),
@@ -239,7 +240,7 @@ class NetworkTimelineRemoteMediatorTest {
         val pages = PageCache().apply {
             add(
                 Page(
-                    data = mutableListOf(mockStatus("7"), mockStatus("6"), mockStatus("5")),
+                    data = mutableListOf(fakeStatus("7"), fakeStatus("6"), fakeStatus("5")),
                     prevKey = "7",
                     nextKey = "5",
                 ),
@@ -250,7 +251,7 @@ class NetworkTimelineRemoteMediatorTest {
         val remoteMediator = NetworkTimelineRemoteMediator(
             api = mock {
                 onBlocking { homeTimeline(maxId = anyOrNull(), minId = anyOrNull(), limit = anyOrNull(), sinceId = anyOrNull()) } doReturn success(
-                    listOf(mockStatus("4"), mockStatus("3"), mockStatus("2")),
+                    listOf(fakeStatus("4"), fakeStatus("3"), fakeStatus("2")),
                     headers = arrayOf(
                         "Link",
                         "<https://mastodon.example/api/v1/timelines/home?max_id=2>; rel=\"next\", <https://mastodon.example/api/v1/timelines/homefavourites?min_id=4>; rel=\"prev\"",
@@ -266,7 +267,7 @@ class NetworkTimelineRemoteMediatorTest {
         val state = state(
             listOf(
                 PagingSource.LoadResult.Page(
-                    data = listOf(mockStatus("7"), mockStatus("6"), mockStatus("5")),
+                    data = listOf(fakeStatus("7"), fakeStatus("6"), fakeStatus("5")),
                     prevKey = "7",
                     nextKey = "5",
                 ),
@@ -280,7 +281,7 @@ class NetworkTimelineRemoteMediatorTest {
         val expectedPages = PageCache().apply {
             add(
                 Page(
-                    data = mutableListOf(mockStatus("7"), mockStatus("6"), mockStatus("5")),
+                    data = mutableListOf(fakeStatus("7"), fakeStatus("6"), fakeStatus("5")),
                     prevKey = "7",
                     nextKey = "5",
                 ),
@@ -288,7 +289,7 @@ class NetworkTimelineRemoteMediatorTest {
             )
             add(
                 Page(
-                    data = mutableListOf(mockStatus("4"), mockStatus("3"), mockStatus("2")),
+                    data = mutableListOf(fakeStatus("4"), fakeStatus("3"), fakeStatus("2")),
                     prevKey = "4",
                     nextKey = "2",
                 ),

--- a/app/src/test/java/app/pachli/components/viewthread/ViewThreadViewModelTest.kt
+++ b/app/src/test/java/app/pachli/components/viewthread/ViewThreadViewModelTest.kt
@@ -5,8 +5,8 @@ import app.cash.turbine.test
 import app.pachli.PachliApplication
 import app.pachli.components.compose.HiltTestApplication_Application
 import app.pachli.components.timeline.CachedTimelineRepository
-import app.pachli.components.timeline.mockStatus
-import app.pachli.components.timeline.mockStatusViewData
+import app.pachli.core.testing.fakes.fakeStatus
+import app.pachli.core.testing.fakes.fakeStatusViewData
 import app.pachli.core.data.repository.AccountManager
 import app.pachli.core.data.repository.StatusDisplayOptionsRepository
 import app.pachli.core.data.repository.StatusRepository
@@ -186,15 +186,15 @@ class ViewThreadViewModelTest {
             assertEquals(
                 ThreadUiState.Success(
                     statusViewData = listOf(
-                        mockStatusViewData(id = "1", spoilerText = "Test"),
-                        mockStatusViewData(
+                        fakeStatusViewData(id = "1", spoilerText = "Test"),
+                        fakeStatusViewData(
                             id = "2",
                             inReplyToId = "1",
                             inReplyToAccountId = "1",
                             isDetailed = true,
                             spoilerText = "Test",
                         ),
-                        mockStatusViewData(
+                        fakeStatusViewData(
                             id = "3",
                             inReplyToId = "2",
                             inReplyToAccountId = "1",
@@ -212,7 +212,7 @@ class ViewThreadViewModelTest {
     @Test
     fun `should emit status even if context fails to load`() = runTest {
         mastodonApi.stub {
-            onBlocking { status(threadId) } doReturn success(mockStatus(id = "2", inReplyToId = "1", inReplyToAccountId = "1"))
+            onBlocking { status(threadId) } doReturn success(fakeStatus(id = "2", inReplyToId = "1", inReplyToAccountId = "1"))
             onBlocking { statusContext(threadId) } doReturn failure()
         }
 
@@ -227,7 +227,7 @@ class ViewThreadViewModelTest {
             assertEquals(
                 ThreadUiState.Success(
                     statusViewData = listOf(
-                        mockStatusViewData(
+                        fakeStatusViewData(
                             id = "2",
                             inReplyToId = "1",
                             inReplyToAccountId = "1",
@@ -270,8 +270,8 @@ class ViewThreadViewModelTest {
             onBlocking { status(threadId) } doReturn failure()
             onBlocking { statusContext(threadId) } doReturn success(
                 StatusContext(
-                    ancestors = listOf(mockStatus(id = "1")),
-                    descendants = listOf(mockStatus(id = "3", inReplyToId = "2", inReplyToAccountId = "1")),
+                    ancestors = listOf(fakeStatus(id = "1")),
+                    descendants = listOf(fakeStatus(id = "3", inReplyToId = "2", inReplyToAccountId = "1")),
                 ),
             )
         }
@@ -304,8 +304,8 @@ class ViewThreadViewModelTest {
             assertEquals(
                 ThreadUiState.Success(
                     statusViewData = listOf(
-                        mockStatusViewData(id = "1", spoilerText = "Test", isExpanded = true),
-                        mockStatusViewData(
+                        fakeStatusViewData(id = "1", spoilerText = "Test", isExpanded = true),
+                        fakeStatusViewData(
                             id = "2",
                             inReplyToId = "1",
                             inReplyToAccountId = "1",
@@ -313,7 +313,7 @@ class ViewThreadViewModelTest {
                             spoilerText = "Test",
                             isExpanded = true,
                         ),
-                        mockStatusViewData(
+                        fakeStatusViewData(
                             id = "3",
                             inReplyToId = "2",
                             inReplyToAccountId = "1",
@@ -342,15 +342,15 @@ class ViewThreadViewModelTest {
             assertEquals(
                 ThreadUiState.Success(
                     statusViewData = listOf(
-                        mockStatusViewData(id = "1", spoilerText = "Test", favourited = false),
-                        mockStatusViewData(
+                        fakeStatusViewData(id = "1", spoilerText = "Test", favourited = false),
+                        fakeStatusViewData(
                             id = "2",
                             inReplyToId = "1",
                             inReplyToAccountId = "1",
                             isDetailed = true,
                             spoilerText = "Test",
                         ),
-                        mockStatusViewData(
+                        fakeStatusViewData(
                             id = "3",
                             inReplyToId = "2",
                             inReplyToAccountId = "1",
@@ -378,8 +378,8 @@ class ViewThreadViewModelTest {
             assertEquals(
                 ThreadUiState.Success(
                     statusViewData = listOf(
-                        mockStatusViewData(id = "1", spoilerText = "Test"),
-                        mockStatusViewData(
+                        fakeStatusViewData(id = "1", spoilerText = "Test"),
+                        fakeStatusViewData(
                             id = "2",
                             inReplyToId = "1",
                             inReplyToAccountId = "1",
@@ -387,7 +387,7 @@ class ViewThreadViewModelTest {
                             spoilerText = "Test",
                             reblogged = true,
                         ),
-                        mockStatusViewData(
+                        fakeStatusViewData(
                             id = "3",
                             inReplyToId = "2",
                             inReplyToAccountId = "1",
@@ -415,15 +415,15 @@ class ViewThreadViewModelTest {
             assertEquals(
                 ThreadUiState.Success(
                     statusViewData = listOf(
-                        mockStatusViewData(id = "1", spoilerText = "Test"),
-                        mockStatusViewData(
+                        fakeStatusViewData(id = "1", spoilerText = "Test"),
+                        fakeStatusViewData(
                             id = "2",
                             inReplyToId = "1",
                             inReplyToAccountId = "1",
                             isDetailed = true,
                             spoilerText = "Test",
                         ),
-                        mockStatusViewData(
+                        fakeStatusViewData(
                             id = "3",
                             inReplyToId = "2",
                             inReplyToAccountId = "1",
@@ -447,13 +447,13 @@ class ViewThreadViewModelTest {
             viewModel.loadThread(threadId)
             while (awaitItem() !is ThreadUiState.Success) {
             }
-            viewModel.removeStatus(mockStatusViewData(id = "3", inReplyToId = "2", inReplyToAccountId = "1", spoilerText = "Test"))
+            viewModel.removeStatus(fakeStatusViewData(id = "3", inReplyToId = "2", inReplyToAccountId = "1", spoilerText = "Test"))
 
             assertEquals(
                 ThreadUiState.Success(
                     statusViewData = listOf(
-                        mockStatusViewData(id = "1", spoilerText = "Test"),
-                        mockStatusViewData(
+                        fakeStatusViewData(id = "1", spoilerText = "Test"),
+                        fakeStatusViewData(
                             id = "2",
                             inReplyToId = "1",
                             inReplyToAccountId = "1",
@@ -479,14 +479,14 @@ class ViewThreadViewModelTest {
             }
             viewModel.changeExpanded(
                 true,
-                mockStatusViewData(id = "2", inReplyToId = "1", inReplyToAccountId = "1", isDetailed = true, spoilerText = "Test"),
+                fakeStatusViewData(id = "2", inReplyToId = "1", inReplyToAccountId = "1", isDetailed = true, spoilerText = "Test"),
             )
 
             assertEquals(
                 ThreadUiState.Success(
                     statusViewData = listOf(
-                        mockStatusViewData(id = "1", spoilerText = "Test"),
-                        mockStatusViewData(
+                        fakeStatusViewData(id = "1", spoilerText = "Test"),
+                        fakeStatusViewData(
                             id = "2",
                             inReplyToId = "1",
                             inReplyToAccountId = "1",
@@ -494,7 +494,7 @@ class ViewThreadViewModelTest {
                             spoilerText = "Test",
                             isExpanded = true,
                         ),
-                        mockStatusViewData(
+                        fakeStatusViewData(
                             id = "3",
                             inReplyToId = "2",
                             inReplyToAccountId = "1",
@@ -519,14 +519,14 @@ class ViewThreadViewModelTest {
             }
             viewModel.changeContentCollapsed(
                 true,
-                mockStatusViewData(id = "2", inReplyToId = "1", inReplyToAccountId = "1", isDetailed = true, spoilerText = "Test"),
+                fakeStatusViewData(id = "2", inReplyToId = "1", inReplyToAccountId = "1", isDetailed = true, spoilerText = "Test"),
             )
 
             assertEquals(
                 ThreadUiState.Success(
                     statusViewData = listOf(
-                        mockStatusViewData(id = "1", spoilerText = "Test"),
-                        mockStatusViewData(
+                        fakeStatusViewData(id = "1", spoilerText = "Test"),
+                        fakeStatusViewData(
                             id = "2",
                             inReplyToId = "1",
                             inReplyToAccountId = "1",
@@ -534,7 +534,7 @@ class ViewThreadViewModelTest {
                             spoilerText = "Test",
                             isCollapsed = true,
                         ),
-                        mockStatusViewData(
+                        fakeStatusViewData(
                             id = "3",
                             inReplyToId = "2",
                             inReplyToAccountId = "1",
@@ -559,14 +559,14 @@ class ViewThreadViewModelTest {
             }
             viewModel.changeContentShowing(
                 true,
-                mockStatusViewData(id = "2", inReplyToId = "1", inReplyToAccountId = "1", isDetailed = true, spoilerText = "Test"),
+                fakeStatusViewData(id = "2", inReplyToId = "1", inReplyToAccountId = "1", isDetailed = true, spoilerText = "Test"),
             )
 
             assertEquals(
                 ThreadUiState.Success(
                     statusViewData = listOf(
-                        mockStatusViewData(id = "1", spoilerText = "Test"),
-                        mockStatusViewData(
+                        fakeStatusViewData(id = "1", spoilerText = "Test"),
+                        fakeStatusViewData(
                             id = "2",
                             inReplyToId = "1",
                             inReplyToAccountId = "1",
@@ -574,7 +574,7 @@ class ViewThreadViewModelTest {
                             spoilerText = "Test",
                             isShowingContent = true,
                         ),
-                        mockStatusViewData(
+                        fakeStatusViewData(
                             id = "3",
                             inReplyToId = "2",
                             inReplyToAccountId = "1",
@@ -591,11 +591,11 @@ class ViewThreadViewModelTest {
 
     private fun mockSuccessResponses() {
         mastodonApi.stub {
-            onBlocking { status(threadId) } doReturn success(mockStatus(id = "2", inReplyToId = "1", inReplyToAccountId = "1", spoilerText = "Test"))
+            onBlocking { status(threadId) } doReturn success(fakeStatus(id = "2", inReplyToId = "1", inReplyToAccountId = "1", spoilerText = "Test"))
             onBlocking { statusContext(threadId) } doReturn success(
                 StatusContext(
-                    ancestors = listOf(mockStatus(id = "1", spoilerText = "Test")),
-                    descendants = listOf(mockStatus(id = "3", inReplyToId = "2", inReplyToAccountId = "1", spoilerText = "Test")),
+                    ancestors = listOf(fakeStatus(id = "1", spoilerText = "Test")),
+                    descendants = listOf(fakeStatus(id = "3", inReplyToId = "2", inReplyToAccountId = "1", spoilerText = "Test")),
                 ),
             )
         }

--- a/app/src/test/java/app/pachli/components/viewthread/ViewThreadViewModelTest.kt
+++ b/app/src/test/java/app/pachli/components/viewthread/ViewThreadViewModelTest.kt
@@ -5,8 +5,6 @@ import app.cash.turbine.test
 import app.pachli.PachliApplication
 import app.pachli.components.compose.HiltTestApplication_Application
 import app.pachli.components.timeline.CachedTimelineRepository
-import app.pachli.core.testing.fakes.fakeStatus
-import app.pachli.core.testing.fakes.fakeStatusViewData
 import app.pachli.core.data.repository.AccountManager
 import app.pachli.core.data.repository.StatusDisplayOptionsRepository
 import app.pachli.core.data.repository.StatusRepository
@@ -24,6 +22,8 @@ import app.pachli.core.network.retrofit.MastodonApi
 import app.pachli.core.network.retrofit.NodeInfoApi
 import app.pachli.core.preferences.SharedPreferencesRepository
 import app.pachli.core.testing.failure
+import app.pachli.core.testing.fakes.fakeStatus
+import app.pachli.core.testing.fakes.fakeStatusViewData
 import app.pachli.core.testing.rules.MainCoroutineRule
 import app.pachli.core.testing.success
 import app.pachli.usecase.TimelineCases

--- a/core/testing/build.gradle.kts
+++ b/core/testing/build.gradle.kts
@@ -31,7 +31,9 @@ android {
 
 dependencies {
     implementation(projects.core.common)
+    implementation(projects.core.data)
     implementation(projects.core.database)
+    implementation(projects.core.model)
     implementation(projects.core.network)
 
     implementation(libs.hilt.android.testing)

--- a/core/testing/src/main/kotlin/app/pachli/core/testing/fakes/FakeStatus.kt
+++ b/core/testing/src/main/kotlin/app/pachli/core/testing/fakes/FakeStatus.kt
@@ -1,4 +1,21 @@
-package app.pachli.components.timeline
+/*
+ * Copyright (c) 2025 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.core.testing.fakes
 
 import app.pachli.core.data.model.StatusViewData
 import app.pachli.core.database.model.StatusEntity
@@ -12,7 +29,7 @@ import java.util.Date
 
 private val fixedDate = Date(1638889052000)
 
-fun mockStatus(
+fun fakeStatus(
     id: String = "100",
     inReplyToId: String? = null,
     inReplyToAccountId: String? = null,
@@ -61,7 +78,7 @@ fun mockStatus(
     filtered = null,
 )
 
-fun mockStatusViewData(
+fun fakeStatusViewData(
     id: String = "100",
     inReplyToId: String? = null,
     inReplyToAccountId: String? = null,
@@ -75,7 +92,7 @@ fun mockStatusViewData(
     bookmarked: Boolean = true,
 ) = StatusViewData(
     pachliAccountId = 1L,
-    status = mockStatus(
+    status = fakeStatus(
         id = id,
         inReplyToId = inReplyToId,
         inReplyToAccountId = inReplyToAccountId,
@@ -91,20 +108,20 @@ fun mockStatusViewData(
     translationState = TranslationState.SHOW_ORIGINAL,
 )
 
-fun mockStatusEntityWithAccount(
+fun fakeStatusEntityWithAccount(
     id: String = "100",
     userId: Long = 1,
     expanded: Boolean = false,
 ): TimelineStatusWithAccount {
-    val mockedStatus = mockStatus(id)
+    val status = fakeStatus(id)
 
     return TimelineStatusWithAccount(
         status = StatusEntity.from(
-            mockedStatus,
+            status,
             timelineUserId = userId,
         ),
         account = TimelineAccountEntity.from(
-            mockedStatus.account,
+            status.account,
             accountId = userId,
         ),
         viewData = StatusViewDataEntity(


### PR DESCRIPTION
Rename the functions to be more accurate (they return fakes, not mocks).

Move the functions to core.testing so they're available to tests in other modules.