### PR TITLE
fix: Filter correctly in threads and private messages

### DIFF
--- a/app/src/main/java/app/pachli/components/viewthread/ThreadAdapter.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/ThreadAdapter.kt
@@ -71,10 +71,13 @@ class ThreadAdapter(
 
     override fun getItemViewType(position: Int): Int {
         val viewData = getItem(position)
-        return if (viewData.isDetailed) {
-            VIEW_TYPE_STATUS_DETAILED
-        } else if (viewData.contentFilterAction == FilterAction.WARN) {
+        // Check contentFilterAction first to ensure that detailed statuses are also
+        // filtered. This allows the user to view the thread and get more context to
+        // decide whether or not to view the detailed status.
+        return if (viewData.contentFilterAction == FilterAction.WARN) {
             VIEW_TYPE_STATUS_FILTERED
+        } else if (viewData.isDetailed) {
+            VIEW_TYPE_STATUS_DETAILED
         } else {
             VIEW_TYPE_STATUS
         }

--- a/app/src/test/java/app/pachli/components/viewthread/ViewThreadViewModelTest.kt
+++ b/app/src/test/java/app/pachli/components/viewthread/ViewThreadViewModelTest.kt
@@ -161,7 +161,6 @@ class ViewThreadViewModelTest {
 
         viewModel = ViewThreadViewModel(
             mastodonApi,
-            timelineCases,
             eventHub,
             accountManager,
             timelineDao,

--- a/core/model/src/main/kotlin/app/pachli/core/model/ContentFilters.kt
+++ b/core/model/src/main/kotlin/app/pachli/core/model/ContentFilters.kt
@@ -110,7 +110,7 @@ enum class FilterContext {
     @Json(name = "public")
     PUBLIC,
 
-    /** Filter applies to conversations. */
+    /** Filter applies to conversations (threads, **not** private messages). */
     @Json(name = "thread")
     CONVERSATIONS,
 
@@ -139,7 +139,7 @@ enum class FilterContext {
             Timeline.TrendingLinks,
             is Timeline.Link,
             -> PUBLIC
-            Timeline.Conversations -> CONVERSATIONS
+            Timeline.Conversations -> null
         }
     }
 }

--- a/core/network/src/main/kotlin/app/pachli/core/network/model/FilterContext.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/FilterContext.kt
@@ -17,7 +17,6 @@
 
 package app.pachli.core.network.model
 
-import app.pachli.core.model.Timeline
 import app.pachli.core.network.json.Default
 import app.pachli.core.network.json.HasDefault
 import com.squareup.moshi.Json
@@ -45,7 +44,7 @@ enum class FilterContext {
     @Json(name = "public")
     PUBLIC,
 
-    /** Filter applies to conversation. */
+    /** Filter applies to conversations (threads, **not** private messages). */
     @Json(name = "thread")
     CONVERSATION,
 
@@ -56,28 +55,6 @@ enum class FilterContext {
     ;
 
     companion object {
-        /**
-         * @return The filter context for [timeline], or null if filters are not applied
-         *     to this timeline.
-         */
-        @Deprecated("Use app.pachli.core.model.FilterContext instead")
-        fun from(timeline: Timeline): FilterContext? = when (timeline) {
-            is Timeline.Home, is Timeline.UserList -> HOME
-            is Timeline.User -> ACCOUNT
-            Timeline.Notifications -> NOTIFICATIONS
-            Timeline.Bookmarks,
-            Timeline.Favourites,
-            Timeline.PublicFederated,
-            Timeline.PublicLocal,
-            is Timeline.Hashtags,
-            Timeline.TrendingStatuses,
-            Timeline.TrendingHashtags,
-            Timeline.TrendingLinks,
-            is Timeline.Link,
-            -> PUBLIC
-            Timeline.Conversations -> null
-        }
-
         fun from(filterContext: app.pachli.core.model.FilterContext) = when (filterContext) {
             app.pachli.core.model.FilterContext.HOME -> HOME
             app.pachli.core.model.FilterContext.NOTIFICATIONS -> NOTIFICATIONS


### PR DESCRIPTION
Previous code:

- Applied filters to private messages.
- Ignored filters when showing the "detailed" message in a thread.
- Used the "notifications" context when filtering threads instead of the correct "conversations" context.

Fix these issues.

Fixes #1385