### PR TITLE
fix: Create filters with the correct content-type

### DIFF
--- a/core/network/src/main/kotlin/app/pachli/core/network/retrofit/MastodonApi.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/retrofit/MastodonApi.kt
@@ -64,6 +64,7 @@ import retrofit2.http.FormUrlEncoded
 import retrofit2.http.GET
 import retrofit2.http.HTTP
 import retrofit2.http.Header
+import retrofit2.http.Headers
 import retrofit2.http.Multipart
 import retrofit2.http.PATCH
 import retrofit2.http.POST
@@ -661,6 +662,7 @@ interface MastodonApi {
         @Path("id") id: String,
     ): ApiResult<Unit>
 
+    @Headers("Content-Type: application/x-www-form-urlencoded")
     @POST("api/v2/filters")
     suspend fun createFilter(@Body newContentFilter: NewContentFilter): ApiResult<Filter>
 


### PR DESCRIPTION
Content filters are created with a form-encoded POST request. The Mastodon API defines these in a way that can't be replicated with Retrofit's normal mechanisms for defining an API (including using the `@FormUrlEncoded annotation`), so `NewContentFilterConverterFactory` converts the `NewContentFilter` object to the body of the request.

However, for some servers (at least, GoToSocial) the content-type header is required. That's normally provided by the `@FormUrlEncoded` annotation, but that can't be used here.

So provide the header directly in the API definition.

Fixes #1375