### PR TITLE
feat: Render Mathstodon Latex formulae when Markdown is enabled

### DIFF
--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -56,9 +56,11 @@ dependencies {
     implementation(libs.markwon)
     implementation(libs.markwon.html)
     implementation(libs.markwon.inline.parser)
+    implementation(libs.markwon.latex)
     implementation(libs.markwon.simple.ext)
     implementation(libs.markwon.strikethrough)
     implementation(libs.markwon.syntax.highlight)
     kapt(libs.prism4j)
     implementation(libs.ksoup.entities)
+    implementation(libs.jlatexmath.android)
 }

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/SetStatusContent.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/SetStatusContent.kt
@@ -20,10 +20,12 @@ package app.pachli.core.ui
 import android.content.Context
 import android.graphics.Color
 import android.text.style.URLSpan
+import android.util.TypedValue
 import android.widget.TextView
 import androidx.core.text.method.LinkMovementMethodCompat
 import app.pachli.core.activity.emojify
 import app.pachli.core.data.model.StatusDisplayOptions
+import app.pachli.core.designsystem.R
 import app.pachli.core.network.model.Emoji
 import app.pachli.core.network.model.HashTag
 import app.pachli.core.network.model.Status
@@ -35,9 +37,10 @@ import io.noties.markwon.AbstractMarkwonPlugin
 import io.noties.markwon.Markwon
 import io.noties.markwon.SoftBreakAddsNewLinePlugin
 import io.noties.markwon.core.MarkwonTheme
+import io.noties.markwon.ext.latex.JLatexMathPlugin
 import io.noties.markwon.ext.strikethrough.StrikethroughPlugin
 import io.noties.markwon.html.HtmlPlugin
-import io.noties.markwon.simple.ext.SimpleExtPlugin
+import io.noties.markwon.inlineparser.MarkwonInlineParserPlugin
 import io.noties.markwon.syntax.Prism4jThemeDefault
 import io.noties.markwon.syntax.SyntaxHighlightPlugin
 import io.noties.prism4j.Prism4j
@@ -93,10 +96,24 @@ object SetMastodonHtmlContent : SetStatusContent {
  */
 @PrismBundle(includeAll = true, grammarLocatorClassName = ".MySuperGrammerLocator")
 class SetMarkdownContent(context: Context) : SetStatusContent {
+    val textSize: Float
+
+    init {
+        val typedValue = TypedValue()
+        val displayMetrics = context.resources.displayMetrics
+        context.theme.resolveAttribute(R.attr.status_text_medium, typedValue, true)
+        textSize = typedValue.getDimension(displayMetrics)
+    }
+
     private val markwon = Markwon.builder(context)
-        .usePlugin(SimpleExtPlugin.create())
         .usePlugin(HtmlPlugin.create())
         .usePlugin(SoftBreakAddsNewLinePlugin.create())
+        .usePlugin(MarkwonInlineParserPlugin.create())
+        .usePlugin(
+            JLatexMathPlugin.create(textSize) {
+                it.inlinesEnabled(true)
+            },
+        )
         .usePlugin(
             SyntaxHighlightPlugin.create(
                 Prism4j(MySuperGrammerLocator()),
@@ -224,6 +241,14 @@ object PreProcessMastodonHtml : AbstractMarkwonPlugin() {
             //
             // https://dair-community.social/@emilymbender/114172441506624981
             .replace(rxThreeTilde, Regex.escapeReplacement("""\~\~\~"""))
+            // Hack for Mathstodon. Mathstodon uses `\[...\]` for block latex content
+            // and `\(...\)` for inline latex content (those are literal backslash and
+            // bracket/brace characters). Rewrite those to block or inline level `$$`
+            // strings so the JLatexMath plugin will parse them.
+            .replace("""\[""", "\n\n$$\n")
+            .replace("""\]""", "\n$$\n\n")
+            .replace("""\(""", "$$")
+            .replace("""\)""", "$$")
             // HTML in fenced code blocks is treated literally by Markwon.
             // So remove all HTML tags inside fenced blocks (keep the content).
             //

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,6 +45,7 @@ glide = "4.16.0"
 glide-animation-plugin = "2.23.0"
 hilt = "2.55"
 org-json = "20250107"
+jlatexmath-android = "0.2.0"
 junit = "4.13.2"
 kotlin = "2.1.10"
 kotlin-result = "1.1.20"
@@ -179,6 +180,7 @@ glide-okhttp3-integration = { module = "com.github.bumptech.glide:okhttp3-integr
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
 hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hilt" }
 hilt-android-testing = { module = "com.google.dagger:hilt-android-testing", version.ref = "hilt" }
+jlatexmath-android = { module = "ru.noties:jlatexmath-android", version.ref = "jlatexmath-android" }
 junit = { module = "junit:junit", version.ref = "junit" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit-jupiter" }
@@ -200,6 +202,7 @@ markwon = { module = "io.noties.markwon:core", version.ref = "markwon" }
 markwon-html = { module = "io.noties.markwon:html", version.ref = "markwon" }
 markwon-inline-parser = { module = "io.noties.markwon:inline-parser", version.ref = "markwon" }
 markwon-simple-ext = { module = "io.noties.markwon:simple-ext", version.ref = "markwon" }
+markwon-latex = { module = "io.noties.markwon:ext-latex", version.ref = "markwon" }
 markwon-strikethrough = { module = "io.noties.markwon:ext-strikethrough", version.ref = "markwon" }
 markwon-syntax-highlight = { module = "io.noties.markwon:syntax-highlight", version.ref = "markwon" }
 markwon-tables = { module = "io.noties.markwon:ext-tables", version.ref = "markwon" }


### PR DESCRIPTION
Enable the Latex Markdown plugin, which renders Latex in `$$` delimited blocks.

Re-write `\(` / `\{` and `)` / `\}` (which Mathstodon uses as Latex markers) to `$$` to trigger the Latex processing.