### PR TITLE
refactor: Push .emojify and .loadAvatar down to core.ui

### DIFF
--- a/app/src/main/java/app/pachli/MainActivity.kt
+++ b/app/src/main/java/app/pachli/MainActivity.kt
@@ -65,7 +65,6 @@ import app.pachli.components.notifications.domain.EnableAllNotificationsUseCase
 import app.pachli.core.activity.BottomSheetActivity
 import app.pachli.core.activity.PostLookupFallbackBehavior
 import app.pachli.core.activity.ReselectableFragment
-import app.pachli.core.activity.emojify
 import app.pachli.core.activity.extensions.TransitionKind
 import app.pachli.core.activity.extensions.startActivityWithDefaultTransition
 import app.pachli.core.activity.extensions.startActivityWithTransition
@@ -112,6 +111,7 @@ import app.pachli.core.preferences.MainNavigationPosition
 import app.pachli.core.preferences.TabAlignment
 import app.pachli.core.preferences.TabContents
 import app.pachli.core.ui.AlignableTabLayoutAlignment
+import app.pachli.core.ui.emojify
 import app.pachli.core.ui.extensions.await
 import app.pachli.core.ui.extensions.reduceSwipeSensitivity
 import app.pachli.core.ui.makeIcon

--- a/app/src/main/java/app/pachli/adapter/AccountViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/AccountViewHolder.kt
@@ -18,12 +18,12 @@
 package app.pachli.adapter
 
 import androidx.recyclerview.widget.RecyclerView
-import app.pachli.core.activity.emojify
-import app.pachli.core.activity.loadAvatar
 import app.pachli.core.common.extensions.visible
 import app.pachli.core.designsystem.R as DR
 import app.pachli.core.network.model.TimelineAccount
 import app.pachli.core.ui.LinkListener
+import app.pachli.core.ui.emojify
+import app.pachli.core.ui.loadAvatar
 import app.pachli.databinding.ItemAccountBinding
 import app.pachli.interfaces.AccountActionListener
 

--- a/app/src/main/java/app/pachli/adapter/FollowRequestViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/FollowRequestViewHolder.kt
@@ -24,8 +24,6 @@ import android.text.style.StyleSpan
 import androidx.recyclerview.widget.RecyclerView
 import app.pachli.R
 import app.pachli.components.notifications.NotificationsPagingAdapter
-import app.pachli.core.activity.emojify
-import app.pachli.core.activity.loadAvatar
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
 import app.pachli.core.common.extensions.visible
@@ -35,6 +33,8 @@ import app.pachli.core.designsystem.R as DR
 import app.pachli.core.network.model.TimelineAccount
 import app.pachli.core.network.parseAsMastodonHtml
 import app.pachli.core.ui.LinkListener
+import app.pachli.core.ui.emojify
+import app.pachli.core.ui.loadAvatar
 import app.pachli.core.ui.setClickableText
 import app.pachli.databinding.ItemFollowRequestBinding
 import app.pachli.interfaces.AccountActionListener

--- a/app/src/main/java/app/pachli/adapter/PollAdapter.kt
+++ b/app/src/main/java/app/pachli/adapter/PollAdapter.kt
@@ -19,10 +19,10 @@ package app.pachli.adapter
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
-import app.pachli.core.activity.emojify
 import app.pachli.core.common.extensions.visible
 import app.pachli.core.network.model.Emoji
 import app.pachli.core.ui.BindingHolder
+import app.pachli.core.ui.emojify
 import app.pachli.core.ui.makeIcon
 import app.pachli.databinding.ItemPollBinding
 import app.pachli.viewdata.PollOptionViewData

--- a/app/src/main/java/app/pachli/adapter/ReportNotificationViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/ReportNotificationViewHolder.kt
@@ -23,8 +23,6 @@ import androidx.recyclerview.widget.RecyclerView
 import app.pachli.R
 import app.pachli.components.notifications.NotificationActionListener
 import app.pachli.components.notifications.NotificationsPagingAdapter
-import app.pachli.core.activity.emojify
-import app.pachli.core.activity.loadAvatar
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
 import app.pachli.core.common.string.unicodeWrap
@@ -32,6 +30,8 @@ import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.database.model.NotificationReportEntity
 import app.pachli.core.designsystem.R as DR
 import app.pachli.core.network.model.TimelineAccount
+import app.pachli.core.ui.emojify
+import app.pachli.core.ui.loadAvatar
 import app.pachli.databinding.ItemReportNotificationBinding
 import app.pachli.util.getRelativeTimeSpanString
 import app.pachli.viewdata.NotificationViewData

