### PR TITLE
fix: Remove old account data before creating FK constraints

### DIFF
--- a/core/database/src/main/kotlin/app/pachli/core/database/AppDatabase.kt
+++ b/core/database/src/main/kotlin/app/pachli/core/database/AppDatabase.kt
@@ -321,7 +321,7 @@ val MIGRATE_8_9 = object : Migration(8, 9) {
  * Clears references to deleted accounts.
  *
  * The migration from 10 -> 11 adds FK relationships to the AccountEntity table. Because of
- * earlier bugs the child tables in those relationships may contain orphoned rows that
+ * earlier bugs the child tables in those relationships may contain orphaned rows that
  * reference accounts that have been logged out and deleted from AccountEntity. Trying to
  * create those FK relationships will fail because of that.
  *

--- a/core/database/src/main/kotlin/app/pachli/core/database/di/DatabaseModule.kt
+++ b/core/database/src/main/kotlin/app/pachli/core/database/di/DatabaseModule.kt
@@ -22,6 +22,7 @@ import androidx.room.Room
 import androidx.room.withTransaction
 import app.pachli.core.database.AppDatabase
 import app.pachli.core.database.Converters
+import app.pachli.core.database.MIGRATE_10_11
 import app.pachli.core.database.MIGRATE_12_13
 import app.pachli.core.database.MIGRATE_18_19
 import app.pachli.core.database.MIGRATE_8_9
@@ -45,6 +46,7 @@ object DatabaseModule {
             .addTypeConverter(converters)
             .allowMainThreadQueries()
             .addMigrations(MIGRATE_8_9)
+            .addMigrations(MIGRATE_10_11)
             .addMigrations(MIGRATE_12_13)
             .addMigrations(MIGRATE_18_19)
             .build()


### PR DESCRIPTION
The 10 -> 11 database migration adds FK constraints with `AccountEntity.id` as the parent.

Because of previous bugs there may be orphaned data in some tables that references accounts that no longer exist in `AccountEntity`. This causes a crash during migration.

This migration was previously automatic. Rewrite it to be manual, by copying the code that was previously generated and inserting explcit `DELETE` statements ahead of the migration to remove the orphaned rows.

Fixes #1320