### PR TITLE
refactor: Improve `Loadable` interface ergnomonics

### DIFF
--- a/app/src/main/java/app/pachli/components/compose/ComposeViewModel.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeViewModel.kt
@@ -147,7 +147,7 @@ class ComposeViewModel @AssistedInject constructor(
             flow {
                 when (val i = composeOptions?.inReplyTo) {
                     is InReplyTo.Id -> {
-                        emit(Ok(Loadable.Loading<InReplyTo.Status>()))
+                        emit(Ok(Loadable.Loading))
                         api.status(i.statusId).mapEither(
                             { Loadable.Loaded(InReplyTo.Status.from(it.body)) },
                             { UiError.LoadInReplyToError(it) },

--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/AccountManager.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/AccountManager.kt
@@ -196,17 +196,12 @@ class AccountManager @Inject constructor(
         accountDao.getActiveAccountFlow()
             .distinctUntilChanged()
             .map { Loadable.Loaded(it) }
-            .stateIn(externalScope, SharingStarted.Eagerly, Loadable.Loading())
+            .stateIn(externalScope, SharingStarted.Eagerly, Loadable.Loading)
 
     /** The active account, or null if there is no active account. */
     @Deprecated("Caller should use getPachliAccountFlow with a specific account ID")
     val activeAccount: AccountEntity?
-        get() {
-            return when (val loadable = activeAccountFlow.value) {
-                is Loadable.Loading -> null
-                is Loadable.Loaded -> loadable.data
-            }
-        }
+        get() = activeAccountFlow.value.get()
 
     /** All logged in accounts. */
     val accountsFlow = accountDao.loadAllFlow().stateIn(externalScope, SharingStarted.Eagerly, emptyList())

--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/Loadable.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/Loadable.kt
@@ -17,6 +17,11 @@
 
 package app.pachli.core.data.repository
 
+import app.pachli.core.data.repository.Loadable.Loaded
+import app.pachli.core.data.repository.Loadable.Loading
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
+
 /**
  * Generic interface for loadable content.
  *
@@ -24,8 +29,23 @@ package app.pachli.core.data.repository
  * for that.
  */
 // Note: Experimental for the moment.
-sealed interface Loadable<T> {
-    /** Data is loading from a remote source. */
-    class Loading<T>() : Loadable<T>
+sealed interface Loadable<out T> {
+    /** Data is loading. */
+    data object Loading : Loadable<Nothing>
+
+    /** Data is loaded. */
     data class Loaded<T>(val data: T) : Loadable<T>
+}
+
+@OptIn(ExperimentalContracts::class)
+fun <T> Loadable<T>.get(): T? {
+    contract {
+        returnsNotNull() implies (this@get is Loaded<T>)
+        returns(null) implies (this@get is Loading)
+    }
+
+    return when (this) {
+        is Loaded<T> -> this.data
+        is Loading -> null
+    }
 }


### PR DESCRIPTION
Rewrite `Loading` as a data object (no constructor parens required to create) with a `Nothing` generic type.

Implement `.get()` which returns the `.Loaded` value, or null if there isn't one.

Update use sites.