### PR TITLE
fix: Don't crash if download error happens when sharing media

### DIFF
--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -604,7 +604,7 @@
     <string name="notification_prune_cache">Mantenimiento de caché…</string>
     <string name="pref_summary_content_filters">Tu servidor no es compatible con los filtros de contenido</string>
     <string name="server_repository_error">No se pudo obtener la info del servidor %1$s: %2$s</string>
-    <string name="error_media_download">No se pudo descargar %1$s: %2$d %3$s</string>
+    <string name="error_media_download">No se pudo descargar %1$s: %2$s</string>
     <string name="pref_title_update_check_now">Buscar actualizaciones ahora</string>
     <string name="pref_update_check_no_updates">No hay actualizaciones disponibles</string>
     <string name="pref_update_next_scheduled_check">Próxima comprobación: %1$s</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -596,7 +596,7 @@
     <string name="pref_title_update_check_now">Etsi päivitystä nyt</string>
     <string name="pref_update_next_scheduled_check">Seuraava ajoitettu tarkistus: %1$s</string>
     <string name="pref_update_check_no_updates">Ei päivityksiä tarjolla</string>
-    <string name="error_media_download">Lataaminen epäonnistui %1$s: %2$d%3$s</string>
+    <string name="error_media_download">Lataaminen epäonnistui %1$s: %2$s</string>
     <string name="manage_lists">Hallinnoi listoja</string>
     <string name="poll_show_votes">Näytä äänet</string>
     <string name="notification_severed_relationships_name">Katkaistut yhteydet</string>

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -742,7 +742,7 @@
     <string name="pref_notification_battery_optimisation_ok">Ní gá optamú ceallraí a dhíchumasú.</string>
     <string name="pref_notification_method_push">Brúigh</string>
     <string name="pref_update_next_scheduled_check">An chéad seiceáil sceidealta eile: %1$s</string>
-    <string name="error_media_download">Níorbh fhéidir %1$s a íoslódáil: %2$d%3$s</string>
+    <string name="error_media_download">Níorbh fhéidir %1$s a íoslódáil: %2$s</string>
     <string name="action_add_to_tab_success">Cuireadh \'%1$s\' le cluaisíní</string>
     <string name="action_remove_tab">Bain cluaisín</string>
     <string name="search_operator_where_dialog_library_hint">Do phoist féin, boosts, Favorites, leabharmharcanna, agus poist a @mention tú</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -678,7 +678,7 @@
     <string name="search_operator_where_dialog_library">A túa biblioteca</string>
     <string name="search_operator_where_dialog_public">Publicacións públicas</string>
     <string name="search_operator_where_dialog_public_hint">Públicas, publicacións ás que pode acceder calquera servidor</string>
-    <string name="error_media_download">Non se descargou %1$s: %2$d %3$s</string>
+    <string name="error_media_download">Non se descargou %1$s: %2$s</string>
     <string name="action_remove_tab">Retirar pestana</string>
     <string name="pref_update_next_scheduled_check">Próxima comprobación: %1$s</string>
     <string name="action_open_byline_account">Ver o perfil da autora do artigo</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -612,7 +612,7 @@
     <string name="update_dialog_negative">Minn meg aldri</string>
     <string name="server_repository_error">Kunne ikke hente inn serveropplysninger for %1$s: %2$s</string>
     <string name="pref_update_next_scheduled_check">Nest planlagt kontroll: %1$s</string>
-    <string name="error_media_download">Klarte ikke laste ned %1$s: %2$d %3$s</string>
+    <string name="error_media_download">Klarte ikke laste ned %1$s: %2$s</string>
     <string name="compose_warn_language_dialog_accept_language_fmt">Tut slik som det er (på %1$s)</string>
     <string name="action_add_to_tab">Legg til til fane</string>
     <string name="pref_title_update_check_now">Se etter oppdateringer nå</string>

--- a/app/src/main/res/values-nn/strings.xml
+++ b/app/src/main/res/values-nn/strings.xml
@@ -565,7 +565,7 @@
     <string name="pref_notification_fetch_needs_push">Kontoen har ikkje «push»-løyve. Å logge ut og så inn igjen kan fikse dette.</string>
     <string name="pref_update_check_no_updates">Det finst ingen tigjengelege oppdateringar</string>
     <string name="pref_update_next_scheduled_check">Nest planlagt kontroll: %1$s</string>
