### PR TITLE
feat: Make new content filters default to active in all contexts

### DIFF
--- a/app/src/main/java/app/pachli/components/filters/EditContentFilterViewModel.kt
+++ b/app/src/main/java/app/pachli/components/filters/EditContentFilterViewModel.kt
@@ -64,7 +64,11 @@ data class ContentFilterViewData(
     /** Filter's ID. Null if this is a new, un-saved filter. */
     val id: String? = null,
     val title: String = "",
-    val contexts: Set<FilterContext> = emptySet(),
+    /**
+     * Contexts the filter applies to. Default for new filters is to
+     * apply to all contexts.
+     */
+    val contexts: Set<FilterContext> = FilterContext.entries.toSet(),
     /**
      * The number of seconds in the future the filter should expire.
      * "-1" means "use the filter's current value".


### PR DESCRIPTION
Content filters make sense if they're applied to all contexts.

Otherwise you can have a situation where e.g., a status that @-mentions you is filtered from the Home timeline, but the notification about the mention is not filtered from the Notifications timeline.

To make this easier for users change the default behaviour for the filter contexts for new filters. Previously all contexts were disabled and the user would choose which contexts to enable.

Now all contexts are enabled, and the user chooses which ones to disable.

Fixes #1383