### PR TITLE
feat: Show hashtag statistics in the Followed Tags screen

### DIFF
--- a/app/src/main/java/app/pachli/components/followedtags/FollowedTagsActivity.kt
+++ b/app/src/main/java/app/pachli/components/followedtags/FollowedTagsActivity.kt
@@ -99,7 +99,7 @@ class FollowedTagsActivity :
     }
 
     private fun setupAdapter(): FollowedTagsAdapter {
-        return FollowedTagsAdapter(this, viewModel).apply {
+        return FollowedTagsAdapter(this).apply {
             addLoadStateListener { loadState ->
                 binding.followedTagsProgressBar.visible(loadState.refresh == LoadState.Loading && itemCount == 0)
 

--- a/app/src/main/java/app/pachli/components/followedtags/FollowedTagsAdapter.kt
+++ b/app/src/main/java/app/pachli/components/followedtags/FollowedTagsAdapter.kt
@@ -4,6 +4,7 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.DiffUtil
+import app.pachli.R
 import app.pachli.core.network.model.HashTag
 import app.pachli.core.ui.BindingHolder
 import app.pachli.databinding.ItemFollowedHashtagBinding
@@ -11,7 +12,6 @@ import app.pachli.interfaces.HashtagActionListener
 
 class FollowedTagsAdapter(
     private val actionListener: HashtagActionListener,
-    private val viewModel: FollowedTagsViewModel,
 ) : PagingDataAdapter<HashTag, BindingHolder<ItemFollowedHashtagBinding>>(HashTagComparator) {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BindingHolder<ItemFollowedHashtagBinding> = BindingHolder(ItemFollowedHashtagBinding.inflate(LayoutInflater.from(parent.context), parent, false))
 
@@ -23,14 +23,21 @@ class FollowedTagsAdapter(
                     actionListener.onViewTag(tag.name)
                 }
 
+                val usage = tag.history.sumOf { it.uses }
+                val accounts = tag.history.sumOf { it.accounts }
+
+                tagStats.text = root.resources.getString(
+                    R.string.followed_hashtags_summary_fmt,
+                    root.resources.getQuantityString(R.plurals.followed_hashtags_posts_count_fmt, usage, usage),
+                    root.resources.getQuantityString(R.plurals.followed_hashtags_accounts_count_fmt, accounts, accounts),
+                )
+
                 followedTagUnfollow.setOnClickListener {
                     actionListener.unfollow(tag.name)
                 }
             }
         }
     }
-
-    override fun getItemCount(): Int = viewModel.tags.size
 
     companion object {
         val HashTagComparator = object : DiffUtil.ItemCallback<HashTag>() {

--- a/app/src/main/java/app/pachli/components/followedtags/FollowedTagsViewModel.kt
+++ b/app/src/main/java/app/pachli/components/followedtags/FollowedTagsViewModel.kt
@@ -52,17 +52,20 @@ class FollowedTagsViewModel @Inject constructor(
 
     suspend fun searchAutocompleteSuggestions(token: String): List<ComposeAutoCompleteAdapter.AutocompleteResult> {
         return api.search(query = token, type = SearchType.Hashtag.apiParameter, limit = 10)
-            .mapBoth({
-                val searchResult = it.body
-                searchResult.hashtags.map {
-                    ComposeAutoCompleteAdapter.AutocompleteResult.HashtagResult(
-                        hashtag = it.name,
-                        usage7d = it.history.sumOf { it.uses },
-                    )
-                }
-            }, { e ->
-                Timber.e("Autocomplete search for %s failed: %s", token, e)
-                emptyList()
-            })
+            .mapBoth(
+                {
+                    val searchResult = it.body
+                    searchResult.hashtags.map {
+                        ComposeAutoCompleteAdapter.AutocompleteResult.HashtagResult(
+                            hashtag = it.name,
+                            usage7d = it.history.sumOf { it.uses },
+                        )
+                    }.sortedByDescending { it.usage7d }
+                },
+                { e ->
+                    Timber.e("Autocomplete search for %s failed: %s", token, e)
+                    emptyList()
+                },
+            )
     }
 }

--- a/app/src/main/res/layout/activity_followed_tags.xml
+++ b/app/src/main/res/layout/activity_followed_tags.xml
@@ -15,10 +15,9 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:scrollbars="vertical"
-        tools:itemCount="5"
-        tools:listitem="@layout/item_followed_hashtag"
         app:layout_behavior="@string/appbar_scrolling_view_behavior"
-        />
+        tools:itemCount="5"
+        tools:listitem="@layout/item_followed_hashtag" />
 
     <app.pachli.core.ui.BackgroundMessageView
         android:id="@+id/followedTagsMessageView"
@@ -26,8 +25,7 @@
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         app:layout_behavior="@string/appbar_scrolling_view_behavior"
-        tools:visibility="gone"
-        />
+        tools:visibility="gone" />
 
     <ProgressBar
         android:id="@+id/followedTagsProgressBar"
@@ -35,8 +33,7 @@
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         app:layout_behavior="@string/appbar_scrolling_view_behavior"
-        tools:visibility="gone"
-        />
+        tools:visibility="gone" />
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/fab"

--- a/app/src/main/res/layout/item_followed_hashtag.xml
+++ b/app/src/main/res/layout/item_followed_hashtag.xml
@@ -21,6 +21,7 @@
         android:gravity="center_vertical"
         android:maxLines="1"
         android:textAppearance="?android:attr/textAppearanceListItemSmall"
+        android:textIsSelectable="false"
         app:layout_constraintEnd_toStartOf="@+id/followed_tag_unfollow"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"

--- a/app/src/main/res/layout/item_followed_hashtag.xml
+++ b/app/src/main/res/layout/item_followed_hashtag.xml
@@ -1,26 +1,40 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:background="?attr/selectableItemBackground"
     android:minHeight="?android:attr/listPreferredItemHeightSmall"
-    android:gravity="center_vertical"
     android:paddingStart="?android:attr/listPreferredItemPaddingStart"
+    android:paddingTop="8dp"
     android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
-    >
+    android:paddingBottom="8dp">
 
     <TextView
         android:id="@+id/followed_tag"
         android:layout_width="0dp"
-        android:layout_weight="1"
         android:layout_height="wrap_content"
-        android:gravity="center_vertical"
+        android:layout_weight="1"
         android:ellipsize="end"
+        android:gravity="center_vertical"
         android:maxLines="1"
         android:textAppearance="?android:attr/textAppearanceListItemSmall"
+        app:layout_constraintEnd_toStartOf="@+id/followed_tag_unfollow"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
         tools:text="hashtag" />
+
+    <TextView
+        android:id="@+id/tag_stats"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@id/followed_tag"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/followed_tag_unfollow"
+        tools:text="4 posts from 2 accounts (last 7 days)" />
 
     <ImageButton
         android:id="@+id/followed_tag_unfollow"
@@ -30,7 +44,7 @@
         android:background="?attr/selectableItemBackgroundBorderless"
         android:contentDescription="@string/action_unfollow"
         android:padding="4dp"
-        app:srcCompat="@drawable/ic_person_remove_24dp"
-        />
-
-</LinearLayout>
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/ic_person_remove_24dp" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,6 +65,15 @@
     <string name="title_scheduled_posts">Scheduled posts</string>
     <string name="title_announcements">Announcements</string>
     <string name="title_followed_hashtags">Followed hashtags</string>
+    <plurals name="followed_hashtags_posts_count_fmt">
+        <item quantity="one">%1$s post</item>
+        <item quantity="other">%1$s posts</item>
+    </plurals>
+    <plurals name="followed_hashtags_accounts_count_fmt">
+        <item quantity="one">%1$s account</item>
+        <item quantity="other">%1$s accounts</item>
+    </plurals>
+    <string name="followed_hashtags_summary_fmt">%1$s from %2$s (last 7 days)</string>
     <string name="title_edits">Edits</string>
     <string name="dialog_follow_hashtag_title">Follow hashtag</string>
     <string name="dialog_follow_hashtag_hint">#hashtag</string>


### PR DESCRIPTION
Use the statistics in two places:

1. Most obviously, as a second line of detail for each hashtag in the list.
2. When adding a new hashtag, sort the list of hashtags by the usage count