### PR TITLE
feat: Support translation throughout the app

### DIFF
--- a/app/src/main/java/app/pachli/components/conversation/ConversationsFragment.kt
+++ b/app/src/main/java/app/pachli/components/conversation/ConversationsFragment.kt
@@ -349,6 +349,9 @@ class ConversationsFragment :
         adapter.refresh()
     }
 
+    // Can't translate conversations because of Mastodon privacy settings.
+    override fun canTranslate() = false
+
     override fun onReblog(viewData: ConversationViewData, reblog: Boolean) {
         // its impossible to reblog private messages
     }

--- a/app/src/main/java/app/pachli/components/notifications/NotificationsFragment.kt
+++ b/app/src/main/java/app/pachli/components/notifications/NotificationsFragment.kt
@@ -480,23 +480,37 @@ class NotificationsFragment :
     }
 
     override fun onReblog(viewData: NotificationViewData, reblog: Boolean) {
-        viewModel.accept(StatusAction.Reblog(reblog, viewData.statusViewData!!))
+        viewModel.accept(FallibleStatusAction.Reblog(reblog, viewData.statusViewData!!))
     }
 
     override fun onFavourite(viewData: NotificationViewData, favourite: Boolean) {
-        viewModel.accept(StatusAction.Favourite(favourite, viewData.statusViewData!!))
+        viewModel.accept(FallibleStatusAction.Favourite(favourite, viewData.statusViewData!!))
     }
 
     override fun onBookmark(viewData: NotificationViewData, bookmark: Boolean) {
-        viewModel.accept(StatusAction.Bookmark(bookmark, viewData.statusViewData!!))
+        viewModel.accept(FallibleStatusAction.Bookmark(bookmark, viewData.statusViewData!!))
     }
 
     override fun onVoteInPoll(viewData: NotificationViewData, poll: Poll, choices: List<Int>) {
-        viewModel.accept(StatusAction.VoteInPoll(poll, choices, viewData.statusViewData!!))
+        viewModel.accept(FallibleStatusAction.VoteInPoll(poll, choices, viewData.statusViewData!!))
     }
 
     override fun onMore(view: View, viewData: NotificationViewData) {
         super.more(view, viewData)
+    }
+
+    override fun canTranslate() = true
+
+    override fun onTranslate(statusViewData: NotificationViewData) {
+        statusViewData.statusViewData?.let {
+            viewModel.accept(FallibleStatusAction.Translate(it))
+        }
+    }
+
+    override fun onTranslateUndo(statusViewData: NotificationViewData) {
+        statusViewData.statusViewData?.let {
+            viewModel.accept(InfallibleStatusAction.TranslateUndo(it))
+        }
     }
 
     override fun onViewMedia(viewData: NotificationViewData, attachmentIndex: Int, view: View?) {

--- a/app/src/main/java/app/pachli/components/timeline/CachedTimelineRepository.kt
+++ b/app/src/main/java/app/pachli/components/timeline/CachedTimelineRepository.kt
@@ -26,7 +26,6 @@ import app.pachli.components.timeline.TimelineRepository.Companion.PAGE_SIZE
 import app.pachli.components.timeline.viewmodel.CachedTimelineRemoteMediator
 import app.pachli.components.timeline.viewmodel.CachedTimelineRemoteMediator.Companion.RKE_TIMELINE_ID
 import app.pachli.core.common.di.ApplicationScope
-import app.pachli.core.data.repository.StatusRepository
 import app.pachli.core.database.dao.RemoteKeyDao
 import app.pachli.core.database.dao.StatusDao
 import app.pachli.core.database.dao.TimelineDao
@@ -64,7 +63,6 @@ class CachedTimelineRepository @Inject constructor(
     private val remoteKeyDao: RemoteKeyDao,
     private val translatedStatusDao: TranslatedStatusDao,
     private val statusDao: StatusDao,
-    private val statusRepository: StatusRepository,
     @ApplicationScope private val externalScope: CoroutineScope,
 ) : TimelineRepository<TimelineStatusWithAccount> {
     private var factory: InvalidatingPagingSourceFactory<Int, TimelineStatusWithAccount>? = null

--- a/app/src/main/java/app/pachli/components/timeline/TimelineFragment.kt
+++ b/app/src/main/java/app/pachli/components/timeline/TimelineFragment.kt
@@ -50,7 +50,6 @@ import app.pachli.components.timeline.viewmodel.FallibleStatusAction
 import app.pachli.components.timeline.viewmodel.InfallibleStatusAction
 import app.pachli.components.timeline.viewmodel.InfallibleUiAction
 import app.pachli.components.timeline.viewmodel.NetworkTimelineViewModel
-import app.pachli.components.timeline.viewmodel.StatusActionSuccess
 import app.pachli.components.timeline.viewmodel.TimelineViewModel
 import app.pachli.components.timeline.viewmodel.UiError
 import app.pachli.components.timeline.viewmodel.UiSuccess
@@ -327,40 +326,6 @@ class TimelineFragment :
         }
 
         uiResult.onSuccess {
-            // Update adapter data when status actions are successful, and re-bind to update
-            // the UI.
-            // TODO: No - this should be handled by the ViewModel updating the data
-            // and invalidating the paging source
-            if (it is StatusActionSuccess) {
-                val indexedViewData = adapter.snapshot()
-                    .withIndex()
-                    .firstOrNull { indexed ->
-                        indexed.value?.id == it.action.statusViewData.id
-                    } ?: return
-
-                val statusViewData = indexedViewData.value ?: return
-
-                val status = when (it) {
-                    is StatusActionSuccess.Bookmark ->
-                        statusViewData.status.copy(bookmarked = it.action.state)
-
-                    is StatusActionSuccess.Favourite ->
-                        statusViewData.status.copy(favourited = it.action.state)
-
-                    is StatusActionSuccess.Reblog ->
-                        statusViewData.status.copy(reblogged = it.action.state)
-
-                    is StatusActionSuccess.VoteInPoll ->
-                        statusViewData.status.copy(
-                            poll = it.action.poll.votedCopy(it.action.choices),
-                        )
-
-                    is StatusActionSuccess.Translate -> statusViewData.status
-                }
-                (indexedViewData.value as StatusViewData).status = status
-                adapter.notifyItemChanged(indexedViewData.index)
-            }
-
             // Refresh adapter on mutes and blocks
             when (it) {
                 is UiSuccess.Block, is UiSuccess.Mute, is UiSuccess.MuteConversation,
@@ -607,11 +572,11 @@ class TimelineFragment :
     }
 
     override fun onExpandedChange(viewData: StatusViewData, expanded: Boolean) {
-        viewModel.changeExpanded(expanded, viewData)
+        viewModel.onChangeExpanded(expanded, viewData)
     }
 
     override fun onContentHiddenChange(viewData: StatusViewData, isShowingContent: Boolean) {
-        viewModel.changeContentShowing(isShowingContent, viewData)
+        viewModel.onChangeContentShowing(isShowingContent, viewData)
     }
 
     override fun onShowReblogs(statusId: String) {
@@ -625,11 +590,10 @@ class TimelineFragment :
     }
 
     override fun onContentCollapsedChange(viewData: StatusViewData, isCollapsed: Boolean) {
-        viewModel.changeContentCollapsed(isCollapsed, viewData)
+        viewModel.onContentCollapsed(isCollapsed, viewData)
     }
 
-    // Can only translate the home timeline at the moment
-    override fun canTranslate() = timeline == Timeline.Home
+    override fun canTranslate() = true
 
     override fun onTranslate(statusViewData: StatusViewData) {
         viewModel.accept(FallibleStatusAction.Translate(statusViewData))

--- a/app/src/main/java/app/pachli/interfaces/StatusActionListener.kt
+++ b/app/src/main/java/app/pachli/interfaces/StatusActionListener.kt
@@ -56,6 +56,14 @@ interface StatusActionListener<T : IStatusViewData> : LinkListener {
      * called when the favourite count has been clicked
      */
     fun onShowFavs(statusId: String) {}
+
+    /**
+     * Called when voting on a poll.
+     *
+     * @param viewData
+     * @param poll The poll the user is voting in.
+     * @param choices The indices of the options the user is voting for.
+     */
     fun onVoteInPoll(viewData: T, poll: Poll, choices: List<Int>)
     fun onShowEdits(statusId: String) {}
 

--- a/app/src/main/java/app/pachli/usecase/TimelineCases.kt
+++ b/app/src/main/java/app/pachli/usecase/TimelineCases.kt
@@ -107,7 +107,7 @@ class TimelineCases @Inject constructor(
         return translation
     }
 
-    suspend fun translateUndo(pachliAccountId: Long, statusViewData: StatusViewData) {
+    suspend fun translateUndo(statusViewData: StatusViewData) {
         statusRepository.setTranslationState(statusViewData.pachliAccountId, statusViewData.id, TranslationState.SHOW_ORIGINAL)
     }
 

--- a/app/src/test/java/app/pachli/components/notifications/NotificationsViewModelTestStatusFilterAction.kt
+++ b/app/src/test/java/app/pachli/components/notifications/NotificationsViewModelTestStatusFilterAction.kt
@@ -34,7 +34,7 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.stub
 
 /**
- * Verify that [StatusAction] are handled correctly on receipt:
+ * Verify that [FallibleStatusAction] are handled correctly on receipt:
  *
  * - Is the correct [UiSuccess] or [UiError] value emitted?
  * - Is the correct [TimelineCases] function called, with the correct arguments?
@@ -54,16 +54,16 @@ class NotificationsViewModelTestStatusFilterAction : NotificationsViewModelTestB
     )
 
     /** Action to bookmark a status */
-    private val bookmarkAction = StatusAction.Bookmark(true, statusViewData)
+    private val bookmarkAction = FallibleStatusAction.Bookmark(true, statusViewData)
 
     /** Action to favourite a status */
-    private val favouriteAction = StatusAction.Favourite(true, statusViewData)
+    private val favouriteAction = FallibleStatusAction.Favourite(true, statusViewData)
 
     /** Action to reblog a status */
-    private val reblogAction = StatusAction.Reblog(true, statusViewData)
+    private val reblogAction = FallibleStatusAction.Reblog(true, statusViewData)
 
     /** Action to vote in a poll */
-    private val voteInPollAction = StatusAction.VoteInPoll(
+    private val voteInPollAction = FallibleStatusAction.VoteInPoll(
         poll = status.poll!!,
         choices = listOf(1, 0, 0),
         statusViewData,

--- a/app/src/test/java/app/pachli/components/timeline/NetworkTimelineViewModelTestBase.kt
+++ b/app/src/test/java/app/pachli/components/timeline/NetworkTimelineViewModelTestBase.kt
@@ -25,6 +25,8 @@ import app.pachli.core.data.repository.AccountManager
 import app.pachli.core.data.repository.ContentFiltersRepository
 import app.pachli.core.data.repository.StatusDisplayOptionsRepository
 import app.pachli.core.data.repository.StatusRepository
+import app.pachli.core.database.dao.StatusDao
+import app.pachli.core.database.dao.TranslatedStatusDao
 import app.pachli.core.eventhub.EventHub
 import app.pachli.core.model.Timeline
 import app.pachli.core.network.di.test.DEFAULT_INSTANCE_V2
@@ -91,6 +93,12 @@ abstract class NetworkTimelineViewModelTestBase {
 
     @Inject
     lateinit var statusRepository: StatusRepository
+
+    @Inject
+    lateinit var statusDao: StatusDao
+
+    @Inject
+    lateinit var translatedStatusDao: TranslatedStatusDao
 
     protected lateinit var timelineCases: TimelineCases
     protected lateinit var viewModel: NetworkTimelineViewModel

--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/StatusRepository.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/StatusRepository.kt
@@ -20,6 +20,7 @@ package app.pachli.core.data.repository
 import app.pachli.core.common.PachliError
 import app.pachli.core.common.di.ApplicationScope
 import app.pachli.core.database.dao.StatusDao
+import app.pachli.core.database.dao.TranslatedStatusDao
 import app.pachli.core.database.di.TransactionProvider
 import app.pachli.core.database.model.StatusViewDataContentCollapsed
 import app.pachli.core.database.model.StatusViewDataContentShowing
@@ -75,6 +76,7 @@ class StatusRepository @Inject constructor(
     private val mastodonApi: MastodonApi,
     private val transactionProvider: TransactionProvider,
     private val statusDao: StatusDao,
+    private val translatedStatusDao: TranslatedStatusDao,
     private val eventHub: EventHub,
 ) {
     /**
@@ -291,4 +293,8 @@ class StatusRepository @Inject constructor(
             ),
         )
     }
+
+    suspend fun getStatusViewData(pachliAccountId: Long, statusId: String) = statusDao.getStatusViewData(pachliAccountId, statusId)
+
+    suspend fun getTranslation(pachliAccountId: Long, statusId: String) = translatedStatusDao.getTranslation(pachliAccountId, statusId)
 }

--- a/core/data/src/test/kotlin/app/pachli/core/data/repository/StatusRepositoryTest.kt
+++ b/core/data/src/test/kotlin/app/pachli/core/data/repository/StatusRepositoryTest.kt
@@ -21,6 +21,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
 import app.pachli.core.common.di.ApplicationScope
 import app.pachli.core.database.dao.StatusDao
+import app.pachli.core.database.dao.TranslatedStatusDao
 import app.pachli.core.database.di.TransactionProvider
 import app.pachli.core.eventhub.EventHub
 import app.pachli.core.eventhub.PinEvent
@@ -71,9 +72,12 @@ class StatusRepositoryTest {
     lateinit var statusDao: StatusDao
 
     @Inject
+    lateinit var translatedStatusDao: TranslatedStatusDao
+
+    @Inject
     lateinit var eventHub: EventHub
 
-    lateinit var statusRepository: StatusRepository
+    private lateinit var statusRepository: StatusRepository
 
     private val statusId = "1234"
 
@@ -87,6 +91,7 @@ class StatusRepositoryTest {
             mastodonApi,
             transactionProvider,
             statusDao,
+            translatedStatusDao,
             eventHub,
         )
     }

--- a/core/database/src/main/kotlin/app/pachli/core/database/dao/StatusDao.kt
+++ b/core/database/src/main/kotlin/app/pachli/core/database/dao/StatusDao.kt
@@ -162,6 +162,25 @@ WHERE
         StatusViewDataEntity,
         >
 
+    /**
+     * @param accountId the accountId to query.
+     * @param serverId the IDs of the status to check.
+     * @return [StatusViewDataEntity] for [serverId], null if none exists.
+     */
+    @Query(
+        """
+SELECT *
+FROM StatusViewDataEntity
+WHERE
+    pachliAccountId = :accountId
+    AND serverId = :serverId
+""",
+    )
+    abstract suspend fun getStatusViewData(
+        accountId: Long,
+        serverId: String,
+    ): StatusViewDataEntity?
+
     /** Upserts [partial], setting the [expanded][StatusViewDataEntity.expanded] property. */
     @Upsert(entity = StatusViewDataEntity::class)
     abstract suspend fun setExpanded(partial: StatusViewDataExpanded)

--- a/core/database/src/main/kotlin/app/pachli/core/database/dao/TranslatedStatusDao.kt
+++ b/core/database/src/main/kotlin/app/pachli/core/database/dao/TranslatedStatusDao.kt
@@ -48,4 +48,21 @@ WHERE
         String,
         TranslatedStatusEntity,
         >
+
+    /**
+     * @return [TranslatedStatusEntity] for [serverId], null if none exists.
+     */
+    @Query(
+        """
+SELECT *
+FROM TranslatedStatusEntity
+WHERE
+    timelineUserId = :accountId
+    AND serverId = :serverId
+""",
+    )
+    suspend fun getTranslation(
+        accountId: Long,
+        serverId: String,
+    ): TranslatedStatusEntity?
 }

--- a/core/network/src/main/kotlin/app/pachli/core/network/model/Poll.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/Poll.kt
@@ -20,6 +20,12 @@ data class Poll(
     @Json(name = "own_votes") val ownVotes: List<Int>?,
 ) {
 
+    /**
+     * @param choices Indices of the user's choices
+     * @return A copy of the poll with the vote counts for each choice
+     * updated to reflect the user's voting choices in [choices], and
+     * with [voted][Poll.voted] set to `true`.
+     */
     fun votedCopy(choices: List<Int>): Poll {
         val newOptions = options.mapIndexed { index, option ->
             if (choices.contains(index)) {


### PR DESCRIPTION
Previous code could translate statuses in the home timeline and threads, but nowhere else.

Extend this support to almost all timelines, in particular:

- Notifications
- Local and federated timelines
- Trending
- Bookmarks
- Favourites

Places where translation is not possible are still:

- Conversations; translation isn't permitted on statuses with `direct` visibility
- Search results; more work has to be done there

To do this the primary adjustments are to `TimelineViewModel` and `NetworkTimelineViewModel`. Previously `TimelineViewModel` contained code that more properly belonged in `CachedTimelineViewModel`; that code has been moved there, and the actions code in `{Cached,Network}TimelineViewModel` is now more explicit.

This also fixes a long-standing TODO in `TimelineFragment`, which was updating adapter data directly instead of relying on the repository data to change and invalidate the repository.

Similar changes were made to the `Notifications{Timeline,ViewModel}` files.

Fixes #359