### PR TITLE
refactor: Rename LoginResult subclasses

### DIFF
--- a/feature/login/src/main/kotlin/app/pachli/feature/login/LoginActivity.kt
+++ b/feature/login/src/main/kotlin/app/pachli/feature/login/LoginActivity.kt
@@ -82,10 +82,11 @@ class LoginActivity : BaseActivity() {
 
     private val doWebViewAuth = registerForActivityResult(OauthLogin()) { result ->
         when (result) {
-            is LoginResult.Ok -> lifecycleScope.launch {
+            is LoginResult.Code -> lifecycleScope.launch {
                 fetchOauthToken(result.code)
             }
-            is LoginResult.Err -> displayError(result.errorMessage)
+
+            is LoginResult.Error -> displayError(result.errorMessage)
             is LoginResult.Cancel -> setLoading(false)
         }
     }
@@ -175,9 +176,7 @@ class LoginActivity : BaseActivity() {
         }
     }
 
-    override fun requiresLogin(): Boolean {
-        return false
-    }
+    override fun requiresLogin() = false
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {
         menu?.add(R.string.action_browser_login)?.apply {


### PR DESCRIPTION
Rename to Code and Error so they don't class with the `Result` type used through the rest of the code.