### PR TITLE
fix(deps): update aboutlibraries to v11.6.3

### DIFF
--- a/feature/about/build.gradle.kts
+++ b/feature/about/build.gradle.kts
@@ -37,8 +37,6 @@ aboutLibraries {
     includePlatform = false
     duplicationMode = com.mikepenz.aboutlibraries.plugin.DuplicateMode.MERGE
     prettyPrint = true
-    // The "generated" field contains a timestamp, which breaks reproducible builds.
-    excludeFields = arrayOf("generated")
 }
 
 markdown2resource {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-aboutlibraries = "11.5.0"
+aboutlibraries = "11.6.3"
 acra = "5.12.0"
 agp = "8.8.2"
 androidx-activity = "1.10.0"


### PR DESCRIPTION
This includes https://github.com/mikepenz/AboutLibraries/pull/1056 which disables `generated` metadata, so remove our override which does the same.