### PR TITLE
test: Prevent exceptions, don't explicitly close the injected database

### DIFF
--- a/app/src/test/java/app/pachli/components/compose/ComposeActivityTest.kt
+++ b/app/src/test/java/app/pachli/components/compose/ComposeActivityTest.kt
@@ -55,7 +55,6 @@ import kotlin.properties.Delegates
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -189,9 +188,6 @@ class ComposeActivityTest {
             .onSuccess { accountManager.refresh(it) }
             .get()!!.id
     }
-
-    @After
-    fun closeDb() = db.close()
 
     /**
      * When tests do something like this (lines marked "->")

--- a/app/src/test/java/app/pachli/components/timeline/CachedTimelineRemoteMediatorTest.kt
+++ b/app/src/test/java/app/pachli/components/timeline/CachedTimelineRemoteMediatorTest.kt
@@ -36,7 +36,6 @@ import java.util.Date
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -84,12 +83,6 @@ class CachedTimelineRemoteMediatorTest {
         runTest { db.accountDao().upsert(activeAccount) }
 
         pagingSourceFactory = mock()
-    }
-
-    @After
-    @ExperimentalCoroutinesApi
-    fun tearDown() {
-        db.close()
     }
 
     @Test

--- a/core/data/src/test/kotlin/app/pachli/core/data/repository/InstanceInfoRepositoryTest.kt
+++ b/core/data/src/test/kotlin/app/pachli/core/data/repository/InstanceInfoRepositoryTest.kt
@@ -41,7 +41,6 @@ import javax.inject.Inject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
@@ -146,11 +145,6 @@ class InstanceInfoRepositoryTest {
         )
             .andThen { accountManager.setActiveAccount(it) }
             .onSuccess { accountManager.refresh(it) }
-    }
-
-    @After
-    fun tearDown() {
-        appDatabase.close()
     }
 
     @Test

--- a/core/data/src/test/kotlin/app/pachli/core/data/repository/filtersRepository/BaseContentFiltersRepositoryTest.kt
+++ b/core/data/src/test/kotlin/app/pachli/core/data/repository/filtersRepository/BaseContentFiltersRepositoryTest.kt
@@ -53,7 +53,6 @@ import java.util.Date
 import javax.inject.Inject
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
-import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.runner.RunWith
@@ -182,11 +181,6 @@ abstract class V2Test : BaseContentFiltersRepositoryTest() {
             instanceDao,
         )
     }
-
-    @After
-    fun tearDown() {
-        appDatabase.close()
-    }
 }
 
 abstract class V1Test : BaseContentFiltersRepositoryTest() {
@@ -248,11 +242,6 @@ abstract class V1Test : BaseContentFiltersRepositoryTest() {
             remoteDataSource,
             instanceDao,
         )
-    }
-
-    @After
-    fun tearDown() {
-        appDatabase.close()
     }
 }
 

--- a/core/database/src/androidTest/kotlin/app/pachli/core/database/dao/TimelineDaoTest.kt
+++ b/core/database/src/androidTest/kotlin/app/pachli/core/database/dao/TimelineDaoTest.kt
@@ -33,7 +33,6 @@ import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import javax.inject.Inject
 import kotlinx.coroutines.test.runTest
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
@@ -86,11 +85,6 @@ class TimelineDaoTest {
 
             accountDao.upsert(inactiveAccount)
         }
-    }
-
-    @After
-    fun tearDown() {
-        db.close()
     }
 
     @Test

--- a/core/database/src/test/kotlin/app/pachli/core/database/dao/AccountEntityForeignKeyTest.kt
+++ b/core/database/src/test/kotlin/app/pachli/core/database/dao/AccountEntityForeignKeyTest.kt
@@ -53,7 +53,6 @@ import java.time.temporal.ChronoUnit
 import java.util.Date
 import javax.inject.Inject
 import kotlinx.coroutines.test.runTest
-import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -143,11 +142,6 @@ class AccountEntityForeignKeyTest {
             accountDao.upsert(activeAccount)
             timelineDao.insertAccount(timelineAccount)
         }
-    }
-
-    @After
-    fun tearDown() {
-        db.close()
     }
 
     @Test

--- a/core/database/src/test/kotlin/app/pachli/core/database/dao/NotificationEntityForeignKeyTest.kt
+++ b/core/database/src/test/kotlin/app/pachli/core/database/dao/NotificationEntityForeignKeyTest.kt
@@ -34,7 +34,6 @@ import java.time.Instant
 import java.time.temporal.ChronoUnit
 import javax.inject.Inject
 import kotlinx.coroutines.test.runTest
-import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -104,11 +103,6 @@ class NotificationEntityForeignKeyTest {
             accountDao.upsert(activeAccount)
             timelineDao.insertAccount(timelineAccount)
         }
-    }
-
-    @After
-    fun tearDown() {
-        db.close()
     }
 
     @Suppress("DEPRECATION")


### PR DESCRIPTION
Tests were occasionally failing with exceptions indicating the database was not available. Experimentation suggests the code that was closing the database after each test was the cause, possibly because it's running in Retrofit rather than a device.