### PR TITLE
refactor: Move core.data.model.InstanceInfo to core.model

### DIFF
--- a/app/src/main/java/app/pachli/EditProfileActivity.kt
+++ b/app/src/main/java/app/pachli/EditProfileActivity.kt
@@ -38,8 +38,8 @@ import app.pachli.adapter.AccountFieldEditAdapter
 import app.pachli.core.activity.BaseActivity
 import app.pachli.core.common.extensions.show
 import app.pachli.core.common.extensions.viewBinding
-import app.pachli.core.data.model.InstanceInfo.Companion.DEFAULT_MAX_ACCOUNT_FIELDS
 import app.pachli.core.designsystem.R as DR
+import app.pachli.core.model.InstanceInfo.Companion.DEFAULT_MAX_ACCOUNT_FIELDS
 import app.pachli.core.navigation.pachliAccountId
 import app.pachli.core.ui.extensions.await
 import app.pachli.core.ui.extensions.getErrorString

--- a/app/src/main/java/app/pachli/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeActivity.kt
@@ -80,11 +80,11 @@ import app.pachli.core.common.extensions.viewBinding
 import app.pachli.core.common.extensions.visible
 import app.pachli.core.common.string.mastodonLength
 import app.pachli.core.common.util.unsafeLazy
-import app.pachli.core.data.model.InstanceInfo.Companion.DEFAULT_CHARACTER_LIMIT
-import app.pachli.core.data.model.InstanceInfo.Companion.DEFAULT_MAX_MEDIA_ATTACHMENTS
 import app.pachli.core.data.repository.Loadable
 import app.pachli.core.database.model.AccountEntity
 import app.pachli.core.designsystem.R as DR
+import app.pachli.core.model.InstanceInfo.Companion.DEFAULT_CHARACTER_LIMIT
+import app.pachli.core.model.InstanceInfo.Companion.DEFAULT_MAX_MEDIA_ATTACHMENTS
 import app.pachli.core.navigation.ComposeActivityIntent
 import app.pachli.core.navigation.ComposeActivityIntent.ComposeOptions
 import app.pachli.core.navigation.ComposeActivityIntent.ComposeOptions.InReplyTo

--- a/app/src/main/java/app/pachli/components/compose/MediaUploader.kt
+++ b/app/src/main/java/app/pachli/components/compose/MediaUploader.kt
@@ -33,7 +33,7 @@ import app.pachli.components.compose.UploadState.Uploaded
 import app.pachli.core.common.PachliError
 import app.pachli.core.common.string.randomAlphanumericString
 import app.pachli.core.common.util.formatNumber
-import app.pachli.core.data.model.InstanceInfo
+import app.pachli.core.model.InstanceInfo
 import app.pachli.core.network.model.MediaUploadApi
 import app.pachli.core.network.retrofit.apiresult.ApiError
 import app.pachli.util.MEDIA_SIZE_UNKNOWN

--- a/app/src/test/java/app/pachli/components/compose/ComposeActivityTest.kt
+++ b/app/src/test/java/app/pachli/components/compose/ComposeActivityTest.kt
@@ -22,11 +22,11 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.pachli.PachliApplication
 import app.pachli.R
-import app.pachli.core.data.model.InstanceInfo.Companion.DEFAULT_CHARACTERS_RESERVED_PER_URL
-import app.pachli.core.data.model.InstanceInfo.Companion.DEFAULT_CHARACTER_LIMIT
 import app.pachli.core.data.repository.AccountManager
 import app.pachli.core.data.repository.InstanceInfoRepository
 import app.pachli.core.database.AppDatabase
+import app.pachli.core.model.InstanceInfo.Companion.DEFAULT_CHARACTERS_RESERVED_PER_URL
+import app.pachli.core.model.InstanceInfo.Companion.DEFAULT_CHARACTER_LIMIT
 import app.pachli.core.navigation.ComposeActivityIntent
 import app.pachli.core.navigation.ComposeActivityIntent.ComposeOptions
 import app.pachli.core.network.model.Account

--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/AccountManager.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/AccountManager.kt
@@ -667,10 +667,8 @@ class AccountManager @Inject constructor(
     private suspend fun fetchInstanceInfo(domain: String): Result<InstanceInfoEntity, ApiError> {
         // TODO: InstanceInfoEntity needs to gain support for recording translation
         return mastodonApi.getInstanceV2()
-            .map { InstanceInfoEntity.make(domain, it.body) }
-            .orElse {
-                mastodonApi.getInstanceV1().map { InstanceInfoEntity.make(domain, it.body) }
-            }
+            .map { it.body.asEntity(domain) }
+            .orElse { mastodonApi.getInstanceV1().map { it.body.asEntity(domain) } }
     }
 
     /**

--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/InstanceInfoRepository.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/InstanceInfoRepository.kt
@@ -19,16 +19,22 @@ package app.pachli.core.data.repository
 
 import androidx.annotation.VisibleForTesting
 import app.pachli.core.common.di.ApplicationScope
-import app.pachli.core.data.model.InstanceInfo
-import app.pachli.core.data.model.InstanceInfo.Companion.DEFAULT_CHARACTER_LIMIT
 import app.pachli.core.database.dao.InstanceDao
 import app.pachli.core.database.model.AccountEntity
 import app.pachli.core.database.model.EmojisEntity
 import app.pachli.core.database.model.InstanceInfoEntity
+import app.pachli.core.database.model.asModel
+import app.pachli.core.model.InstanceInfo
+import app.pachli.core.model.InstanceInfo.Companion.DEFAULT_CHARACTER_LIMIT
+import app.pachli.core.model.InstanceInfo.Companion.DEFAULT_MAX_ACCOUNT_FIELDS
 import app.pachli.core.network.model.Emoji
+import app.pachli.core.network.model.InstanceV1
+import app.pachli.core.network.model.InstanceV2
 import app.pachli.core.network.retrofit.MastodonApi
+import com.github.michaelbull.result.map
 import com.github.michaelbull.result.mapBoth
 import com.github.michaelbull.result.onSuccess
+import com.github.michaelbull.result.orElse
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineScope
@@ -121,32 +127,74 @@ class InstanceInfoRepository @Inject constructor(
     }
 
     /**
-     * Returns information about the instance.
-     * Will always try to fetch the most up-to-date data from the api, falls back to cache in case it is not available.
-     * Never throws, returns defaults of vanilla Mastodon in case of error.
+     * Refreshes the local cache of instance info, and returns it.
+     *
+     * If the network call fails then returns the cached copy. If there is no cached copy
+     * then returns vanilla defaults.
      */
     private suspend fun getInstanceInfo(domain: String): InstanceInfo {
-        api.getInstanceV1().onSuccess { result ->
-            val instance = result.body
-            val instanceEntity = InstanceInfoEntity(
-                instance = domain,
-                maxPostCharacters = instance.configuration.statuses.maxCharacters ?: instance.maxTootChars ?: DEFAULT_CHARACTER_LIMIT,
-                maxPollOptions = instance.configuration.polls.maxOptions,
-                maxPollOptionLength = instance.configuration.polls.maxCharactersPerOption,
-                minPollDuration = instance.configuration.polls.minExpiration,
-                maxPollDuration = instance.configuration.polls.maxExpiration,
-                charactersReservedPerUrl = instance.configuration.statuses.charactersReservedPerUrl,
-                version = instance.version,
-                videoSizeLimit = instance.configuration.mediaAttachments.videoSizeLimit,
-                imageSizeLimit = instance.configuration.mediaAttachments.imageSizeLimit,
-                imageMatrixLimit = instance.configuration.mediaAttachments.imageMatrixLimit,
-                maxMediaAttachments = instance.configuration.statuses.maxMediaAttachments,
-                maxFields = instance.pleroma?.metadata?.fieldLimits?.maxFields,
-                maxFieldNameLength = instance.pleroma?.metadata?.fieldLimits?.nameLength,
-                maxFieldValueLength = instance.pleroma?.metadata?.fieldLimits?.valueLength,
-            )
-            instanceDao.upsert(instanceEntity)
-        }
-        return instanceDao.getInstanceInfo(domain)?.let { InstanceInfo.from(it) } ?: InstanceInfo()
+        return api.getInstanceV2()
+            .map { it.body.asEntity(domain) }
+            .orElse { api.getInstanceV1().map { it.body.asEntity(domain) } }
+            .onSuccess { instanceDao.upsert(it) }
+            .mapBoth({ it.asModel() }, { InstanceInfo() })
     }
 }
