### PR TITLE
fix: Invalidate NetworkTimelineRepository after clearing status filter

### DIFF
--- a/app/src/main/java/app/pachli/components/timeline/NetworkTimelineRepository.kt
+++ b/app/src/main/java/app/pachli/components/timeline/NetworkTimelineRepository.kt
@@ -157,6 +157,7 @@ class NetworkTimelineRepository @Inject constructor(
                 }
             }
         }
+        invalidate()
     }
 
     fun reload() {

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelineViewModel.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelineViewModel.kt
@@ -161,7 +161,6 @@ class NetworkTimelineViewModel @Inject constructor(
                 it.copy(favourited = favEvent.favourite)
             }
         }
-        repository.invalidate()
     }
 
     override fun handleBookmarkEvent(bookmarkEvent: BookmarkEvent) {
@@ -170,7 +169,6 @@ class NetworkTimelineViewModel @Inject constructor(
                 it.copy(bookmarked = bookmarkEvent.bookmark)
             }
         }
-        repository.invalidate()
     }
 
     override fun handlePinEvent(pinEvent: PinEvent) {
@@ -179,7 +177,6 @@ class NetworkTimelineViewModel @Inject constructor(
                 it.copy(pinned = pinEvent.pinned)
             }
         }
-        repository.invalidate()
     }
 
     override fun clearWarning(statusViewData: StatusViewData) {


### PR DESCRIPTION
When a status is partially filtered ("Hide with a warning"), its "Show anyway" button would be no-op on some timelines, like "Trending posts" or a user's profile.

It turns out the functionality was broken on `NetworkTimelineViewModel/Repository`. The call to `NetworkTimelineViewModel.clearWarning()` wasn't having an effect because `repository.invalidate()` wasn't being called, although it was present on all other methods that also made use of `repository.updateActionableStatusById()` (`handleFavEvent()`, `handleBookmarkEvent()` and `handlePinEvent()`).

Instead of just adding `repository.invalidate()` to `clearWarning()`, I preferred to remove the call from the other methods and move it inside `NetworkTimelineRepository.updateActionableStatusById()`. This should prevent something similar from happening again, and is also how `NetworkTimelineRepository.updateStatusById()` works.

<img src="https://github.com/user-attachments/assets/4843399f-e45e-4a9d-b579-681d76da0895" width=320/>