--- a/app/src/main/java/app/pachli/adapter/StatusBaseViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/StatusBaseViewHolder.kt
@@ -19,9 +19,6 @@ import androidx.core.text.HtmlCompat
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
 import app.pachli.R
-import app.pachli.core.activity.decodeBlurHash
-import app.pachli.core.activity.emojify
-import app.pachli.core.activity.loadAvatar
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
 import app.pachli.core.common.string.unicodeWrap
@@ -40,6 +37,9 @@ import app.pachli.core.network.model.Status
 import app.pachli.core.network.parseAsMastodonHtml
 import app.pachli.core.preferences.CardViewMode
 import app.pachli.core.ui.SetStatusContent
+import app.pachli.core.ui.decodeBlurHash
+import app.pachli.core.ui.emojify
+import app.pachli.core.ui.loadAvatar
 import app.pachli.core.ui.makeIcon
 import app.pachli.core.ui.setClickableMentions
 import app.pachli.interfaces.StatusActionListener

--- a/app/src/main/java/app/pachli/adapter/StatusViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/StatusViewHolder.kt
@@ -20,7 +20,6 @@ import android.text.InputFilter
 import android.text.TextUtils
 import android.view.View
 import app.pachli.R
-import app.pachli.core.activity.emojify
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
 import app.pachli.core.common.extensions.visible
@@ -32,6 +31,7 @@ import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.model.FilterAction
 import app.pachli.core.network.model.Emoji
 import app.pachli.core.ui.SetStatusContent
+import app.pachli.core.ui.emojify
 import app.pachli.databinding.ItemStatusBinding
 import app.pachli.interfaces.StatusActionListener
 import at.connyduck.sparkbutton.helpers.Utils

--- a/app/src/main/java/app/pachli/components/account/AccountActivity.kt
+++ b/app/src/main/java/app/pachli/components/account/AccountActivity.kt
@@ -54,11 +54,9 @@ import androidx.viewpager2.widget.MarginPageTransformer
 import app.pachli.R
 import app.pachli.core.activity.BottomSheetActivity
 import app.pachli.core.activity.ReselectableFragment
-import app.pachli.core.activity.emojify
 import app.pachli.core.activity.extensions.TransitionKind
 import app.pachli.core.activity.extensions.startActivityWithDefaultTransition
 import app.pachli.core.activity.extensions.startActivityWithTransition
-import app.pachli.core.activity.loadAvatar
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
 import app.pachli.core.common.extensions.viewBinding
@@ -80,8 +78,10 @@ import app.pachli.core.network.parseAsMastodonHtml
 import app.pachli.core.preferences.AppTheme
 import app.pachli.core.ui.ClipboardUseCase
 import app.pachli.core.ui.LinkListener
+import app.pachli.core.ui.emojify
 import app.pachli.core.ui.extensions.reduceSwipeSensitivity
 import app.pachli.core.ui.getDomain
+import app.pachli.core.ui.loadAvatar
 import app.pachli.core.ui.setClickableText
 import app.pachli.databinding.ActivityAccountBinding
 import app.pachli.db.DraftsAlert

--- a/app/src/main/java/app/pachli/components/account/AccountFieldAdapter.kt
+++ b/app/src/main/java/app/pachli/components/account/AccountFieldAdapter.kt
@@ -20,12 +20,12 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import app.pachli.R
-import app.pachli.core.activity.emojify
 import app.pachli.core.network.model.Emoji
 import app.pachli.core.network.model.Field
 import app.pachli.core.network.parseAsMastodonHtml
 import app.pachli.core.ui.BindingHolder
 import app.pachli.core.ui.LinkListener
+import app.pachli.core.ui.emojify
 import app.pachli.core.ui.setClickableText
 import app.pachli.databinding.ItemAccountFieldBinding
 

--- a/app/src/main/java/app/pachli/components/account/media/AccountMediaGridAdapter.kt
+++ b/app/src/main/java/app/pachli/components/account/media/AccountMediaGridAdapter.kt
@@ -12,13 +12,13 @@ import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.DiffUtil
 import app.pachli.R
 import app.pachli.adapter.isPlayable
-import app.pachli.core.activity.decodeBlurHash
 import app.pachli.core.common.extensions.show
 import app.pachli.core.common.extensions.visible
 import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.navigation.AttachmentViewData
 import app.pachli.core.network.model.Attachment
 import app.pachli.core.ui.BindingHolder
+import app.pachli.core.ui.decodeBlurHash
 import app.pachli.databinding.ItemAccountMediaBinding
 import app.pachli.util.getFormattedDescription
 import app.pachli.util.iconResource