-    <string name="error_media_download">Mislykkast i å laste ned %1$s: %2$d%3$s</string>
+    <string name="error_media_download">Mislykkast i å laste ned %1$s: %2$s</string>
     <string name="action_add_to_tab">Legg til i fane</string>
     <string name="action_add_to_tab_success">La til «%1$s» i fanene</string>
     <string name="error_filter_missing_title">Tittel krevst</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -603,7 +603,7 @@
     <string name="error_filter_missing_keyword">Co najmniej jedno słowo kluczowe lub fraza są wymagane</string>
     <string name="update_dialog_title">Aktualizacja jest dostępna</string>
     <string name="update_dialog_neutral">Nie przypominaj mi o tej wersji</string>
-    <string name="error_media_download">Nie udało się pobrać %1$s: %2$d %3$s</string>
+    <string name="error_media_download">Nie udało się pobrać %1$s: %2$s</string>
     <string name="compose_warn_language_dialog_change_language_fmt">Zmień język na %1$s i opublikuj</string>
     <string name="compose_warn_language_dialog_accept_language_fmt">Wyślij bez zmiany (%1$s)</string>
     <string name="error_media_uploader_upload_not_found_fmt">nie odnaleziono multimediów wgranych z ID %1$s</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -671,7 +671,7 @@
     <string name="search_operator_attachment_has_media_except_2_label_fmt">Všetky okrem %1$s, %2$s</string>
     <string name="search_operator_attachment_no_media_label">Žiadne médiá</string>
     <string name="server_repository_error">Nepodarilo sa načítať informácie o serveri pre %1$s: %2$s</string>
-    <string name="error_media_download">Nepodarilo sa stiahnuť %1$s: %2$d %3$s</string>
+    <string name="error_media_download">Nepodarilo sa stiahnuť %1$s: %2$s</string>
     <string name="compose_warn_language_dialog_accept_and_dont_ask_fmt">Uverejniť tak, ako je (%1$s) a viac sa nepýtať</string>
     <string name="error_prepare_media_unsupported_mime_type_fmt">server nepodporuje typ súboru: %1$s</string>
     <string name="search_operator_attachment_dialog_title">Obmedziť na príspevky s médiami?</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -466,7 +466,7 @@
     <string name="pref_title_notification_up_distributor">ஒருங்கிணைந்த புச் விநியோகச்தர்</string>
     <string name="pref_notification_fetch_err_timestamp_fmt">✖ %1$s முன்பு @ %2$s</string>
     <string name="pref_notification_fetch_server_rejected">%1$s நிராகரிக்கப்பட்ட புச் பதிவு</string>
-    <string name="error_media_download">%1$s ஐ பதிவிறக்கம் செய்ய முடியவில்லை: %2$d %3$s</string>
+    <string name="error_media_download">%1$s ஐ பதிவிறக்கம் செய்ய முடியவில்லை: %2$s</string>
     <string name="action_manage_tabs">தாவல்களை நிர்வகிக்கவும்</string>
     <string name="error_prepare_media_io_fmt">%1$s</string>
     <string name="search_operator_date_all">தேதிகள்</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -707,7 +707,7 @@
     <string name="pref_title_update_check_now">Check for update now</string>
     <string name="pref_update_check_no_updates">There are no updates available</string>
     <string name="pref_update_next_scheduled_check">Next scheduled check: %1$s</string>
-    <string name="error_media_download">Could not download %1$s: %2$d %3$s</string>
+    <string name="error_media_download">Could not download %1$s: %2$s</string>
     <string name="action_add_to_tab">Add to tab</string>
     <string name="action_add_to_tab_success">Added \'%1$s\' to tabs</string>
     <string name="action_remove_tab">Remove tab</string>


### PR DESCRIPTION
Previous code executed an OkHttp call without catching the exception that could occur if the call failed.

Rewrite this to use `runSuspendCatching` and convert the error response to an `ApiError`. This gives a better error message using `fmt()`, and the error message format string can be simplified.