### PR TITLE
refactor: Modularise the translation code

### DIFF
--- a/app/src/fdroid/kotlin/app/pachli/di/TranslatorModule.kt
+++ b/app/src/fdroid/kotlin/app/pachli/di/TranslatorModule.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.di
+
+import app.pachli.core.network.retrofit.MastodonApi
+import app.pachli.translation.ServerTranslator
+import app.pachli.translation.Translator
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@InstallIn(SingletonComponent::class)
+@Module
+object TranslatorModule {
+    @Provides
+    @Singleton
+    fun providesTranslator(mastodonApi: MastodonApi): Translator = ServerTranslator(mastodonApi)
+}

--- a/app/src/github/kotlin/app/pachli/di/TranslatorModule.kt
+++ b/app/src/github/kotlin/app/pachli/di/TranslatorModule.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.di
+
+import app.pachli.core.network.retrofit.MastodonApi
+import app.pachli.translation.ServerTranslator
+import app.pachli.translation.Translator
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@InstallIn(SingletonComponent::class)
+@Module
+object TranslatorModule {
+    @Provides
+    @Singleton
+    fun providesTranslator(mastodonApi: MastodonApi): Translator = ServerTranslator(mastodonApi)
+}

--- a/app/src/google/kotlin/app/pachli/di/TranslatorModule.kt
+++ b/app/src/google/kotlin/app/pachli/di/TranslatorModule.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.di
+
+import app.pachli.core.network.retrofit.MastodonApi
+import app.pachli.translation.ServerTranslationService
+import app.pachli.translation.TranslationService
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@InstallIn(SingletonComponent::class)
+@Module
+object TranslatorModule {
+    @Provides
+    @Singleton
+    fun providesTranslator(mastodonApi: MastodonApi): TranslationService = ServerTranslationService(mastodonApi)
+}

--- a/app/src/main/java/app/pachli/components/viewthread/ViewThreadFragment.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/ViewThreadFragment.kt
@@ -38,6 +38,7 @@ import app.pachli.core.activity.extensions.TransitionKind
 import app.pachli.core.activity.extensions.startActivityWithDefaultTransition
 import app.pachli.core.activity.extensions.startActivityWithTransition
 import app.pachli.core.activity.openLink
+import app.pachli.core.common.PachliError
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
 import app.pachli.core.common.extensions.viewBinding
@@ -50,7 +51,6 @@ import app.pachli.core.network.model.Poll
 import app.pachli.core.network.model.Status
 import app.pachli.core.ui.SetMarkdownContent
 import app.pachli.core.ui.SetMastodonHtmlContent
-import app.pachli.core.ui.extensions.getErrorString
 import app.pachli.databinding.FragmentViewThreadBinding
 import app.pachli.fragment.SFragment
 import app.pachli.interfaces.StatusActionListener
@@ -65,7 +65,6 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlin.properties.Delegates
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-import timber.log.Timber
 
 @AndroidEntryPoint
 class ViewThreadFragment :
@@ -234,11 +233,10 @@ class ViewThreadFragment :
         }
     }
 