--- a/app/src/main/java/app/pachli/components/accountlist/adapter/BlocksAdapter.kt
+++ b/app/src/main/java/app/pachli/components/accountlist/adapter/BlocksAdapter.kt
@@ -18,11 +18,11 @@ package app.pachli.components.accountlist.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import app.pachli.core.activity.emojify
-import app.pachli.core.activity.loadAvatar
 import app.pachli.core.common.extensions.visible
 import app.pachli.core.designsystem.R as DR
 import app.pachli.core.ui.BindingHolder
+import app.pachli.core.ui.emojify
+import app.pachli.core.ui.loadAvatar
 import app.pachli.databinding.ItemBlockedUserBinding
 import app.pachli.interfaces.AccountActionListener
 

--- a/app/src/main/java/app/pachli/components/accountlist/adapter/MutesAdapter.kt
+++ b/app/src/main/java/app/pachli/components/accountlist/adapter/MutesAdapter.kt
@@ -20,11 +20,11 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.view.ViewCompat
 import app.pachli.R
-import app.pachli.core.activity.emojify
-import app.pachli.core.activity.loadAvatar
 import app.pachli.core.common.extensions.visible
 import app.pachli.core.designsystem.R as DR
 import app.pachli.core.ui.BindingHolder
+import app.pachli.core.ui.emojify
+import app.pachli.core.ui.loadAvatar
 import app.pachli.databinding.ItemMutedUserBinding
 import app.pachli.interfaces.AccountActionListener
 

--- a/app/src/main/java/app/pachli/components/announcements/AnnouncementAdapter.kt
+++ b/app/src/main/java/app/pachli/components/announcements/AnnouncementAdapter.kt
@@ -25,14 +25,14 @@ import android.view.ViewGroup
 import androidx.core.view.size
 import androidx.recyclerview.widget.RecyclerView
 import app.pachli.R
-import app.pachli.core.activity.EmojiSpan
-import app.pachli.core.activity.emojify
 import app.pachli.core.common.extensions.visible
 import app.pachli.core.common.util.AbsoluteTimeFormatter
 import app.pachli.core.network.model.Announcement
 import app.pachli.core.network.parseAsMastodonHtml
 import app.pachli.core.ui.BindingHolder
+import app.pachli.core.ui.EmojiSpan
 import app.pachli.core.ui.LinkListener
+import app.pachli.core.ui.emojify
 import app.pachli.core.ui.setClickableText
 import app.pachli.databinding.ItemAnnouncementBinding
 import app.pachli.util.equalByMinute

--- a/app/src/main/java/app/pachli/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeActivity.kt
@@ -74,8 +74,6 @@ import app.pachli.components.compose.dialog.showAddPollDialog
 import app.pachli.components.compose.view.ComposeOptionsListener
 import app.pachli.components.compose.view.ComposeScheduleView
 import app.pachli.core.activity.BaseActivity
-import app.pachli.core.activity.emojify
-import app.pachli.core.activity.loadAvatar
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
 import app.pachli.core.common.extensions.viewBinding
@@ -97,7 +95,9 @@ import app.pachli.core.network.model.Emoji
 import app.pachli.core.network.model.Status
 import app.pachli.core.preferences.AppTheme
 import app.pachli.core.preferences.SharedPreferencesRepository
+import app.pachli.core.ui.emojify
 import app.pachli.core.ui.extensions.await
+import app.pachli.core.ui.loadAvatar
 import app.pachli.core.ui.makeIcon
 import app.pachli.databinding.ActivityComposeBinding
 import app.pachli.languageidentification.LanguageIdentifier

--- a/app/src/main/java/app/pachli/components/compose/ComposeAutoCompleteAdapter.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeAutoCompleteAdapter.kt
@@ -25,13 +25,13 @@ import android.widget.Filterable
 import androidx.annotation.WorkerThread
 import app.pachli.R
 import app.pachli.core.activity.databinding.ItemAutocompleteAccountBinding
-import app.pachli.core.activity.emojify
-import app.pachli.core.activity.loadAvatar
 import app.pachli.core.common.extensions.visible
 import app.pachli.core.common.util.formatNumber
 import app.pachli.core.designsystem.R as DR
 import app.pachli.core.network.model.Emoji
 import app.pachli.core.network.model.TimelineAccount
+import app.pachli.core.ui.emojify
+import app.pachli.core.ui.loadAvatar
 import app.pachli.databinding.ItemAutocompleteEmojiBinding
 import app.pachli.databinding.ItemAutocompleteHashtagBinding
 import com.bumptech.glide.Glide

--- a/app/src/main/java/app/pachli/components/conversation/ConversationViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/conversation/ConversationViewHolder.kt
@@ -22,13 +22,13 @@ import android.view.View
 import android.widget.ImageView
 import app.pachli.R
 import app.pachli.adapter.StatusBaseViewHolder
