### PR TITLE
fix: Use parsed status content as accessible contentDescription

### DIFF
--- a/app/src/main/java/app/pachli/util/ListStatusAccessibilityDelegate.kt
+++ b/app/src/main/java/app/pachli/util/ListStatusAccessibilityDelegate.kt
@@ -86,6 +86,8 @@ class ListStatusAccessibilityDelegate<T : IStatusViewData>(
 
             val parsedContent = status.content.parseAsMastodonHtml()
 
+            info.contentDescription = parsedContent
+
             info.addAction(openProfileAction)
             if (parsedContent.getLinks().any()) info.addAction(linksAction)
 
@@ -215,10 +217,6 @@ class ListStatusAccessibilityDelegate<T : IStatusViewData>(
                 else -> return super.performAccessibilityAction(host, action, args)
             }
             return true
-        }
-
-        private fun getStatus(childView: View): T {
-            return statusProvider.getStatus(recyclerView.getChildAdapterPosition(childView))!!
         }
     }
 


### PR DESCRIPTION
The change that introduced `SetStatusContent` meant the status text used by the accessibility delegate was now the raw HTML. This meant TalkBack was reading out the HTML instead of the parsed content.

Explicitly set the `contentDescription` to the parsed text so it reads correctly.