### PR TITLE
ci: Save Pachli Current releases to pachli-android-current

### DIFF
--- a/.github/workflows/upload-orange-release-google-play.yml
+++ b/.github/workflows/upload-orange-release-google-play.yml
@@ -80,7 +80,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           artifactErrorsFailBuild: false
-          artifacts: ${{steps.sign_app_aab.outputs.signedReleaseFile}}
+          artifacts: ${{steps.sign_app_apk.outputs.signedReleaseFile}}
           bodyFile: googleplay/whatsnew/whatsnew-en-US
           repo: pachli-android-current
           tag: pachli-current-${{ github.sha }}


### PR DESCRIPTION
Experiment with saving Pachli Current releases to the release page on the new pachli-android-current repository.