-import app.pachli.core.activity.loadAvatar
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
 import app.pachli.core.common.util.SmartLengthInputFilter
 import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.database.model.ConversationAccount
 import app.pachli.core.ui.SetStatusContent
+import app.pachli.core.ui.loadAvatar
 import app.pachli.databinding.ItemConversationBinding
 import app.pachli.interfaces.StatusActionListener
 

--- a/app/src/main/java/app/pachli/components/notifications/FollowViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/notifications/FollowViewHolder.kt
@@ -23,8 +23,6 @@ import android.text.Spanned
 import android.text.style.StyleSpan
 import androidx.recyclerview.widget.RecyclerView
 import app.pachli.R
-import app.pachli.core.activity.emojify
-import app.pachli.core.activity.loadAvatar
 import app.pachli.core.common.string.unicodeWrap
 import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.database.model.NotificationEntity
@@ -32,6 +30,8 @@ import app.pachli.core.designsystem.R as DR
 import app.pachli.core.network.model.TimelineAccount
 import app.pachli.core.network.parseAsMastodonHtml
 import app.pachli.core.ui.LinkListener
+import app.pachli.core.ui.emojify
+import app.pachli.core.ui.loadAvatar
 import app.pachli.core.ui.setClickableText
 import app.pachli.databinding.ItemFollowBinding
 import app.pachli.viewdata.NotificationViewData

--- a/app/src/main/java/app/pachli/components/notifications/StatusNotificationViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/notifications/StatusNotificationViewHolder.kt
@@ -28,8 +28,6 @@ import android.view.View
 import androidx.recyclerview.widget.RecyclerView
 import app.pachli.R
 import app.pachli.adapter.StatusBaseViewHolder
-import app.pachli.core.activity.emojify
-import app.pachli.core.activity.loadAvatar
 import app.pachli.core.common.string.unicodeWrap
 import app.pachli.core.common.util.AbsoluteTimeFormatter
 import app.pachli.core.common.util.SmartLengthInputFilter
@@ -40,6 +38,8 @@ import app.pachli.core.designsystem.R as DR
 import app.pachli.core.network.model.Emoji
 import app.pachli.core.ui.LinkListener
 import app.pachli.core.ui.SetStatusContent
+import app.pachli.core.ui.emojify
+import app.pachli.core.ui.loadAvatar
 import app.pachli.databinding.ItemStatusNotificationBinding
 import app.pachli.interfaces.StatusActionListener
 import app.pachli.util.getRelativeTimeSpanString

--- a/app/src/main/java/app/pachli/components/report/adapter/StatusViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/report/adapter/StatusViewHolder.kt
@@ -21,7 +21,6 @@ import android.view.View
 import androidx.recyclerview.widget.RecyclerView
 import app.pachli.R
 import app.pachli.components.report.model.StatusViewState
-import app.pachli.core.activity.emojify
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
 import app.pachli.core.common.util.AbsoluteTimeFormatter
@@ -35,6 +34,7 @@ import app.pachli.core.network.model.Status
 import app.pachli.core.network.parseAsMastodonHtml
 import app.pachli.core.ui.LinkListener
 import app.pachli.core.ui.SetStatusContent
+import app.pachli.core.ui.emojify
 import app.pachli.core.ui.setClickableMentions
 import app.pachli.databinding.ItemReportStatusBinding
 import app.pachli.util.StatusViewHelper

--- a/app/src/main/java/app/pachli/components/viewthread/edits/ViewEditsAdapter.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/edits/ViewEditsAdapter.kt
@@ -20,8 +20,6 @@ import androidx.recyclerview.widget.RecyclerView
 import app.pachli.R
 import app.pachli.adapter.PollAdapter
 import app.pachli.adapter.PollAdapter.DisplayMode
-import app.pachli.core.activity.decodeBlurHash
-import app.pachli.core.activity.emojify
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
 import app.pachli.core.common.extensions.visible
@@ -31,6 +29,8 @@ import app.pachli.core.network.model.StatusEdit
 import app.pachli.core.network.parseAsMastodonHtml
 import app.pachli.core.ui.BindingHolder
 import app.pachli.core.ui.LinkListener
+import app.pachli.core.ui.decodeBlurHash
+import app.pachli.core.ui.emojify
 import app.pachli.core.ui.setClickableText
 import app.pachli.databinding.ItemStatusEditBinding
 import app.pachli.util.aspectRatios

--- a/app/src/main/java/app/pachli/components/viewthread/edits/ViewEditsFragment.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/edits/ViewEditsFragment.kt
@@ -31,9 +31,7 @@ import androidx.recyclerview.widget.SimpleItemAnimator
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout.OnRefreshListener
 import app.pachli.R
 import app.pachli.core.activity.BottomSheetActivity
