### PR TITLE
fix: Correctly parse `action_taken` and similar in report notifications

### DIFF
--- a/core/network/src/main/kotlin/app/pachli/core/network/model/Report.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/Report.kt
@@ -27,7 +27,9 @@ import java.time.Instant
 data class Report(
     val id: String,
     val category: Category,
+    @Json(name = "action_taken")
     val actionTaken: Boolean,
+    @Json(name = "action_taken_at")
     val actionTakenAt: Instant,
     val comment: String,
     val forwarded: Boolean,


### PR DESCRIPTION
Fixes #1366