### PR TITLE
fix: Set initial reading position for non-cached timelines to the top

### DIFF
--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelinePagingSource.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelinePagingSource.kt
@@ -56,9 +56,9 @@ class NetworkTimelinePagingSource @Inject constructor(
         }
 
         if (page == null) {
-            Timber.d("  Returning empty page")
+            Timber.d("  Returning empty page for %s", params.javaClass.simpleName)
         } else {
-            Timber.d("  Returning full page:")
+            Timber.d("  Returning full page for %s", params.javaClass.simpleName)
             Timber.d("     %s", page)
         }
 
@@ -66,7 +66,7 @@ class NetworkTimelinePagingSource @Inject constructor(
         // is a lot of spurious animation, especially during the initial load, as multiple pages
         // are loaded and the paging source is repeatedly invalidated.
         if (invalid) {
-            Timber.d("Invalidated, returning LoadResult.Invalid")
+            Timber.d("Invalidated, returning LoadResult.Invalid for %s", params.javaClass.simpleName)
             return INVALID
         }
 


### PR DESCRIPTION
This was earlier behaviour, but by accident. b08a0ba28218 broke this when database lookups were added in `NetworkTimelineViewModel.getStatuses()`.

The data didn't need to be used -- simply making the database lookup was enough to lose the race. This could also be dependent on network timing and the speed the remote server returned results, so never showed up in local tests.

This changed the timing for when results were returned, resulting in `state.anchorPosition` being much lower down the list (i.e,. instead of being e.g., `2` it might be `39`.