-import app.pachli.core.activity.emojify
 import app.pachli.core.activity.extensions.startActivityWithDefaultTransition
-import app.pachli.core.activity.loadAvatar
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
 import app.pachli.core.common.extensions.viewBinding
@@ -44,6 +42,8 @@ import app.pachli.core.navigation.TimelineActivityIntent
 import app.pachli.core.preferences.SharedPreferencesRepository
 import app.pachli.core.ui.BackgroundMessage
 import app.pachli.core.ui.LinkListener
+import app.pachli.core.ui.emojify
+import app.pachli.core.ui.loadAvatar
 import app.pachli.databinding.FragmentViewEditsBinding
 import com.google.android.material.color.MaterialColors
 import com.google.android.material.divider.MaterialDividerItemDecoration

--- a/app/src/main/java/app/pachli/util/StatusViewHelper.kt
+++ b/app/src/main/java/app/pachli/util/StatusViewHelper.kt
@@ -24,8 +24,6 @@ import android.widget.ImageView
 import android.widget.TextView
 import androidx.core.graphics.drawable.toDrawable
 import app.pachli.R
-import app.pachli.core.activity.decodeBlurHash
-import app.pachli.core.activity.emojify
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
 import app.pachli.core.common.util.AbsoluteTimeFormatter
@@ -34,6 +32,8 @@ import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.network.model.Attachment
 import app.pachli.core.network.model.Emoji
 import app.pachli.core.network.model.Status
+import app.pachli.core.ui.decodeBlurHash
+import app.pachli.core.ui.emojify
 import app.pachli.view.MediaPreviewImageView
 import app.pachli.viewdata.PollViewData
 import app.pachli.viewdata.buildDescription

--- a/app/src/main/java/app/pachli/view/PreviewCardView.kt
+++ b/app/src/main/java/app/pachli/view/PreviewCardView.kt
@@ -26,8 +26,6 @@ import android.widget.LinearLayout
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.text.HtmlCompat
 import app.pachli.R
-import app.pachli.core.activity.decodeBlurHash
-import app.pachli.core.activity.emojify
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
 import app.pachli.core.common.string.unicodeWrap
@@ -36,6 +34,8 @@ import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.designsystem.R as DR
 import app.pachli.core.network.model.PreviewCard
 import app.pachli.core.network.model.TrendsLink
+import app.pachli.core.ui.decodeBlurHash
+import app.pachli.core.ui.emojify
 import app.pachli.databinding.PreviewCardBinding
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.MultiTransformation

--- a/core/activity/build.gradle.kts
+++ b/core/activity/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     implementation(projects.core.network)
 
     implementation(projects.core.preferences)
+    implementation(projects.core.ui)
 
     implementation(libs.bundles.androidx)
 

--- a/core/activity/src/main/kotlin/app/pachli/core/activity/AccountSelectionAdapter.kt
+++ b/core/activity/src/main/kotlin/app/pachli/core/activity/AccountSelectionAdapter.kt
@@ -25,6 +25,8 @@ import android.widget.ArrayAdapter
 import app.pachli.core.activity.databinding.ItemAutocompleteAccountBinding
 import app.pachli.core.database.model.AccountEntity
 import app.pachli.core.designsystem.R as DR
