### PR TITLE
refactor: Use flows instead of observables in the "Report" code

### DIFF
--- a/app/src/main/java/app/pachli/components/report/Screen.kt
+++ b/app/src/main/java/app/pachli/components/report/Screen.kt
@@ -16,10 +16,19 @@
 
 package app.pachli.components.report
 
+/**
+ * The "Report account" screen to display.
+ */
 enum class Screen {
+    /** Shows [ReportStatusesFragment][app.pachli.components.report.fragments.ReportStatusesFragment]. */
     Statuses,
+
+    /** Shows [ReportNoteFragment][app.pachli.components.report.fragments.ReportNoteFragment]. */
     Note,
+
+    /** Shows [ReportDoneFragment][app.pachli.components.report.fragments.ReportDoneFragment]. */
     Done,
-    Back,
+
+    /** Signal to finish [ReportActivity][app.pachli.components.report.ReportActivity]. */
     Finish,
 }

--- a/app/src/main/java/app/pachli/components/report/fragments/ReportDoneFragment.kt
+++ b/app/src/main/java/app/pachli/components/report/fragments/ReportDoneFragment.kt
@@ -20,16 +20,29 @@ import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import app.pachli.R
 import app.pachli.components.report.ReportViewModel
 import app.pachli.components.report.Screen
+import app.pachli.core.common.PachliError
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
 import app.pachli.core.common.extensions.viewBinding
+import app.pachli.core.data.repository.Loadable
 import app.pachli.databinding.FragmentReportDoneBinding
-import app.pachli.util.Loading
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.onFailure
+import com.github.michaelbull.result.onSuccess
+import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 
+/**
+ * Confirms the report has been sent, and allows the user to optionally
+ * mute or block the account they just reported.
+ */
 @AndroidEntryPoint
 class ReportDoneFragment : Fragment(R.layout.fragment_report_done) {
 
@@ -40,41 +53,73 @@ class ReportDoneFragment : Fragment(R.layout.fragment_report_done) {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         binding.textReported.text = getString(R.string.report_sent_success, viewModel.reportedAccountUsername)
         handleClicks()
-        subscribeObservables()
+        bind()
     }
 
-    private fun subscribeObservables() {
-        viewModel.muteState.observe(viewLifecycleOwner) {
-            if (it !is Loading) {
-                binding.buttonMute.show()
-                binding.progressMute.show()
-            } else {
-                binding.buttonMute.hide()
-                binding.progressMute.hide()
+    private fun bind() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.RESUMED) {
+                launch { viewModel.muting.collect(::bindMute) }
+                launch { viewModel.blocking.collect(::bindBlock) }
             }
-
-            binding.buttonMute.setText(
-                when (it.data) {
-                    true -> R.string.action_unmute
-                    else -> R.string.action_mute
-                },
-            )
         }
+    }
 
-        viewModel.blockState.observe(viewLifecycleOwner) {
-            if (it !is Loading) {
-                binding.buttonBlock.show()
-                binding.progressBlock.show()
-            } else {
-                binding.buttonBlock.hide()
-                binding.progressBlock.hide()
+    private fun bindMute(result: Result<Loadable<Boolean>, PachliError>) {
+        result.onSuccess { loadable ->
+            when (loadable) {
+                is Loadable.Loading -> {
+                    binding.buttonMute.isEnabled = false
+                    binding.progressMute.show()
+                }
+
+                is Loadable.Loaded<Boolean> -> {
+                    binding.buttonMute.setText(
+                        when (loadable.data) {
+                            true -> R.string.action_unmute
+                            false -> R.string.action_mute
+                        },
+                    )
+                    binding.buttonMute.isEnabled = true
+                    binding.progressMute.hide()
+                }
             }
-            binding.buttonBlock.setText(
-                when (it.data) {
-                    true -> R.string.action_unblock
-                    else -> R.string.action_block
-                },
-            )
+        }.onFailure {
+            binding.buttonMute.isEnabled = false
+            binding.progressMute.hide()
+
+            Snackbar.make(binding.root, it.fmt(requireContext()), Snackbar.LENGTH_INDEFINITE)
+                .setAction(app.pachli.core.ui.R.string.action_retry) { viewModel.reloadRelationship() }
+                .show()
+        }
+    }
+
+    private fun bindBlock(result: Result<Loadable<Boolean>, PachliError>) {
+        result.onSuccess { loadable ->
+            when (loadable) {
+                is Loadable.Loading -> {
+                    binding.buttonBlock.isEnabled = false
+                    binding.progressBlock.show()
+                }
+
+                is Loadable.Loaded<Boolean> -> {
+                    binding.buttonBlock.setText(
+                        when (loadable.data) {
+                            true -> R.string.action_unblock
+                            false -> R.string.action_block
+                        },
+                    )
+                    binding.buttonBlock.isEnabled = true
+                    binding.progressBlock.hide()
+                }
+            }
+        }.onFailure {
+            binding.buttonBlock.isEnabled = false
+            binding.progressBlock.hide()
+
+            Snackbar.make(binding.root, it.fmt(requireContext()), Snackbar.LENGTH_INDEFINITE)
+                .setAction(app.pachli.core.ui.R.string.action_retry) { viewModel.reloadRelationship() }
+                .show()
         }
     }
 

--- a/app/src/main/java/app/pachli/components/report/fragments/ReportStatusesFragment.kt
+++ b/app/src/main/java/app/pachli/components/report/fragments/ReportStatusesFragment.kt
@@ -62,6 +62,10 @@ import kotlin.properties.Delegates
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
+/**
+ * Show a list of statuses from the account the user is reporting. Allow
+ * the user to choose one or more of these to include in the report.
+ */
 @AndroidEntryPoint
 class ReportStatusesFragment :
     Fragment(R.layout.fragment_report_statuses),
@@ -167,7 +171,7 @@ class ReportStatusesFragment :
     }
 
     private fun initStatusesView() {
-        lifecycleScope.launch {
+        viewLifecycleOwner.lifecycleScope.launch {
             binding.recyclerView.addItemDecoration(
                 MaterialDividerItemDecoration(
                     requireContext(),
@@ -214,7 +218,7 @@ class ReportStatusesFragment :
 
     private fun handleClicks() {
         binding.buttonCancel.setOnClickListener {
-            viewModel.navigateTo(Screen.Back)
+            viewModel.navigateBack()
         }
 
         binding.buttonContinue.setOnClickListener {

--- a/core/network/src/main/kotlin/app/pachli/core/network/model/Relationship.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/Relationship.kt
@@ -26,7 +26,9 @@ data class Relationship(
     val id: String,
     val following: Boolean,
     @Json(name = "followed_by") val followedBy: Boolean,
+    /** True if this account is blocked. */
     val blocking: Boolean,
+    /** True if this account is muted. */
     val muting: Boolean,
     @Json(name = "muting_notifications") val mutingNotifications: Boolean,
     val requested: Boolean,


### PR DESCRIPTION
Changes include:

- Use `Result<V, E>` for carrying success/error state.
- Use `PachliError` for reporting errors, including formatted error messages.
- Use `bind()` as the function name that starts binding values to the UI.
- Use `Loadable` to track data during the loading process.
- Make network calls when flows are collected from the view model, not the `init` block.
- Move navigation logic in to the view model.