### PR TITLE
fix: Handle initial whitespace and `~~~` when parsing Markdown

### DIFF
--- a/core/ui/src/main/kotlin/app/pachli/core/ui/SetStatusContent.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/SetStatusContent.kt
@@ -176,11 +176,24 @@ object PreProcessMastodonHtml : AbstractMarkwonPlugin() {
     /** Match any inline code element (i.e., between two literal backquotes. */
     private val rxLiteral = """(?<!`)`(.+?)`""".toRegex(setOf(RegexOption.MULTILINE))
 
-    /** Match any opening `p` element, with optional whitespace before it. */
-    private val rxPEl = """\s*<p\s*>""".toRegex()
+    /**
+     * Match any opening `p` element, with optional whitespace before it, and optional
+     * whitespace immediately after the opening tag.
+     *
+     * The optional whitespace after the tag is to catch `<p>   ...`, which would
+     * appear as a code block because of the indentation.
+     */
+    private val rxPEl = """\s*<p\s*>\s*""".toRegex()
 
     /** Match `<br>`, `<br/>` (with optional spaces). */
     private val rxBrEl = """<br\s*/?>""".toRegex()
+
+    /**
+     * Match `~~~` at the start of a line. These are an alternative mechanism for
+     * starting a fenced code block. They seem to be much less frequent than
+     * using backticks.
+     */
+    private val rxThreeTilde = """^~~~""".toRegex(RegexOption.MULTILINE)
 
     /**
      * Processes [input] and removes/replaces some HTML content.
@@ -195,7 +208,7 @@ object PreProcessMastodonHtml : AbstractMarkwonPlugin() {
         // - Links in fenced code blocks are not clickable
         //   Eg., a hashtag in a fenced code block is not clickable
         val processed = input
-            // Remove <p> with any preceeding whitespace (just in case a parapgraph was
+            // Remove <p> with any preceeding whitespace (just in case a paragraph was
             // indented -- not removing the whitespace could cause it to be treated as
             // a code block).
             .replace(rxPEl, "")
@@ -205,6 +218,12 @@ object PreProcessMastodonHtml : AbstractMarkwonPlugin() {
             .replace(rxBrEl, "\n")
             // Convert leading quote markers from entities to ">".
             .replace("&gt; ", "> ")
+            // Three ~ at the start of a line are unlikely to be a fenced code block
+            // and are more likely to be decoration. Escape them so they are not parsed
+            // as code.
+            //
+            // https://dair-community.social/@emilymbender/114172441506624981
+            .replace(rxThreeTilde, Regex.escapeReplacement("""\~\~\~"""))
             // HTML in fenced code blocks is treated literally by Markwon.
             // So remove all HTML tags inside fenced blocks (keep the content).
             //


### PR DESCRIPTION
Adjust Markdown pre-processing to provide better results in two cases.

1. Trim leading spaces immediately after a `<p>` element. This prevents quoted regions from starting with leading whitespace (effectively requiring `>` before each quoted line).
2. Escape `~~~`, so only three-backticks can be used to start a fenced code block.