### PR TITLE
feat: Enable client-side encrypted cloud backups

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -26,6 +26,36 @@ All locally cached data for an account is deleted if you do any of the following
 
 You can not delete your Mastodon account using the application. Deleting your account must be done through your server's web interface.
 
+## Data backups
+
+Pachli participates in Android's backup system.
+
+### Data backup and restore with Google Drive
+
+Android *may* store an encrypted backup of Pachli data in your Google Drive.
+
+For this to happen all of the following conditions must be met:
+
+1. Your device must be running Android 9 or higher ([instructions on how to check your Android version](https://support.google.com/android/answer/7680439?sjid=2548273967416916128-EU)).
+2. You must be signed in to your device with a Google account.
+3. You must have enabled Google's [Android backup and restore](https://support.google.com/android/answer/2819582?hl=en) feature on your device (**Settings** > **System** > **Backup**).
+4. You must have enabled screen-unlock, with a pin, pattern, or password.
+
+If all these conditions are met then a copy of your Pachli data, including your account information
+and preferences are **encrypted** and periodically uploaded to your Google Drive, approximately once per day when:
+
+1. At least 24 hours have elapsed since the last backup.
+2. The device is idle.
+3. The device is connected to a Wi-Fi network (if you have not opted in to mobile-data backups).
+
+Data is restored whenever Pachli is installed.
+
+You can disable this functionality on your device at **Settings** > **System** > **Backup**.
+
+Your device backups in Google Drive can be viewed at https://drive.google.com/drive/backups.
+
+For more information on Android's backup and restore feature see [Backup or restore data on your Android device](https://support.google.com/android/answer/2819582?hl=en).
+
 ## Data sharing
 
 ### If you have installed Pachli from F-Droid or GitHub releases

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -41,8 +41,7 @@ For this to happen all of the following conditions must be met:
 3. You must have enabled Google's [Android backup and restore](https://support.google.com/android/answer/2819582?hl=en) feature on your device (**Settings** > **System** > **Backup**).
 4. You must have enabled screen-unlock, with a pin, pattern, or password.
 
-If all these conditions are met then a copy of your Pachli data, including your account information
-and preferences are **encrypted** and periodically uploaded to your Google Drive, approximately once per day when:
+If all these conditions are met then a copy of your Pachli data, including your account information and preferences are **encrypted** and periodically uploaded to your Google Drive, approximately once per day when:
 
 1. At least 24 hours have elapsed since the last backup.
 2. The device is idle.

--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -33,7 +33,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/AndroidManifest.xml"
-            line="25"
+            line="27"
             column="9"/>
     </issue>
 
@@ -44,7 +44,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/AndroidManifest.xml"
-            line="26"
+            line="28"
             column="9"/>
     </issue>
 
@@ -55,7 +55,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/AndroidManifest.xml"
-            line="27"
+            line="29"
             column="9"/>
     </issue>
 
@@ -423,19 +423,8 @@
         errorLine2="                              ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/AndroidManifest.xml"
-            line="25"
+            line="27"
             column="31"/>
-    </issue>
-
-    <issue
-        id="DataExtractionRules"
-        message="The attribute `android:allowBackup` is deprecated from Android 12 and higher and may be removed in future versions. Consider adding the attribute `android:dataExtractionRules` specifying an `@xml` resource which configures cloud backups and device transfers on Android 12 and higher."
-        errorLine1="        android:allowBackup=&quot;false&quot;"
-        errorLine2="                             ~~~~~">
-        <location
-            file="src/main/AndroidManifest.xml"
-            line="19"
-            column="30"/>
     </issue>
 
     <issue

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,7 +16,9 @@
     <application
         android:name=".PachliApplication"
         android:appCategory="social"
-        android:allowBackup="false"
+        android:allowBackup="true"
+        android:fullBackupContent="@xml/backup_rules"
+        android:dataExtractionRules="@xml/data_extraction_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2025 Pachli Association
+  ~
+  ~ This file is a part of Pachli.
+  ~
+  ~ This program is free software; you can redistribute it and/or modify it under the terms of the
+  ~ GNU General Public License as published by the Free Software Foundation; either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+  ~ the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+  ~ Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License along with Pachli; if not,
+  ~ see <http://www.gnu.org/licenses>.
+  -->
+
+<full-backup-content xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- App data isn't included in user's backup
+         unless client-side encryption is enabled. -->
+    <include domain="root" path="." requireFlags="clientSideEncryption" />
+</full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2025 Pachli Association
+  ~
+  ~ This file is a part of Pachli.
+  ~
+  ~ This program is free software; you can redistribute it and/or modify it under the terms of the
+  ~ GNU General Public License as published by the Free Software Foundation; either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+  ~ the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+  ~ Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License along with Pachli; if not,
+  ~ see <http://www.gnu.org/licenses>.
+  -->
+
+<data-extraction-rules xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- App data isn't included in user's backup
+         unless client-side encryption is enabled. -->
+    <cloud-backup disableIfNoEncryptionCapabilities="true" />
+</data-extraction-rules>

--- a/test-cloud-backup.sh
+++ b/test-cloud-backup.sh
@@ -1,0 +1,43 @@
+#!/bin/bash -eu
+#
+# ./test-cloud.backup.sh app.pachli.current
+#
+# - Ensures cloud backups are enabled
+# - Triggers a backup, waits for it to complete
+# - Fetches the APK from the device
+# - Deletes the app from the device
+# - Reinstalls the app using the downloaded APK
+# 
+# Then you should open the app and check data has been restored.
+#
+# See https://developer.android.com/identity/data/testingbackup
+
+: "${1?"Usage: $0 package name"}"
+
+# Initialize and create a backup
+adb shell bmgr enable true
+adb shell bmgr transport com.android.localtransport/.LocalTransport | grep -q "Selected transport" || (echo "Error: error selecting local transport"; exit 1)
+adb shell settings put secure backup_local_transport_parameters 'is_encrypted=true'
+adb shell bmgr backupnow "$1" | grep -F "Package $1 with result: Success" || (echo "Backup failed"; exit 1)
+
+# Uninstall and reinstall the app to clear the data and trigger a restore
+apk_path_list=$(adb shell pm path "$1")
+OIFS=$IFS
+IFS=$'\n'
+apk_number=0
+for apk_line in $apk_path_list
+do
+    (( ++apk_number ))
+    apk_path=${apk_line:8:1000}
+    adb pull "$apk_path" "myapk${apk_number}.apk"
+done
+IFS=$OIFS
+adb shell pm uninstall --user 0 "$1"
+apks=$(seq -f 'myapk%.f.apk' 1 $apk_number)
+adb install-multiple -t --user 0 $apks
+
+# Clean up
+adb shell bmgr transport com.google.android.gms/.backup.BackupTransportService
+rm $apks
+
+echo "Done"


### PR DESCRIPTION
- Add a copy of the test script to verify backups are working
- Cover backups in the privacy policy

Fixes #961