### PR TITLE
ci: Generate a more complete "What's New" file for Pachli Current releases

### DIFF
--- a/.github/workflows/upload-orange-release.yml
+++ b/.github/workflows/upload-orange-release.yml
@@ -81,7 +81,7 @@ jobs:
           git log --pretty=format:"%s" "${commitid}"..HEAD | awk '!x[$0]++' > googleplay/whatsnew/whatsnew-en-US
           whatsnew_size=$(wc -c < googleplay/whatsnew/whatsnew-en-US)
           if [ "$whatsnew_size" -gt "500" ]; then
-                  git log --pretty=format:"%s" "${commitid}..HEAD | awk '!x[$0]++' | awk '{i += (length() + 1); if (i <= 485) print $ALL}' > googleplay/whatsnew/whatsnew-en-US
+                  git log --pretty=format:"%s" "${commitid}"..HEAD | awk '!x[$0]++' | awk '{i += (length() + 1); if (i <= 485) print $ALL}' > googleplay/whatsnew/whatsnew-en-US
                   echo "... and more" >> googleplay/whatsnew/whatsnew-en-US
           fi
 

--- a/.github/workflows/upload-orange-release.yml
+++ b/.github/workflows/upload-orange-release.yml
@@ -77,7 +77,13 @@ jobs:
         id: generate-whatsnew
         run: |
           mkdir -p googleplay/whatsnew
-          git log -1 --pretty=format:"%s" > googleplay/whatsnew/whatsnew-en-US
+          commitid=$(curl -s https://api.github.com/repos/pachli/pachli-android-current/releases/latest | jq -r '.tag_name | split("-") | .[2]')
+          git log --pretty=format:"%s" "${commitid}"..HEAD | awk '!x[$0]++' > googleplay/whatsnew/whatsnew-en-US
+          whatsnew_size=$(wc -c < googleplay/whatsnew/whatsnew-en-US)
+          if [ "$whatsnew_size" -gt "500" ]; then
+                  git log --pretty=format:"%s" "${commitid}..HEAD | awk '!x[$0]++' | awk '{i += (length() + 1); if (i <= 485) print $ALL}' > googleplay/whatsnew/whatsnew-en-US
+                  echo "... and more" >> googleplay/whatsnew/whatsnew-en-US
+          fi
 
       - name: Upload AAB to Google Play
         id: upload-release-asset-aab


### PR DESCRIPTION
Previous code used the first line of the most recent commit as the contents of the "whatsnew" file.

Expand that, by:

1. Fetch the commit ID associated with the most recent Orange release.
2. Fetch the first line of each log since then, and filter for uniqueness (e.g., to filter out multiple updates to a single language).
3. If the generated file size is > 500 bytes then cut it down to 485 bytes and append "... and more"