### PR TITLE
feat: Improve the display of admin notifications

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -91,7 +91,7 @@
             line="410"
             column="28"/>
         <location
-            file="${:core:activity*buildDir}/generated/res/resValues/orangeFdroid/debug/values/gradleResValues.xml"
+            file="${:core:activity*buildDir}/generated/res/resValues/blueFdroid/debug/values/gradleResValues.xml"
             line="7"
             column="5"
             message="This definition does not require arguments"/>
@@ -302,7 +302,7 @@
         errorLine2="                                                  ^">
         <location
             file="src/main/res/values-nb-rNO/strings.xml"
-            line="498"
+            line="500"
             column="51"/>
     </issue>
 
@@ -313,7 +313,7 @@
         errorLine2="                                          ^">
         <location
             file="src/main/res/values-nb-rNO/strings.xml"
-            line="614"
+            line="616"
             column="43"/>
     </issue>
 
@@ -324,7 +324,7 @@
         errorLine2="                                                  ^">
         <location
             file="src/main/res/values-nb-rNO/strings.xml"
-            line="706"
+            line="708"
             column="51"/>
     </issue>
 
@@ -335,7 +335,7 @@
         errorLine2="                                                                   ^">
         <location
             file="src/main/res/values-nb-rNO/strings.xml"
-            line="730"
+            line="732"
             column="68"/>
     </issue>
 
@@ -363,23 +363,12 @@
 
     <issue
         id="PluralsCandidate"
-        message="Formatting %d followed by words (&quot;posts&quot;): This should probably be a plural rather than a string"
-        errorLine1="    &lt;string name=&quot;notification_summary_report_format&quot;>%s · %d posts attached&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="118"
-            column="5"/>
-    </issue>
-
-    <issue
-        id="PluralsCandidate"
         message="Formatting %d followed by words (&quot;and&quot;): This should probably be a plural rather than a string"
         errorLine1="    &lt;string name=&quot;pref_title_http_proxy_port_message&quot;>Port should be between %d and %d&lt;/string>"
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="303"
+            line="306"
             column="5"/>
     </issue>
 
@@ -390,7 +379,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="349"
+            line="352"
             column="5"/>
     </issue>
 
@@ -401,7 +390,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="466"
+            line="469"
             column="5"/>
     </issue>
 
@@ -412,7 +401,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="638"
+            line="643"
             column="5"/>
     </issue>
 
@@ -885,7 +874,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="120"
+            line="123"
             column="13"/>
     </issue>
 
@@ -896,7 +885,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="128"
+            line="131"
             column="13"/>
     </issue>
 
@@ -907,7 +896,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="166"
+            line="169"
             column="13"/>
     </issue>
 
@@ -918,7 +907,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="220"
+            line="223"
             column="13"/>
     </issue>
 
@@ -929,7 +918,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="241"
+            line="244"
             column="13"/>
     </issue>
 
@@ -940,7 +929,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="242"
+            line="245"
             column="13"/>
     </issue>
 
@@ -951,7 +940,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="293"
+            line="296"
             column="13"/>
     </issue>
 
@@ -962,7 +951,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="398"
+            line="401"
             column="13"/>
     </issue>
 
@@ -973,7 +962,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="432"
+            line="435"
             column="13"/>
     </issue>
 
@@ -984,7 +973,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="435"
+            line="438"
             column="13"/>
     </issue>
 
@@ -995,7 +984,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="436"
+            line="439"
             column="13"/>
     </issue>
 
@@ -1006,7 +995,7 @@
         errorLine2="            ~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="437"
+            line="440"
             column="13"/>
     </issue>
 
@@ -1017,7 +1006,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="439"
+            line="442"
             column="13"/>
     </issue>
 
@@ -1028,7 +1017,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="451"
+            line="454"
             column="13"/>
     </issue>
 
@@ -1039,7 +1028,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="452"
+            line="455"
             column="13"/>
     </issue>
 
@@ -1050,7 +1039,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="504"
+            line="507"
             column="13"/>
     </issue>
 
@@ -1061,7 +1050,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="505"
+            line="508"
             column="13"/>
     </issue>
 
@@ -1072,7 +1061,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="515"
+            line="518"
             column="13"/>
     </issue>
 
@@ -1083,7 +1072,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="516"
+            line="519"
             column="13"/>
     </issue>
 
@@ -1094,7 +1083,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="517"
+            line="520"
             column="13"/>
     </issue>
 
@@ -1105,7 +1094,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="520"
+            line="523"
             column="13"/>
     </issue>
 
@@ -1116,7 +1105,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="558"
+            line="561"
             column="13"/>
     </issue>
 
@@ -1127,7 +1116,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="600"
+            line="603"
             column="13"/>
     </issue>
 
@@ -1138,7 +1127,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="606"
+            line="609"
             column="13"/>
     </issue>
 
@@ -1149,7 +1138,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="630"
+            line="635"
             column="13"/>
     </issue>
 
@@ -1160,7 +1149,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="656"
+            line="661"
             column="13"/>
     </issue>
 