-    private fun bindError(throwable: Throwable) {
-        Timber.w(throwable, "failed to load status context")
+    private fun bindError(error: PachliError) {
         try {
             val context = view?.context ?: return
-            val msg = throwable.getErrorString(context)
+            val msg = error.fmt(context)
             Snackbar.make(binding.root, msg, Snackbar.LENGTH_INDEFINITE)
                 .setAction(app.pachli.core.ui.R.string.action_retry) {
                     viewModel.retry(thisThreadsStatusId)

--- a/app/src/main/java/app/pachli/components/viewthread/ViewThreadViewModel.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/ViewThreadViewModel.kt
@@ -47,6 +47,7 @@ import app.pachli.core.network.retrofit.MastodonApi
 import app.pachli.core.network.retrofit.apiresult.ApiError
 import app.pachli.core.network.retrofit.apiresult.ClientError
 import app.pachli.network.ContentFilterModel
+import app.pachli.usecase.TimelineCases
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
@@ -79,6 +80,7 @@ class ViewThreadViewModel @Inject constructor(
     private val repository: CachedTimelineRepository,
     statusDisplayOptionsRepository: StatusDisplayOptionsRepository,
     private val statusRepository: StatusRepository,
+    private val timelineCases: TimelineCases,
 ) : ViewModel() {
     // TODO: For consistency with other fragments the UiState should not include
     // the list of statuses. Look at SuggestionsViewModel for ideas.
@@ -481,7 +483,7 @@ class ViewThreadViewModel @Inject constructor(
 
     fun translate(statusViewData: StatusViewData) {
         viewModelScope.launch {
-            repository.translate(statusViewData).onSuccess {
+            timelineCases.translate(statusViewData).onSuccess {
                 val body = it.body
                 val translatedEntity = TranslatedStatusEntity(
                     serverId = statusViewData.actionableId,

--- a/app/src/main/java/app/pachli/components/viewthread/ViewThreadViewModel.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/ViewThreadViewModel.kt
@@ -27,8 +27,8 @@ import app.pachli.core.data.repository.StatusDisplayOptionsRepository
 import app.pachli.core.data.repository.StatusRepository
 import app.pachli.core.database.dao.TimelineDao
 import app.pachli.core.database.model.AccountEntity
-import app.pachli.core.database.model.TranslatedStatusEntity
 import app.pachli.core.database.model.TranslationState
+import app.pachli.core.database.model.toEntity
 import app.pachli.core.eventhub.BlockEvent
 import app.pachli.core.eventhub.BookmarkEvent
 import app.pachli.core.eventhub.EventHub
@@ -45,7 +45,6 @@ import app.pachli.core.network.model.Poll
 import app.pachli.core.network.model.Status
 import app.pachli.core.network.retrofit.MastodonApi
 import app.pachli.core.network.retrofit.apiresult.ApiError
-import app.pachli.core.network.retrofit.apiresult.ClientError
 import app.pachli.network.ContentFilterModel
 import app.pachli.usecase.TimelineCases
 import com.github.michaelbull.result.Err
@@ -89,7 +88,7 @@ class ViewThreadViewModel @Inject constructor(
     val uiResult: Flow<Result<ThreadUiState, ThreadError>>
         get() = _uiResult
 
-    private val _errors = Channel<Throwable>()
+    private val _errors = Channel<PachliError>()
     val errors = _errors.receiveAsFlow()
 
     var isInitialLoad: Boolean = true
@@ -268,7 +267,7 @@ class ViewThreadViewModel @Inject constructor(
                             revealButton = RevealButtonState.NO_BUTTON,
                         ),
                     )
-                    _errors.send(error.throwable)
+                    _errors.send(error)
                 }
         }
     }
@@ -483,29 +482,14 @@ class ViewThreadViewModel @Inject constructor(
 
     fun translate(statusViewData: StatusViewData) {
         viewModelScope.launch {
-            timelineCases.translate(statusViewData).onSuccess {
-                val body = it.body
-                val translatedEntity = TranslatedStatusEntity(
-                    serverId = statusViewData.actionableId,
-                    timelineUserId = statusViewData.pachliAccountId,
-                    content = body.content,
-                    spoilerText = body.spoilerText,
-                    poll = body.poll,
-                    attachments = body.attachments,
-                    provider = body.provider,
-                )
-                updateStatusViewData(statusViewData.id) { viewData ->
-                    viewData.copy(translation = translatedEntity, translationState = TranslationState.SHOW_TRANSLATION)
+            timelineCases.translate(statusViewData)
+                .onSuccess {
+                    val translatedEntity = it.toEntity(statusViewData.pachliAccountId, statusViewData.actionableId)
+                    updateStatusViewData(statusViewData.id) { viewData ->
+                        viewData.copy(translation = translatedEntity, translationState = TranslationState.SHOW_TRANSLATION)
+                    }
                 }
-            }
-                .onFailure {
-                    // Mastodon returns 403 if it thinks the original status language is the
-                    // same as the user's language, ignoring the actual content of the status
-                    // (https://github.com/mastodon/documentation/issues/1330). Nothing useful
-                    // to do here so swallow the error
-                    if (it is ClientError && it.exception.code() == 403) return@launch
-                    _errors.send(it.throwable)
-                }
+                .onFailure { _errors.send(it) }
         }
     }
 

--- a/app/src/main/java/app/pachli/fragment/SFragment.kt
+++ b/app/src/main/java/app/pachli/fragment/SFragment.kt
@@ -62,6 +62,7 @@ import app.pachli.core.network.parseAsMastodonHtml
 import app.pachli.core.network.retrofit.MastodonApi
 import app.pachli.core.ui.ClipboardUseCase
 import app.pachli.interfaces.StatusActionListener
+import app.pachli.translation.TranslationService
 import app.pachli.usecase.TimelineCases
 import app.pachli.view.showMuteAccountDialog
 import com.github.michaelbull.result.onFailure
@@ -97,6 +98,9 @@ abstract class SFragment<T : IStatusViewData> : Fragment(), StatusActionListener
 
     @Inject
     lateinit var clipboard: ClipboardUseCase
+
+    @Inject
+    lateinit var translationService: TranslationService
 
     private var serverCanTranslate = false
 
@@ -233,7 +237,7 @@ abstract class SFragment<T : IStatusViewData> : Fragment(), StatusActionListener
         } else {
             popup.inflate(R.menu.status_more)
             popup.menu.findItem(R.id.status_download_media).isVisible = status.attachments.isNotEmpty()
-            if (serverCanTranslate && canTranslate() && status.visibility != Status.Visibility.PRIVATE && status.visibility != Status.Visibility.DIRECT) {
+            if (serverCanTranslate && canTranslate() && translationService.canTranslate(viewData)) {
                 popup.menu.findItem(R.id.status_translate).isVisible = viewData.translationState == TranslationState.SHOW_ORIGINAL
                 popup.menu.findItem(R.id.status_translate_undo).isVisible = viewData.translationState == TranslationState.SHOW_TRANSLATION
             } else {

--- a/app/src/main/java/app/pachli/fragment/SFragment.kt
+++ b/app/src/main/java/app/pachli/fragment/SFragment.kt
@@ -376,8 +376,14 @@ abstract class SFragment<T : IStatusViewData> : Fragment(), StatusActionListener
      */
     open fun canTranslate() = false
 
+    /**
+     * Translate [statusViewData].
+     */
     open fun onTranslate(statusViewData: T) {}
 
+    /**
+     * Undo the translation of [statusViewData].
+     */
     open fun onTranslateUndo(statusViewData: T) {}
 
     private fun onMute(accountId: String, accountUsername: String) {

--- a/app/src/main/java/app/pachli/languageidentification/LanguageIdentification.kt
+++ b/app/src/main/java/app/pachli/languageidentification/LanguageIdentification.kt
@@ -49,7 +49,7 @@ data class IdentifiedLanguage(
 
 sealed class LanguageIdentifierError(
     @StringRes override val resourceId: Int = -1,
-    override val formatArgs: Array<out String>? = null,
+    override val formatArgs: Array<out Any>? = null,
     override val cause: PachliError? = null,
 ) : PachliError {
 

--- a/app/src/main/java/app/pachli/translation/Translation.kt
+++ b/app/src/main/java/app/pachli/translation/Translation.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.translation
+
+import app.pachli.core.common.PachliError
+import app.pachli.core.data.model.IStatusViewData
+import app.pachli.core.model.translation.TranslatedStatus
+import app.pachli.core.network.model.Status
+import app.pachli.core.network.retrofit.MastodonApi
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.mapEither
+
+/**
+ * Errors that can occur when translating a status.
+ */
+sealed interface TranslatorError : PachliError {
+    @JvmInline
+    value class ApiError(val error: app.pachli.core.network.retrofit.apiresult.ApiError) : TranslatorError, PachliError by error
+}
+
+interface TranslationService {
+    /**
+     * @return True if this [TranslationService] can translate [statusViewData].
+     * Does not indicate if the translation will be successful, only that the
+     * translation option should be visible in the UI.
+     */
+    fun canTranslate(statusViewData: IStatusViewData): Boolean
+
+    /**
+     * Translates some/all of the content of [statusViewData]. The precise content
+     * translated depends on the implementation.
+     */
+    suspend fun translate(statusViewData: IStatusViewData): Result<TranslatedStatus, TranslatorError>
+}
+
+/**
+ * [TranslationService] that translates using the translation API provided by
+ * the user's server.
+ */
+class ServerTranslationService(
+    private val mastodonApi: MastodonApi,
+) : TranslationService {
+    override fun canTranslate(statusViewData: IStatusViewData) = statusViewData.actionable.visibility != Status.Visibility.PRIVATE &&
+        statusViewData.actionable.visibility != Status.Visibility.DIRECT
+
+    override suspend fun translate(statusViewData: IStatusViewData) = mastodonApi.translate(statusViewData.actionableId).mapEither(
+        { it.body.toModel() },
+        { TranslatorError.ApiError(it) },
+    )
+}

--- a/core/database/src/main/kotlin/app/pachli/core/database/model/TranslatedStatusEntity.kt
+++ b/core/database/src/main/kotlin/app/pachli/core/database/model/TranslatedStatusEntity.kt
@@ -20,8 +20,11 @@ package app.pachli.core.database.model
 import androidx.room.Entity
 import androidx.room.TypeConverters
 import app.pachli.core.database.Converters
+import app.pachli.core.model.translation.TranslatedStatus
 import app.pachli.core.network.model.TranslatedAttachment
 import app.pachli.core.network.model.TranslatedPoll
+import app.pachli.core.network.model.Translation
+import app.pachli.core.network.model.toNetworkModel
 
 /**
  * Translated version of a status, see https://docs.joinmastodon.org/entities/Translation/.
@@ -68,4 +71,24 @@ data class TranslatedStatusEntity(
 
     /** The service that provided the machine translation */
     val provider: String,
+)
+
+fun Translation.toEntity(pachliAccountId: Long, serverId: String) = TranslatedStatusEntity(
+    serverId = serverId,
+    timelineUserId = pachliAccountId,
+    content = content,
+    spoilerText = spoilerText,
+    poll = poll,
+    attachments = attachments,
+    provider = provider,
+)
+
+fun TranslatedStatus.toEntity(pachliAccountId: Long, serverId: String) = TranslatedStatusEntity(
+    serverId = serverId,
+    timelineUserId = pachliAccountId,
+    content = content,
+    spoilerText = spoilerText,
+    poll = poll?.toNetworkModel(),
+    attachments = attachments.map { it.toNetworkModel() },
+    provider = provider,
 )

--- a/core/model/src/main/kotlin/app/pachli/core/model/translation/TranslatedStatus.kt
+++ b/core/model/src/main/kotlin/app/pachli/core/model/translation/TranslatedStatus.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.core.model.translation
+
+data class TranslatedStatus(
+    /** The translated text of the status (HTML), equivalent to [Status.content] */
+    val content: String,
+
+    /**
+     * The language of the source text, as auto-detected by the machine translation
+     * (ISO 639 language code)
+     */
+    val detectedSourceLanguage: String,
+
+    /**
+     * The translated spoiler text of the status (text), if it exists, equivalent to
+     * [Status.spoilerText]
+     */
+    val spoilerText: String,
+
+    /** The translated poll (if it exists) */
+    val poll: TranslatedPoll?,
+
+    /**
+     * Translated descriptions for media attachments, if any were attached. Other metadata has
+     * to be determined from the original attachment.
+     */
+    val attachments: List<TranslatedAttachment>,
+
+    /** The service that provided the machine translation */
+    val provider: String,
+)
+
+/**
+ * A translated poll. Does not contain all the poll data, only the translated text.
+ * Vote counts and other metadata has to be determined from the original poll object.
+ */
+data class TranslatedPoll(
+    val id: String,
+    val options: List<TranslatedPollOption>,
+)
+
+/** A translated poll option. */
+data class TranslatedPollOption(
+    val title: String,
+)
+
+/** A translated attachment. Only the description is translated */
+data class TranslatedAttachment(
+    val id: String,
+    val description: String?,
+)

--- a/core/network/src/main/kotlin/app/pachli/core/network/model/Translation.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/Translation.kt
@@ -52,7 +52,16 @@ data class Translation(
 
     /** The service that provided the machine translation */
     val provider: String,
-)
+) {
+    fun toModel() = app.pachli.core.model.translation.TranslatedStatus(
+        content = content,
+        detectedSourceLanguage = detectedSourceLanguage,
+        spoilerText = spoilerText,
+        poll = this.poll?.toModel(),
+        attachments = attachments.map { it.toModel() },
+        provider = this.provider,
+    )
+}
 
 /**
  * A translated poll. Does not contain all the poll data, only the translated text.
@@ -62,17 +71,41 @@ data class Translation(
 data class TranslatedPoll(
     val id: String,
     val options: List<TranslatedPollOption>,
-)
+) {
+    fun toModel() = app.pachli.core.model.translation.TranslatedPoll(
+        id = this.id,
+        options = this.options.map { it.toModel() },
+    )
+}
 
 /** A translated poll option. */
 @JsonClass(generateAdapter = true)
 data class TranslatedPollOption(
     val title: String,
-)
+) {
+    fun toModel() = app.pachli.core.model.translation.TranslatedPollOption(title)
+}
 
 /** A translated attachment. Only the description is translated */
 @JsonClass(generateAdapter = true)
 data class TranslatedAttachment(
     val id: String,
-    val description: String,
+    val description: String?,
+) {
+    fun toModel() = app.pachli.core.model.translation.TranslatedAttachment(
+        id = id,
+        description = description,
+    )
+}
+
+fun app.pachli.core.model.translation.TranslatedPoll.toNetworkModel() = TranslatedPoll(
+    id = this.id,
+    options = this.options.map { it.toNetworkModel() },
+)
+
+fun app.pachli.core.model.translation.TranslatedPollOption.toNetworkModel() = TranslatedPollOption(this.title)
+
+fun app.pachli.core.model.translation.TranslatedAttachment.toNetworkModel() = TranslatedAttachment(
+    id = this.id,
+    description = this.description,
 )


### PR DESCRIPTION
Abstract the translation service behind an interface to allow different
translation services in the future.

Provide core.model classes to represent a translation result, and mappers
to go to/from the network/entity classes and the model class.

Surface translation errors in `ViewThreadViewModel` so they are visible to
the user.