### PR TITLE
fix: Show translated posts / media descriptions when viewing threads

### DIFF
--- a/app/src/main/java/app/pachli/components/viewthread/ViewThreadFragment.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/ViewThreadFragment.kt
@@ -42,9 +42,10 @@ import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
 import app.pachli.core.common.extensions.viewBinding
 import app.pachli.core.data.model.StatusViewData
+import app.pachli.core.database.model.TranslationState
 import app.pachli.core.designsystem.R as DR
 import app.pachli.core.navigation.AccountListActivityIntent
-import app.pachli.core.navigation.AttachmentViewData.Companion.list
+import app.pachli.core.navigation.AttachmentViewData
 import app.pachli.core.navigation.EditContentFilterActivityIntent
 import app.pachli.core.network.model.Poll
 import app.pachli.core.network.model.Status
@@ -77,7 +78,7 @@ class ViewThreadFragment :
     private val binding by viewBinding(FragmentViewThreadBinding::bind)
 
     private lateinit var adapter: ThreadAdapter
-    private lateinit var thisThreadsStatusId: String
+    private val thisThreadsStatusId by lazy { requireArguments().getString(ARG_ID)!! }
 
     override var pachliAccountId by Delegates.notNull<Long>()
 
@@ -94,7 +95,6 @@ class ViewThreadFragment :
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         pachliAccountId = requireArguments().getLong(ARG_PACHLI_ACCOUNT_ID)
-        thisThreadsStatusId = requireArguments().getString(ARG_ID)!!
 
         val setStatusContent = if (viewModel.statusDisplayOptions.value.renderMarkdown) {
             SetMarkdownContent(requireContext())
@@ -320,12 +320,18 @@ class ViewThreadFragment :
     }
 
     override fun onViewMedia(viewData: StatusViewData, attachmentIndex: Int, view: View?) {
-        super.viewMedia(
-            viewData.username,
-            attachmentIndex,
-            list(viewData.actionable, viewModel.statusDisplayOptions.value.showSensitiveMedia),
-            view,
-        )
+        // Pass the translated media descriptions through (if appropriate)
+        val actionable = if (viewData.translationState == TranslationState.SHOW_TRANSLATION) {
+            viewData.actionable.copy(
+                attachments = viewData.translation?.attachments?.zip(viewData.actionable.attachments) { t, a ->
+                    a.copy(description = t.description)
+                } ?: viewData.actionable.attachments,
+            )
+        } else {
+            viewData.actionable
+        }
+
+        super.viewMedia(actionable.account.username, attachmentIndex, AttachmentViewData.list(actionable), view)
     }
 
     override fun onViewThread(status: Status) {


### PR DESCRIPTION
Previous code didn't fetch the translation state or data from the database when viewing a thread, so statuses that were translated on a timeline were not translated in a thread. This also applied to any translated media descriptions.

Fix this by fetching the local translation info and merging with the network data, and by ensuring translated media descriptions are passed in onViewMedia.

Fixes #1483