@@ -1464,18 +1453,7 @@
         errorLine2="     ~~~~~~~~">
         <location
             file="src/main/res/layout/item_follow.xml"
-            line="41"
-            column="6"/>
-    </issue>
-
-    <issue
-        id="SelectableText"
-        message="Consider making the text value selectable by specifying `android:textIsSelectable=&quot;true&quot;`"
-        errorLine1="    &lt;TextView"
-        errorLine2="     ~~~~~~~~">
-        <location
-            file="src/main/res/layout/item_follow.xml"
-            line="57"
+            line="42"
             column="6"/>
     </issue>
 
@@ -1629,7 +1607,7 @@
         errorLine2="     ~~~~~~~~">
         <location
             file="src/main/res/layout/item_report_notification.xml"
-            line="50"
+            line="51"
             column="6"/>
     </issue>
 
@@ -1640,7 +1618,7 @@
         errorLine2="     ~~~~~~~~">
         <location
             file="src/main/res/layout/item_report_notification.xml"
-            line="65"
+            line="66"
             column="6"/>
     </issue>
 
@@ -2080,7 +2058,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/item_report_notification.xml"
-            line="54"
+            line="55"
             column="9"/>
     </issue>
 

--- a/app/src/main/java/app/pachli/adapter/ReportNotificationViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/ReportNotificationViewHolder.kt
@@ -25,6 +25,8 @@ import app.pachli.components.notifications.NotificationActionListener
 import app.pachli.components.notifications.NotificationsPagingAdapter
 import app.pachli.core.activity.emojify
 import app.pachli.core.activity.loadAvatar
+import app.pachli.core.common.extensions.hide
+import app.pachli.core.common.extensions.show
 import app.pachli.core.common.string.unicodeWrap
 import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.database.model.NotificationReportEntity
@@ -87,12 +89,25 @@ class ReportNotificationViewHolder(
             reporterName,
             reporteeName,
         )
-        binding.notificationSummary.text = itemView.context.getString(
-            R.string.notification_summary_report_format,
+        binding.notificationSummary.text = itemView.context.resources.getQuantityString(
+            R.plurals.notification_summary_report_format,
+            report.statusIds?.size ?: 0,
             getRelativeTimeSpanString(itemView.context, report.createdAt.toEpochMilli(), System.currentTimeMillis()),
             report.statusIds?.size ?: 0,
         )
-        binding.notificationCategory.text = getTranslatedCategory(itemView.context, report.category)
+        binding.notificationCategory.text = itemView.context.getString(
+            R.string.title_report_category_fmt,
+            getTranslatedCategory(itemView.context, report.category),
+        )
+
+        if (report.comment.isNotBlank()) {
+            binding.titleReportComment.show()
+            binding.reportComment.text = report.comment
+            binding.reportComment.show()
+        } else {
+            binding.titleReportComment.hide()
+            binding.reportComment.hide()
+        }
 
         // Fancy avatar inset
         val padding = Utils.dpToPx(binding.notificationReporteeAvatar.context, 12)

--- a/app/src/main/java/app/pachli/components/notifications/FollowViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/notifications/FollowViewHolder.kt
@@ -17,6 +17,10 @@
 
 package app.pachli.components.notifications
 
+import android.graphics.Typeface
+import android.text.SpannableStringBuilder
+import android.text.Spanned
+import android.text.style.StyleSpan
 import androidx.recyclerview.widget.RecyclerView
 import app.pachli.R
 import app.pachli.core.activity.emojify
@@ -75,7 +79,14 @@ class FollowViewHolder(
                 },
             )
         val wrappedDisplayName = account.name.unicodeWrap()
