### PR TITLE
feat: Implement Markdown rendering, controlled by a lab preference

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -109,6 +109,10 @@ configurations {
     testImplementation {
         exclude(group = "org.conscrypt", module = "conscrypt-android")
     }
+
+    implementation {
+        exclude(group = "org.jetbrains", module = "annotations")
+    }
 }
 
 dependencies {

--- a/app/src/main/java/app/pachli/adapter/FilterableStatusViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/FilterableStatusViewHolder.kt
@@ -25,12 +25,14 @@ import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.model.FilterAction
 import app.pachli.core.network.model.Filter
 import app.pachli.core.network.model.FilterAction as NetworkFilterAction
+import app.pachli.core.ui.SetStatusContent
 import app.pachli.databinding.ItemStatusWrapperBinding
 import app.pachli.interfaces.StatusActionListener
 
 open class FilterableStatusViewHolder<T : IStatusViewData>(
     private val binding: ItemStatusWrapperBinding,
-) : StatusViewHolder<T>(binding.statusContainer, binding.root) {
+    setStatusContent: SetStatusContent,
+) : StatusViewHolder<T>(binding.statusContainer, setStatusContent, binding.root) {
     /** The filter that matched the status, null if the status is not being filtered. */
     var matchedFilter: Filter? = null
 

--- a/app/src/main/java/app/pachli/adapter/StatusDetailedViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/StatusDetailedViewHolder.kt
@@ -14,6 +14,7 @@ import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.data.model.StatusViewData
 import app.pachli.core.preferences.CardViewMode
 import app.pachli.core.ui.NoUnderlineURLSpan
+import app.pachli.core.ui.SetStatusContent
 import app.pachli.core.ui.createClickableText
 import app.pachli.databinding.ItemStatusDetailedBinding
 import app.pachli.interfaces.StatusActionListener
@@ -24,7 +25,8 @@ import java.util.Locale
 
 class StatusDetailedViewHolder(
     private val binding: ItemStatusDetailedBinding,
-) : StatusBaseViewHolder<StatusViewData>(binding.root) {
+    setStatusContent: SetStatusContent,
+) : StatusBaseViewHolder<StatusViewData>(binding.root, setStatusContent) {
 
     override fun setMetaData(
         viewData: StatusViewData,

--- a/app/src/main/java/app/pachli/adapter/StatusViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/StatusViewHolder.kt
@@ -31,14 +31,16 @@ import app.pachli.core.data.model.IStatusViewData
 import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.model.FilterAction
 import app.pachli.core.network.model.Emoji
+import app.pachli.core.ui.SetStatusContent
 import app.pachli.databinding.ItemStatusBinding
 import app.pachli.interfaces.StatusActionListener
 import at.connyduck.sparkbutton.helpers.Utils
 
 open class StatusViewHolder<T : IStatusViewData>(
     private val binding: ItemStatusBinding,
+    setStatusContent: SetStatusContent,
     root: View? = null,
-) : StatusBaseViewHolder<T>(root ?: binding.root) {
+) : StatusBaseViewHolder<T>(root ?: binding.root, setStatusContent) {
 
     override fun setupWithStatus(
         viewData: T,

--- a/app/src/main/java/app/pachli/components/conversation/ConversationAdapter.kt
+++ b/app/src/main/java/app/pachli/components/conversation/ConversationAdapter.kt
@@ -29,6 +29,7 @@ import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.model.AccountFilterDecision
 import app.pachli.core.model.AccountFilterReason
 import app.pachli.core.model.FilterAction
+import app.pachli.core.ui.SetStatusContent
 import app.pachli.databinding.ItemConversationBinding
 import app.pachli.databinding.ItemConversationFilteredBinding
 import app.pachli.databinding.ItemStatusWrapperBinding
@@ -36,6 +37,7 @@ import app.pachli.interfaces.StatusActionListener
 
 internal class ConversationAdapter(
     private var statusDisplayOptions: StatusDisplayOptions,
+    private val setStatusContent: SetStatusContent,
     private val listener: StatusActionListener<ConversationViewData>,
     private val accept: (UiAction) -> Unit,
 ) : PagingDataAdapter<ConversationViewData, RecyclerView.ViewHolder>(CONVERSATION_COMPARATOR) {
@@ -78,11 +80,13 @@ internal class ConversationAdapter(
             ConversationViewKind.STATUS ->
                 ConversationViewHolder(
                     ItemConversationBinding.inflate(inflater, parent, false),
+                    setStatusContent,
                     listener,
                 )
             ConversationViewKind.STATUS_FILTERED ->
                 FilterableConversationStatusViewHolder(
                     ItemStatusWrapperBinding.inflate(inflater, parent, false),
+                    setStatusContent,
                     listener,
                 )
             ConversationViewKind.ACCOUNT_FILTERED ->
@@ -153,8 +157,9 @@ enum class ConversationViewKind {
  */
 class FilterableConversationStatusViewHolder internal constructor(
     binding: ItemStatusWrapperBinding,
+    setStatusContent: SetStatusContent,
     private val listener: StatusActionListener<ConversationViewData>,
-) : ConversationAdapter.ViewHolder, FilterableStatusViewHolder<ConversationViewData>(binding) {
+) : ConversationAdapter.ViewHolder, FilterableStatusViewHolder<ConversationViewData>(binding, setStatusContent) {
     override fun bind(viewData: ConversationViewData, payloads: List<*>?, statusDisplayOptions: StatusDisplayOptions) {
         if (payloads.isNullOrEmpty()) {
             showStatusContent(true)

--- a/app/src/main/java/app/pachli/components/conversation/ConversationViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/conversation/ConversationViewHolder.kt
@@ -28,13 +28,15 @@ import app.pachli.core.common.extensions.show
 import app.pachli.core.common.util.SmartLengthInputFilter
 import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.database.model.ConversationAccount
+import app.pachli.core.ui.SetStatusContent
 import app.pachli.databinding.ItemConversationBinding
 import app.pachli.interfaces.StatusActionListener
 
 class ConversationViewHolder internal constructor(
     private val binding: ItemConversationBinding,
+    setStatusContent: SetStatusContent,
     private val listener: StatusActionListener<ConversationViewData>,
-) : ConversationAdapter.ViewHolder, StatusBaseViewHolder<ConversationViewData>(binding.root) {
+) : ConversationAdapter.ViewHolder, StatusBaseViewHolder<ConversationViewData>(binding.root, setStatusContent) {
     private val avatars: Array<ImageView> = arrayOf(
         avatar,
         binding.statusAvatar1,

--- a/app/src/main/java/app/pachli/components/conversation/ConversationsFragment.kt
+++ b/app/src/main/java/app/pachli/components/conversation/ConversationsFragment.kt
@@ -58,6 +58,8 @@ import app.pachli.core.preferences.PrefKeys
 import app.pachli.core.preferences.SharedPreferencesRepository
 import app.pachli.core.ui.ActionButtonScrollListener
 import app.pachli.core.ui.BackgroundMessage
+import app.pachli.core.ui.SetMarkdownContent
+import app.pachli.core.ui.SetMastodonHtmlContent
 import app.pachli.databinding.FragmentTimelineBinding
 import app.pachli.fragment.SFragment
 import app.pachli.interfaces.ActionButtonActivity
@@ -167,7 +169,13 @@ class ConversationsFragment :
         viewLifecycleOwner.lifecycleScope.launch {
             val statusDisplayOptions = statusDisplayOptionsRepository.flow.value
 
-            adapter = ConversationAdapter(statusDisplayOptions, this@ConversationsFragment, accept)
+            val setStatusContent = if (statusDisplayOptions.renderMarkdown) {
+                SetMarkdownContent(requireContext())
+            } else {
+                SetMastodonHtmlContent
+            }
+
+            adapter = ConversationAdapter(statusDisplayOptions, setStatusContent, this@ConversationsFragment, accept)
 
             setupRecyclerView()
 

--- a/app/src/main/java/app/pachli/components/notifications/NotificationsFragment.kt
+++ b/app/src/main/java/app/pachli/components/notifications/NotificationsFragment.kt
@@ -63,6 +63,8 @@ import app.pachli.core.network.model.Status
 import app.pachli.core.preferences.TabTapBehaviour
 import app.pachli.core.ui.ActionButtonScrollListener
 import app.pachli.core.ui.BackgroundMessage
+import app.pachli.core.ui.SetMarkdownContent
+import app.pachli.core.ui.SetMastodonHtmlContent
 import app.pachli.core.ui.makeIcon
 import app.pachli.databinding.FragmentTimelineNotificationsBinding
 import app.pachli.fragment.SFragment
@@ -115,12 +117,7 @@ class NotificationsFragment :
 
     private val binding by viewBinding(FragmentTimelineNotificationsBinding::bind)
 
-    private val adapter = NotificationsPagingAdapter(
-        notificationDiffCallback,
-        statusActionListener = this,
-        notificationActionListener = this,
-        accountActionListener = this,
-    )
+    private lateinit var adapter: NotificationsPagingAdapter
 
     private lateinit var layoutManager: LinearLayoutManager
 
@@ -163,6 +160,20 @@ class NotificationsFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
+
+        val setStatusContent = if (viewModel.statusDisplayOptions.value.renderMarkdown) {
+            SetMarkdownContent(requireContext())
+        } else {
+            SetMastodonHtmlContent
+        }
+
+        adapter = NotificationsPagingAdapter(
+            notificationDiffCallback,
+            setStatusContent,
+            statusActionListener = this,
+            notificationActionListener = this,
+            accountActionListener = this,
+        )
 
         // Setup the SwipeRefreshLayout.
         binding.swipeRefreshLayout.setOnRefreshListener(this)

--- a/app/src/main/java/app/pachli/components/notifications/NotificationsPagingAdapter.kt
+++ b/app/src/main/java/app/pachli/components/notifications/NotificationsPagingAdapter.kt
@@ -31,6 +31,7 @@ import app.pachli.core.database.model.NotificationEntity
 import app.pachli.core.model.AccountFilterDecision
 import app.pachli.core.model.FilterAction
 import app.pachli.core.network.model.Status
+import app.pachli.core.ui.SetStatusContent
 import app.pachli.databinding.ItemFollowBinding
 import app.pachli.databinding.ItemFollowRequestBinding
 import app.pachli.databinding.ItemNotificationFilteredBinding
@@ -145,6 +146,7 @@ interface NotificationActionListener {
  */
 class NotificationsPagingAdapter(
     diffCallback: DiffUtil.ItemCallback<NotificationViewData>,
+    private val setStatusContent: SetStatusContent,
     private val statusActionListener: StatusActionListener<NotificationViewData>,
     private val notificationActionListener: NotificationActionListener,
     private val accountActionListener: AccountActionListener,
@@ -183,12 +185,14 @@ class NotificationsPagingAdapter(
             NotificationViewKind.STATUS -> {
                 StatusViewHolder(
                     ItemStatusBinding.inflate(inflater, parent, false),
+                    setStatusContent,
                     statusActionListener,
                 )
             }
             NotificationViewKind.STATUS_FILTERED -> {
                 FilterableStatusViewHolder(
                     ItemStatusWrapperBinding.inflate(inflater, parent, false),
+                    setStatusContent,
                     statusActionListener,
                 )
             }
@@ -202,6 +206,7 @@ class NotificationsPagingAdapter(
             NotificationViewKind.NOTIFICATION -> {
                 StatusNotificationViewHolder(
                     ItemStatusNotificationBinding.inflate(inflater, parent, false),
+                    setStatusContent,
                     statusActionListener,
                     notificationActionListener,
                     absoluteTimeFormatter,

--- a/app/src/main/java/app/pachli/components/notifications/StatusNotificationViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/notifications/StatusNotificationViewHolder.kt
@@ -39,7 +39,7 @@ import app.pachli.core.database.model.NotificationEntity
 import app.pachli.core.designsystem.R as DR
 import app.pachli.core.network.model.Emoji
 import app.pachli.core.ui.LinkListener
-import app.pachli.core.ui.setClickableText
+import app.pachli.core.ui.SetStatusContent
 import app.pachli.databinding.ItemStatusNotificationBinding
 import app.pachli.interfaces.StatusActionListener
 import app.pachli.util.getRelativeTimeSpanString
@@ -60,6 +60,7 @@ import java.util.Date
  */
 internal class StatusNotificationViewHolder(
     private val binding: ItemStatusNotificationBinding,
+    private val setStatusContent: SetStatusContent,
     private val statusActionListener: StatusActionListener<NotificationViewData>,
     private val notificationActionListener: NotificationActionListener,
     private val absoluteTimeFormatter: AbsoluteTimeFormatter,
@@ -118,7 +119,7 @@ internal class StatusNotificationViewHolder(
                     notificationActionListener.onViewAccount(viewData.account.id)
                 }
             }
-            setMessage(viewData, statusActionListener, statusDisplayOptions.animateEmojis)
+            setMessage(viewData, statusActionListener, statusDisplayOptions)
         } else {
             for (item in payloads) {
                 if (StatusBaseViewHolder.Key.KEY_CREATED == item && statusViewData != null) {
@@ -224,7 +225,7 @@ internal class StatusNotificationViewHolder(
     fun setMessage(
         viewData: NotificationViewData,
         listener: LinkListener,
-        animateEmojis: Boolean,
+        statusDisplayOptions: StatusDisplayOptions,
     ) {
         val statusViewData = viewData.statusViewData
         val displayName = viewData.account.name.unicodeWrap()
@@ -270,7 +271,7 @@ internal class StatusNotificationViewHolder(
         val emojifiedText = str.emojify(
             viewData.account.emojis,
             binding.notificationTopText,
-            animateEmojis,
+            statusDisplayOptions.animateEmojis,
         )
         binding.notificationTopText.text = emojifiedText
 
@@ -300,14 +301,15 @@ internal class StatusNotificationViewHolder(
             binding.notificationContent.visibility =
                 if (statusViewData.isExpanded) View.GONE else View.VISIBLE
         }
-        setupContentAndSpoiler(listener, viewData, statusViewData, animateEmojis)
+        setupContentAndSpoiler(listener, viewData, statusViewData, statusDisplayOptions)
     }
 
     private fun setupContentAndSpoiler(
         listener: LinkListener,
         viewData: NotificationViewData,
         statusViewData: StatusViewData,
-        animateEmojis: Boolean,
+        statusDisplayOptions: StatusDisplayOptions,
+        // animateEmojis: Boolean,
     ) {
         val shouldShowContentIfSpoiler = statusViewData.isExpanded
         val hasSpoiler = !TextUtils.isEmpty(statusViewData.status.spoilerText)
@@ -344,23 +346,20 @@ internal class StatusNotificationViewHolder(
             binding.buttonToggleNotificationContent.visibility = View.GONE
             binding.notificationContent.filters = NO_INPUT_FILTER
         }
-        val emojifiedText =
-            content.emojify(
-                emojis,
-                binding.notificationContent,
-                animateEmojis,
-            )
-        setClickableText(
+        setStatusContent(
             binding.notificationContent,
-            emojifiedText,
+            content,
+            statusDisplayOptions,
+            emojis,
             statusViewData.actionable.mentions,
             statusViewData.actionable.tags,
             listener,
         )
+
         val emojifiedContentWarning: CharSequence = statusViewData.spoilerText.emojify(
             statusViewData.actionable.emojis,
             binding.notificationContentWarningDescription,
-            animateEmojis,
+            statusDisplayOptions.animateEmojis,
         )
         binding.notificationContentWarningDescription.text = emojifiedContentWarning
     }

--- a/app/src/main/java/app/pachli/components/notifications/StatusViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/notifications/StatusViewHolder.kt
@@ -21,6 +21,7 @@ import app.pachli.adapter.FilterableStatusViewHolder
 import app.pachli.adapter.StatusViewHolder
 import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.database.model.NotificationEntity
+import app.pachli.core.ui.SetStatusContent
 import app.pachli.databinding.ItemStatusBinding
 import app.pachli.databinding.ItemStatusWrapperBinding
 import app.pachli.interfaces.StatusActionListener
@@ -28,8 +29,9 @@ import app.pachli.viewdata.NotificationViewData
 
 internal class StatusViewHolder(
     binding: ItemStatusBinding,
+    setStatusContent: SetStatusContent,
     private val statusActionListener: StatusActionListener<NotificationViewData>,
-) : NotificationsPagingAdapter.ViewHolder, StatusViewHolder<NotificationViewData>(binding) {
+) : NotificationsPagingAdapter.ViewHolder, StatusViewHolder<NotificationViewData>(binding, setStatusContent) {
 
     override fun bind(
         viewData: NotificationViewData,
@@ -62,8 +64,9 @@ internal class StatusViewHolder(
 
 class FilterableStatusViewHolder(
     binding: ItemStatusWrapperBinding,
+    setStatusContent: SetStatusContent,
     private val statusActionListener: StatusActionListener<NotificationViewData>,
-) : NotificationsPagingAdapter.ViewHolder, FilterableStatusViewHolder<NotificationViewData>(binding) {
+) : NotificationsPagingAdapter.ViewHolder, FilterableStatusViewHolder<NotificationViewData>(binding, setStatusContent) {
     // Note: Identical to bind() in StatusViewHolder above
     override fun bind(
         viewData: NotificationViewData,

--- a/app/src/main/java/app/pachli/components/preference/LabPreferencesFragment.kt
+++ b/app/src/main/java/app/pachli/components/preference/LabPreferencesFragment.kt
@@ -65,6 +65,12 @@ class LabPreferencesFragment : PreferenceFragmentCompat() {
                 key = PrefKeys.TAB_TAP_BEHAVIOUR
                 isIconSpaceReserved = false
             }
+
+            switchPreference {
+                key = PrefKeys.LAB_RENDER_MARKDOWN
+                setTitle(app.pachli.core.preferences.R.string.pref_title_render_markdown)
+                isIconSpaceReserved = false
+            }
         }
     }
 

--- a/app/src/main/java/app/pachli/components/report/adapter/StatusViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/report/adapter/StatusViewHolder.kt
@@ -16,7 +16,6 @@
 
 package app.pachli.components.report.adapter
 
-import android.text.Spanned
 import android.text.TextUtils
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
@@ -33,6 +32,7 @@ import app.pachli.core.designsystem.R as DR
 import app.pachli.core.network.model.Emoji
 import app.pachli.core.network.model.HashTag
 import app.pachli.core.network.model.Status
+import app.pachli.core.network.parseAsMastodonHtml
 import app.pachli.core.ui.LinkListener
 import app.pachli.core.ui.setClickableMentions
 import app.pachli.core.ui.setClickableText
@@ -105,7 +105,7 @@ open class StatusViewHolder(
     private fun updateTextView() {
         viewdata()?.let { viewdata ->
             setupCollapsedState(
-                shouldTrimStatus(viewdata.content),
+                shouldTrimStatus(viewdata.content.parseAsMastodonHtml()),
                 viewState.isCollapsed(viewdata.id, true),
                 viewState.isContentShow(viewdata.id, viewdata.status.sensitive),
                 viewdata.spoilerText,
@@ -145,7 +145,7 @@ open class StatusViewHolder(
 
     private fun setTextVisible(
         expanded: Boolean,
-        content: Spanned,
+        content: CharSequence,
         mentions: List<Status.Mention>,
         tags: List<HashTag>?,
         emojis: List<Emoji>,

--- a/app/src/main/java/app/pachli/components/search/adapter/SearchStatusesAdapter.kt
+++ b/app/src/main/java/app/pachli/components/search/adapter/SearchStatusesAdapter.kt
@@ -23,10 +23,12 @@ import androidx.recyclerview.widget.DiffUtil
 import app.pachli.adapter.StatusViewHolder
 import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.data.model.StatusViewData
+import app.pachli.core.ui.SetStatusContent
 import app.pachli.databinding.ItemStatusBinding
 import app.pachli.interfaces.StatusActionListener
 
 class SearchStatusesAdapter(
+    private val setStatusContent: SetStatusContent,
     private val statusDisplayOptions: StatusDisplayOptions,
     private val statusListener: StatusActionListener<StatusViewData>,
 ) : PagingDataAdapter<StatusViewData, StatusViewHolder<StatusViewData>>(STATUS_COMPARATOR) {
@@ -34,6 +36,7 @@ class SearchStatusesAdapter(
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): StatusViewHolder<StatusViewData> {
         return StatusViewHolder(
             ItemStatusBinding.inflate(LayoutInflater.from(parent.context), parent, false),
+            setStatusContent,
         )
     }
 
@@ -45,11 +48,9 @@ class SearchStatusesAdapter(
 
     companion object {
         val STATUS_COMPARATOR = object : DiffUtil.ItemCallback<StatusViewData>() {
-            override fun areContentsTheSame(oldItem: StatusViewData, newItem: StatusViewData): Boolean =
-                oldItem == newItem
+            override fun areContentsTheSame(oldItem: StatusViewData, newItem: StatusViewData): Boolean = oldItem == newItem
 
-            override fun areItemsTheSame(oldItem: StatusViewData, newItem: StatusViewData): Boolean =
-                oldItem.id == newItem.id
+            override fun areItemsTheSame(oldItem: StatusViewData, newItem: StatusViewData): Boolean = oldItem.id == newItem.id
         }
     }
 }

--- a/app/src/main/java/app/pachli/components/search/fragments/SearchStatusesFragment.kt
+++ b/app/src/main/java/app/pachli/components/search/fragments/SearchStatusesFragment.kt
@@ -54,6 +54,8 @@ import app.pachli.core.network.model.Poll
 import app.pachli.core.network.model.Status
 import app.pachli.core.network.model.Status.Mention
 import app.pachli.core.ui.ClipboardUseCase
+import app.pachli.core.ui.SetMarkdownContent
+import app.pachli.core.ui.SetMastodonHtmlContent
 import app.pachli.interfaces.StatusActionListener
 import app.pachli.view.showMuteAccountDialog
 import com.github.michaelbull.result.onFailure
@@ -83,11 +85,17 @@ class SearchStatusesFragment : SearchFragment<StatusViewData>(), StatusActionLis
     override fun createAdapter(): PagingDataAdapter<StatusViewData, *> {
         val statusDisplayOptions = statusDisplayOptionsRepository.flow.value
 
+        val setStatusContent = if (statusDisplayOptions.renderMarkdown) {
+            SetMarkdownContent(requireContext())
+        } else {
+            SetMastodonHtmlContent
+        }
+
         binding.searchRecyclerView.addItemDecoration(
             MaterialDividerItemDecoration(requireContext(), MaterialDividerItemDecoration.VERTICAL),
         )
         binding.searchRecyclerView.layoutManager = LinearLayoutManager(binding.searchRecyclerView.context)
-        return SearchStatusesAdapter(statusDisplayOptions, this)
+        return SearchStatusesAdapter(setStatusContent, statusDisplayOptions, this)
     }
 
     override fun onContentHiddenChange(viewData: StatusViewData, isShowingContent: Boolean) {

--- a/app/src/main/java/app/pachli/components/timeline/TimelineFragment.kt
+++ b/app/src/main/java/app/pachli/components/timeline/TimelineFragment.kt
@@ -73,6 +73,8 @@ import app.pachli.core.network.model.Status
 import app.pachli.core.preferences.TabTapBehaviour
 import app.pachli.core.ui.ActionButtonScrollListener
 import app.pachli.core.ui.BackgroundMessage
+import app.pachli.core.ui.SetMarkdownContent
+import app.pachli.core.ui.SetMastodonHtmlContent
 import app.pachli.databinding.FragmentTimelineBinding
 import app.pachli.fragment.SFragment
 import app.pachli.interfaces.ActionButtonActivity
@@ -185,8 +187,6 @@ class TimelineFragment :
         timeline = arguments.getParcelable(ARG_KIND)!!
 
         isSwipeToRefreshEnabled = arguments.getBoolean(ARG_ENABLE_SWIPE_TO_REFRESH, true)
-
-        adapter = TimelinePagingAdapter(this, viewModel.statusDisplayOptions.value)
     }
 
     override fun onCreateView(
@@ -200,6 +200,14 @@ class TimelineFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
+
+        val setStatusContent = if (viewModel.statusDisplayOptions.value.renderMarkdown) {
+            SetMarkdownContent(requireContext())
+        } else {
+            SetMastodonHtmlContent
+        }
+
+        adapter = TimelinePagingAdapter(setStatusContent, this, viewModel.statusDisplayOptions.value)
 
         layoutManager = LinearLayoutManager(context)
 

--- a/app/src/main/java/app/pachli/components/timeline/TimelinePagingAdapter.kt
+++ b/app/src/main/java/app/pachli/components/timeline/TimelinePagingAdapter.kt
@@ -28,11 +28,13 @@ import app.pachli.adapter.StatusViewHolder
 import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.data.model.StatusViewData
 import app.pachli.core.model.FilterAction
+import app.pachli.core.ui.SetStatusContent
 import app.pachli.databinding.ItemStatusBinding
 import app.pachli.databinding.ItemStatusWrapperBinding
 import app.pachli.interfaces.StatusActionListener
 
 class TimelinePagingAdapter(
+    private val setStatusContent: SetStatusContent,
     private val statusListener: StatusActionListener<StatusViewData>,
     var statusDisplayOptions: StatusDisplayOptions,
 ) : PagingDataAdapter<StatusViewData, RecyclerView.ViewHolder>(TimelineDifferCallback) {
@@ -40,10 +42,16 @@ class TimelinePagingAdapter(
         val inflater = LayoutInflater.from(viewGroup.context)
         return when (viewType) {
             VIEW_TYPE_STATUS_FILTERED -> {
-                FilterableStatusViewHolder<StatusViewData>(ItemStatusWrapperBinding.inflate(inflater, viewGroup, false))
+                FilterableStatusViewHolder<StatusViewData>(
+                    ItemStatusWrapperBinding.inflate(inflater, viewGroup, false),
+                    setStatusContent,
+                )
             }
             VIEW_TYPE_STATUS -> {
-                StatusViewHolder<StatusViewData>(ItemStatusBinding.inflate(inflater, viewGroup, false))
+                StatusViewHolder<StatusViewData>(
+                    ItemStatusBinding.inflate(inflater, viewGroup, false),
+                    setStatusContent,
+                )
             }
             else -> return object : RecyclerView.ViewHolder(inflater.inflate(R.layout.item_placeholder, viewGroup, false)) {}
         }

--- a/app/src/main/java/app/pachli/components/viewthread/ThreadAdapter.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/ThreadAdapter.kt
@@ -27,6 +27,7 @@ import app.pachli.adapter.StatusViewHolder
 import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.data.model.StatusViewData
 import app.pachli.core.model.FilterAction
+import app.pachli.core.ui.SetStatusContent
 import app.pachli.databinding.ItemStatusBinding
 import app.pachli.databinding.ItemStatusDetailedBinding
 import app.pachli.databinding.ItemStatusWrapperBinding
@@ -35,19 +36,29 @@ import app.pachli.interfaces.StatusActionListener
 class ThreadAdapter(
     private val statusDisplayOptions: StatusDisplayOptions,
     private val statusActionListener: StatusActionListener<StatusViewData>,
+    private val setStatusContent: SetStatusContent,
 ) : ListAdapter<StatusViewData, StatusBaseViewHolder<StatusViewData>>(ThreadDifferCallback) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): StatusBaseViewHolder<StatusViewData> {
         val inflater = LayoutInflater.from(parent.context)
         return when (viewType) {
             VIEW_TYPE_STATUS -> {
-                StatusViewHolder(ItemStatusBinding.inflate(inflater, parent, false))
+                StatusViewHolder(
+                    ItemStatusBinding.inflate(inflater, parent, false),
+                    setStatusContent,
+                )
             }
             VIEW_TYPE_STATUS_FILTERED -> {
-                FilterableStatusViewHolder(ItemStatusWrapperBinding.inflate(inflater, parent, false))
+                FilterableStatusViewHolder(
+                    ItemStatusWrapperBinding.inflate(inflater, parent, false),
+                    setStatusContent,
+                )
             }
             VIEW_TYPE_STATUS_DETAILED -> {
-                StatusDetailedViewHolder(ItemStatusDetailedBinding.inflate(inflater, parent, false))
+                StatusDetailedViewHolder(
+                    ItemStatusDetailedBinding.inflate(inflater, parent, false),
+                    setStatusContent,
+                )
             }
             else -> error("Unknown item type: $viewType")
         }

--- a/app/src/main/java/app/pachli/components/viewthread/ViewThreadFragment.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/ViewThreadFragment.kt
@@ -47,6 +47,8 @@ import app.pachli.core.navigation.AttachmentViewData.Companion.list
 import app.pachli.core.navigation.EditContentFilterActivityIntent
 import app.pachli.core.network.model.Poll
 import app.pachli.core.network.model.Status
+import app.pachli.core.ui.SetMarkdownContent
+import app.pachli.core.ui.SetMastodonHtmlContent
 import app.pachli.core.ui.extensions.getErrorString
 import app.pachli.databinding.FragmentViewThreadBinding
 import app.pachli.fragment.SFragment
@@ -91,9 +93,13 @@ class ViewThreadFragment :
         pachliAccountId = requireArguments().getLong(ARG_PACHLI_ACCOUNT_ID)
         thisThreadsStatusId = requireArguments().getString(ARG_ID)!!
 
-        lifecycleScope.launch {
-            adapter = ThreadAdapter(viewModel.statusDisplayOptions.value, this@ViewThreadFragment)
+        val setStatusContent = if (viewModel.statusDisplayOptions.value.renderMarkdown) {
+            SetMarkdownContent(requireContext())
+        } else {
+            SetMastodonHtmlContent
         }
+
+        adapter = ThreadAdapter(viewModel.statusDisplayOptions.value, this, setStatusContent)
     }
 
     override fun onCreateView(

--- a/app/src/main/java/app/pachli/util/ListStatusAccessibilityDelegate.kt
+++ b/app/src/main/java/app/pachli/util/ListStatusAccessibilityDelegate.kt
@@ -12,6 +12,7 @@ import app.pachli.adapter.StatusBaseViewHolder
 import app.pachli.core.activity.openLink
 import app.pachli.core.data.model.IStatusViewData
 import app.pachli.core.network.model.Status.Companion.MAX_MEDIA_ATTACHMENTS
+import app.pachli.core.network.parseAsMastodonHtml
 import app.pachli.core.ui.accessibility.PachliRecyclerViewAccessibilityDelegate
 import app.pachli.interfaces.StatusActionListener
 import app.pachli.viewdata.NotificationViewData
@@ -83,13 +84,15 @@ class ListStatusAccessibilityDelegate<T : IStatusViewData>(
                 )
             }
 
+            val parsedContent = status.content.parseAsMastodonHtml()
+
             info.addAction(openProfileAction)
-            if (status.content.getLinks().any()) info.addAction(linksAction)
+            if (parsedContent.getLinks().any()) info.addAction(linksAction)
 
             val mentions = actionable.mentions
             if (mentions.isNotEmpty()) info.addAction(mentionsAction)
 
-            if (status.content.getHashtags().any()) info.addAction(hashtagsAction)
+            if (parsedContent.getHashtags().any()) info.addAction(hashtagsAction)
             if (!status.status.reblog?.account?.username.isNullOrEmpty()) {
                 info.addAction(openRebloggerAction)
             }
@@ -157,7 +160,7 @@ class ListStatusAccessibilityDelegate<T : IStatusViewData>(
                 }
 
                 app.pachli.core.ui.R.id.action_links -> {
-                    val links = status.content.getLinks()
+                    val links = status.content.parseAsMastodonHtml().getLinks()
                     showA11yDialogWithCopyButton(
                         app.pachli.core.ui.R.string.title_links_dialog,
                         links.map { it.url },
@@ -173,7 +176,7 @@ class ListStatusAccessibilityDelegate<T : IStatusViewData>(
                 }
 
                 app.pachli.core.ui.R.id.action_hashtags -> {
-                    val hashtags = status.content.getHashtags()
+                    val hashtags = status.content.parseAsMastodonHtml().getHashtags()
                     showA11yDialogWithCopyButton(
                         app.pachli.core.ui.R.string.title_hashtags_dialog,
                         hashtags.map { "#$it" },

--- a/app/src/main/java/app/pachli/viewdata/NotificationViewData.kt
+++ b/app/src/main/java/app/pachli/viewdata/NotificationViewData.kt
@@ -17,7 +17,6 @@
 
 package app.pachli.viewdata
 
-import android.text.Spanned
 import app.pachli.core.data.model.IStatusViewData
 import app.pachli.core.data.model.StatusViewData
 import app.pachli.core.database.model.AccountEntity
@@ -133,7 +132,7 @@ data class NotificationViewData(
         get() = statusViewData?.isCollapsed ?: throw IllegalStateException()
     override val spoilerText: String
         get() = statusViewData?.spoilerText ?: throw IllegalStateException()
-    override val content: Spanned
+    override val content: CharSequence
         get() = statusViewData?.content ?: throw IllegalStateException()
     override val status: Status
         get() = statusViewData?.status ?: throw IllegalStateException()

--- a/core/activity/src/main/kotlin/app/pachli/core/activity/CustomEmojiHelper.kt
+++ b/core/activity/src/main/kotlin/app/pachli/core/activity/CustomEmojiHelper.kt
@@ -22,6 +22,7 @@ import android.graphics.Paint
 import android.graphics.drawable.Animatable
 import android.graphics.drawable.Drawable
 import android.text.SpannableStringBuilder
+import android.text.Spanned
 import android.text.style.ReplacementSpan
 import android.view.View
 import app.pachli.core.network.model.Emoji
@@ -39,13 +40,16 @@ import java.util.regex.Pattern
  * @param view a reference to the a view the emojis will be shown in (should be the TextView, but parents of the TextView are also acceptable)
  * @return the text with the shortcodes replaced by EmojiSpans
 */
-fun CharSequence.emojify(emojis: List<Emoji>?, view: View, animate: Boolean): CharSequence {
+fun CharSequence.emojify(emojis: List<Emoji>?, view: View, animate: Boolean): Spanned {
     if (emojis.isNullOrEmpty()) {
-        return this
+        return SpannableStringBuilder.valueOf(this)
     }
 
     val builder = SpannableStringBuilder.valueOf(this)
 
+    // TODO: This is O(len(emojis)) x O(len(input)). Would be better to parse the string
+    // once, looking up each emoji shortcode as it's found (and accept a
+    // Map<shortcode: String, (url: String, staticUrl: String)>
     emojis.forEach { (shortcode, url, staticUrl) ->
         val matcher = Pattern.compile(":$shortcode:", Pattern.LITERAL)
             .matcher(this)

--- a/core/common/src/main/kotlin/app/pachli/core/common/util/SmartLengthInputFilter.kt
+++ b/core/common/src/main/kotlin/app/pachli/core/common/util/SmartLengthInputFilter.kt
@@ -38,7 +38,7 @@ private const val LENGTH_DEFAULT = 500
  * @param message The message to trim.
  * @return Whether the message should be trimmed or not.
  */
-fun shouldTrimStatus(message: Spanned): Boolean {
+fun shouldTrimStatus(message: CharSequence): Boolean {
     return message.isNotEmpty() && LENGTH_DEFAULT.toFloat() / message.length < 0.75
 }
 

--- a/core/data/src/main/kotlin/app/pachli/core/data/model/StatusDisplayOptions.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/model/StatusDisplayOptions.kt
@@ -48,4 +48,5 @@ data class StatusDisplayOptions(
     val openSpoiler: Boolean = false,
     @get:JvmName("canTranslate")
     val canTranslate: Boolean = false,
+    val renderMarkdown: Boolean = false,
 )

--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/StatusDisplayOptionsRepository.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/StatusDisplayOptionsRepository.kt
@@ -76,11 +76,10 @@ class StatusDisplayOptionsRepository @Inject constructor(
         PrefKeys.USE_BLURHASH,
         PrefKeys.WELLBEING_HIDE_STATS_POSTS,
         PrefKeys.SHOW_STATS_INLINE,
+        PrefKeys.LAB_RENDER_MARKDOWN,
     )
 
     init {
-        Timber.d("Created StatusDisplayOptionsRepository")
-
         // Update whenever preferences change
         externalScope.launch {
             sharedPreferencesRepository.changes.filter { prefKeys.contains(it) }.collect { key ->
@@ -125,6 +124,9 @@ class StatusDisplayOptionsRepository @Inject constructor(
                         )
                         PrefKeys.SHOW_STATS_INLINE -> prev.copy(
                             showStatsInline = sharedPreferencesRepository.getBoolean(key, default.showStatsInline),
+                        )
+                        PrefKeys.LAB_RENDER_MARKDOWN -> prev.copy(
+                            renderMarkdown = sharedPreferencesRepository.getBoolean(key, default.renderMarkdown),
                         )
                         else -> {
                             prev
@@ -195,6 +197,7 @@ class StatusDisplayOptionsRepository @Inject constructor(
             showSensitiveMedia = account?.alwaysShowSensitiveMedia ?: default.showSensitiveMedia,
             openSpoiler = account?.alwaysOpenSpoiler ?: default.openSpoiler,
             canTranslate = default.canTranslate,
+            renderMarkdown = sharedPreferencesRepository.getBoolean(PrefKeys.LAB_RENDER_MARKDOWN, default.renderMarkdown),
         )
     }
 }

--- a/core/network/src/main/kotlin/app/pachli/core/network/StatusParsingHelper.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/StatusParsingHelper.kt
@@ -27,8 +27,8 @@ import app.pachli.core.common.string.trimTrailingWhitespace
  * parse a String containing html from the Mastodon api to Spanned
  */
 @JvmOverloads
-fun String.parseAsMastodonHtml(tagHandler: TagHandler? = null): Spanned {
-    return this.replace("<br> ", "<br>&nbsp;")
+fun CharSequence.parseAsMastodonHtml(tagHandler: TagHandler? = null): Spanned {
+    return this.replace("<br> ".toRegex(), "<br>&nbsp;")
         .replace("<br /> ", "<br />&nbsp;")
         .replace("<br/> ", "<br/>&nbsp;")
         .replace("  ", "&nbsp;&nbsp;")
@@ -42,6 +42,7 @@ fun replaceCrashingCharacters(content: Spanned): Spanned {
     return replaceCrashingCharacters(content as CharSequence) as Spanned
 }
 
+// See https://github.com/tuskyapp/Tusky/issues/563
 fun replaceCrashingCharacters(content: CharSequence): CharSequence? {
     var replacing = false
     var builder: SpannableStringBuilder? = null

--- a/core/preferences/src/main/kotlin/app/pachli/core/preferences/SettingsConstants.kt
+++ b/core/preferences/src/main/kotlin/app/pachli/core/preferences/SettingsConstants.kt
@@ -137,6 +137,9 @@ object PrefKeys {
     /** Tab contents. See [TabContents]. */
     const val TAB_CONTENTS = "tabContents"
 
+    /** True if experimental support for rendering markdown is enabled. */
+    const val LAB_RENDER_MARKDOWN = "labRenderMarkdown"
+
     /** Keys that are no longer used (e.g., the preference has been removed */
     object Deprecated {
         const val WELLBEING_LIMITED_NOTIFICATIONS = "wellbeingModeLimitedNotifications"

--- a/core/preferences/src/main/res/values/strings.xml
+++ b/core/preferences/src/main/res/values/strings.xml
@@ -48,4 +48,6 @@
     <string name="pref_tab_contents_text_only">Text only</string>
     <string name="pref_tab_contents_icon_text_inline">Icon with text beside</string>
     <string name="pref_tab_contents_icon_text_below">Icon with text below</string>
+
+    <string name="pref_title_render_markdown">Render Markdown</string>
 </resources>

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -18,6 +18,7 @@
 plugins {
     alias(libs.plugins.pachli.android.library)
     alias(libs.plugins.pachli.android.hilt)
+    kotlin("kapt")
 }
 
 android {
@@ -50,4 +51,14 @@ dependencies {
 
     api(libs.material.iconics)
     api(libs.material.typeface)
+
+    // Markdown support
+    implementation(libs.markwon)
+    implementation(libs.markwon.html)
+    implementation(libs.markwon.inline.parser)
+    implementation(libs.markwon.simple.ext)
+    implementation(libs.markwon.strikethrough)
+    implementation(libs.markwon.syntax.highlight)
+    kapt(libs.prism4j)
+    implementation(libs.ksoup.entities)
 }

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/LinkHelper.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/LinkHelper.kt
@@ -70,8 +70,18 @@ fun setClickableText(view: TextView, content: CharSequence, mentions: List<Menti
     view.movementMethod = LinkMovementMethodCompat.getInstance()
 }
 
-@VisibleForTesting
-fun markupHiddenUrls(textView: TextView, content: CharSequence): SpannableStringBuilder {
+/**
+ * Ensures "hidden" URLs show the destination.
+ *
+ * For a status created through Mastodon there's no mechanism to post an
+ * `<a href="...">...</a>` link, so the link target is always visible to the
+ * user.
+ *
+ * That is not the case for statuses that may have originated from
+ * non-Mastodon servers. Find those links and insert a "🔗" marker and the
+ * link's domain.
+ */
+internal fun markupHiddenUrls(textView: TextView, content: CharSequence): SpannableStringBuilder {
     val spannableContent = SpannableStringBuilder(content)
     val originalSpans = spannableContent.getSpans(0, content.length, URLSpan::class.java)
     val obscuredLinkSpans = originalSpans.filter {
@@ -132,8 +142,7 @@ fun markupHiddenUrls(textView: TextView, content: CharSequence): SpannableString
  * Replaces [span] with a more appropriate span type based on the text contents
  * of [span].
  */
-@VisibleForTesting
-fun setClickableText(
+internal fun setClickableText(
     span: URLSpan,
     builder: SpannableStringBuilder,
     mentions: List<Mention>,
@@ -180,7 +189,7 @@ fun getTagName(text: CharSequence, tags: List<HashTag>?): String? {
     val scrapedName = normalizeToASCII(text.subSequence(1, text.length)).toString()
     return when (tags) {
         null -> scrapedName
-        else -> tags.firstOrNull { it.name.equals(scrapedName, true) }?.name
+        else -> tags.firstOrNull { it.name.equals(scrapedName, true) }?.name ?: scrapedName
     }
 }
 

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/LinkHelper.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/LinkHelper.kt
@@ -189,7 +189,7 @@ fun getTagName(text: CharSequence, tags: List<HashTag>?): String? {
     val scrapedName = normalizeToASCII(text.subSequence(1, text.length)).toString()
     return when (tags) {
         null -> scrapedName
-        else -> tags.firstOrNull { it.name.equals(scrapedName, true) }?.name ?: scrapedName
+        else -> tags.firstOrNull { it.name.equals(scrapedName, true) }?.name
     }
 }
 

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/SetStatusContent.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/SetStatusContent.kt
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2025 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.core.ui
+
+import android.content.Context
+import android.graphics.Color
+import android.text.style.URLSpan
+import android.widget.TextView
+import androidx.core.text.method.LinkMovementMethodCompat
+import app.pachli.core.activity.emojify
+import app.pachli.core.data.model.StatusDisplayOptions
+import app.pachli.core.network.model.Emoji
+import app.pachli.core.network.model.HashTag
+import app.pachli.core.network.model.Status
+import app.pachli.core.network.parseAsMastodonHtml
+import app.pachli.core.ui.PreProcessMastodonHtml.processMarkdown
+import com.google.android.material.color.MaterialColors
+import com.mohamedrejeb.ksoup.entities.KsoupEntities
+import io.noties.markwon.AbstractMarkwonPlugin
+import io.noties.markwon.Markwon
+import io.noties.markwon.SoftBreakAddsNewLinePlugin
+import io.noties.markwon.core.MarkwonTheme
+import io.noties.markwon.ext.strikethrough.StrikethroughPlugin
+import io.noties.markwon.html.HtmlPlugin
+import io.noties.markwon.simple.ext.SimpleExtPlugin
+import io.noties.markwon.syntax.Prism4jThemeDefault
+import io.noties.markwon.syntax.SyntaxHighlightPlugin
+import io.noties.prism4j.Prism4j
+import io.noties.prism4j.annotations.PrismBundle
+
+/** Interface for setting the content of a status. */
+interface SetStatusContent {
+    /**
+     * Processes [content] according to [statusDisplayOptions], embedding any [emojis],
+     * [mentions], and [hashtags]. Clicks on these are sent to [listener]. Sets the
+     * processed content as the [text][TextView.setText] on [textView].
+     *
+     * @param textView
+     * @param content
+     * @param statusDisplayOptions
+     * @param emojis
+     * @param mentions
+     * @param hashtags
+     * @param listener
+     */
+    operator fun invoke(
+        textView: TextView,
+        content: CharSequence,
+        statusDisplayOptions: StatusDisplayOptions,
+        emojis: List<Emoji>,
+        mentions: List<Status.Mention>,
+        hashtags: List<HashTag>?,
+        listener: LinkListener,
+    )
+}
+
+/**
+ * Sets status content by parsing it as Mastodon HTML.
+ */
+object SetMastodonHtmlContent : SetStatusContent {
+    override operator fun invoke(
+        textView: TextView,
+        content: CharSequence,
+        statusDisplayOptions: StatusDisplayOptions,
+        emojis: List<Emoji>,
+        mentions: List<Status.Mention>,
+        hashtags: List<HashTag>?,
+        listener: LinkListener,
+    ) {
+        val parsedContent = content.parseAsMastodonHtml()
+        val emojifiedText = parsedContent.emojify(emojis, textView, statusDisplayOptions.animateEmojis)
+        setClickableText(textView, emojifiedText, mentions, hashtags, listener)
+    }
+}
+
+/**
+ * Sets status content by parsing it as Markdown.
+ */
+@PrismBundle(includeAll = true, grammarLocatorClassName = ".MySuperGrammerLocator")
+class SetMarkdownContent(context: Context) : SetStatusContent {
+    private val markwon = Markwon.builder(context)
+        .usePlugin(SimpleExtPlugin.create())
+        .usePlugin(HtmlPlugin.create())
+        .usePlugin(SoftBreakAddsNewLinePlugin.create())
+        .usePlugin(
+            SyntaxHighlightPlugin.create(
+                Prism4j(MySuperGrammerLocator()),
+                Prism4jThemeDefault.create(),
+            ),
+        )
+        .usePlugin(StrikethroughPlugin.create())
+        .usePlugin(PreProcessMastodonHtml)
+        // Has to be at the end of the list, see https://github.com/noties/Markwon/issues/494
+        .usePlugin(PachliMarkwonTheme(context))
+        .build()
+
+    override operator fun invoke(
+        textView: TextView,
+        content: CharSequence,
+        statusDisplayOptions: StatusDisplayOptions,
+        emojis: List<Emoji>,
+        mentions: List<Status.Mention>,
+        hashtags: List<HashTag>?,
+        listener: LinkListener,
+    ) {
+        val spanned = markwon.toMarkdown(content.toString())
+
+        val emojifiedText = spanned.emojify(emojis, textView, statusDisplayOptions.animateEmojis)
+
+        // This block does what setClickableText does.
+        val spannableContent = markupHiddenUrls(textView, emojifiedText)
+        val finalText = spannableContent.apply {
+            getSpans(0, spannableContent.length, URLSpan::class.java).forEach {
+                setClickableText(it, this, mentions, hashtags, listener)
+            }
+        }
+        markwon.setParsedMarkdown(textView, finalText)
+        textView.movementMethod = LinkMovementMethodCompat.getInstance()
+    }
+}
+
+/**
+ * Markwon theme plugin to set foreground and background colours for code blocks
+ * (inline and fenced) from the app theme, to ensure code blocks are still legible
+ * in light and dark themes.
+ */
+class PachliMarkwonTheme(private val context: Context) : AbstractMarkwonPlugin() {
+    override fun configureTheme(builder: MarkwonTheme.Builder) {
+        val codeBackgroundColor = MaterialColors.getColor(
+            context,
+            com.google.android.material.R.attr.colorSurfaceVariant,
+            Color.WHITE,
+        )
+        val codeTextColor = MaterialColors.getColor(
+            context,
+            com.google.android.material.R.attr.colorOnSurfaceVariant,
+            Color.BLACK,
+        )
+
+        builder
+            .codeBackgroundColor(codeBackgroundColor)
+            .codeTextColor(codeTextColor)
+            .codeBlockBackgroundColor(codeBackgroundColor)
+            .codeBlockTextColor(codeTextColor)
+    }
+}
+
+/**
+ * Markwon plugin that pre-processes HTML from Mastodon before processing as Markdown.
+ *
+ * @see [processMarkdown]
+ */
+object PreProcessMastodonHtml : AbstractMarkwonPlugin() {
+    /** Match the contents of a fenced code block. */
+    private val rxCodeBlock =
+        """^```(.*?)^```""".toRegex(setOf(RegexOption.DOT_MATCHES_ALL, RegexOption.MULTILINE))
+
+    /** Match any start or end tag. */
+    private val rxTag = """</?[^>]+?>""".toRegex(RegexOption.DOT_MATCHES_ALL)
+
+    /** Match any inline code element (i.e., between two literal backquotes. */
+    private val rxLiteral = """(?<!`)`(.+?)`""".toRegex(setOf(RegexOption.MULTILINE))
+
+    /** Match any opening `p` element, with optional whitespace before it. */
+    private val rxPEl = """\s*<p\s*>""".toRegex()
+
+    /** Match `<br>`, `<br/>` (with optional spaces). */
+    private val rxBrEl = """<br\s*/?>""".toRegex()
+
+    /**
+     * Processes [input] and removes/replaces some HTML content.
+     *
+     * Any Markdown in [input] will be wrapped in HTML block elements. Undo those,
+     * so the content becomes "Markdown that possibly contains embedded HTML" and not
+     * "HTML that might contain some Markdown directives".
+     */
+    override fun processMarkdown(input: String): String {
+        // Known differences from Mastodon web rendering
+        //
+        // - Links in fenced code blocks are not clickable
+        //   Eg., a hashtag in a fenced code block is not clickable
+        val processed = input
+            // Remove <p> with any preceeding whitespace (just in case a parapgraph was
+            // indented -- not removing the whitespace could cause it to be treated as
+            // a code block).
+            .replace(rxPEl, "")
+            // </p> ends a paragraph, Markdown needs two blank lines as separators.
+            .replace("</p>", "\n\n")
+            // <br> and variations become "\n".
+            .replace(rxBrEl, "\n")
+            // Convert leading quote markers from entities to ">".
+            .replace("&gt; ", "> ")
+            // HTML in fenced code blocks is treated literally by Markwon.
+            // So remove all HTML tags inside fenced blocks (keep the content).
+            //
+            // There may be HTML entities that need to be converted.
+            .replace(rxCodeBlock) { KsoupEntities.decodeHtml(it.value.replace(rxTag, "")) }
+            // Convert any HTML entities in inline code.
+            .replace(rxLiteral) { KsoupEntities.decodeHtml(it.value) }
+
+        return processed
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,10 +48,12 @@ org-json = "20240303"
 junit = "4.13.2"
 kotlin = "2.1.10"
 kotlin-result = "1.1.20"
+ksoup = "0.5.0"
 ksp = "2.1.10-1.0.29"
 image-cropper = "4.3.2"
 leakcanary = "2.14"
 lint = "31.8.2" # = agp + 23.0.0 (= 8.8.2), see https://github.com/googlesamples/android-custom-lint-rules#lint-version
+markwon = "4.6.2"
 material = "1.12.0"
 material-drawer = "9.0.2"
 material-iconics = "5.5.0-compose01"
@@ -64,6 +66,7 @@ moshix = "0.29.0"
 okhttp = "4.12.0"
 okio = "3.10.2"
 play-services-base = "18.5.0"
+prism4j = "2.0.0"
 quadrant = "1.9.1"
 retrofit = "2.11.0"
 robolectric = "4.14.1"
@@ -186,12 +189,19 @@ kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-c
 kotlinx-coroutines-play-services = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services", version.ref = "coroutines-play-services" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
+ksoup-entities = { module = "com.mohamedrejeb.ksoup:ksoup-entities", version.ref = "ksoup" }
 image-cropper = { module = "com.github.CanHub:Android-Image-Cropper", version.ref = "image-cropper" }
 leakcanary = { module = "com.squareup.leakcanary:leakcanary-android", version.ref = "leakcanary" }
 lint-api = { module = "com.android.tools.lint:lint-api", version.ref = "lint" }
 lint-checks = { module = "com.android.tools.lint:lint-checks", version.ref = "lint" }
 lint-cli = { module = "com.android.tools.lint:lint", version.ref = "lint" }
 lint-tests = { module = "com.android.tools.lint:lint-tests", version.ref = "lint" }
+markwon = { module = "io.noties.markwon:core", version.ref = "markwon" }
+markwon-html = { module = "io.noties.markwon:html", version.ref = "markwon" }
+markwon-inline-parser = { module = "io.noties.markwon:inline-parser", version.ref = "markwon" }
+markwon-simple-ext = { module = "io.noties.markwon:simple-ext", version.ref = "markwon" }
+markwon-strikethrough = { module = "io.noties.markwon:ext-strikethrough", version.ref = "markwon" }
+markwon-syntax-highlight = { module = "io.noties.markwon:syntax-highlight", version.ref = "markwon" }
 material-drawer-core = { module = "com.mikepenz:materialdrawer", version.ref = "material-drawer" }
 material-drawer-iconics = { module = "com.mikepenz:materialdrawer-iconics", version.ref = "material-drawer" }
 material-iconics = { module = "com.mikepenz:iconics-core", version.ref="material-iconics" }
@@ -211,6 +221,7 @@ okhttp-tls = { module = "com.squareup.okhttp3:okhttp-tls", version.ref = "okhttp
 okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 org-json = { module = "org.json:json", version.ref = "org-json"}
 play-services-base = { module = "com.google.android.gms:play-services-base", version.ref = "play-services-base" }
+prism4j = { module = "io.noties:prism4j-bundler", version.ref = "prism4j" }
 retrofit-converter-moshi = { module = "com.squareup.retrofit2:converter-moshi", version.ref = "retrofit" }
 retrofit-core = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }


### PR DESCRIPTION
Provide a new lab preference to control whether status content should be pre-processed from HTML to Markdown, and then rendered as Markdown.

Hoist processing of status content out of the different viewholders into implementations of a new `SetStatusContent` interface.

Provide two implementations of this interface; one processes the content as Mastodon HTML, consistent with the previous behaviour.

The other implementation pre-processes the content to remove some HTML block and other elements, then runs the content through the Markwon Markdown processor.

The correct implementation has to be passed to the viewholders, so modify the different fragments that show statuses to create the appropriate implementation based on the user's preferences, and then pass it through the adapter which will pass it to the viewholder.

Add this as a parameter to `StatusBaseViewHolder()`

Fixes #878