### PR TITLE
fix: Use parsed status content when building contentDescription

### DIFF
--- a/app/src/main/java/app/pachli/adapter/StatusBaseViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/StatusBaseViewHolder.kt
@@ -37,6 +37,7 @@ import app.pachli.core.network.model.Attachment
 import app.pachli.core.network.model.Emoji
 import app.pachli.core.network.model.PreviewCardKind
 import app.pachli.core.network.model.Status
+import app.pachli.core.network.parseAsMastodonHtml
 import app.pachli.core.preferences.CardViewMode
 import app.pachli.core.ui.SetStatusContent
 import app.pachli.core.ui.makeIcon
@@ -796,7 +797,7 @@ abstract class StatusBaseViewHolder<T : IStatusViewData> protected constructor(
             // Content is optional, and hidden if there are spoilers or the status is
             // marked sensitive, and it has not been expanded.
             if (TextUtils.isEmpty(viewData.spoilerText) || !sensitive || viewData.isExpanded) {
-                append(viewData.content, ", ")
+                append(viewData.content.parseAsMastodonHtml(), ", ")
             }
 
             viewData.actionable.poll?.let {

--- a/app/src/main/java/app/pachli/util/ListStatusAccessibilityDelegate.kt
+++ b/app/src/main/java/app/pachli/util/ListStatusAccessibilityDelegate.kt
@@ -86,8 +86,6 @@ class ListStatusAccessibilityDelegate<T : IStatusViewData>(
 
             val parsedContent = status.content.parseAsMastodonHtml()
 
-            info.contentDescription = parsedContent
-
             info.addAction(openProfileAction)
             if (parsedContent.getLinks().any()) info.addAction(linksAction)
 


### PR DESCRIPTION
Previous change overwrote the entire content description built in `setContentDescriptionForStatus`, so some content was dropped from the description.

Revert that, and use the parsed content in `setContentDescriptionForStatus` to get the right effect.