### PR TITLE
fix: Show join date in grammatically correct form

### DIFF
--- a/app/src/main/java/app/pachli/components/account/AccountActivity.kt
+++ b/app/src/main/java/app/pachli/components/account/AccountActivity.kt
@@ -541,7 +541,7 @@ class AccountActivity :
                 account.createdAt?.let { createdAt ->
                     binding.accountDateJoined.text = resources.getString(
                         R.string.account_date_joined,
-                        SimpleDateFormat("MMMM, yyyy", Locale.getDefault()).format(createdAt),
+                        SimpleDateFormat("LLLL yyyy", Locale.getDefault()).format(createdAt),
                     )
                     binding.accountDateJoined.show()
                 } ?: binding.accountDateJoined.hide()


### PR DESCRIPTION
Previous code used "MMMM" for the month, which is only appropriate if the day of the month is also included (this is a "context sensitive" month). While this looks correct in English it is incorrect in some other languages.

Use "LLLL", the "standalone" form, which is correct in all languages when the day of the month is not included.

Fixes #1358