+import app.pachli.core.ui.emojify
+import app.pachli.core.ui.loadAvatar
 
 class AccountSelectionAdapter(
     context: Context,

--- a/core/activity/src/test/kotlin/app/pachli/core/activity/UrlMatchingTests.kt
+++ b/core/activity/src/test/kotlin/app/pachli/core/activity/UrlMatchingTests.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2025 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.core.activity
+
+import app.pachli.core.activity.BottomSheetActivity.Companion.looksLikeMastodonUrl
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+class UrlMatchingTests(private val url: String, private val expectedResult: Boolean) {
+    companion object {
+        @Parameterized.Parameters(name = "match_{0}")
+        @JvmStatic
+        fun data(): Iterable<Any> {
+            return listOf(
+                arrayOf("https://mastodon.foo.bar/@User", true),
+                arrayOf("http://mastodon.foo.bar/@abc123", true),
+                arrayOf("https://mastodon.foo.bar/@user/345667890345678", true),
+                arrayOf("https://mastodon.foo.bar/@user/3", true),
+                arrayOf("https://mastodon.foo.bar/users/User/statuses/43456787654678", true),
+                arrayOf("https://pleroma.foo.bar/users/meh3223", true),
+                arrayOf("https://pleroma.foo.bar/users/meh3223_bruh", true),
+                arrayOf("https://pleroma.foo.bar/users/2345", true),
+                arrayOf("https://pleroma.foo.bar/notice/9", true),
+                arrayOf("https://pleroma.foo.bar/notice/9345678", true),
+                arrayOf("https://pleroma.foo.bar/notice/wat", true),
+                arrayOf("https://pleroma.foo.bar/notice/9qTHT2ANWUdXzENqC0", true),
+                arrayOf("https://pleroma.foo.bar/objects/abcdef-123-abcd-9876543", true),
+                arrayOf("https://misskey.foo.bar/notes/mew", true),
+                arrayOf("https://misskey.foo.bar/notes/1421564653", true),
+                arrayOf("https://misskey.foo.bar/notes/qwer615985ddf", true),
+                arrayOf("https://friendica.foo.bar/profile/user", true),
+                arrayOf("https://friendica.foo.bar/profile/uSeR", true),
+                arrayOf("https://friendica.foo.bar/profile/user_user", true),
+                arrayOf("https://friendica.foo.bar/profile/123", true),
+                arrayOf("https://friendica.foo.bar/display/abcdef-123-abcd-9876543", true),
+                arrayOf("https://google.com/", false),
+                arrayOf("https://mastodon.foo.bar/@User?foo=bar", false),
+                arrayOf("https://mastodon.foo.bar/@User#foo", false),
+                arrayOf("http://mastodon.foo.bar/@", false),
+                arrayOf("http://mastodon.foo.bar/@/345678", false),
+                arrayOf("https://mastodon.foo.bar/@user/345667890345678/", false),
+                arrayOf("https://mastodon.foo.bar/@user/3abce", false),
+                arrayOf("https://pleroma.foo.bar/users/", false),
+                arrayOf("https://pleroma.foo.bar/users/meow/", false),
+                arrayOf("https://pleroma.foo.bar/users/@meow", false),
+                arrayOf("https://pleroma.foo.bar/user/2345", false),
+                arrayOf("https://pleroma.foo.bar/notices/123456", false),
+                arrayOf("https://pleroma.foo.bar/notice/@neverhappen/", false),
+                arrayOf("https://pleroma.foo.bar/object/abcdef-123-abcd-9876543", false),
+                arrayOf("https://pleroma.foo.bar/objects/xabcdef-123-abcd-9876543", false),
+                arrayOf("https://pleroma.foo.bar/objects/xabcdef-123-abcd-9876543/", false),
+                arrayOf("https://pleroma.foo.bar/objects/xabcdef-123-abcd_9876543", false),
+                arrayOf("https://friendica.foo.bar/display/xabcdef-123-abcd-9876543", false),
+                arrayOf("https://friendica.foo.bar/display/xabcdef-123-abcd-9876543/", false),
+                arrayOf("https://friendica.foo.bar/display/xabcdef-123-abcd_9876543", false),
+                arrayOf("https://friendica.foo.bar/profile/@mew", false),
+                arrayOf("https://friendica.foo.bar/profile/@mew/", false),
+                arrayOf("https://misskey.foo.bar/notes/@nyan", false),
+                arrayOf("https://misskey.foo.bar/notes/NYAN123", false),
+                arrayOf("https://misskey.foo.bar/notes/meow123/", false),
+                arrayOf("https://pixelfed.social/p/connyduck/391263492998670833", true),
+                arrayOf("https://pixelfed.social/connyduck", true),
+                arrayOf("https://gts.foo.bar/@goblin/statuses/01GH9XANCJ0TA8Y95VE9H3Y0Q2", true),
+                arrayOf("https://gts.foo.bar/@goblin", true),
+                arrayOf("https://foo.microblog.pub/o/5b64045effd24f48a27d7059f6cb38f5", true),
+            )
+        }
+    }
+
+    @Test
+    fun test() {
+        Assert.assertEquals(expectedResult, looksLikeMastodonUrl(url))
+    }
+}

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -31,9 +31,8 @@ android {
 }
 
 dependencies {
-    // Calls "openLink" from projects.core.activity
-    implementation(projects.core.activity)
     implementation(projects.core.common)
+    implementation(projects.core.data)
     implementation(projects.core.designsystem)
     implementation(projects.core.preferences)
         ?.because("PreferenceEnum types in EnumListPreference")
@@ -42,6 +41,9 @@ dependencies {
         ?.because("Uses HttpException")
     implementation(projects.core.network)
         ?.because("ThrowableExtensions uses getServerErrorMessage")
+
+    implementation(libs.bundles.glide)
+        ?.because("Loads account avatars and emojis")
 
     // Uses JsonDataException from Moshi
     implementation(libs.moshi)

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/CustomEmojiHelper.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/CustomEmojiHelper.kt
@@ -15,7 +15,7 @@
  * see <http://www.gnu.org/licenses>.
  */
 
-package app.pachli.core.activity
+package app.pachli.core.ui
 
 import android.graphics.Canvas
 import android.graphics.Paint

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/ImageLoadingHelper.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/ImageLoadingHelper.kt
@@ -15,7 +15,7 @@
  * see <http://www.gnu.org/licenses>.
  */
 
-package app.pachli.core.activity
+package app.pachli.core.ui
 
 import android.content.Context
 import android.graphics.Bitmap

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/LinkHelper.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/LinkHelper.kt
@@ -24,7 +24,6 @@ import android.widget.TextView
 import androidx.annotation.VisibleForTesting
 import androidx.core.net.toUri
 import androidx.core.text.method.LinkMovementMethodCompat
-import app.pachli.core.activity.EmojiSpan
 import app.pachli.core.network.model.HashTag
 import app.pachli.core.network.model.Status.Mention
 import com.mikepenz.iconics.IconicsColor

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/SetStatusContent.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/SetStatusContent.kt
@@ -23,7 +23,6 @@ import android.text.style.URLSpan
 import android.util.TypedValue
 import android.widget.TextView
 import androidx.core.text.method.LinkMovementMethodCompat
-import app.pachli.core.activity.emojify
 import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.designsystem.R
 import app.pachli.core.network.model.Emoji

--- a/core/ui/src/test/kotlin/app/pachli/core/ui/LinkHelperTest.kt
+++ b/core/ui/src/test/kotlin/app/pachli/core/ui/LinkHelperTest.kt
@@ -23,13 +23,11 @@ import android.text.style.URLSpan
 import android.widget.TextView
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
-import app.pachli.core.activity.BottomSheetActivity.Companion.looksLikeMastodonUrl
 import app.pachli.core.network.model.HashTag
 import app.pachli.core.network.model.Status
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
 
 @RunWith(AndroidJUnit4::class)
 class LinkHelperTest {
@@ -325,74 +323,6 @@ class LinkHelperTest {
         val markedUpContent = markupHiddenUrls(textView, builder)
         for (tag in tags) {
             Assert.assertFalse(markedUpContent.contains("${getDomain(tag.url)})"))
-        }
-    }
-
-    @RunWith(Parameterized::class)
-    class UrlMatchingTests(private val url: String, private val expectedResult: Boolean) {
-        companion object {
-            @Parameterized.Parameters(name = "match_{0}")
-            @JvmStatic
-            fun data(): Iterable<Any> {
-                return listOf(
-                    arrayOf("https://mastodon.foo.bar/@User", true),
-                    arrayOf("http://mastodon.foo.bar/@abc123", true),
-                    arrayOf("https://mastodon.foo.bar/@user/345667890345678", true),
-                    arrayOf("https://mastodon.foo.bar/@user/3", true),
-                    arrayOf("https://mastodon.foo.bar/users/User/statuses/43456787654678", true),
-                    arrayOf("https://pleroma.foo.bar/users/meh3223", true),
-                    arrayOf("https://pleroma.foo.bar/users/meh3223_bruh", true),
-                    arrayOf("https://pleroma.foo.bar/users/2345", true),
-                    arrayOf("https://pleroma.foo.bar/notice/9", true),
-                    arrayOf("https://pleroma.foo.bar/notice/9345678", true),
-                    arrayOf("https://pleroma.foo.bar/notice/wat", true),
-                    arrayOf("https://pleroma.foo.bar/notice/9qTHT2ANWUdXzENqC0", true),
-                    arrayOf("https://pleroma.foo.bar/objects/abcdef-123-abcd-9876543", true),
-                    arrayOf("https://misskey.foo.bar/notes/mew", true),
-                    arrayOf("https://misskey.foo.bar/notes/1421564653", true),
-                    arrayOf("https://misskey.foo.bar/notes/qwer615985ddf", true),
-                    arrayOf("https://friendica.foo.bar/profile/user", true),
-                    arrayOf("https://friendica.foo.bar/profile/uSeR", true),
-                    arrayOf("https://friendica.foo.bar/profile/user_user", true),
-                    arrayOf("https://friendica.foo.bar/profile/123", true),
-                    arrayOf("https://friendica.foo.bar/display/abcdef-123-abcd-9876543", true),
-                    arrayOf("https://google.com/", false),
-                    arrayOf("https://mastodon.foo.bar/@User?foo=bar", false),
-                    arrayOf("https://mastodon.foo.bar/@User#foo", false),
-                    arrayOf("http://mastodon.foo.bar/@", false),
-                    arrayOf("http://mastodon.foo.bar/@/345678", false),
-                    arrayOf("https://mastodon.foo.bar/@user/345667890345678/", false),
-                    arrayOf("https://mastodon.foo.bar/@user/3abce", false),
-                    arrayOf("https://pleroma.foo.bar/users/", false),
-                    arrayOf("https://pleroma.foo.bar/users/meow/", false),
-                    arrayOf("https://pleroma.foo.bar/users/@meow", false),
-                    arrayOf("https://pleroma.foo.bar/user/2345", false),
-                    arrayOf("https://pleroma.foo.bar/notices/123456", false),
-                    arrayOf("https://pleroma.foo.bar/notice/@neverhappen/", false),
-                    arrayOf("https://pleroma.foo.bar/object/abcdef-123-abcd-9876543", false),
-                    arrayOf("https://pleroma.foo.bar/objects/xabcdef-123-abcd-9876543", false),
-                    arrayOf("https://pleroma.foo.bar/objects/xabcdef-123-abcd-9876543/", false),
-                    arrayOf("https://pleroma.foo.bar/objects/xabcdef-123-abcd_9876543", false),
-                    arrayOf("https://friendica.foo.bar/display/xabcdef-123-abcd-9876543", false),
-                    arrayOf("https://friendica.foo.bar/display/xabcdef-123-abcd-9876543/", false),
-                    arrayOf("https://friendica.foo.bar/display/xabcdef-123-abcd_9876543", false),
-                    arrayOf("https://friendica.foo.bar/profile/@mew", false),
-                    arrayOf("https://friendica.foo.bar/profile/@mew/", false),
-                    arrayOf("https://misskey.foo.bar/notes/@nyan", false),
-                    arrayOf("https://misskey.foo.bar/notes/NYAN123", false),
-                    arrayOf("https://misskey.foo.bar/notes/meow123/", false),
-                    arrayOf("https://pixelfed.social/p/connyduck/391263492998670833", true),
-                    arrayOf("https://pixelfed.social/connyduck", true),
-                    arrayOf("https://gts.foo.bar/@goblin/statuses/01GH9XANCJ0TA8Y95VE9H3Y0Q2", true),
-                    arrayOf("https://gts.foo.bar/@goblin", true),
-                    arrayOf("https://foo.microblog.pub/o/5b64045effd24f48a27d7059f6cb38f5", true),
-                )
-            }
-        }
-
-        @Test
-        fun test() {
-            Assert.assertEquals(expectedResult, looksLikeMastodonUrl(url))
         }
     }
 }

--- a/feature/lists/src/main/kotlin/app/pachli/feature/lists/AccountsInListFragment.kt
+++ b/feature/lists/src/main/kotlin/app/pachli/feature/lists/AccountsInListFragment.kt
@@ -32,8 +32,6 @@ import androidx.recyclerview.widget.DefaultItemAnimator
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.ListAdapter
-import app.pachli.core.activity.emojify
-import app.pachli.core.activity.loadAvatar
 import app.pachli.core.common.PachliError
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
@@ -46,6 +44,8 @@ import app.pachli.core.network.model.TimelineAccount
 import app.pachli.core.network.retrofit.apiresult.ApiError
 import app.pachli.core.preferences.SharedPreferencesRepository
 import app.pachli.core.ui.BindingHolder
+import app.pachli.core.ui.emojify
+import app.pachli.core.ui.loadAvatar
 import app.pachli.feature.lists.databinding.FragmentAccountsInListBinding
 import app.pachli.feature.lists.databinding.ItemAccountInListBinding
 import com.github.michaelbull.result.Result

--- a/feature/suggestions/src/main/kotlin/app/pachli/feature/suggestions/SuggestionsAdapter.kt
+++ b/feature/suggestions/src/main/kotlin/app/pachli/feature/suggestions/SuggestionsAdapter.kt
@@ -27,8 +27,6 @@ import androidx.core.view.children
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import app.pachli.core.activity.emojify
-import app.pachli.core.activity.loadAvatar
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
 import app.pachli.core.common.extensions.visible
@@ -37,6 +35,8 @@ import app.pachli.core.common.util.formatNumber
 import app.pachli.core.data.model.Suggestion
 import app.pachli.core.network.parseAsMastodonHtml
 import app.pachli.core.ui.LinkListener
+import app.pachli.core.ui.emojify
+import app.pachli.core.ui.loadAvatar
 import app.pachli.core.ui.setClickableText
 import app.pachli.feature.suggestions.SuggestionViewHolder.ChangePayload
 import app.pachli.feature.suggestions.UiAction.NavigationAction


### PR DESCRIPTION
This makes them available to (future) code that doesn't inherit from BaseActivity.