### PR TITLE
fix: Avoid duplicate "Refresh" menus, rename to "Refresh account"

### DIFF
--- a/app/src/main/java/app/pachli/components/account/AccountActivity.kt
+++ b/app/src/main/java/app/pachli/components/account/AccountActivity.kt
@@ -1051,7 +1051,7 @@ class AccountActivity :
                 viewModel.changeShowReblogsState()
                 return true
             }
-            R.id.action_refresh -> {
+            R.id.action_refresh_account -> {
                 binding.swipeRefreshLayout.isRefreshing = true
                 onRefresh()
                 return true

--- a/app/src/main/res/menu/account_toolbar.xml
+++ b/app/src/main/res/menu/account_toolbar.xml
@@ -44,8 +44,8 @@
         app:showAsAction="never" />
 
     <item
-        android:id="@+id/action_refresh"
-        android:title="@string/action_refresh"
+        android:id="@+id/action_refresh_account"
+        android:title="@string/action_refresh_account"
         app:showAsAction="never" />
 
     <item

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -191,6 +191,7 @@
     <string name="download_image">Downloading %1$s</string>
     <string name="action_copy_link">Copy the link</string>
     <string name="action_share_as">Share as …</string>
+    <string name="action_refresh_account">Refresh account</string>
     <string name="download_media">Download media</string>
     <string name="downloading_media">Downloading media</string>
     <string name="send_post_link_to">Share post URL to…</string>

--- a/feature/about/src/main/res/values-en-rGB/strings.xml
+++ b/feature/about/src/main/res/values-en-rGB/strings.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="title_licenses">Licenses</string>
-    <string name="action_refresh">Refresh</string>
 </resources>

--- a/feature/about/src/main/res/values-es/strings.xml
+++ b/feature/about/src/main/res/values-es/strings.xml
@@ -42,7 +42,6 @@
     <string name="notification_log_method_unknown">El mecanismo de notificación no ha sido determinado</string>
     <string name="notification_log_download_failed">Falló la descarga: %1$s</string>
     <string name="notitication_log_filter_dialog_title">Mostrar prioridades del registro</string>
-    <string name="action_refresh">Recargar</string>
     <string name="notification_details_title">Detalles</string>
     <string name="notification_details_android_notifications_enabled">¿Están habilitadas las notificaciones de Android?</string>
     <string name="notification_details_notifications_enabled_help">Las notificaciones no están habilitadas para ninguna de tus cuentas. Modifícalo en Preferencias de cuenta &gt; Notificaciones. En tanto, todas las notificaciones permanecerán deshabilitadas.</string>

--- a/feature/about/src/main/res/values-fi/strings.xml
+++ b/feature/about/src/main/res/values-fi/strings.xml
@@ -35,5 +35,4 @@
     <string name="notification_details_ntfy_exempt_help">NTFY ei ole vapautettu akunkäytön optimoinnista. Android voi viivyttää ilmoituksia kun näyttö ei ole käytössä.</string>
     <string name="notification_details_pachli_exempt_help">Pachli ei ole vapautettu akunkäytön optimoinnista. Android saattaa viivyttää ilmoituksia kun näyttö ei ole käytössä.</string>
     <string name="notification_details_pachli_exempt">Onko Pachli vapautettu akunkäytön optimoinnista?</string>
-    <string name="action_refresh">Päivitä</string>
 </resources>

--- a/feature/about/src/main/res/values-ga/strings.xml
+++ b/feature/about/src/main/res/values-ga/strings.xml
@@ -39,7 +39,6 @@
     <string name="about_account_info">\@%s@%s
 \nLeagan: %s</string>
     <string name="about_nivenly_foundation">Is tionscadal <a href="https://nivenly.org">Fondúireacht Nivenly</a> é Pachli.</string>
-    <string name="action_refresh">Athnuaigh</string>
     <string name="about_copied">Leagan cóipeáilte agus faisnéis gléas</string>
     <string name="notification_log_filter_content_description">Scag logs de réir clib</string>
     <string name="notification_details_title">Sonraí</string>

--- a/feature/about/src/main/res/values-gl/strings.xml
+++ b/feature/about/src/main/res/values-gl/strings.xml
@@ -62,7 +62,6 @@
     <string name="notification_log_method_pusherror">UnifiedPush está activado pero tivo un erro: %1$s</string>
     <string name="notification_log_download_failed">Fallou a descarga: %1$s</string>
     <string name="notitication_log_filter_dialog_title">Mostrar prioridade no rexistro</string>
-    <string name="action_refresh">Actualizar</string>
     <string name="notification_details_usage_event_label">Android pode limitar a actividade en segundo plano das aplicacións. Esta lista mostra o xeito en que Pachli estivo limitada nos últimos 3 días, con orde cronolóxica.</string>
     <string name="notification_details_standby_bucket_restricted">Restrinxida. Unha vez ao día</string>
     <string name="about_nivenly_foundation">Pachli é un proxecto da <a href="https://nivenly.org">Nivenly Foundation</a>.</string>

--- a/feature/about/src/main/res/values-kab/strings.xml
+++ b/feature/about/src/main/res/values-kab/strings.xml
@@ -6,5 +6,4 @@
 \n https://pachli.app</string>
     <string name="about_pachli_account">Amaɣnu n Pachli</string>
     <string name="title_licenses">Turagin</string>
-    <string name="action_refresh">Smiren</string>
 </resources>

--- a/feature/about/src/main/res/values-lt/strings.xml
+++ b/feature/about/src/main/res/values-lt/strings.xml
@@ -20,6 +20,5 @@
     <string name="notification_details_title">Išsami informacija</string>
     <string name="notification_details_notifications_enabled_help">Pranešimai neįjungti nė vienoje jūsų paskyroje. Pakeiskite tai per Paskyros nuostatos &gt; Pranešimai. Iki tol visi pranešimai yra išjungti.</string>
     <string name="notification_details_unifiedpush_available">„UnifiedPush“ pasiekiama?</string>
-    <string name="action_refresh">Atnaujinti</string>
     <string name="notitication_log_filter_dialog_title">Rodyti žurnalo prioritetus</string>
 </resources>

--- a/feature/about/src/main/res/values-nb-rNO/strings.xml
+++ b/feature/about/src/main/res/values-nb-rNO/strings.xml
@@ -66,5 +66,4 @@
     <string name="notification_log_method_unknown">Metoden som brukes for å levere varslinger, er ukjent</string>
     <string name="notification_log_method_pusherror">UnifiedPush er påslått men har oppdaget en feil: %1$s</string>
     <string name="notification_log_download_failed">Nedlasting mislyktes: %1$s</string>
-    <string name="action_refresh">Last inn på nytt</string>
 </resources>

--- a/feature/about/src/main/res/values-nl/strings.xml
+++ b/feature/about/src/main/res/values-nl/strings.xml
@@ -59,7 +59,6 @@
     <string name="notification_log_method_pusherror">UnifiedPush is ingeschakeld maar had een fout: %1$s</string>
     <string name="notification_log_download_failed">Download mislukt: %1$s</string>
     <string name="notitication_log_filter_dialog_title">Toon log prioriteiten</string>
-    <string name="action_refresh">Ververs</string>
     <string name="notification_details_notifications_enabled_help">Notificaties zijn niet ingeschakeld voor je accounts. Wijzig dit in Account Voorkeuren &gt; Notificaties. Totdan zijn alle notificaties uitgeschakeld.</string>
     <string name="notification_details_unifiedpush_available_help">UnifiedPush (ntfy.sh) is niet beschikbaar, notificaties worden periodiek opgehaald. De rest van deze sectie verklaard waarom UnifiedPush niet wordt gebruikt, maar is niet relevant voor hoe notificaties worden opgehaald.</string>
     <string name="notification_details_accounts_unified_push_subscription">Alle accounts zijn geabonneerd?</string>

--- a/feature/about/src/main/res/values-pl/strings.xml
+++ b/feature/about/src/main/res/values-pl/strings.xml
@@ -26,7 +26,6 @@
     <string name="notification_log_method_unknown">Mechanizm powiadomień nie został określony</string>
     <string name="notification_log_download_failed">Pobieranie się nie powiodło: %1$s</string>
     <string name="notitication_log_filter_dialog_title">Pokaż priorytety dziennika</string>
-    <string name="action_refresh">Odśwież</string>
     <string name="about_copied">Skopiowano numer wersji i informacje o urządzeniu</string>
     <string name="about_copy">Skopiuj numer wersji i informacje o urządzeniu</string>
     <string name="about_device_info">%s %s\nWersja Androida: %s\nPoziom SDK: %d</string>

--- a/feature/about/src/main/res/values-sk/strings.xml
+++ b/feature/about/src/main/res/values-sk/strings.xml
@@ -61,5 +61,4 @@
     <string name="notification_log_download_content_description">Stiahnuť logy</string>
     <string name="notification_log_method_push">Upozornenia sú doručované pomocou UnifiedPush a mali by byť okamžité</string>
     <string name="notitication_log_filter_dialog_title">Zobraziť priority logu</string>
-    <string name="action_refresh">Obnoviť</string>
 </resources>

--- a/feature/about/src/main/res/values-zh-rCN/strings.xml
+++ b/feature/about/src/main/res/values-zh-rCN/strings.xml
@@ -18,5 +18,4 @@
     <string name="about_account_info">\@%s@%s
 \n版本: %s</string>
     <string name="license_description">Pachli 使用了以下开源项目的源码：</string>
-    <string name="action_refresh">刷新</string>
 </resources>

--- a/feature/about/src/main/res/values-zh-rHK/strings.xml
+++ b/feature/about/src/main/res/values-zh-rHK/strings.xml
@@ -11,5 +11,4 @@
     <string name="about_pachli_account">Pachli 官方帳號</string>
     <string name="title_licenses">開源授權</string>
     <string name="license_description">Pachli 使用了以下開源專案的原始碼：</string>
-    <string name="action_refresh">重新整理</string>
 </resources>

--- a/feature/about/src/main/res/values-zh-rTW/strings.xml
+++ b/feature/about/src/main/res/values-zh-rTW/strings.xml
@@ -11,5 +11,4 @@
     <string name="about_pachli_account">Pachli 官方帳號</string>
     <string name="title_licenses">開源授權</string>
     <string name="license_description">Pachli 使用了以下開源專案的原始碼：</string>
-    <string name="action_refresh">重新整理</string>
 </resources>

--- a/feature/about/src/main/res/values/strings.xml
+++ b/feature/about/src/main/res/values/strings.xml
@@ -63,6 +63,5 @@
     <string name="notification_log_method_pusherror">UnifiedPush is enabled but had an error: %1$s</string>
     <string name="notification_log_download_failed">Download failed: %1$s</string>
     <string name="notitication_log_filter_dialog_title">Show log priorities</string>
-    <string name="action_refresh">Refresh</string>
     <string name="about_nivenly_foundation">Pachli is a <a href="https://nivenly.org">Nivenly Foundation</a> project.</string>
 </resources>


### PR DESCRIPTION
The account screen allows the user to refresh the account info (avatar, bio, etc), or whichever timeline is showing at the bottom of the screen.

Both the menu items were labelled "Refresh". Change the ID and label of the first one to "Refresh account".

While I'm here there were duplicate `action_refresh` strings in `feature/about`. Remove or move them as appropriate.

Fixes #1295