### PR TITLE
ci: Always mark pachli-android-current release as latest

### DIFF
--- a/.github/workflows/upload-orange-release.yml
+++ b/.github/workflows/upload-orange-release.yml
@@ -100,3 +100,4 @@ jobs:
           bodyFile: googleplay/whatsnew/whatsnew-en-US
           repo: pachli-android-current
           tag: pachli-current-${{ github.sha }}
+          makeLatest: true


### PR DESCRIPTION
Github doesn't always sort the releases sensibly per the discussion at https://github.com/orgs/community/discussions/8226, so explicitly mark each release from this workflow as the latest release.