### PR TITLE
feat: Deploy/fetch Pachli Current from Github pachli-android-current repository

### DIFF
--- a/.github/workflows/upload-orange-release.yml
+++ b/.github/workflows/upload-orange-release.yml
@@ -1,4 +1,4 @@
-name: Upload orangeRelease to Google Play
+name: Upload orangeRelease
 
 on:
   workflow_dispatch:
@@ -20,17 +20,32 @@ jobs:
       - name: Test
         run: ./gradlew app:testOrangeGoogleReleaseUnitTest --stacktrace
 
-      - name: Build APK
+      - name: Build APK for Google
         run: ./gradlew assembleOrangeGoogleRelease --stacktrace
 
-      - name: Build AAB
+      - name: Build APK for Github
+        run: ./gradlew assembleOrangeGithubRelease --stacktrace
+
+      - name: Build AAB for Google
         run: ./gradlew :app:bundleOrangeGoogleRelease --stacktrace
 
       - uses: r0adkll/sign-android-release@dbeba6b98a60b0fd540c02443c7f428cdedf0e7f # v1.0.4
-        name: Sign app APK
-        id: sign_app_apk
+        name: Sign app Google APK
+        id: sign_app_google_apk
         with:
           releaseDirectory: app/build/outputs/apk/orangeGoogle/release
+          signingKeyBase64: ${{ secrets.SIGNING_KEY }}
+          alias: ${{ secrets.SIGNING_KEY_ALIAS }}
+          keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
+          keyPassword: ${{ secrets.KEY_PASSWORD }}
+        env:
+          BUILD_TOOLS_VERSION: "34.0.0"
+
+      - uses: r0adkll/sign-android-release@dbeba6b98a60b0fd540c02443c7f428cdedf0e7f # v1.0.4
+        name: Sign app Github APK
+        id: sign_app_github_apk
+        with:
+          releaseDirectory: app/build/outputs/apk/orangeGithub/release
           signingKeyBase64: ${{ secrets.SIGNING_KEY }}
           alias: ${{ secrets.SIGNING_KEY_ALIAS }}
           keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
@@ -50,12 +65,12 @@ jobs:
         env:
           BUILD_TOOLS_VERSION: "34.0.0"
 
-      - name: Upload APK Release Asset
+      - name: Upload Google APK Release Asset
         id: upload-release-asset-apk
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
         with:
           name: app-release.apk
-          path: ${{steps.sign_app_apk.outputs.signedReleaseFile}}
+          path: ${{steps.sign_app_google_apk.outputs.signedReleaseFile}}
           compression-level: 0
 
       - name: Generate whatsnew
@@ -81,7 +96,7 @@ jobs:
         with:
           token: ${{ secrets.PACHLI_ANDROID_CURRENT_CONTENTS_PAT }}
           artifactErrorsFailBuild: false
-          artifacts: ${{steps.sign_app_apk.outputs.signedReleaseFile}}
+          artifacts: ${{steps.sign_app_github_apk.outputs.signedReleaseFile}}
           bodyFile: googleplay/whatsnew/whatsnew-en-US
           repo: pachli-android-current
           tag: pachli-current-${{ github.sha }}

--- a/app/src/github/kotlin/app/pachli/updatecheck/UpdateCheck.kt
+++ b/app/src/github/kotlin/app/pachli/updatecheck/UpdateCheck.kt
@@ -19,6 +19,7 @@ package app.pachli.updatecheck
 
 import android.content.Intent
 import android.net.Uri
+import app.pachli.BuildConfig
 import app.pachli.core.preferences.SharedPreferencesRepository
 import com.github.michaelbull.result.get
 import javax.inject.Inject
@@ -30,11 +31,18 @@ class UpdateCheck @Inject constructor(
     private val versionCodeExtractor = """(\d+)\.apk""".toRegex()
 
     override val updateIntent = Intent(Intent.ACTION_VIEW).apply {
-        data = Uri.parse("https://www.github.com/pachli/pachli-android/releases/latest")
+        data = when (BuildConfig.FLAVOR_color) {
+            "orange" -> Uri.parse("https://www.github.com/pachli/pachli-android-current/releases/latest")
+            else -> Uri.parse("https://www.github.com/pachli/pachli-android/releases/latest")
+        }
     }
 
     override suspend fun remoteFetchLatestVersionCode(): Int? {
-        val release = gitHubService.getLatestRelease("pachli", "pachli-android").get()?.body ?: return null
+        val release = when (BuildConfig.FLAVOR_color) {
+            "orange" -> gitHubService.getLatestRelease("pachli", "pachli-android-current").get()?.body
+            else -> gitHubService.getLatestRelease("pachli", "pachli-android").get()?.body
+        } ?: return null
+
         for (asset in release.assets) {
             if (asset.contentType != "application/vnd.android.package-archive") continue
             return versionCodeExtractor.find(asset.name)?.groups?.get(1)?.value?.toIntOrNull() ?: continue


### PR DESCRIPTION
Update CI for the orange / Pachli Current release to build an APK specifically for Github and upload that to the `pachli-android-current` repository.

Modify the `UpdateCheck` code to look in `pachli-android-current` if it's the Pachli Current build.