### PR TITLE
refactor: Simplify list of visible notification types

### DIFF
--- a/core/network/src/main/kotlin/app/pachli/core/network/model/Notification.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/Notification.kt
@@ -95,19 +95,7 @@ data class Notification(
             fun byString(s: String) = entries.firstOrNull { s == it.presentation } ?: UNKNOWN
 
             /** Notification types for UI display (omits UNKNOWN) */
-            val visibleTypes = listOf(
-                MENTION,
-                REBLOG,
-                FAVOURITE,
-                FOLLOW,
-                FOLLOW_REQUEST,
-                POLL,
-                STATUS,
-                SIGN_UP,
-                UPDATE,
-                REPORT,
-                SEVERED_RELATIONSHIPS,
-            )
+            val visibleTypes = Type.entries.filter { it != UNKNOWN }
         }
 
         override fun toString(): String {


### PR DESCRIPTION
Previous code listed them in full, omitting `UNKNOWN`. This makes it possible to inadvertently forget to update this list when new notification types are created.

Rewrite to use all types, explicitly filtered to omit `UNKNOWN`, to prevent this.