### PR TITLE
fix: Support editing captions of uploaded images

### DIFF
--- a/app/src/main/java/app/pachli/components/compose/ComposeViewModel.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeViewModel.kt
@@ -548,7 +548,14 @@ class ComposeViewModel @AssistedInject constructor(
     fun updateDescription(localId: Int, serverId: String?, description: String) {
         // If the image hasn't been uploaded then update the state locally.
         if (serverId == null) {
-            updateMediaItem(localId) { mediaItem -> mediaItem.copy(description = description) }
+            updateMediaItem(localId) { it.copy(description = description) }
+            return
+        }
+
+        // If editing an existing post the update must go through the status edit API
+        // when user presses the button, just update the local copy of the description.
+        if (editing) {
+            updateMediaItem(localId) { it.copy(description = description) }
             return
         }
 


### PR DESCRIPTION
Previous code tried to use the media update API to update captions when editing a status, but that only works if the status has not been posted yet.

When editing a status the caption edits go through the status edit API, so just record the new caption and exit early.

Fixes #1380