### PR TITLE
fix: Improve display of lists of content filters

### DIFF
--- a/app/src/main/res/layout/item_removable.xml
+++ b/app/src/main/res/layout/item_removable.xml
@@ -1,37 +1,37 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:paddingStart="?listPreferredItemPaddingStart"
+    android:paddingEnd="?listPreferredItemPaddingEnd"
+    android:background="?attr/selectableItemBackground"
     android:orientation="horizontal">
 
     <TextView
         android:id="@+id/textPrimary"
         android:layout_width="0dp"
-        android:layout_height="match_parent"
-        android:layout_weight="0.91"
+        android:layout_height="wrap_content"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toStartOf="@id/delete"
         app:layout_constraintTop_toTopOf="parent"
-        android:paddingStart="8dp"
-        android:paddingEnd="8dp"
         android:paddingTop="8dp"
-        android:textSize="?attr/status_text_medium"
+        android:textAppearance="?android:attr/textAppearanceListItemSmall"
+        tools:text="Some list name"
         />
 
     <TextView
         android:id="@+id/textSecondary"
         android:layout_width="0dp"
         android:layout_height="match_parent"
-        android:layout_weight="0.91"
         app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/delete"
         app:layout_constraintTop_toBottomOf="@id/textPrimary"
         app:layout_constraintBottom_toBottomOf="parent"
-        android:paddingStart="8dp"
-        android:paddingEnd="8dp"
         android:paddingBottom="8dp"
-        android:textSize="?attr/status_text_small"
+        android:textAppearance="?android:attr/textAppearanceListItemSecondary"
+        tools:text="Warn: Home / Notifications"
         />
 
     <ImageButton
@@ -50,3 +50,4 @@
         app:srcCompat="@drawable/ic_clear_24dp" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>
+


### PR DESCRIPTION
Previous code:

- Used the wrong padding and text sizes when listing filters.
- Showed filters and filter contexts unsorted in the list.
- Recreated the adapter every time filters were updated.

Fix this.

- Use standard list padding and text sizes.
- Locale-aware sort filters by their title, and filter contexts by their order
- Create the adapter once and call `submitList()` when the filter list changes.