+
+/**
+ * Returns [InstanceInfoEntity] for this [InstanceV1].
+ *
+ * There's no guarantee the [InstanceV1.uri] field will be just the domain, as some
+ * servers return URLs or possibly other junk (https://akkoma.dev/AkkomaGang/akkoma/issues/907,
+ * https://activitypub.software/TransFem-org/Sharkey/-/issues/1046), so require the
+ * caller to explicitly provide the domain to use as the primary key for this entity.
+ *
+ * @param domain Primary key for this domain
+ */
+fun InstanceV1.asEntity(domain: String) = InstanceInfoEntity(
+    instance = domain,
+    maxPostCharacters = configuration.statuses.maxCharacters ?: maxTootChars ?: DEFAULT_CHARACTER_LIMIT,
+    maxPollOptions = configuration.polls.maxOptions,
+    maxPollOptionLength = configuration.polls.maxCharactersPerOption,
+    minPollDuration = configuration.polls.minExpiration,
+    maxPollDuration = configuration.polls.maxExpiration,
+    charactersReservedPerUrl = configuration.statuses.charactersReservedPerUrl,
+    version = version,
+    videoSizeLimit = configuration.mediaAttachments.videoSizeLimit,
+    imageSizeLimit = configuration.mediaAttachments.imageSizeLimit,
+    imageMatrixLimit = configuration.mediaAttachments.imageMatrixLimit,
+    maxMediaAttachments = configuration.statuses.maxMediaAttachments,
+    maxFields = pleroma?.metadata?.fieldLimits?.maxFields ?: DEFAULT_MAX_ACCOUNT_FIELDS,
+    maxFieldNameLength = null,
+    maxFieldValueLength = null,
+    enabledTranslation = false,
+)
+
+/**
+ * Returns [InstanceInfoEntity] for this [InstanceV2].
+ *
+ * There's no guarantee the [InstanceV2.domain] field will be just the domain, as some
+ * servers return URLs or possibly other junk (https://akkoma.dev/AkkomaGang/akkoma/issues/907,
+ * https://activitypub.software/TransFem-org/Sharkey/-/issues/1046), so require the
+ * caller to explicitly provide the domain to use as the primary key for this entity.
+ *
+ * @param domain Primary key for this domain
+ */
+fun InstanceV2.asEntity(domain: String) = InstanceInfoEntity(
+    instance = domain,
+    maxPostCharacters = configuration.statuses.maxCharacters,
+    maxPollOptions = configuration.polls.maxOptions,
+    maxPollOptionLength = configuration.polls.maxCharactersPerOption,
+    minPollDuration = configuration.polls.minExpiration,
+    maxPollDuration = configuration.polls.maxExpiration,
+    charactersReservedPerUrl = configuration.statuses.charactersReservedPerUrl,
+    version = version,
+    videoSizeLimit = configuration.mediaAttachments.videoSizeLimit,
+    imageSizeLimit = configuration.mediaAttachments.imageSizeLimit,
+    imageMatrixLimit = configuration.mediaAttachments.imageMatrixLimit,
+    maxMediaAttachments = configuration.statuses.maxMediaAttachments,
+    maxFields = DEFAULT_MAX_ACCOUNT_FIELDS,
+    maxFieldNameLength = null,
+    maxFieldValueLength = null,
+    enabledTranslation = configuration.translation.enabled,
+)

--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/PachliAccount.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/PachliAccount.kt
@@ -17,11 +17,12 @@
 
 package app.pachli.core.data.repository
 
-import app.pachli.core.data.model.InstanceInfo
 import app.pachli.core.data.model.MastodonList
 import app.pachli.core.data.model.Server
 import app.pachli.core.database.model.AccountEntity
 import app.pachli.core.database.model.FollowingAccountEntity
+import app.pachli.core.database.model.asModel
+import app.pachli.core.model.InstanceInfo
 import app.pachli.core.model.ServerKind
 import app.pachli.core.network.model.Announcement
 import app.pachli.core.network.model.Emoji
