### PR TITLE
build: Work around "Something has been appended to this collector already"

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,3 +10,7 @@ org.gradle.configuration-cache.parallel=true
 android.defaults.buildfeatures.resvalues=false
 android.defaults.buildfeatures.shaders=false
 android.useAndroidX=true
+
+# Work around "Something has been appended to this collector already" issue.
+# https://youtrack.jetbrains.com/issue/KT-74394/KGP-isolated-projects-Something-has-been-appended-to-this-collector-already
+kotlin.internal.collectFUSMetrics=false


### PR DESCRIPTION
Newer gradle is sometimes crashing with the message:

> Something has been appended to this collector already

Per https://youtrack.jetbrains.com/issue/KT-74394/KGP-isolated-projects-Something-has-been-appended-to-this-collector-already
this setting resolves it.