-        val wholeMessage = String.format(format, wrappedDisplayName)
+        val wholeMessage = SpannableStringBuilder(String.format(format, wrappedDisplayName))
+        val displayNameIndex = format.indexOf("%s")
+        wholeMessage.setSpan(
+            StyleSpan(Typeface.BOLD),
+            displayNameIndex,
+            displayNameIndex + wrappedDisplayName.length,
+            Spanned.SPAN_EXCLUSIVE_EXCLUSIVE,
+        )
         val emojifiedMessage =
             wholeMessage.emojify(
                 account.emojis,
@@ -85,12 +96,6 @@ class FollowViewHolder(
         binding.notificationText.text = emojifiedMessage
         val username = context.getString(DR.string.post_username_format, account.username)
         binding.notificationUsername.text = username
-        val emojifiedDisplayName = wrappedDisplayName.emojify(
-            account.emojis,
-            binding.notificationUsername,
-            animateEmojis,
-        )
-        binding.notificationDisplayName.text = emojifiedDisplayName
         loadAvatar(
             account.avatar,
             binding.notificationAvatar,

--- a/app/src/main/res/layout/item_follow.xml
+++ b/app/src/main/res/layout/item_follow.xml
@@ -11,17 +11,18 @@
 
     <TextView
         android:id="@+id/notification_text"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
         app:drawableStartCompat="@drawable/ic_person_add_24dp"
         android:drawablePadding="10dp"
         android:ellipsize="end"
         android:gravity="center_vertical"
-        android:maxLines="1"
+        android:maxLines="2"
         android:paddingStart="28dp"
         android:textSize="?attr/status_text_medium"
         app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         tools:text="Someone followed you" />
 
@@ -39,30 +40,17 @@
         tools:src="@drawable/avatar_default" />
 
     <TextView
-        android:id="@+id/notification_display_name"
-        android:layout_width="wrap_content"
+        android:id="@+id/notification_username"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="14dp"
         android:layout_marginTop="6dp"
         android:ellipsize="end"
         android:maxLines="1"
-        android:paddingEnd="@dimen/status_display_name_padding_end"
         android:textSize="?attr/status_text_medium"
-        android:textStyle="normal|bold"
         app:layout_constraintStart_toEndOf="@id/notification_avatar"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/notification_text"
-        tools:text="Test User"
-        tools:ignore="RtlSymmetry" />
-
-    <TextView
-        android:id="@+id/notification_username"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:ellipsize="end"
-        android:maxLines="1"
-        android:textSize="?attr/status_text_medium"
-        app:layout_constraintStart_toEndOf="@+id/notification_display_name"
-        app:layout_constraintBaseline_toBaselineOf="@id/notification_display_name"
         tools:text="\@testuser" />
 
     <app.pachli.core.ui.ClickableSpanTextView
@@ -76,8 +64,8 @@
         android:textIsSelectable="true"
         app:layout_constrainedWidth="true"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="@+id/notification_display_name"
-        app:layout_constraintTop_toBottomOf="@+id/notification_display_name"
+        app:layout_constraintStart_toStartOf="@+id/notification_username"
+        app:layout_constraintTop_toBottomOf="@+id/notification_username"
         tools:text="Account note" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_report_notification.xml
+++ b/app/src/main/res/layout/item_report_notification.xml
@@ -19,7 +19,7 @@
         android:drawablePadding="10dp"
         android:ellipsize="end"
         android:gravity="center_vertical"
-        android:maxLines="1"
+        android:maxLines="2"
         android:paddingStart="28dp"
         android:textColor="?android:textColorSecondary"
         android:textSize="?attr/status_text_medium"
@@ -43,6 +43,7 @@
         android:id="@+id/notification_reporter_avatar"
         android:layout_width="24dp"
         android:layout_height="24dp"
+        android:layout_marginBottom="8dp"
         app:layout_constraintRight_toRightOf="@id/notification_reportee_avatar"
         app:layout_constraintBottom_toBottomOf="@id/notification_reportee_avatar"
         android:contentDescription="@string/action_view_profile" />
@@ -77,5 +78,36 @@
         android:textSize="?attr/status_text_medium"
         android:textStyle="bold"
         tools:text="Spam" />
+
+    <TextView
+        android:id="@+id/title_report_comment"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@id/notification_category"
+        app:layout_constraintStart_toStartOf="@id/notification_category"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:importantForAccessibility="no"
+        android:hyphenationFrequency="full"
+        android:lineSpacingMultiplier="1.1"
+        android:textColor="?android:textColorTertiary"
+        android:textSize="?attr/status_text_medium"
+        android:textStyle="bold"
+        android:text="@string/title_report_comment" />
+
+    <TextView
+        android:id="@+id/report_comment"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@id/title_report_comment"
+        app:layout_constraintStart_toStartOf="@id/title_report_comment"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:importantForAccessibility="no"
+        android:hyphenationFrequency="full"
+        android:lineSpacingMultiplier="1.1"
+        android:paddingBottom="10dp"
+        android:textColor="?android:textColorTertiary"
+        android:textSize="?attr/status_text_medium"
+        tools:ignore="SelectableText"
+        tools:text="Reporting because..." />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -526,7 +526,9 @@
     <string name="action_continue_edit">الاستمرار في التعديل</string>
     <string name="post_media_alt">ALT</string>
     <string name="notification_header_report_format">%s أبلغ عن %s</string>
-    <string name="notification_summary_report_format">%s · %d منشورات ملحقة</string>
+    <plurals name="notification_summary_report_format">
+        <item quantity="other">%1$s · %2$d منشورات ملحقة</item>
+    </plurals>
     <string name="failed_to_pin">فشل التثبيت</string>
     <string name="description_post_language">لغة المنشور</string>
     <string name="delete_scheduled_post_warning">هل تريد حذف هذا المنشور المُبَرمَج؟</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -61,7 +61,9 @@
     <string name="notification_update_format">%s адрэдагаваў(-ла) свой допіс</string>
     <string name="notification_report_format">Новая скарга на %s</string>
     <string name="notification_header_report_format">%s скардзіцца на %s</string>
-    <string name="notification_summary_report_format">%s · %d допісаў дададзена</string>
+    <plurals name="notification_summary_report_format">
+        <item quantity="other">%1$s · %2$d допісаў дададзена</item>
+    </plurals>
     <string name="report_username_format">Паскардзіцца на @%s</string>
     <string name="action_quick_reply">Хуткі адказ</string>
     <string name="action_reply">Адказаць</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -442,7 +442,9 @@
     <string name="notification_update_format">%s ha editat la seva publicació</string>
     <string name="notification_report_format">Nou informe sobre %s</string>
     <string name="notification_header_report_format">%s ha informat %s</string>
-    <string name="notification_summary_report_format">%s · %d publicacions adjuntes</string>
+    <plurals name="notification_summary_report_format">
+        <item quantity="other">%1$s · %2$d publicacions adjuntes</item>
+    </plurals>
     <string name="action_unbookmark">Elimina el marcador</string>
     <string name="action_delete_conversation">Suprimeix la conversa</string>
     <string name="notification_sign_up_name">Inscripcions</string>

--- a/app/src/main/res/values-cy/strings.xml
+++ b/app/src/main/res/values-cy/strings.xml
@@ -399,7 +399,9 @@
     <string name="review_notifications">Adolygu hysbysiadau</string>
     <string name="notification_report_format">Adroddiad newydd ar %s</string>
     <string name="notification_header_report_format">Adroddodd %s %s</string>
-    <string name="notification_summary_report_format">%s · %d o negeseuon a atodwyd</string>
+    <plurals name="notification_summary_report_format">
+        <item quantity="other">%1$s · %2$d o negeseuon a atodwyd</item>
+    </plurals>
     <string name="pref_title_notification_filter_reports">mae yna adroddiad newydd</string>
     <string name="report_category_violation">Toriad rheol</string>
     <string name="report_category_spam">Sbam</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -469,7 +469,9 @@
     <string name="description_post_language">Sprache des Beitrags</string>
     <string name="action_set_focus">Fokuspunkt setzen</string>
     <string name="action_add_reaction">Reaktion hinzufügen</string>
-    <string name="notification_summary_report_format">%s · %d Beiträge angehängt</string>
+    <plurals name="notification_summary_report_format">
+        <item quantity="other">%1$s · %2$d Beiträge angehängt</item>
+    </plurals>
     <string name="notification_header_report_format">%s hat %s gemeldet</string>
     <string name="confirmation_hashtag_unfollowed">#%s entfolgt</string>
     <string name="pref_default_post_language">Standard-Beitragssprache</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -483,7 +483,9 @@
     <string name="description_post_edited">Editado</string>
     <string name="notification_report_format">Nueva denuncia en %s</string>
     <string name="notification_header_report_format">%s denunció a %s</string>
-    <string name="notification_summary_report_format">%s · %d publicaciones fijadas</string>
+    <plurals name="notification_summary_report_format">
+        <item quantity="other">%1$s · %2$d publicaciones fijadas</item>
+    </plurals>
     <string name="language_display_name_format">%s (%s)</string>
     <string name="error_muting_hashtag_format">Error al silenciar #%s</string>
     <string name="error_unmuting_hashtag_format">Error al reactivar #%s</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -437,7 +437,9 @@
     <string name="title_edits">Aldaketak</string>
     <string name="notification_report_format">Salaketa berria %s-(r)i</string>
     <string name="notification_header_report_format">%s-(e)k %s salatu du</string>
-    <string name="notification_summary_report_format">%s · %d tutak finkatuak</string>
+    <plurals name="notification_summary_report_format">
+        <item quantity="other">%1$s · %2$d tutak finkatuak</item>
+    </plurals>
     <string name="title_followed_hashtags">Jarraitutako traolak</string>
     <string name="notification_update_format">%s-(e)k bere tuta editatu du</string>
     <string name="title_migration_relogin">Berriro saioa hasi push motako jakinarazpenak gaitzeko</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -465,7 +465,9 @@
     <string name="compose_save_draft_loses_media">ذخیرهٔ پیش‌نویس؟ (پیوست‌ها هنگام بازگردانی پیش‌نویس، دوباره بارگذاری خواهند شد)</string>
     <string name="notification_report_format">گزارش جدید روی %s</string>
     <string name="notification_header_report_format">%s، %s را گزارش داد</string>
-    <string name="notification_summary_report_format">%s · %d فرسته پیوسته</string>
+    <plurals name="notification_summary_report_format">
+        <item quantity="other">%1$s · %2$d فرسته پیوسته</item>
+    </plurals>
     <string name="error_following_hashtags_unsupported">این نمونه از پی‌گیری برچسب‌ها پشتیبانی نمی‌کند.</string>
     <string name="title_followed_hashtags">برچسب‌های دنبالی</string>
     <string name="confirmation_hashtag_unfollowed">پی‌گیری #%s لغو شد</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -312,7 +312,9 @@
     <string name="pref_title_alway_open_spoiler">Avaa aina sisältövaroituksella varustetut julkaisut</string>
     <string name="title_tab_public_trending_statuses">Julkaisut</string>
     <string name="action_share_account_link">Jaa linkki tiliin</string>
-    <string name="notification_summary_report_format">%s · %d julkaisua liitteenä</string>
+    <plurals name="notification_summary_report_format">
+        <item quantity="other">%1$s · %2$d julkaisua liitteenä</item>
+    </plurals>
     <string name="send_account_link_to">Jaa tilin URL…</string>
     <string name="abbreviated_hours_ago">%dt</string>
     <string name="filter_expiration_format">%s (%s)</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -492,7 +492,9 @@
     <string name="post_media_alt">ALT</string>
     <string name="notification_report_format">Nouveau signalement sur %s</string>
     <string name="notification_header_report_format">%s a signalé %s</string>
-    <string name="notification_summary_report_format">%s · %d posts joints</string>
+    <plurals name="notification_summary_report_format">
+        <item quantity="other">%1$s · %2$d posts joints</item>
+    </plurals>
     <string name="notification_report_name">Signalements</string>
     <string name="set_focus_description">Appuyez ou faites glissez le cercle pour déplacer le point focal, qui sera toujours visible sur les vignettes.</string>
     <string name="notification_unknown_name">Inconnu</string>

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -573,7 +573,9 @@
     <string name="notification_severed_relationships_account_suspension_body">Chuir modhnóir an cuntas ar fionraí</string>
     <string name="notification_severed_relationships_unknown_body">Cúis anaithnid</string>
     <string name="notification_header_report_format">%s tuairiscithe %s</string>
-    <string name="notification_summary_report_format">%s · %d post ceangailte</string>
+    <plurals name="notification_summary_report_format">
+        <item quantity="other">%1$s · %2$d post ceangailte</item>
+    </plurals>
     <string name="action_add_reaction">cuir imoibriú leis</string>
     <string name="action_translate">Aistrigh</string>
     <string name="account_username_copied">Cóipeáladh an t- ainm úsáideora</string>

--- a/app/src/main/res/values-gd/strings.xml
+++ b/app/src/main/res/values-gd/strings.xml
@@ -518,7 +518,9 @@
     <string name="post_edited">Air a dheasachadh %s</string>
     <string name="notification_report_format">Gearan ùr air %s</string>
     <string name="notification_header_report_format">Rinn %s gearan mu %s</string>
-    <string name="notification_summary_report_format">%s · Tha postaichean ris, %d dhiubh</string>
+    <plurals name="notification_summary_report_format">
+        <item quantity="other">%1$s · Tha postaichean ris, %2$d dhiubh</item>
+    </plurals>
     <string name="action_share_account_link">Co-roinn ceangal dhan chunntas</string>
     <string name="account_username_copied">Chaidh lethbhreac a dhèanamh dhen ainm-chleachdaiche</string>
     <string name="unsaved_changes">Tha atharraichean gun sàbhaladh agad.</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -469,7 +469,9 @@
     <string name="status_created_at_now">agora</string>
     <string name="notification_report_format">Nova denuncia en %s</string>
     <string name="notification_header_report_format">%s denunciou a %s</string>
-    <string name="notification_summary_report_format">%s · %d publicacións fixadas</string>
+    <plurals name="notification_summary_report_format">
+        <item quantity="other">%1$s · %2$d publicacións fixadas</item>
+    </plurals>
     <string name="confirmation_hashtag_unfollowed">Xa non segues a #%s</string>
     <string name="pref_title_notification_filter_reports">hai unha nova denuncia</string>
     <string name="hint_media_description_missing">O multimedia debería ter unha descrición.</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -477,7 +477,9 @@
     <string name="error_unmuting_hashtag_format">Hiba #%s némításának feloldása közben</string>
     <string name="notification_report_format">Új bejelentés a %s-n</string>
     <string name="notification_header_report_format">%s bejelentette %s-t</string>
-    <string name="notification_summary_report_format">%s · %d bejegyzés csatolva</string>
+    <plurals name="notification_summary_report_format">
+        <item quantity="other">%1$s · %2$d bejegyzés csatolva</item>
+    </plurals>
     <string name="confirmation_hashtag_unfollowed">#%s kikövetve</string>
     <string name="notification_report_name">Bejelentések</string>
     <string name="notification_report_description">Értesítések moderációs bejelentésekről</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -218,7 +218,9 @@
     <string name="post_content_show_less">Tutup</string>
     <string name="post_edited">Diedit %s</string>
     <string name="notification_report_format">Laporan baru tentang %s</string>
-    <string name="notification_summary_report_format">%s - %d posting terlampir</string>
+    <plurals name="notification_summary_report_format">
+        <item quantity="other">%1$s - %2$d posting terlampir</item>
+    </plurals>
     <string name="action_bookmark">Penanda</string>
     <string name="action_post_failed">Unggahan gagal</string>
     <string name="action_post_failed_detail">Postingan Anda gagal diunggah dan telah disimpan ke draf.

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -464,7 +464,9 @@
     <string name="action_unfollow_hashtag_format">Hætta að fylgjast með #%s\?</string>
     <string name="notification_report_format">Ný kæra vegna %s</string>
     <string name="notification_header_report_format">%s kærði %s</string>
-    <string name="notification_summary_report_format">%s · %d færslur viðhengdar</string>
+    <plurals name="notification_summary_report_format">
+        <item quantity="other">%1$s · %2$d færslur viðhengdar</item>
+    </plurals>
     <string name="post_edited">Breytti %s</string>
     <string name="confirmation_hashtag_unfollowed">Hætt að fylgjast með #%s</string>
     <string name="notification_report_name">Kærur</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -513,7 +513,9 @@
     <string name="action_continue_edit">Continua a modificare</string>
     <string name="notification_report_format">Nuova segnalazione su %s</string>
     <string name="notification_header_report_format">%s ha segnalato %s</string>
-    <string name="notification_summary_report_format">%s · %d post allegati</string>
+    <plurals name="notification_summary_report_format">
+        <item quantity="other">%1$s · %2$d post allegati</item>
+    </plurals>
     <string name="action_add_reaction">aggiungi reazione</string>
     <string name="unsaved_changes">Hai delle modifiche non salvate.</string>
     <string name="confirmation_hashtag_unfollowed">Non segui più #%s</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -576,7 +576,9 @@
     <string name="pref_title_show_self_boosts_description">自分の投稿をブーストすること</string>
     <string name="confirmation_hashtag_unmuted">%s を非表示にしました</string>
     <string name="pref_title_show_self_boosts">セルフブーストを表示</string>
-    <string name="notification_summary_report_format">%sさん・%d件のポストが添付されています</string>
+    <plurals name="notification_summary_report_format">
+        <item quantity="other">%1$sさん・%2$d件のポストが添付されています</item>
+    </plurals>
     <string name="ui_error_translate_status_fmt">翻訳に失敗しました: %1$s</string>
     <string name="update_dialog_negative">通知しない</string>
     <string name="translating">翻訳中です…</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -285,7 +285,9 @@
     <string name="post_media_hidden_title">Multivide ir paslēpta</string>
     <string name="notification_reblog_format">%s pastiprināja Tavu ierakstu</string>
     <string name="notification_follow_request_format">%s lūdza atļauju sekot Tev</string>
-    <string name="notification_summary_report_format">%s · pievienoti %d ieraksti</string>
+    <plurals name="notification_summary_report_format">
+        <item quantity="other">%1$s · pievienoti %2$d ieraksti</item>
+    </plurals>
     <string name="action_compose">Rakstīt</string>
     <string name="action_logout_confirm">Vai tiešām atteikties no %1$s? Tas izdzēsīs visus vietējos konta datus, tajā skaitā melnrakstus un iestatījumus.</string>
     <string name="action_add_media">Pievienot multividi</string>

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -36,7 +36,9 @@
     <string name="notification_update_format">%s သည်၎င်းတို့၌ပိုစ့်ကိုပြုပြင်ခဲ့သည်</string>
     <string name="notification_report_format">%s သို့တိုင်ကြားမှုများ</string>
     <string name="notification_severed_relationships_unknown_body">အမျိုးအမည်မသိသောအကြောင်းပြချက်</string>
-    <string name="notification_summary_report_format">%s မှ %d အထိပိုစ့်များပါဝင်သည်</string>
+    <plurals name="notification_summary_report_format">
+        <item quantity="other">%1$s မှ %2$d အထိပိုစ့်များပါဝင်သည်</item>
+    </plurals>
     <string name="report_comment_hint">ဖြည့်စွက်မှတ်ချက်များရှိပါသလား</string>
     <string name="action_unreblog">ပယ်ဖျက်မည်</string>
     <string name="action_favourite">ကြိုက်သည်</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -462,7 +462,9 @@
     <string name="language_display_name_format">%s (%s)</string>
     <string name="status_created_at_now">nå</string>
     <string name="post_edited">Redigert %s</string>
-    <string name="notification_summary_report_format">%s · %d innlegg vedlagt</string>
+    <plurals name="notification_summary_report_format">
+        <item quantity="other">%1$s · %2$d innlegg vedlagt</item>
+    </plurals>
     <string name="notification_report_format">Ny rapport på %s</string>
     <string name="notification_header_report_format">%s rapporterte %s</string>
     <string name="notification_report_description">Varsler om moderasjonsrapporter</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -502,7 +502,9 @@
     <string name="action_discard">Veranderingen ongedaan maken</string>
     <string name="post_edited">Bewerkt %s</string>
     <string name="notification_header_report_format">%s gerapporteerd %s</string>
-    <string name="notification_summary_report_format">%s · %d berichten bijgevoegd</string>
+    <plurals name="notification_summary_report_format">
+        <item quantity="other">%1$s · %2$d berichten bijgevoegd</item>
+    </plurals>
     <string name="action_share_account_link">Link naar account delen</string>
     <string name="action_share_account_username">Deel de gebruikersnaam van het account</string>
     <string name="send_account_username_to">Accountgebruikersnaam delen om…</string>

--- a/app/src/main/res/values-nn/strings.xml
+++ b/app/src/main/res/values-nn/strings.xml
@@ -73,7 +73,9 @@
     <string name="notification_severed_relationships_account_suspension_body">Ein moderator suspenderte kontoen</string>
     <string name="notification_severed_relationships_unknown_body">Ukjend årsak</string>
     <string name="notification_header_report_format">%s rapporterte %s</string>
-    <string name="notification_summary_report_format">%s · %d innlegg lagt ved</string>
+    <plurals name="notification_summary_report_format">
+        <item quantity="other">%1$s · %2$d innlegg lagt ved</item>
+    </plurals>
     <string name="report_username_format">Rapporter @%s</string>
     <string name="report_comment_hint">Har du fleire kommentarar?</string>
     <string name="action_quick_reply">Hurtigsvar</string>

--- a/app/src/main/res/values-oc/strings.xml
+++ b/app/src/main/res/values-oc/strings.xml
@@ -482,7 +482,9 @@
     <string name="pref_title_http_proxy_port_message">Lo pòrt deu èsser entre %d e %d</string>
     <string name="error_muting_hashtag_format">Fracàs en silenciant #%s</string>
     <string name="error_unmuting_hashtag_format">Fracàs en quitant de silenciar #%s</string>
-    <string name="notification_summary_report_format">%s · %d publicacions juntadas</string>
+    <plurals name="notification_summary_report_format">
+        <item quantity="other">%1$s · %2$d publicacions juntadas</item>
+    </plurals>
     <string name="post_edited">%s modificat</string>
     <string name="description_post_edited">Modificada</string>
     <string name="error_status_source_load">Fracàs del cargament de l’estatut a partir del servidor.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -515,7 +515,9 @@
     <string name="description_login">Działa w większości przypadków. Żadne dane nie są udostępniane innym aplikacjom.</string>
     <string name="description_browser_login">Może obsługiwać dodatkowe formy weryfikacji, ale wymaga kompatybilnej przeglądarki.</string>
     <string name="notification_report_format">Nowe zgłoszenie dotyczące %s</string>
-    <string name="notification_summary_report_format">%s · %d załączonych wpisów</string>
+    <plurals name="notification_summary_report_format">
+        <item quantity="other">%1$s · %2$d załączonych wpisów</item>
+    </plurals>
     <string name="failed_to_pin">Nie udało się przypiąć</string>
     <string name="failed_to_unpin">Nie udało się odpiąć</string>
     <string name="error_status_source_load">Błąd ładowania źródła statusu z serwera.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -572,7 +572,9 @@
     <string name="notification_report_name">Denúncias</string>
     <string name="filter_description_hide">Ocultar completamente</string>
     <string name="filter_description_format">%s: %s</string>
-    <string name="notification_summary_report_format">%s · %d Toots anexados</string>
+    <plurals name="notification_summary_report_format">
+        <item quantity="other">%1$s · %2$d Toots anexados</item>
+    </plurals>
     <string name="send_account_link_to">Compartilhar URL da conta para…</string>
     <string name="post_media_image">Imagem</string>
     <string name="filter_action_hide">Ocultar</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -215,7 +215,9 @@
     <string name="notification_favourite_description">Upozornenia, keď sú tvoje príspevky označené ako obľúbené</string>
     <string name="notification_unknown">Neznámy typ upozornenia</string>
     <string name="notification_header_report_format">%s nahlásil %s</string>
-    <string name="notification_summary_report_format">%s · %d priložených príspevkov</string>
+    <plurals name="notification_summary_report_format">
+        <item quantity="other">%1$s · %2$d priložených príspevkov</item>
+    </plurals>
     <string name="report_comment_hint">Ďalšie komentáre?</string>
     <string name="action_unfavourite">Odstrániť z obľúbených</string>
     <string name="action_unbookmark">Odstrániť záložku</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -474,7 +474,9 @@
     <string name="status_created_at_now">nu</string>
     <string name="notification_report_format">Ny rapport för %s</string>
     <string name="notification_header_report_format">%s rapporterade %s</string>
-    <string name="notification_summary_report_format">%s · %d inlägg bifogade</string>
+    <plurals name="notification_summary_report_format">
+        <item quantity="other">%1$s · %2$d inlägg bifogade</item>
+    </plurals>
     <string name="confirmation_hashtag_unfollowed">#%s avföljd</string>
     <string name="pref_title_notification_filter_reports">det finns en ny rapport</string>
     <string name="notification_report_name">Rapporter</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -327,7 +327,9 @@
     <string name="dialog_follow_hashtag_title">ஏச்டேக்கைப் பின்தொடரவும்</string>
     <string name="notification_update_format">%s தங்கள் இடுகையைத் திருத்தியுள்ளன</string>
     <string name="notification_header_report_format">%s %s</string>
-    <string name="notification_summary_report_format">%s · %d பதிவுகள் இணைக்கப்பட்டுள்ளன</string>
+    <plurals name="notification_summary_report_format">
+        <item quantity="other">%1$s · %2$d பதிவுகள் இணைக்கப்பட்டுள்ளன</item>
+    </plurals>
     <string name="action_post_failed_detail_plural">உங்கள் பதிவுகள் பதிவேற்றத் தவறிவிட்டன, மேலும் அவை வரைவுகளுக்கு சேமிக்கப்பட்டுள்ளன.\n\n சேவையகத்தைத் தொடர்பு கொள்ள முடியவில்லை, அல்லது அது இடுகைகளை நிராகரித்தது.</string>
     <string name="action_post_failed_do_nothing">தள்ளுபடி</string>
     <string name="action_send">டூட்</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -405,7 +405,9 @@
     <string name="pref_title_notification_filter_reports">yeni bir rapor olduğunda</string>
     <string name="pref_title_animate_custom_emojis">Özel ayarlanmış emojileri oynat</string>
     <string name="notification_header_report_format">%s rapor edilmiş %s</string>
-    <string name="notification_summary_report_format">%s · %d ekli gönderiler</string>
+    <plurals name="notification_summary_report_format">
+        <item quantity="other">%1$s · %2$d ekli gönderiler</item>
+    </plurals>
     <string name="post_edited">Düzenleme %s</string>
     <string name="account_note_hint">Bu hesap hakkındaki özel notun</string>
     <string name="title_migration_relogin">Bildirim beslemesi için yeniden giriş yapın</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -483,7 +483,9 @@
     <string name="action_unfollow_hashtag_format">Не слідкувати за #%s\?</string>
     <string name="status_created_at_now">зараз</string>
     <string name="notification_header_report_format">%s скаржиться %s</string>
-    <string name="notification_summary_report_format">%s · %d прикріплених дописів</string>
+    <plurals name="notification_summary_report_format">
+        <item quantity="other">%1$s · %2$d прикріплених дописів</item>
+    </plurals>
     <string name="confirmation_hashtag_unfollowed">#%s не відстежується</string>
     <string name="pref_title_notification_filter_reports">з\'явилася нова скарга</string>
     <string name="notification_report_name">Скарги</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -451,7 +451,9 @@
     <string name="status_created_at_now">vừa xong</string>
     <string name="notification_report_format">Báo cáo mới trên %s</string>
     <string name="notification_header_report_format">%s báo cáo %s</string>
-    <string name="notification_summary_report_format">%s trước · %d tút</string>
+    <plurals name="notification_summary_report_format">
+        <item quantity="other">%1$s trước · %2$d tút</item>
+    </plurals>
     <string name="confirmation_hashtag_unfollowed">Đã bỏ theo dõi #%s</string>
     <string name="pref_title_notification_filter_reports">có một báo cáo mới</string>
     <string name="notification_report_name">Báo cáo</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -466,7 +466,9 @@
     <string name="notification_report_name">报告</string>
     <string name="action_unfollow_hashtag_format">取关 #%s 吗？</string>
     <string name="status_created_at_now">立即</string>
-    <string name="notification_summary_report_format">附上了 %s · %d 个嘟文</string>
+    <plurals name="notification_summary_report_format">
+        <item quantity="other">附上了 %1$s · %2$d 个嘟文</item>
+    </plurals>
     <string name="confirmation_hashtag_unfollowed">取关了 #%s</string>
     <string name="notification_report_description">审核报告的通知</string>
     <string name="report_category_violation">违反规则</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -115,7 +115,10 @@
     </plurals>
     <string name="notification_unknown">Unknown notification type</string>
     <string name="notification_header_report_format">%s reported %s</string>
-    <string name="notification_summary_report_format">%s · %d posts attached</string>
+    <plurals name="notification_summary_report_format">
+        <item quantity="one">%1$s · %2$d post attached</item>
+        <item quantity="other">%1$s · %2$d posts attached</item>
+    </plurals>
     <string name="report_username_format">Report @%s</string>
     <string name="report_comment_hint">Additional comments?</string>
     <string name="action_quick_reply">Quick Reply</string>
@@ -624,9 +627,11 @@
     <string name="saving_draft">Saving draft…</string>
     <string name="delete_scheduled_post_warning">Delete this scheduled post?</string>
     <string name="language_display_name_format">%s (%s)</string>
+    <string name="title_report_category_fmt">Category: %1$s</string>
     <string name="report_category_violation">Rule violation</string>
     <string name="report_category_spam">Spam</string>
     <string name="report_category_other">Other</string>
+    <string name="title_report_comment">Comment from reporter</string>
     <string name="action_unfollow_hashtag_format">Unfollow #%s?</string>
     <string name="mute_notifications_switch">Mute notifications</string>
     <!-- Reading order preference -->


### PR DESCRIPTION
Allow two lines of top text for `admin.report` notifications, so there's space for the reporter and reportee's details.

Show the comment attached to the report (if present).

Use plural strings so the count of attached posts is grammatically correct.

Ensure the content doesn't run off the edge of the screen in the constraint layouts.

Don't duplicate the account's name When displaying `admin.signup` notifications. Previously there was a header line that showed the name, and a second line that showed the name and the username. Now show the name (bolded) on the notification top line, and just the username next to the avatar. Since the same view is used for follow notifications the change also happens there.