### PR TITLE
fix: Stop the report UI from sometimes hanging, honour Markdown setting

### DIFF
--- a/app/src/main/java/app/pachli/components/report/ReportActivity.kt
+++ b/app/src/main/java/app/pachli/components/report/ReportActivity.kt
@@ -26,13 +26,25 @@ import app.pachli.core.navigation.ReportActivityIntent
 import app.pachli.core.navigation.pachliAccountId
 import app.pachli.databinding.ActivityReportBinding
 import dagger.hilt.android.AndroidEntryPoint
+import dagger.hilt.android.lifecycle.withCreationCallback
 
 /**
  * Report a status or user.
  */
 @AndroidEntryPoint
 class ReportActivity : BottomSheetActivity() {
-    private val viewModel: ReportViewModel by viewModels()
+    private val viewModel: ReportViewModel by viewModels(
+        extrasProducer = {
+            defaultViewModelCreationExtras.withCreationCallback<ReportViewModel.Factory> {
+                it.create(
+                    intent.pachliAccountId,
+                    ReportActivityIntent.getAccountId(intent),
+                    ReportActivityIntent.getAccountUserName(intent),
+                    ReportActivityIntent.getStatusId(intent),
+                )
+            }
+        },
+    )
 
     private val binding by viewBinding(ActivityReportBinding::inflate)
 
@@ -44,14 +56,12 @@ class ReportActivity : BottomSheetActivity() {
             throw IllegalStateException("accountId ($accountId) or accountUserName ($accountUserName) is blank")
         }
 
-        viewModel.init(accountId, accountUserName, ReportActivityIntent.getStatusId(intent))
-
         setContentView(binding.root)
 
         setSupportActionBar(binding.includedToolbar.toolbar)
 
         supportActionBar?.apply {
-            title = getString(R.string.report_username_format, viewModel.accountUserName)
+            title = getString(R.string.report_username_format, viewModel.reportedAccountUsername)
             setDisplayHomeAsUpEnabled(true)
             setDisplayShowHomeEnabled(true)
             setHomeAsUpIndicator(app.pachli.core.ui.R.drawable.ic_close_24dp)

--- a/app/src/main/java/app/pachli/components/report/adapter/StatusViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/report/adapter/StatusViewHolder.kt
@@ -34,8 +34,8 @@ import app.pachli.core.network.model.HashTag
 import app.pachli.core.network.model.Status
 import app.pachli.core.network.parseAsMastodonHtml
 import app.pachli.core.ui.LinkListener
+import app.pachli.core.ui.SetStatusContent
 import app.pachli.core.ui.setClickableMentions
-import app.pachli.core.ui.setClickableText
 import app.pachli.databinding.ItemReportStatusBinding
 import app.pachli.util.StatusViewHelper
 import app.pachli.util.StatusViewHelper.Companion.COLLAPSE_INPUT_FILTER
@@ -46,6 +46,7 @@ import java.util.Date
 
 open class StatusViewHolder(
     private val binding: ItemReportStatusBinding,
+    private val setStatusContent: SetStatusContent,
     private val statusDisplayOptions: StatusDisplayOptions,
     private val viewState: StatusViewState,
     private val adapterHandler: AdapterHandler,
@@ -152,8 +153,7 @@ open class StatusViewHolder(
         listener: LinkListener,
     ) {
         if (expanded) {
-            val emojifiedText = content.emojify(emojis, binding.statusContent, statusDisplayOptions.animateEmojis)
-            setClickableText(binding.statusContent, emojifiedText, mentions, tags, listener)
+            setStatusContent(binding.statusContent, content, statusDisplayOptions, emojis, mentions, tags, listener)
         } else {
             setClickableMentions(binding.statusContent, mentions, listener)
         }

--- a/app/src/main/java/app/pachli/components/report/adapter/StatusesAdapter.kt
+++ b/app/src/main/java/app/pachli/components/report/adapter/StatusesAdapter.kt
@@ -24,9 +24,11 @@ import androidx.recyclerview.widget.RecyclerView
 import app.pachli.components.report.model.StatusViewState
 import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.data.model.StatusViewData
+import app.pachli.core.ui.SetStatusContent
 import app.pachli.databinding.ItemReportStatusBinding
 
 class StatusesAdapter(
+    private val setStatusContent: SetStatusContent,
     private val statusDisplayOptions: StatusDisplayOptions,
     private val statusViewState: StatusViewState,
     private val adapterHandler: AdapterHandler,
@@ -40,6 +42,7 @@ class StatusesAdapter(
         val binding = ItemReportStatusBinding.inflate(LayoutInflater.from(parent.context), parent, false)
         return StatusViewHolder(
             binding,
+            setStatusContent,
             statusDisplayOptions,
             statusViewState,
             adapterHandler,
@@ -55,11 +58,9 @@ class StatusesAdapter(
 
     companion object {
         val STATUS_COMPARATOR = object : DiffUtil.ItemCallback<StatusViewData>() {
-            override fun areContentsTheSame(oldItem: StatusViewData, newItem: StatusViewData): Boolean =
-                oldItem == newItem
+            override fun areContentsTheSame(oldItem: StatusViewData, newItem: StatusViewData): Boolean = oldItem == newItem
 
-            override fun areItemsTheSame(oldItem: StatusViewData, newItem: StatusViewData): Boolean =
-                oldItem.id == newItem.id
+            override fun areItemsTheSame(oldItem: StatusViewData, newItem: StatusViewData): Boolean = oldItem.id == newItem.id
         }
     }
 }

--- a/app/src/main/java/app/pachli/components/report/fragments/ReportDoneFragment.kt
+++ b/app/src/main/java/app/pachli/components/report/fragments/ReportDoneFragment.kt
@@ -38,7 +38,7 @@ class ReportDoneFragment : Fragment(R.layout.fragment_report_done) {
     private val binding by viewBinding(FragmentReportDoneBinding::bind)
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        binding.textReported.text = getString(R.string.report_sent_success, viewModel.accountUserName)
+        binding.textReported.text = getString(R.string.report_sent_success, viewModel.reportedAccountUsername)
         handleClicks()
         subscribeObservables()
     }

--- a/app/src/main/java/app/pachli/components/report/fragments/ReportStatusesFragment.kt
+++ b/app/src/main/java/app/pachli/components/report/fragments/ReportStatusesFragment.kt
@@ -46,6 +46,8 @@ import app.pachli.core.navigation.TimelineActivityIntent
 import app.pachli.core.navigation.ViewMediaActivityIntent
 import app.pachli.core.network.model.Attachment
 import app.pachli.core.network.model.Status
+import app.pachli.core.ui.SetMarkdownContent
+import app.pachli.core.ui.SetMastodonHtmlContent
 import app.pachli.databinding.FragmentReportStatusesBinding
 import com.google.android.material.color.MaterialColors
 import com.google.android.material.divider.MaterialDividerItemDecoration
@@ -83,6 +85,19 @@ class ReportStatusesFragment :
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         pachliAccountId = requireArguments().getLong(ARG_PACHLI_ACCOUNT_ID)
+
+        val setStatusContent = if (viewModel.statusDisplayOptions.value.renderMarkdown) {
+            SetMarkdownContent(requireContext())
+        } else {
+            SetMastodonHtmlContent
+        }
+
+        adapter = StatusesAdapter(
+            setStatusContent,
+            viewModel.statusDisplayOptions.value,
+            viewModel.statusViewState,
+            this@ReportStatusesFragment,
+        )
     }
 
     override fun showMedia(v: View?, status: Status?, idx: Int) {
@@ -153,14 +168,6 @@ class ReportStatusesFragment :
 
     private fun initStatusesView() {
         lifecycleScope.launch {
-            val statusDisplayOptions = viewModel.statusDisplayOptions.value
-
-            adapter = StatusesAdapter(
-                statusDisplayOptions,
-                viewModel.statusViewState,
-                this@ReportStatusesFragment,
-            )
-
             binding.recyclerView.addItemDecoration(
                 MaterialDividerItemDecoration(
                     requireContext(),


### PR DESCRIPTION
The report UI could get stuck loading account info. Re-write to use the information provided in the initial intent so it's not a problem.

Also, use `SetStatusContent` so the user's choice of Markdown rendering is respected.