### PR TITLE
fix: Always set an accessible description on the "Toot" button

### DIFF
--- a/app/src/main/java/app/pachli/components/compose/view/TootButton.kt
+++ b/app/src/main/java/app/pachli/components/compose/view/TootButton.kt
@@ -57,5 +57,13 @@ class TootButton
                 Status.Visibility.DIRECT -> setText(R.string.action_send)
             }
         }
+
+        when (visibility) {
+            Status.Visibility.UNKNOWN -> null
+            Status.Visibility.PUBLIC -> R.string.action_send_public_content_description
+            Status.Visibility.UNLISTED -> R.string.action_send_unlisted_content_description
+            Status.Visibility.PRIVATE -> R.string.action_send_private_content_description
+            Status.Visibility.DIRECT -> R.string.action_send_direct_content_description
+        }?.let { contentDescription = context.getString(it) }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -140,6 +140,10 @@
     <string name="action_continue_edit">Continue editing</string>
     <string name="action_send">TOOT</string>
     <string name="action_send_public">TOOT!</string>
+    <string name="action_send_public_content_description">Send public post</string>
+    <string name="action_send_unlisted_content_description">Send unlisted post</string>
+    <string name="action_send_private_content_description">Send followers-only post</string>
+    <string name="action_send_direct_content_description">Send direct message</string>
     <string name="action_view_preferences">Preferences</string>
     <string name="action_view_account_preferences">Account preferences</string>
     <string name="action_view_favourites">Favorites</string>

--- a/core/network/src/main/kotlin/app/pachli/core/network/model/Status.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/Status.kt
@@ -17,7 +17,6 @@
 
 package app.pachli.core.network.model
 
-import android.app.Application
 import android.text.SpannableStringBuilder
 import android.text.style.URLSpan
 import app.pachli.core.common.extensions.getOrElse

--- a/core/network/src/main/kotlin/app/pachli/core/network/model/Status.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/Status.kt
@@ -17,6 +17,7 @@
 
 package app.pachli.core.network.model
 
+import android.app.Application
 import android.text.SpannableStringBuilder
 import android.text.style.URLSpan
 import app.pachli.core.common.extensions.getOrElse
@@ -76,15 +77,19 @@ data class Status(
         @Default
         UNKNOWN,
 
+        /** Visible to everyone, shown in public timelines. */
         @Json(name = "public")
         PUBLIC,
 
+        /* Visible to public, but not included in public timelines. */
         @Json(name = "unlisted")
         UNLISTED,
 
+        /* Visible to followers only, and to any mentioned users. */
         @Json(name = "private")
         PRIVATE,
 
+        /* Visible only to mentioned users. */
         @Json(name = "direct")
         DIRECT,
         ;


### PR DESCRIPTION
If the user was using a small screen the "Toot" button (when writing a post) had no text on it, and with no content description there was nothing for TalkBack to read out.

Fix this by always setting the content description. Include the visibility in the content description so the ramifications of pressing the button are always clear to the user.