### PR TITLE
fix: Don't error on nullable `Report.actionTakenAt` property

### DIFF
--- a/core/network/src/main/kotlin/app/pachli/core/network/json/InstantJsonAdapter.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/json/InstantJsonAdapter.kt
@@ -20,16 +20,27 @@ package app.pachli.core.network.json
 import com.squareup.moshi.FromJson
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonReader.Token.NULL
 import com.squareup.moshi.JsonWriter
 import com.squareup.moshi.ToJson
 import java.time.Instant
 
-class InstantJsonAdapter : JsonAdapter<Instant>() {
+class InstantJsonAdapter : JsonAdapter<Instant?>() {
     @FromJson
-    override fun fromJson(reader: JsonReader): Instant = Instant.parse(reader.readJsonValue().toString())
+    override fun fromJson(reader: JsonReader): Instant? {
+        if (reader.peek() == NULL) {
+            return reader.nextNull()
+        }
+        val string = reader.nextString()
+        return Instant.parse(string)
+    }
 
     @ToJson
     override fun toJson(writer: JsonWriter, value: Instant?) {
-        writer.jsonValue(value.toString())
+        if (value == null) {
+            writer.nullValue()
+        } else {
+            writer.jsonValue(value.toString())
+        }
     }
 }

--- a/core/network/src/main/kotlin/app/pachli/core/network/model/Report.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/Report.kt
@@ -31,7 +31,7 @@ data class Report(
     @Json(name = "action_taken")
     val actionTaken: Boolean,
     @Json(name = "action_taken_at")
-    val actionTakenAt: Instant,
+    val actionTakenAt: Instant?,
     val comment: String,
     // Not documented as being null, but is nullable in the wild.
     // https://github.com/pachli/pachli-android/issues/1352


### PR DESCRIPTION
Two bugs here.

The first is that `Report.actionTakenAt` wasn't marked as nullable when it should be.

The second is the adapter that converts from JSON to `Instant` wasn't written to allow null values.

Together these caused notification loading to fail and display an error.

Fix both of those issues.

Fixes #1469