@@ -62,7 +63,7 @@ data class PachliAccount(
             return PachliAccount(
                 id = account.account.id,
                 entity = account.account,
-                instanceInfo = account.instanceInfo?.let { InstanceInfo.from(it) } ?: InstanceInfo(),
+                instanceInfo = account.instanceInfo.asModel(),
                 lists = account.lists.orEmpty().map { MastodonList.from(it) },
                 emojis = account.emojis?.emojiList.orEmpty(),
                 server = account.server?.let { Server.from(it) } ?: Server(ServerKind.MASTODON, Version(4, 0, 0)),

--- a/core/data/src/test/kotlin/app/pachli/core/data/repository/InstanceInfoRepositoryTest.kt
+++ b/core/data/src/test/kotlin/app/pachli/core/data/repository/InstanceInfoRepositoryTest.kt
@@ -19,8 +19,8 @@ package app.pachli.core.data.repository
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
-import app.pachli.core.data.model.InstanceInfo.Companion.DEFAULT_CHARACTER_LIMIT
 import app.pachli.core.database.AppDatabase
+import app.pachli.core.model.InstanceInfo.Companion.DEFAULT_CHARACTER_LIMIT
 import app.pachli.core.network.model.Account
 import app.pachli.core.network.model.InstanceConfiguration
 import app.pachli.core.network.model.InstanceV1
@@ -208,7 +208,7 @@ class InstanceInfoRepositoryTest {
 
     private fun getInstanceWithCustomConfiguration(maximumLegacyTootCharacters: Int? = null, configuration: InstanceConfiguration = InstanceConfiguration()): InstanceV1 {
         return InstanceV1(
-            uri = "https://example.token",
+            uri = "example.token",
             version = "2.6.3",
             maxTootChars = maximumLegacyTootCharacters,
             pollConfiguration = null,

--- a/core/database/schemas/app.pachli.core.database.AppDatabase/23.json
+++ b/core/database/schemas/app.pachli.core.database.AppDatabase/23.json
@@ -1,0 +1,1988 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 23,
+    "identityHash": "ba0625151c3d8b08e454272c7c08fa46",
+    "entities": [
+      {
+        "tableName": "DraftEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `accountId` INTEGER NOT NULL, `inReplyToId` TEXT, `content` TEXT, `contentWarning` TEXT, `sensitive` INTEGER NOT NULL, `visibility` INTEGER NOT NULL, `attachments` TEXT NOT NULL, `poll` TEXT, `failedToSend` INTEGER NOT NULL, `failedToSendNew` INTEGER NOT NULL, `scheduledAt` INTEGER, `language` TEXT, `statusId` TEXT, FOREIGN KEY(`accountId`) REFERENCES `AccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inReplyToId",
+            "columnName": "inReplyToId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "contentWarning",
+            "columnName": "contentWarning",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "sensitive",
+            "columnName": "sensitive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "visibility",
+            "columnName": "visibility",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attachments",
+            "columnName": "attachments",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "poll",
+            "columnName": "poll",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "failedToSend",
+            "columnName": "failedToSend",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "failedToSendNew",
+            "columnName": "failedToSendNew",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scheduledAt",
+            "columnName": "scheduledAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "statusId",
+            "columnName": "statusId",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_DraftEntity_accountId",
+            "unique": false,
+            "columnNames": [
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_DraftEntity_accountId` ON `${TABLE_NAME}` (`accountId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "AccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "AccountEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `domain` TEXT NOT NULL, `accessToken` TEXT NOT NULL, `clientId` TEXT NOT NULL, `clientSecret` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `accountId` TEXT NOT NULL, `username` TEXT NOT NULL, `displayName` TEXT NOT NULL, `profilePictureUrl` TEXT NOT NULL, `profileHeaderPictureUrl` TEXT NOT NULL DEFAULT '', `notificationsEnabled` INTEGER NOT NULL, `notificationsMentioned` INTEGER NOT NULL, `notificationsFollowed` INTEGER NOT NULL, `notificationsFollowRequested` INTEGER NOT NULL, `notificationsReblogged` INTEGER NOT NULL, `notificationsFavorited` INTEGER NOT NULL, `notificationsPolls` INTEGER NOT NULL, `notificationsSubscriptions` INTEGER NOT NULL, `notificationsSignUps` INTEGER NOT NULL, `notificationsUpdates` INTEGER NOT NULL, `notificationsReports` INTEGER NOT NULL, `notificationsSeveredRelationships` INTEGER NOT NULL DEFAULT true, `notificationSound` INTEGER NOT NULL, `notificationVibration` INTEGER NOT NULL, `notificationLight` INTEGER NOT NULL, `defaultPostPrivacy` INTEGER NOT NULL, `defaultMediaSensitivity` INTEGER NOT NULL, `defaultPostLanguage` TEXT NOT NULL, `alwaysShowSensitiveMedia` INTEGER NOT NULL, `alwaysOpenSpoiler` INTEGER NOT NULL, `mediaPreviewEnabled` INTEGER NOT NULL, `notificationMarkerId` TEXT NOT NULL DEFAULT '0', `emojis` TEXT NOT NULL, `tabPreferences` TEXT NOT NULL, `notificationsFilter` TEXT NOT NULL, `oauthScopes` TEXT NOT NULL, `unifiedPushUrl` TEXT NOT NULL, `pushPubKey` TEXT NOT NULL, `pushPrivKey` TEXT NOT NULL, `pushAuth` TEXT NOT NULL, `pushServerKey` TEXT NOT NULL, `locked` INTEGER NOT NULL DEFAULT 0, `notificationAccountFilterNotFollowed` TEXT NOT NULL DEFAULT 'NONE', `notificationAccountFilterYounger30d` TEXT NOT NULL DEFAULT 'NONE', `notificationAccountFilterLimitedByServer` TEXT NOT NULL DEFAULT 'NONE', `conversationAccountFilterNotFollowed` TEXT NOT NULL DEFAULT 'NONE', `conversationAccountFilterYounger30d` TEXT NOT NULL DEFAULT 'NONE', `conversationAccountFilterLimitedByServer` TEXT NOT NULL DEFAULT 'NONE')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "domain",
+            "columnName": "domain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessToken",
+            "columnName": "accessToken",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "clientId",
+            "columnName": "clientId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "clientSecret",
+            "columnName": "clientSecret",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profilePictureUrl",
+            "columnName": "profilePictureUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileHeaderPictureUrl",
+            "columnName": "profileHeaderPictureUrl",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "notificationsEnabled",
+            "columnName": "notificationsEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsMentioned",
+            "columnName": "notificationsMentioned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsFollowed",
+            "columnName": "notificationsFollowed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsFollowRequested",
+            "columnName": "notificationsFollowRequested",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsReblogged",
+            "columnName": "notificationsReblogged",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsFavorited",
+            "columnName": "notificationsFavorited",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsPolls",
+            "columnName": "notificationsPolls",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsSubscriptions",
+            "columnName": "notificationsSubscriptions",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsSignUps",
+            "columnName": "notificationsSignUps",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsUpdates",
+            "columnName": "notificationsUpdates",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsReports",
+            "columnName": "notificationsReports",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsSeveredRelationships",
+            "columnName": "notificationsSeveredRelationships",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "true"
+          },
+          {
+            "fieldPath": "notificationSound",
+            "columnName": "notificationSound",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationVibration",
+            "columnName": "notificationVibration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationLight",
+            "columnName": "notificationLight",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultPostPrivacy",
+            "columnName": "defaultPostPrivacy",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultMediaSensitivity",
+            "columnName": "defaultMediaSensitivity",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultPostLanguage",
+            "columnName": "defaultPostLanguage",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alwaysShowSensitiveMedia",
+            "columnName": "alwaysShowSensitiveMedia",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alwaysOpenSpoiler",
+            "columnName": "alwaysOpenSpoiler",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaPreviewEnabled",
+            "columnName": "mediaPreviewEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationMarkerId",
+            "columnName": "notificationMarkerId",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'0'"
+          },
+          {
+            "fieldPath": "emojis",
+            "columnName": "emojis",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tabPreferences",
+            "columnName": "tabPreferences",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsFilter",
+            "columnName": "notificationsFilter",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "oauthScopes",
+            "columnName": "oauthScopes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unifiedPushUrl",
+            "columnName": "unifiedPushUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pushPubKey",
+            "columnName": "pushPubKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pushPrivKey",
+            "columnName": "pushPrivKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pushAuth",
+            "columnName": "pushAuth",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pushServerKey",
+            "columnName": "pushServerKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locked",
+            "columnName": "locked",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "notificationAccountFilterNotFollowed",
+            "columnName": "notificationAccountFilterNotFollowed",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'NONE'"
+          },
+          {
+            "fieldPath": "notificationAccountFilterYounger30d",
+            "columnName": "notificationAccountFilterYounger30d",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'NONE'"
+          },
+          {
+            "fieldPath": "notificationAccountFilterLimitedByServer",
+            "columnName": "notificationAccountFilterLimitedByServer",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'NONE'"
+          },
+          {
+            "fieldPath": "conversationAccountFilterNotFollowed",
+            "columnName": "conversationAccountFilterNotFollowed",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'NONE'"
+          },
+          {
+            "fieldPath": "conversationAccountFilterYounger30d",
+            "columnName": "conversationAccountFilterYounger30d",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'NONE'"
+          },
+          {
+            "fieldPath": "conversationAccountFilterLimitedByServer",
+            "columnName": "conversationAccountFilterLimitedByServer",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'NONE'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_AccountEntity_domain_accountId",
+            "unique": true,
+            "columnNames": [
+              "domain",
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_AccountEntity_domain_accountId` ON `${TABLE_NAME}` (`domain`, `accountId`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "InstanceInfoEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`instance` TEXT NOT NULL, `maxPostCharacters` INTEGER NOT NULL, `maxPollOptions` INTEGER NOT NULL, `maxPollOptionLength` INTEGER NOT NULL, `minPollDuration` INTEGER NOT NULL, `maxPollDuration` INTEGER NOT NULL, `charactersReservedPerUrl` INTEGER NOT NULL, `version` TEXT NOT NULL, `videoSizeLimit` INTEGER NOT NULL, `imageSizeLimit` INTEGER NOT NULL, `imageMatrixLimit` INTEGER NOT NULL, `maxMediaAttachments` INTEGER NOT NULL, `maxFields` INTEGER NOT NULL, `maxFieldNameLength` INTEGER, `maxFieldValueLength` INTEGER, `enabledTranslation` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`instance`))",
+        "fields": [
+          {
+            "fieldPath": "instance",
+            "columnName": "instance",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxPostCharacters",
+            "columnName": "maxPostCharacters",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxPollOptions",
+            "columnName": "maxPollOptions",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxPollOptionLength",
+            "columnName": "maxPollOptionLength",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minPollDuration",
+            "columnName": "minPollDuration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxPollDuration",
+            "columnName": "maxPollDuration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "charactersReservedPerUrl",
+            "columnName": "charactersReservedPerUrl",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoSizeLimit",
+            "columnName": "videoSizeLimit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageSizeLimit",
+            "columnName": "imageSizeLimit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageMatrixLimit",
+            "columnName": "imageMatrixLimit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxMediaAttachments",
+            "columnName": "maxMediaAttachments",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxFields",
+            "columnName": "maxFields",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxFieldNameLength",
+            "columnName": "maxFieldNameLength",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "maxFieldValueLength",
+            "columnName": "maxFieldValueLength",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "enabledTranslation",
+            "columnName": "enabledTranslation",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "instance"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "EmojisEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountId` INTEGER NOT NULL, `emojiList` TEXT NOT NULL, PRIMARY KEY(`accountId`), FOREIGN KEY(`accountId`) REFERENCES `AccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "emojiList",
+            "columnName": "emojiList",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "accountId"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "AccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "StatusEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `url` TEXT, `timelineUserId` INTEGER NOT NULL, `authorServerId` TEXT NOT NULL, `inReplyToId` TEXT, `inReplyToAccountId` TEXT, `content` TEXT, `createdAt` INTEGER NOT NULL, `editedAt` INTEGER, `emojis` TEXT, `reblogsCount` INTEGER NOT NULL, `favouritesCount` INTEGER NOT NULL, `repliesCount` INTEGER NOT NULL, `reblogged` INTEGER NOT NULL, `bookmarked` INTEGER NOT NULL, `favourited` INTEGER NOT NULL, `sensitive` INTEGER NOT NULL, `spoilerText` TEXT NOT NULL, `visibility` INTEGER NOT NULL, `attachments` TEXT, `mentions` TEXT, `tags` TEXT, `application` TEXT, `reblogServerId` TEXT, `reblogAccountId` TEXT, `poll` TEXT, `muted` INTEGER, `pinned` INTEGER NOT NULL, `card` TEXT, `language` TEXT, `filtered` TEXT, PRIMARY KEY(`serverId`, `timelineUserId`), FOREIGN KEY(`timelineUserId`) REFERENCES `AccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED, FOREIGN KEY(`authorServerId`, `timelineUserId`) REFERENCES `TimelineAccountEntity`(`serverId`, `timelineUserId`) ON UPDATE NO ACTION ON DELETE NO ACTION DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "timelineUserId",
+            "columnName": "timelineUserId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authorServerId",
+            "columnName": "authorServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inReplyToId",
+            "columnName": "inReplyToId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "inReplyToAccountId",
+            "columnName": "inReplyToAccountId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "editedAt",
+            "columnName": "editedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "emojis",
+            "columnName": "emojis",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "reblogsCount",
+            "columnName": "reblogsCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favouritesCount",
+            "columnName": "favouritesCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repliesCount",
+            "columnName": "repliesCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reblogged",
+            "columnName": "reblogged",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarked",
+            "columnName": "bookmarked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favourited",
+            "columnName": "favourited",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sensitive",
+            "columnName": "sensitive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spoilerText",
+            "columnName": "spoilerText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "visibility",
+            "columnName": "visibility",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attachments",
+            "columnName": "attachments",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mentions",
+            "columnName": "mentions",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "application",
+            "columnName": "application",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "reblogServerId",
+            "columnName": "reblogServerId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "reblogAccountId",
+            "columnName": "reblogAccountId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "poll",
+            "columnName": "poll",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "muted",
+            "columnName": "muted",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pinned",
+            "columnName": "pinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "card",
+            "columnName": "card",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "filtered",
+            "columnName": "filtered",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "timelineUserId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_StatusEntity_authorServerId_timelineUserId",
+            "unique": false,
+            "columnNames": [
+              "authorServerId",
+              "timelineUserId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_StatusEntity_authorServerId_timelineUserId` ON `${TABLE_NAME}` (`authorServerId`, `timelineUserId`)"
+          },
+          {
+            "name": "index_StatusEntity_timelineUserId",
+            "unique": false,
+            "columnNames": [
+              "timelineUserId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_StatusEntity_timelineUserId` ON `${TABLE_NAME}` (`timelineUserId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "AccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "timelineUserId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "TimelineAccountEntity",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "authorServerId",
+              "timelineUserId"
+            ],
+            "referencedColumns": [
+              "serverId",
+              "timelineUserId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "TimelineAccountEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `timelineUserId` INTEGER NOT NULL, `localUsername` TEXT NOT NULL, `username` TEXT NOT NULL, `displayName` TEXT NOT NULL, `url` TEXT NOT NULL, `avatar` TEXT NOT NULL, `emojis` TEXT NOT NULL, `bot` INTEGER NOT NULL, `createdAt` INTEGER, `limited` INTEGER NOT NULL DEFAULT false, `note` TEXT NOT NULL DEFAULT '', PRIMARY KEY(`serverId`, `timelineUserId`), FOREIGN KEY(`timelineUserId`) REFERENCES `AccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timelineUserId",
+            "columnName": "timelineUserId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUsername",
+            "columnName": "localUsername",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatar",
+            "columnName": "avatar",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "emojis",
+            "columnName": "emojis",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bot",
+            "columnName": "bot",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "limited",
+            "columnName": "limited",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "timelineUserId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_TimelineAccountEntity_timelineUserId",
+            "unique": false,
+            "columnNames": [
+              "timelineUserId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_TimelineAccountEntity_timelineUserId` ON `${TABLE_NAME}` (`timelineUserId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "AccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "timelineUserId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "ConversationEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`pachliAccountId` INTEGER NOT NULL, `id` TEXT NOT NULL, `accounts` TEXT NOT NULL, `unread` INTEGER NOT NULL, `lastStatusServerId` TEXT NOT NULL DEFAULT '', `isConversationStarter` INTEGER NOT NULL DEFAULT 1, PRIMARY KEY(`id`, `pachliAccountId`), FOREIGN KEY(`pachliAccountId`) REFERENCES `AccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "pachliAccountId",
+            "columnName": "pachliAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accounts",
+            "columnName": "accounts",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unread",
+            "columnName": "unread",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastStatusServerId",
+            "columnName": "lastStatusServerId",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "isConversationStarter",
+            "columnName": "isConversationStarter",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id",
+            "pachliAccountId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_ConversationEntity_pachliAccountId",
+            "unique": false,
+            "columnNames": [
+              "pachliAccountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ConversationEntity_pachliAccountId` ON `${TABLE_NAME}` (`pachliAccountId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "AccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "pachliAccountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "RemoteKeyEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountId` INTEGER NOT NULL, `timelineId` TEXT NOT NULL, `kind` TEXT NOT NULL, `key` TEXT, PRIMARY KEY(`accountId`, `timelineId`, `kind`), FOREIGN KEY(`accountId`) REFERENCES `AccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timelineId",
+            "columnName": "timelineId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "accountId",
+            "timelineId",
+            "kind"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "AccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "StatusViewDataEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`pachliAccountId` INTEGER NOT NULL, `serverId` TEXT NOT NULL, `expanded` INTEGER, `contentShowing` INTEGER, `contentCollapsed` INTEGER, `translationState` TEXT NOT NULL DEFAULT 'SHOW_ORIGINAL', PRIMARY KEY(`serverId`, `pachliAccountId`), FOREIGN KEY(`pachliAccountId`) REFERENCES `AccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "pachliAccountId",
+            "columnName": "pachliAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expanded",
+            "columnName": "expanded",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "contentShowing",
+            "columnName": "contentShowing",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "contentCollapsed",
+            "columnName": "contentCollapsed",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "translationState",
+            "columnName": "translationState",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'SHOW_ORIGINAL'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "pachliAccountId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_StatusViewDataEntity_pachliAccountId",
+            "unique": false,
+            "columnNames": [
+              "pachliAccountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_StatusViewDataEntity_pachliAccountId` ON `${TABLE_NAME}` (`pachliAccountId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "AccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "pachliAccountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "TranslatedStatusEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `timelineUserId` INTEGER NOT NULL, `content` TEXT NOT NULL, `spoilerText` TEXT NOT NULL, `poll` TEXT, `attachments` TEXT NOT NULL, `provider` TEXT NOT NULL, PRIMARY KEY(`serverId`, `timelineUserId`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timelineUserId",
+            "columnName": "timelineUserId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spoilerText",
+            "columnName": "spoilerText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "poll",
+            "columnName": "poll",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "attachments",
+            "columnName": "attachments",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "timelineUserId"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "LogEntryEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `instant` INTEGER NOT NULL, `priority` INTEGER, `tag` TEXT, `message` TEXT NOT NULL, `t` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instant",
+            "columnName": "instant",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "t",
+            "columnName": "t",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "MastodonListEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountId` INTEGER NOT NULL, `listId` TEXT NOT NULL, `title` TEXT NOT NULL, `repliesPolicy` TEXT NOT NULL, `exclusive` INTEGER NOT NULL, PRIMARY KEY(`accountId`, `listId`), FOREIGN KEY(`accountId`) REFERENCES `AccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listId",
+            "columnName": "listId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repliesPolicy",
+            "columnName": "repliesPolicy",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exclusive",
+            "columnName": "exclusive",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "accountId",
+            "listId"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "AccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "ServerEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountId` INTEGER NOT NULL, `serverKind` TEXT NOT NULL, `version` TEXT NOT NULL, `capabilities` TEXT NOT NULL, PRIMARY KEY(`accountId`), FOREIGN KEY(`accountId`) REFERENCES `AccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverKind",
+            "columnName": "serverKind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "capabilities",
+            "columnName": "capabilities",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "accountId"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "AccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "ContentFiltersEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountId` INTEGER NOT NULL, `version` TEXT NOT NULL, `contentFilters` TEXT NOT NULL, PRIMARY KEY(`accountId`), FOREIGN KEY(`accountId`) REFERENCES `AccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentFilters",
+            "columnName": "contentFilters",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "accountId"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "AccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "AnnouncementEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountId` INTEGER NOT NULL, `announcementId` TEXT NOT NULL, `announcement` TEXT NOT NULL, PRIMARY KEY(`accountId`), FOREIGN KEY(`accountId`) REFERENCES `AccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "announcementId",
+            "columnName": "announcementId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "announcement",
+            "columnName": "announcement",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "accountId"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "AccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "FollowingAccountEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`pachliAccountId` INTEGER NOT NULL, `serverId` TEXT NOT NULL, PRIMARY KEY(`pachliAccountId`, `serverId`), FOREIGN KEY(`pachliAccountId`) REFERENCES `AccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "pachliAccountId",
+            "columnName": "pachliAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "pachliAccountId",
+            "serverId"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "AccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "pachliAccountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "NotificationEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`pachliAccountId` INTEGER NOT NULL, `serverId` TEXT NOT NULL, `type` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `accountServerId` TEXT NOT NULL, `statusServerId` TEXT, PRIMARY KEY(`pachliAccountId`, `serverId`), FOREIGN KEY(`pachliAccountId`) REFERENCES `AccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED, FOREIGN KEY(`accountServerId`, `pachliAccountId`) REFERENCES `TimelineAccountEntity`(`serverId`, `timelineUserId`) ON UPDATE NO ACTION ON DELETE NO ACTION DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "pachliAccountId",
+            "columnName": "pachliAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountServerId",
+            "columnName": "accountServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "statusServerId",
+            "columnName": "statusServerId",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "pachliAccountId",
+            "serverId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_NotificationEntity_accountServerId_pachliAccountId",
+            "unique": false,
+            "columnNames": [
+              "accountServerId",
+              "pachliAccountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_NotificationEntity_accountServerId_pachliAccountId` ON `${TABLE_NAME}` (`accountServerId`, `pachliAccountId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "AccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "pachliAccountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "TimelineAccountEntity",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "accountServerId",
+              "pachliAccountId"
+            ],
+            "referencedColumns": [
+              "serverId",
+              "timelineUserId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "NotificationReportEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`pachliAccountId` INTEGER NOT NULL, `serverId` TEXT NOT NULL, `reportId` TEXT NOT NULL, `actionTaken` INTEGER NOT NULL, `actionTakenAt` INTEGER, `category` TEXT NOT NULL, `comment` TEXT NOT NULL, `forwarded` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `statusIds` TEXT, `ruleIds` TEXT, `target_serverId` TEXT NOT NULL, `target_timelineUserId` INTEGER NOT NULL, `target_localUsername` TEXT NOT NULL, `target_username` TEXT NOT NULL, `target_displayName` TEXT NOT NULL, `target_url` TEXT NOT NULL, `target_avatar` TEXT NOT NULL, `target_emojis` TEXT NOT NULL, `target_bot` INTEGER NOT NULL, `target_createdAt` INTEGER, `target_limited` INTEGER NOT NULL DEFAULT false, `target_note` TEXT NOT NULL DEFAULT '', PRIMARY KEY(`pachliAccountId`, `serverId`), FOREIGN KEY(`pachliAccountId`, `serverId`) REFERENCES `NotificationEntity`(`pachliAccountId`, `serverId`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "pachliAccountId",
+            "columnName": "pachliAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reportId",
+            "columnName": "reportId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actionTaken",
+            "columnName": "actionTaken",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actionTakenAt",
+            "columnName": "actionTakenAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "comment",
+            "columnName": "comment",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "forwarded",
+            "columnName": "forwarded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "statusIds",
+            "columnName": "statusIds",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "ruleIds",
+            "columnName": "ruleIds",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "targetAccount.serverId",
+            "columnName": "target_serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetAccount.timelineUserId",
+            "columnName": "target_timelineUserId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetAccount.localUsername",
+            "columnName": "target_localUsername",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetAccount.username",
+            "columnName": "target_username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetAccount.displayName",
+            "columnName": "target_displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetAccount.url",
+            "columnName": "target_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetAccount.avatar",
+            "columnName": "target_avatar",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetAccount.emojis",
+            "columnName": "target_emojis",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetAccount.bot",
+            "columnName": "target_bot",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetAccount.createdAt",
+            "columnName": "target_createdAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "targetAccount.limited",
+            "columnName": "target_limited",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "targetAccount.note",
+            "columnName": "target_note",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "pachliAccountId",
+            "serverId"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "NotificationEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "pachliAccountId",
+              "serverId"
+            ],
+            "referencedColumns": [
+              "pachliAccountId",
+              "serverId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "NotificationViewDataEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`pachliAccountId` INTEGER NOT NULL, `serverId` TEXT NOT NULL, `contentFilterAction` TEXT, `accountFilterDecision` TEXT, PRIMARY KEY(`pachliAccountId`, `serverId`), FOREIGN KEY(`pachliAccountId`) REFERENCES `AccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "pachliAccountId",
+            "columnName": "pachliAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentFilterAction",
+            "columnName": "contentFilterAction",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "accountFilterDecision",
+            "columnName": "accountFilterDecision",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "pachliAccountId",
+            "serverId"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "AccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "pachliAccountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "NotificationRelationshipSeveranceEventEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`pachliAccountId` INTEGER NOT NULL, `serverId` TEXT NOT NULL, `eventId` TEXT NOT NULL, `type` TEXT NOT NULL, `purged` INTEGER NOT NULL, `targetName` TEXT NOT NULL DEFAULT '', `followersCount` INTEGER NOT NULL, `followingCount` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`pachliAccountId`, `serverId`, `eventId`), FOREIGN KEY(`pachliAccountId`, `serverId`) REFERENCES `NotificationEntity`(`pachliAccountId`, `serverId`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "pachliAccountId",
+            "columnName": "pachliAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventId",
+            "columnName": "eventId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "purged",
+            "columnName": "purged",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetName",
+            "columnName": "targetName",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "followersCount",
+            "columnName": "followersCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "followingCount",
+            "columnName": "followingCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "pachliAccountId",
+            "serverId",
+            "eventId"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "NotificationEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "pachliAccountId",
+              "serverId"
+            ],
+            "referencedColumns": [
+              "pachliAccountId",
+              "serverId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "TimelineStatusEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`kind` TEXT NOT NULL, `pachliAccountId` INTEGER NOT NULL, `statusId` TEXT NOT NULL, PRIMARY KEY(`kind`, `pachliAccountId`, `statusId`))",
+        "fields": [
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pachliAccountId",
+            "columnName": "pachliAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "statusId",
+            "columnName": "statusId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "kind",
+            "pachliAccountId",
+            "statusId"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "ConversationViewDataEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`pachliAccountId` INTEGER NOT NULL, `serverId` TEXT NOT NULL, `contentFilterAction` TEXT, `accountFilterDecision` TEXT, PRIMARY KEY(`pachliAccountId`, `serverId`), FOREIGN KEY(`pachliAccountId`) REFERENCES `AccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "pachliAccountId",
+            "columnName": "pachliAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentFilterAction",
+            "columnName": "contentFilterAction",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "accountFilterDecision",
+            "columnName": "accountFilterDecision",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "pachliAccountId",
+            "serverId"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "AccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "pachliAccountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'ba0625151c3d8b08e454272c7c08fa46')"
+    ]
+  }
+}

--- a/core/database/src/main/kotlin/app/pachli/core/database/AppDatabase.kt
+++ b/core/database/src/main/kotlin/app/pachli/core/database/AppDatabase.kt
@@ -98,7 +98,7 @@ import java.util.TimeZone
         TimelineStatusEntity::class,
         ConversationViewDataEntity::class,
     ],
-    version = 22,
+    version = 23,
     autoMigrations = [
         AutoMigration(from = 1, to = 2, spec = AppDatabase.MIGRATE_1_2::class),
         AutoMigration(from = 2, to = 3),
@@ -121,6 +121,7 @@ import java.util.TimeZone
         AutoMigration(from = 19, to = 20, spec = AppDatabase.MIGRATE_19_20::class),
         AutoMigration(from = 20, to = 21),
         AutoMigration(from = 21, to = 22),
+        AutoMigration(from = 22, to = 23),
     ],
 )
 abstract class AppDatabase : RoomDatabase() {

--- a/core/database/src/main/kotlin/app/pachli/core/database/model/InstanceEntity.kt
+++ b/core/database/src/main/kotlin/app/pachli/core/database/model/InstanceEntity.kt
@@ -22,109 +22,54 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.PrimaryKey
 import androidx.room.TypeConverters
-import app.pachli.core.common.extensions.MiB
 import app.pachli.core.database.Converters
+import app.pachli.core.model.InstanceInfo
 import app.pachli.core.network.model.Emoji
-import app.pachli.core.network.model.InstanceV1
-import app.pachli.core.network.model.InstanceV2
 
 @Entity
 @TypeConverters(Converters::class)
 data class InstanceInfoEntity(
     @PrimaryKey val instance: String,
-    val maxPostCharacters: Int?,
-    val maxPollOptions: Int?,
-    val maxPollOptionLength: Int?,
-    val minPollDuration: Int?,
-    val maxPollDuration: Long?,
-    val charactersReservedPerUrl: Int?,
-    val version: String?,
-    val videoSizeLimit: Long?,
-    val imageSizeLimit: Long?,
-    val imageMatrixLimit: Int?,
-    val maxMediaAttachments: Int?,
-    val maxFields: Int?,
+    val maxPostCharacters: Int,
+    val maxPollOptions: Int,
+    val maxPollOptionLength: Int,
+    val minPollDuration: Int,
+    val maxPollDuration: Long,
+    val charactersReservedPerUrl: Int,
+    val version: String,
+    val videoSizeLimit: Long,
+    val imageSizeLimit: Long,
+    val imageMatrixLimit: Int,
+    val maxMediaAttachments: Int,
+    val maxFields: Int,
     val maxFieldNameLength: Int?,
     val maxFieldValueLength: Int?,
     @ColumnInfo(defaultValue = "0")
     val enabledTranslation: Boolean = false,
-) {
-    companion object {
-        private const val DEFAULT_CHARACTER_LIMIT = 500
-        private const val DEFAULT_MAX_OPTION_COUNT = 4
-        private const val DEFAULT_MAX_OPTION_LENGTH = 50
-        private const val DEFAULT_MIN_POLL_DURATION = 300
-        private const val DEFAULT_MAX_POLL_DURATION = 604800L
+)
 
-        private val DEFAULT_VIDEO_SIZE_LIMIT = 40L.MiB
-        private val DEFAULT_IMAGE_SIZE_LIMIT = 10L.MiB
-        private const val DEFAULT_IMAGE_MATRIX_LIMIT = 4096 * 4096
-
-        // Mastodon only counts URLs as this long in terms of status character limits
-        private const val DEFAULT_CHARACTERS_RESERVED_PER_URL = 23
-
-        private const val DEFAULT_MAX_MEDIA_ATTACHMENTS = 4
-        private const val DEFAULT_MAX_ACCOUNT_FIELDS = 4
-
-        fun defaultForDomain(domain: String) = InstanceInfoEntity(
-            instance = domain,
-            maxPostCharacters = DEFAULT_CHARACTER_LIMIT,
-            maxPollOptions = DEFAULT_MAX_OPTION_COUNT,
-            maxPollOptionLength = DEFAULT_MAX_OPTION_LENGTH,
-            minPollDuration = DEFAULT_MIN_POLL_DURATION,
-            maxPollDuration = DEFAULT_MAX_POLL_DURATION,
-            charactersReservedPerUrl = DEFAULT_CHARACTERS_RESERVED_PER_URL,
-            videoSizeLimit = DEFAULT_VIDEO_SIZE_LIMIT,
-            imageSizeLimit = DEFAULT_IMAGE_SIZE_LIMIT,
-            imageMatrixLimit = DEFAULT_IMAGE_MATRIX_LIMIT,
-            maxMediaAttachments = DEFAULT_MAX_MEDIA_ATTACHMENTS,
-            maxFields = DEFAULT_MAX_ACCOUNT_FIELDS,
-            maxFieldNameLength = null,
-            maxFieldValueLength = null,
-            version = "(Pachli defaults)",
-        )
-
-        fun make(domain: String, instance: InstanceV1): InstanceInfoEntity {
-            return InstanceInfoEntity(
-                instance = domain,
-                maxPostCharacters = instance.configuration.statuses.maxCharacters ?: instance.maxTootChars ?: DEFAULT_CHARACTER_LIMIT,
-                maxPollOptions = instance.configuration.polls.maxOptions,
-                maxPollOptionLength = instance.configuration.polls.maxCharactersPerOption,
-                minPollDuration = instance.configuration.polls.minExpiration,
-                maxPollDuration = instance.configuration.polls.maxExpiration.toLong(),
-                charactersReservedPerUrl = instance.configuration.statuses.charactersReservedPerUrl,
-                version = instance.version,
-                videoSizeLimit = instance.configuration.mediaAttachments.videoSizeLimit,
-                imageSizeLimit = instance.configuration.mediaAttachments.imageSizeLimit,
-                imageMatrixLimit = instance.configuration.mediaAttachments.imageMatrixLimit,
-                maxMediaAttachments = instance.configuration.statuses.maxMediaAttachments,
-                maxFields = instance.pleroma?.metadata?.fieldLimits?.maxFields,
-                maxFieldNameLength = instance.pleroma?.metadata?.fieldLimits?.nameLength,
-                maxFieldValueLength = instance.pleroma?.metadata?.fieldLimits?.valueLength,
-            )
-        }
-
-        fun make(domain: String, instance: InstanceV2): InstanceInfoEntity {
-            return InstanceInfoEntity(
-                instance = domain,
-                maxPostCharacters = instance.configuration.statuses.maxCharacters,
-                maxPollOptions = instance.configuration.polls.maxOptions,
-                maxPollOptionLength = instance.configuration.polls.maxCharactersPerOption,
-                minPollDuration = instance.configuration.polls.minExpiration,
-                maxPollDuration = instance.configuration.polls.maxExpiration,
-                charactersReservedPerUrl = instance.configuration.statuses.charactersReservedPerUrl,
-                version = instance.version,
-                videoSizeLimit = instance.configuration.mediaAttachments.videoSizeLimit,
-                imageSizeLimit = instance.configuration.mediaAttachments.imageSizeLimit,
-                imageMatrixLimit = instance.configuration.mediaAttachments.imageMatrixLimit,
-                maxMediaAttachments = instance.configuration.statuses.maxMediaAttachments,
-                maxFields = DEFAULT_MAX_ACCOUNT_FIELDS,
-                maxFieldNameLength = null,
-                maxFieldValueLength = null,
-                enabledTranslation = instance.configuration.translation.enabled,
-            )
-        }
-    }
+/**
+ * @return [InstanceInfo] model; if this is null then returns the default
+ * [InstanceInfo] values.
+ */
+fun InstanceInfoEntity?.asModel(): InstanceInfo {
+    if (this == null) return InstanceInfo()
+    return InstanceInfo(
+        maxChars = maxPostCharacters,
+        pollMaxOptions = maxPollOptions,
+        pollMaxLength = maxPollOptionLength,
+        pollMinDuration = minPollDuration,
+        pollMaxDuration = maxPollDuration,
+        charactersReservedPerUrl = charactersReservedPerUrl,
+        videoSizeLimit = videoSizeLimit,
+        imageSizeLimit = imageSizeLimit,
+        imageMatrixLimit = imageMatrixLimit,
+        maxMediaAttachments = maxMediaAttachments,
+        maxFields = maxFields,
+        maxFieldNameLength = maxFieldNameLength,
+        maxFieldValueLength = maxFieldValueLength,
+        version = version,
+    )
 }
 
 @Entity(

--- a/core/model/src/main/kotlin/app/pachli/core/model/InstanceInfo.kt
+++ b/core/model/src/main/kotlin/app/pachli/core/model/InstanceInfo.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Tusky contributors
+ * Copyright 2025 Pachli Association
  *
  * This file is a part of Pachli.
  *
@@ -15,9 +15,7 @@
  * see <http://www.gnu.org/licenses>.
  */
 
-package app.pachli.core.data.model
-
-import app.pachli.core.common.extensions.MiB
+package app.pachli.core.model
 
 // Know that these fields are all used somewhere
 //
@@ -36,7 +34,7 @@ data class InstanceInfo(
     val maxFields: Int = DEFAULT_MAX_ACCOUNT_FIELDS,
     val maxFieldNameLength: Int? = null,
     val maxFieldValueLength: Int? = null,
-    val version: String? = "(Pachli defaults)",
+    val version: String = "(Pachli defaults)",
 ) {
     companion object {
         const val DEFAULT_CHARACTER_LIMIT = 500
@@ -45,8 +43,10 @@ data class InstanceInfo(
         const val DEFAULT_MIN_POLL_DURATION = 300
         const val DEFAULT_MAX_POLL_DURATION = 604800L
 
-        val DEFAULT_VIDEO_SIZE_LIMIT = 40L.MiB
-        val DEFAULT_IMAGE_SIZE_LIMIT = 10L.MiB
+        const val DEFAULT_VIDEO_SIZE_LIMIT = 40L * 1024 * 1024 // 40 MiB
+        const val DEFAULT_VIDEO_MATRIX_LIMIX = 4096 * 4096
+        const val DEFAULT_VIDEO_FRAME_RATE_LIMIT = 30
+        const val DEFAULT_IMAGE_SIZE_LIMIT = 10L * 1024 * 1024 // 10 MiB
         const val DEFAULT_IMAGE_MATRIX_LIMIT = 4096 * 4096
 
         // Mastodon only counts URLs as this long in terms of status character limits
@@ -54,24 +54,5 @@ data class InstanceInfo(
 
         const val DEFAULT_MAX_MEDIA_ATTACHMENTS = 4
         const val DEFAULT_MAX_ACCOUNT_FIELDS = 4
-
-        fun from(info: app.pachli.core.database.model.InstanceInfoEntity): InstanceInfo {
-            return InstanceInfo(
-                maxChars = info.maxPostCharacters ?: DEFAULT_CHARACTER_LIMIT,
-                pollMaxOptions = info.maxPollOptions ?: DEFAULT_MAX_OPTION_COUNT,
-                pollMaxLength = info.maxPollOptionLength ?: DEFAULT_MAX_OPTION_COUNT,
-                pollMinDuration = info.minPollDuration ?: DEFAULT_MIN_POLL_DURATION,
-                pollMaxDuration = info.maxPollDuration ?: DEFAULT_MAX_POLL_DURATION,
-                charactersReservedPerUrl = info.charactersReservedPerUrl ?: DEFAULT_CHARACTERS_RESERVED_PER_URL,
-                videoSizeLimit = info.videoSizeLimit ?: DEFAULT_VIDEO_SIZE_LIMIT,
-                imageSizeLimit = info.imageSizeLimit ?: DEFAULT_IMAGE_SIZE_LIMIT,
-                imageMatrixLimit = info.imageMatrixLimit ?: DEFAULT_IMAGE_MATRIX_LIMIT,
-                maxMediaAttachments = info.maxMediaAttachments ?: DEFAULT_MAX_MEDIA_ATTACHMENTS,
-                maxFields = info.maxFields ?: DEFAULT_MAX_ACCOUNT_FIELDS,
-                maxFieldNameLength = info.maxFieldNameLength,
-                maxFieldValueLength = info.maxFieldValueLength,
-                version = info.version ?: "(Pachli defaults)",
-            )
-        }
     }
 }

--- a/core/network/src/main/kotlin/app/pachli/core/network/model/InstanceV1.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/InstanceV1.kt
@@ -16,7 +16,20 @@
 
 package app.pachli.core.network.model
 
-import app.pachli.core.common.extensions.MiB
+import app.pachli.core.model.InstanceInfo.Companion.DEFAULT_CHARACTERS_RESERVED_PER_URL
+import app.pachli.core.model.InstanceInfo.Companion.DEFAULT_CHARACTER_LIMIT
+import app.pachli.core.model.InstanceInfo.Companion.DEFAULT_IMAGE_MATRIX_LIMIT
+import app.pachli.core.model.InstanceInfo.Companion.DEFAULT_IMAGE_SIZE_LIMIT
+import app.pachli.core.model.InstanceInfo.Companion.DEFAULT_MAX_ACCOUNT_FIELDS
+import app.pachli.core.model.InstanceInfo.Companion.DEFAULT_MAX_MEDIA_ATTACHMENTS
+import app.pachli.core.model.InstanceInfo.Companion.DEFAULT_MAX_OPTION_COUNT
+import app.pachli.core.model.InstanceInfo.Companion.DEFAULT_MAX_OPTION_LENGTH
+import app.pachli.core.model.InstanceInfo.Companion.DEFAULT_MAX_POLL_DURATION
+import app.pachli.core.model.InstanceInfo.Companion.DEFAULT_MIN_POLL_DURATION
+import app.pachli.core.model.InstanceInfo.Companion.DEFAULT_VIDEO_FRAME_RATE_LIMIT
+import app.pachli.core.model.InstanceInfo.Companion.DEFAULT_VIDEO_MATRIX_LIMIX
+import app.pachli.core.model.InstanceInfo.Companion.DEFAULT_VIDEO_SIZE_LIMIT
+import app.pachli.core.network.json.DefaultIfNull
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
@@ -34,10 +47,11 @@ data class InstanceV1(
     // val languages: List<String>,
     // @Json(name = "contact_account") val contactAccount: Account,
     @Deprecated("Replaced with StatusConfiguration.max_characters")
-    @Json(name = "max_toot_chars") val maxTootChars: Int? = 500,
+    @DefaultIfNull
+    @Json(name = "max_toot_chars") val maxTootChars: Int? = DEFAULT_CHARACTER_LIMIT,
     @Json(name = "poll_limits") val pollConfiguration: PollConfiguration? = null,
     val configuration: InstanceConfiguration = InstanceConfiguration(),
-    @Json(name = "max_media_attachments") val maxMediaAttachments: Int = 4,
+    @Json(name = "max_media_attachments") val maxMediaAttachments: Int = DEFAULT_MAX_MEDIA_ATTACHMENTS,
     val pleroma: PleromaConfiguration? = null,
     @Json(name = "upload_limit") val uploadLimit: Long? = null,
     val rules: List<InstanceRules> = emptyList(),
@@ -57,11 +71,11 @@ data class InstanceV1(
 
 @JsonClass(generateAdapter = true)
 data class PollConfiguration(
-    @Json(name = "max_options") val maxOptions: Int = 4,
-    @Json(name = "max_option_chars") val maxOptionChars: Int = 50,
-    @Json(name = "max_characters_per_option") val maxCharactersPerOption: Int = 50,
-    @Json(name = "min_expiration") val minExpiration: Int = 300,
-    @Json(name = "max_expiration") val maxExpiration: Long = 604800,
+    @Json(name = "max_options") val maxOptions: Int = DEFAULT_MAX_OPTION_COUNT,
+    @Json(name = "max_option_chars") val maxOptionChars: Int = DEFAULT_MAX_OPTION_LENGTH,
+    @Json(name = "max_characters_per_option") val maxCharactersPerOption: Int = DEFAULT_MAX_OPTION_LENGTH,
+    @Json(name = "min_expiration") val minExpiration: Int = DEFAULT_MIN_POLL_DURATION,
+    @Json(name = "max_expiration") val maxExpiration: Long = DEFAULT_MAX_POLL_DURATION,
 )
 
 @JsonClass(generateAdapter = true)
@@ -74,18 +88,18 @@ data class InstanceConfiguration(
 @JsonClass(generateAdapter = true)
 data class StatusConfiguration(
     @Json(name = "max_characters") val maxCharacters: Int? = null,
-    @Json(name = "max_media_attachments") val maxMediaAttachments: Int = 4,
-    @Json(name = "characters_reserved_per_url") val charactersReservedPerUrl: Int = 23,
+    @Json(name = "max_media_attachments") val maxMediaAttachments: Int = DEFAULT_MAX_OPTION_COUNT,
+    @Json(name = "characters_reserved_per_url") val charactersReservedPerUrl: Int = DEFAULT_CHARACTERS_RESERVED_PER_URL,
 )
 
 @JsonClass(generateAdapter = true)
 data class MediaAttachmentConfiguration(
     @Json(name = "supported_mime_types") val supportedMimeTypes: List<String> = emptyList(),
-    @Json(name = "image_size_limit") val imageSizeLimit: Long = 10L.MiB,
-    @Json(name = "image_matrix_limit") val imageMatrixLimit: Int = 4096 * 4096,
-    @Json(name = "video_size_limit") val videoSizeLimit: Long = 40L.MiB,
-    @Json(name = "video_frame_rate_limit") val videoFrameRateLimit: Int? = 30,
-    @Json(name = "video_matrix_limit") val videoMatrixLimit: Int? = 4096 * 4096,
+    @Json(name = "image_size_limit") val imageSizeLimit: Long = DEFAULT_IMAGE_SIZE_LIMIT,
+    @Json(name = "image_matrix_limit") val imageMatrixLimit: Int = DEFAULT_IMAGE_MATRIX_LIMIT,
+    @Json(name = "video_size_limit") val videoSizeLimit: Long = DEFAULT_VIDEO_SIZE_LIMIT,
+    @Json(name = "video_frame_rate_limit") val videoFrameRateLimit: Int? = DEFAULT_VIDEO_FRAME_RATE_LIMIT,
+    @Json(name = "video_matrix_limit") val videoMatrixLimit: Int? = DEFAULT_VIDEO_MATRIX_LIMIX,
 )
 
 @JsonClass(generateAdapter = true)
@@ -100,7 +114,7 @@ data class PleromaMetadata(
 
 @JsonClass(generateAdapter = true)
 data class PleromaFieldLimits(
-    @Json(name = "max_fields") val maxFields: Int?,
+    @Json(name = "max_fields") val maxFields: Int = DEFAULT_MAX_ACCOUNT_FIELDS,
     @Json(name = "name_length") val nameLength: Int?,
     @Json(name = "value_length") val valueLength: Int?,
 )

--- a/core/network/src/main/kotlin/app/pachli/core/network/model/InstanceV2.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/InstanceV2.kt
@@ -17,7 +17,18 @@
 
 package app.pachli.core.network.model
 
-import app.pachli.core.common.extensions.MiB
+import app.pachli.core.model.InstanceInfo.Companion.DEFAULT_CHARACTERS_RESERVED_PER_URL
+import app.pachli.core.model.InstanceInfo.Companion.DEFAULT_CHARACTER_LIMIT
+import app.pachli.core.model.InstanceInfo.Companion.DEFAULT_IMAGE_MATRIX_LIMIT
+import app.pachli.core.model.InstanceInfo.Companion.DEFAULT_IMAGE_SIZE_LIMIT
+import app.pachli.core.model.InstanceInfo.Companion.DEFAULT_MAX_MEDIA_ATTACHMENTS
+import app.pachli.core.model.InstanceInfo.Companion.DEFAULT_MAX_OPTION_COUNT
+import app.pachli.core.model.InstanceInfo.Companion.DEFAULT_MAX_OPTION_LENGTH
+import app.pachli.core.model.InstanceInfo.Companion.DEFAULT_MAX_POLL_DURATION
+import app.pachli.core.model.InstanceInfo.Companion.DEFAULT_MIN_POLL_DURATION
+import app.pachli.core.model.InstanceInfo.Companion.DEFAULT_VIDEO_FRAME_RATE_LIMIT
+import app.pachli.core.model.InstanceInfo.Companion.DEFAULT_VIDEO_MATRIX_LIMIX
+import app.pachli.core.model.InstanceInfo.Companion.DEFAULT_VIDEO_SIZE_LIMIT
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
@@ -149,15 +160,15 @@ data class InstanceV2Accounts(
 @JsonClass(generateAdapter = true)
 data class InstanceV2Statuses(
     /** The maximum number of allowed characters per status. */
-    @Json(name = "max_characters") val maxCharacters: Int = 500,
+    @Json(name = "max_characters") val maxCharacters: Int = DEFAULT_CHARACTER_LIMIT,
 
     // Missing in some Friendica servers until https://github.com/friendica/friendica/pull/13664
     /** The maximum number of media attachments that can be added to a status. */
-    @Json(name = "max_media_attachments") val maxMediaAttachments: Int = 4,
+    @Json(name = "max_media_attachments") val maxMediaAttachments: Int = DEFAULT_MAX_MEDIA_ATTACHMENTS,
 
     // Missing in some Pleroma servers, https://git.pleroma.social/pleroma/pleroma/-/issues/3250
     /** Each URL in a status will be assumed to be exactly this many characters. */
-    @Json(name = "characters_reserved_per_url") val charactersReservedPerUrl: Int = 23,
+    @Json(name = "characters_reserved_per_url") val charactersReservedPerUrl: Int = DEFAULT_CHARACTERS_RESERVED_PER_URL,
 )
 
 @JsonClass(generateAdapter = true)
@@ -166,35 +177,35 @@ data class MediaAttachments(
     @Json(name = "supported_mime_types") val supportedMimeTypes: List<String> = emptyList(),
 
     /** The maximum size of any uploaded image, in bytes. */
-    @Json(name = "image_size_limit") val imageSizeLimit: Long = 10L.MiB,
+    @Json(name = "image_size_limit") val imageSizeLimit: Long = DEFAULT_IMAGE_SIZE_LIMIT,
 
     /** The maximum number of pixels (width x height) for image uploads. */
-    @Json(name = "image_matrix_limit") val imageMatrixLimit: Int = 4096 * 4096,
+    @Json(name = "image_matrix_limit") val imageMatrixLimit: Int = DEFAULT_IMAGE_MATRIX_LIMIT,
 
     /** The maximum size of any uploaded video, in bytes. */
-    @Json(name = "video_size_limit") val videoSizeLimit: Long = 40L.MiB,
+    @Json(name = "video_size_limit") val videoSizeLimit: Long = DEFAULT_VIDEO_SIZE_LIMIT,
 
     /** The maximum frame rate for any uploaded video. */
-    @Json(name = "video_frame_rate_limit") val videoFrameRateLimit: Int = 30,
+    @Json(name = "video_frame_rate_limit") val videoFrameRateLimit: Int = DEFAULT_VIDEO_FRAME_RATE_LIMIT,
 
     /** The maximum number of pixels (width times height) for video uploads. */
-    @Json(name = "video_matrix_limit") val videoMatrixLimit: Int = 4096 * 4096,
+    @Json(name = "video_matrix_limit") val videoMatrixLimit: Int = DEFAULT_VIDEO_MATRIX_LIMIX,
 )
 
 @JsonClass(generateAdapter = true)
 data class InstanceV2Polls(
     // Some Pleroma servers omit this
     /** Each poll is allowed to have up to this many options. */
-    @Json(name = "max_options") val maxOptions: Int = 4,
+    @Json(name = "max_options") val maxOptions: Int = DEFAULT_MAX_OPTION_COUNT,
 
     /** Each poll option is allowed to have this many characters. */
-    @Json(name = "max_characters_per_option") val maxCharactersPerOption: Int = 50,
+    @Json(name = "max_characters_per_option") val maxCharactersPerOption: Int = DEFAULT_MAX_OPTION_LENGTH,
 
     /** The shortest allowed poll duration, in seconds. */
-    @Json(name = "min_expiration") val minExpiration: Int = 300,
+    @Json(name = "min_expiration") val minExpiration: Int = DEFAULT_MIN_POLL_DURATION,
 
     /** The longest allowed poll duration, in seconds. */
-    @Json(name = "max_expiration") val maxExpiration: Long = 604800,
+    @Json(name = "max_expiration") val maxExpiration: Long = DEFAULT_MAX_POLL_DURATION,
 )
 
 @JsonClass(generateAdapter = true)

--- a/feature/about/build.gradle.kts
+++ b/feature/about/build.gradle.kts
@@ -57,6 +57,7 @@ dependencies {
     implementation(projects.core.data)
     implementation(projects.core.designsystem)
     implementation(projects.core.domain)
+    implementation(projects.core.model)
     implementation(projects.core.navigation)
     implementation(projects.core.ui)
 


### PR DESCRIPTION
The previous location meant the code for mapping from the network type to the entity type to the model type was unergonomic, with duplicate code and constants, and was difficult to follow.

Changes include:

- Move `InstanceInfo` to `core.model`.
- Remove `InstanceInfo.from()`, replace with `.asModel()` functions on the entity classes, and `.asEntity()` functions on the network classes.
- Make some types on `InstanceInfoEntity` non-null, since the underlying values should never be null. This requires a database version bump.
- Use existing constants as defaults in the network classes instead of magic numbers.