### PR TITLE
change: Use different strings for labels in account filter dialogs

### DIFF
--- a/app/src/main/java/app/pachli/components/preference/accountfilters/AccountConversationFiltersPreferenceDialogFragment.kt
+++ b/app/src/main/java/app/pachli/components/preference/accountfilters/AccountConversationFiltersPreferenceDialogFragment.kt
@@ -30,6 +30,9 @@ class AccountConversationFiltersPreferenceDialogFragment :
         AccountFilterTimeline.CONVERSATIONS,
         R.string.pref_title_account_conversation_filters,
         R.string.pref_account_conversation_filters_subtitle,
+        R.string.pref_account_conversation_filters_label_not_followed,
+        R.string.pref_account_conversation_filters_label_younger_30d,
+        R.string.pref_account_conversation_filters_label_limited_by_server,
     ) {
 
     companion object {

--- a/app/src/main/java/app/pachli/components/preference/accountfilters/AccountNotificationFiltersPreferencesDialogFragment.kt
+++ b/app/src/main/java/app/pachli/components/preference/accountfilters/AccountNotificationFiltersPreferencesDialogFragment.kt
@@ -27,6 +27,9 @@ class AccountNotificationFiltersPreferencesDialogFragment :
         AccountFilterTimeline.NOTIFICATIONS,
         R.string.pref_title_account_notification_filters,
         R.string.pref_account_notification_filters_subtitle,
+        R.string.pref_account_notification_filters_label_not_followed,
+        R.string.pref_account_notification_filters_label_younger_30d,
+        R.string.pref_account_notification_filters_label_limited_by_server,
     ) {
     companion object {
         fun newInstance(

--- a/app/src/main/java/app/pachli/components/preference/accountfilters/BaseAccountFiltersPreferencesDialogFragment.kt
+++ b/app/src/main/java/app/pachli/components/preference/accountfilters/BaseAccountFiltersPreferencesDialogFragment.kt
@@ -136,12 +136,18 @@ class FilterActionAdapter(context: Context) : ArrayAdapter<FilterAction>(
  * @param timeline The [AccountFilterTimeline] affected by the filters.
  * @param dialogTitleId String resource to use as the dialog's title.
  * @param dialogSubtitleId String resource to use as the dialog's subtitle.
+ * @param labelNotFollowed String resource to use as the label for the "not followed" menu
+ * @param labelYounger30d String resource to use as the label for the "last 30 days" menu
+ * @param labelLimitedByServer String resource to use as the label for the "limited" menu
  */
 @AndroidEntryPoint
 abstract class BaseAccountFiltersPreferencesDialogFragment(
     private val timeline: AccountFilterTimeline,
     @StringRes private val dialogTitleId: Int,
     @StringRes private val dialogSubtitleId: Int,
+    @StringRes private val labelNotFollowed: Int,
+    @StringRes private val labelYounger30d: Int,
+    @StringRes private val labelLimitedByServer: Int,
 ) : DialogFragment(R.layout.pref_account_filters) {
     private val viewModel: AccountFiltersPreferenceViewModel by viewModels(
         extrasProducer = {
@@ -168,6 +174,10 @@ abstract class BaseAccountFiltersPreferencesDialogFragment(
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         binding = PrefAccountFiltersBinding.inflate(layoutInflater)
         binding.title.text = getString(dialogSubtitleId)
+
+        binding.titleNotFollowed.text = getString(labelNotFollowed)
+        binding.titleYounger30d.text = getString(labelYounger30d)
+        binding.titleLimitedByServer.text = getString(labelLimitedByServer)
 
         val builder = AlertDialog.Builder(requireContext())
             .setTitle(dialogTitleId)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -871,6 +871,9 @@
     <string name="pref_title_account_conversation_filters">Conversation filters</string>
     <string name="pref_summary_account_conversation_filters">Your server does not support conversation filters</string>
     <string name="pref_account_conversation_filters_subtitle">What should happen to conversations started by accounts…</string>
+    <string name="pref_account_conversation_filters_label_not_followed">… you don\'t follow</string>
+    <string name="pref_account_conversation_filters_label_younger_30d">… created in last 30 days</string>
+    <string name="pref_account_conversation_filters_label_limited_by_server">… limited by your moderators</string>
 
     <string name="account_filter_placeholder_type_favourite_fmt">A user @&lt;b>%1s&lt;/b> favorited your post</string>
     <string name="account_filter_placeholder_type_follow_fmt">A user @&lt;b>%1s&lt;/b> followed you</string>


### PR DESCRIPTION
Different languages may need different labels for the options based on whether the filter will affect Notifications or Conversations.

Fixes #1348