### PR TITLE
ci: Use a personal access token to write to pachli-android-current

### DIFF
--- a/.github/workflows/upload-orange-release-google-play.yml
+++ b/.github/workflows/upload-orange-release-google-play.yml
@@ -79,6 +79,7 @@ jobs:
       - name: Create release in pachli-android-current
         uses: ncipollo/release-action@v1
         with:
+          token: ${{ secrets.PACHLI_ANDROID_CURRENT_CONTENTS_PAT }}
           artifactErrorsFailBuild: false
           artifacts: ${{steps.sign_app_apk.outputs.signedReleaseFile}}
           bodyFile: googleplay/whatsnew/whatsnew-en-US


### PR DESCRIPTION
To create the release in `pachli-android-current` the workflow needs a PAT with `write` permission to the `contents` scope on that repository.

That PAT has been created and set as a repository secret here, called `PACHLI_ANDROID_CURRENT_CONTENTS_PAT`. Pass it as the token the workflow will use.