### PR TITLE
fix: Highlight modified hashtags when viewing status edits

### DIFF
--- a/app/src/main/java/app/pachli/components/viewthread/edits/ViewEditsAdapter.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/edits/ViewEditsAdapter.kt
@@ -105,7 +105,7 @@ class ViewEditsAdapter(
 
         binding.statusEditInfo.text = context.getString(infoStringRes, timestamp)
 
-        if (edit.spoilerText.isEmpty()) {
+        if (edit.spoilerText.removePrefix("<div/>").isEmpty()) {
             binding.statusEditContentWarningDescription.hide()
             binding.statusEditContentWarningSeparator.hide()
         } else {
@@ -125,7 +125,7 @@ class ViewEditsAdapter(
             .parseAsMastodonHtml(pachliTagHandler)
             .emojify(edit.emojis, binding.statusEditContent, animateEmojis)
 
-        setClickableText(binding.statusEditContent, emojifiedText, emptyList(), emptyList(), listener)
+        setClickableText(binding.statusEditContent, emojifiedText, emptyList(), null, listener)
 
         val poll = edit.poll
         if (poll == null) {

--- a/app/src/main/java/app/pachli/components/viewthread/edits/ViewEditsViewModel.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/edits/ViewEditsViewModel.kt
@@ -45,6 +45,7 @@ import org.pageseeder.diffx.token.impl.SpaceToken
 import org.pageseeder.diffx.xml.NamespaceSet
 import org.pageseeder.xmlwriter.XML.NamespaceAware
 import org.pageseeder.xmlwriter.XMLStringWriter
+import timber.log.Timber
 
 @HiltViewModel
 class ViewEditsViewModel @Inject constructor(private val api: MastodonApi) : ViewModel() {
@@ -91,7 +92,12 @@ class ViewEditsViewModel @Inject constructor(private val api: MastodonApi) : Vie
                     // a block element ("<a ...> some text") is not. Guard against
                     // this be wrapping everything in a div.
                     // https://github.com/tuskyapp/Tusky/issues/4253
-                    .map { it.copy(content = "<div>${it.content}</div>") }
+                    .map {
+                        it.copy(
+                            content = "<div>${it.content}</div>",
+                            spoilerText = "<div>${it.spoilerText}</div>",
+                        )
+                    }
                     .sortedBy { it.createdAt }
                     .reversed()
                     .toMutableList()
@@ -109,8 +115,8 @@ class ViewEditsViewModel @Inject constructor(private val api: MastodonApi) : Vie
                 val contentDiff = HtmlDiffOutput()
 
                 try {
-                    var currentSpoilerText = loader.load("<div>${sortedEdits[0].spoilerText}</div>")
-                    var previousSpoilerText = loader.load("<div>${sortedEdits[1].spoilerText}</div>")
+                    var currentSpoilerText = loader.load(sortedEdits[0].spoilerText)
+                    var previousSpoilerText = loader.load(sortedEdits[1].spoilerText)
 
                     // The XML processor expects `br` to be closed
                     var currentContent =
@@ -122,7 +128,7 @@ class ViewEditsViewModel @Inject constructor(private val api: MastodonApi) : Vie
                         processor.diff(previousSpoilerText, currentSpoilerText, spoilerDiff)
                         processor.diff(previousContent, currentContent, contentDiff)
                         sortedEdits[i - 1] = sortedEdits[i - 1].copy(
-                            spoilerText = spoilerDiff.xml.toString().removePrefix("<div/>"),
+                            spoilerText = spoilerDiff.xml.toString(),
                             content = contentDiff.xml.toString(),
                         )
 
@@ -136,7 +142,8 @@ class ViewEditsViewModel @Inject constructor(private val api: MastodonApi) : Vie
                         }
                     }
                     _uiState.value = EditsUiState.Success(sortedEdits)
-                } catch (_: LoadingException) {
+                } catch (e: LoadingException) {
+                    Timber.e(e, "Could not diff")
                     // Something failed parsing the XML from the server. Rather than
                     // show an error just return the sorted edits so the user can at
                     // least visually scan the differences.

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/NoUnderlineURLSpan.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/NoUnderlineURLSpan.kt
@@ -45,3 +45,14 @@ open class NoUnderlineURLSpan(val url: String) : URLSpan(url) {
  * Mentions of other users ("@user@example.org")
  */
 open class MentionSpan(url: String) : NoUnderlineURLSpan(url)
+
+/**
+ * Hashtags (`#foo`)
+ *
+ * @param hashtag Text of the tag, without the leading `#`.
+ * @param url URL for the tag.
+ * @param listener Listener for clicks on the tag.
+ */
+class HashtagSpan(val hashtag: String, url: String, val listener: LinkListener) : NoUnderlineURLSpan(url) {
+    override fun onClick(view: View) = listener.onViewTag(hashtag)
+}


### PR DESCRIPTION
Previous code used `unicodeWrap` to add the directional isolates, which returns a `String`. This overwrites any existing spans in the text, and in particular, the spans that marked insertions or deletions.

The effect was to remove the insert/delete markup for hashtags (and probably mentions) when viewing edits to a status.

Fix this by avoiding `unicodeWrap` in this case and adding the isolates to the spanned text.

While I'm here, cleanup up spoiler text wrangling in edits.