### PR TITLE
fix: Prevent "Record not found" when opening as a different account

### DIFF
--- a/core/activity/src/main/kotlin/app/pachli/core/activity/BaseActivity.kt
+++ b/core/activity/src/main/kotlin/app/pachli/core/activity/BaseActivity.kt
@@ -292,7 +292,7 @@ abstract class BaseActivity : AppCompatActivity(), MenuProvider {
         }
 
     fun openAsAccount(url: String, account: AccountEntity) {
-        startActivity(MainActivityIntent.redirect(this, account.id, url))
+        startActivity(MainActivityIntent.openAs(this, account.id, url))
         finish()
     }
 

--- a/core/navigation/src/main/kotlin/app/pachli/core/navigation/Navigation.kt
+++ b/core/navigation/src/main/kotlin/app/pachli/core/navigation/Navigation.kt
@@ -292,10 +292,9 @@ class EditContentFilterActivityIntent(context: Context, pachliAccountId: Long) :
          * @param contentFilterId ID of the content filter to load
          * @see [app.pachli.components.filters.EditContentFilterActivity]
          */
-        fun edit(context: Context, accountId: Long, contentFilterId: String) =
-            EditContentFilterActivityIntent(context, accountId).apply {
-                putExtra(EXTRA_CONTENT_FILTER_ID_TO_LOAD, contentFilterId)
-            }
+        fun edit(context: Context, accountId: Long, contentFilterId: String) = EditContentFilterActivityIntent(context, accountId).apply {
+            putExtra(EXTRA_CONTENT_FILTER_ID_TO_LOAD, contentFilterId)
+        }
 
         /** @return the [ContentFilter] passed in this intent, or null */
         fun getContentFilter(intent: Intent) = IntentCompat.getParcelableExtra(intent, EXTRA_CONTENT_FILTER_TO_EDIT, ContentFilter::class.java)
@@ -398,7 +397,7 @@ class MainActivityIntent(context: Context, pachliAccountId: Long) : Intent() {
          * Started to redirect to [url].
          */
         @Parcelize
-        data class Redirect(val url: String) : Payload
+        data class OpenAs(val url: String) : Payload
     }
 
     companion object {
@@ -456,17 +455,16 @@ class MainActivityIntent(context: Context, pachliAccountId: Long) : Intent() {
             composeOptions: ComposeOptions,
             notificationId: Int,
             notificationTag: String,
-        ) =
-            MainActivityIntent(context, pachliAccountId).apply {
-                putExtra(
-                    EXTRA_PAYLOAD,
-                    Payload.NotificationCompose(
-                        composeOptions,
-                        notificationId,
-                        notificationTag,
-                    ),
-                )
-            }
+        ) = MainActivityIntent(context, pachliAccountId).apply {
+            putExtra(
+                EXTRA_PAYLOAD,
+                Payload.NotificationCompose(
+                    composeOptions,
+                    notificationId,
+                    notificationTag,
+                ),
+            )
+        }
 
         /**
          * Switches the active account to [pachliAccountId] and takes the user to the correct place
@@ -499,14 +497,19 @@ class MainActivityIntent(context: Context, pachliAccountId: Long) : Intent() {
 
         /**
          * Switches the active account to [pachliAccountId] and then tries to resolve and
-         * show the provided url
+         * show the provided [url].
+         *
+         * [url] is expected to be the URL to a status to be viewed. The active account
+         * is changed, then a search is performed for the URL on the server of the
+         * new active account. This will (hopefully) find the status (which will not
+         * have the same ID on the new server), and it can be shown to the user.
          */
-        fun redirect(
+        fun openAs(
             context: Context,
             pachliAccountId: Long,
             url: String,
         ) = MainActivityIntent(context, pachliAccountId).apply {
-            putExtra(EXTRA_PAYLOAD, Payload.Redirect(url))
+            putExtra(EXTRA_PAYLOAD, Payload.OpenAs(url))
             flags = FLAG_ACTIVITY_NEW_TASK or FLAG_ACTIVITY_CLEAR_TASK
         }
 


### PR DESCRIPTION
Previous code raced when opening as a different account. In one case the code would:

1. Open MainActivity
2. Start to change the active account
3. Finish changing the active account
4. Search for the status to open
5. Load the status

In the bad case it would:

1. Open MainActivity
2. Start to change the active account
3. Search for the status to open
4. Finish changing the active account
5. Load the status

I.e., steps 3 and 4 are swapped. When that happens the search is performed **before** the active account is changed, so the results are for the previous account. Then (step 5) the new account tries to show results from the old account. If they are on different servers you get a "Record not found" error.

While I'm here, `Redirect` et al for the name of the action are misleading, so rename to `OpenAs` et al.