### PR TITLE
refactor: Cancel Glide requests in fragments earlier

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -161,9 +161,6 @@ dependencies {
 
     implementation(libs.conscrypt.android)
 
-    implementation(libs.bundles.glide)
-    ksp(libs.glide.compiler)
-
     implementation(libs.sparkbutton)
 
     implementation(libs.touchimageview)

--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -412,7 +412,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/components/account/AccountActivity.kt"
-            line="520"
+            line="519"
             column="9"/>
     </issue>
 
@@ -467,7 +467,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/components/accountlist/adapter/MutesAdapter.kt"
-            line="109"
+            line="111"
             column="9"/>
     </issue>
 

--- a/app/src/main/java/app/pachli/EditProfileActivity.kt
+++ b/app/src/main/java/app/pachli/EditProfileActivity.kt
@@ -49,7 +49,6 @@ import app.pachli.util.Loading
 import app.pachli.util.Success
 import app.pachli.viewmodel.EditProfileViewModel
 import app.pachli.viewmodel.ProfileDataInUi
-import com.bumptech.glide.Glide
 import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.bumptech.glide.load.resource.bitmap.FitCenter
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners
@@ -174,8 +173,7 @@ class EditProfileActivity : BaseActivity() {
                             (me.source?.fields?.size ?: 0) < maxAccountFields
 
                         if (viewModel.avatarData.value == null) {
-                            Glide.with(this)
-                                .load(me.avatar)
+                            glide.load(me.avatar)
                                 .placeholder(DR.drawable.avatar_default)
                                 .transform(
                                     FitCenter(),
@@ -185,8 +183,7 @@ class EditProfileActivity : BaseActivity() {
                         }
 
                         if (viewModel.headerData.value == null) {
-                            Glide.with(this)
-                                .load(me.header)
+                            glide.load(me.header)
                                 .into(binding.headerPreview)
                         }
                     }
@@ -266,18 +263,17 @@ class EditProfileActivity : BaseActivity() {
         ) { imageUri ->
 
             // skipping all caches so we can always reuse the same uri
-            val glide = Glide.with(imageView)
-                .load(imageUri)
+            val request = glide.load(imageUri)
                 .skipMemoryCache(true)
                 .diskCacheStrategy(DiskCacheStrategy.NONE)
 
             if (roundedCorners) {
-                glide.transform(
+                request.transform(
                     FitCenter(),
                     RoundedCorners(resources.getDimensionPixelSize(DR.dimen.avatar_radius_80dp)),
                 ).into(imageView)
             } else {
-                glide.into(imageView)
+                request.into(imageView)
             }
 
             imageView.show()

--- a/app/src/main/java/app/pachli/MainActivity.kt
+++ b/app/src/main/java/app/pachli/MainActivity.kt
@@ -117,7 +117,6 @@ import app.pachli.updatecheck.UpdateCheck
 import app.pachli.usecase.DeveloperToolsUseCase
 import app.pachli.util.UpdateShortCutsUseCase
 import app.pachli.util.getDimension
-import com.bumptech.glide.Glide
 import com.bumptech.glide.RequestManager
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners
 import com.bumptech.glide.request.target.CustomTarget
@@ -213,8 +212,6 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
 
     private var onTabSelectedListener: OnTabSelectedListener? = null
 
-    private lateinit var glide: RequestManager
-
     // We need to know if the emoji pack has been changed
     private var selectedEmojiPack: String? = null
 
@@ -281,8 +278,6 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
         }
 
         window.statusBarColor = Color.TRANSPARENT // don't draw a status bar, the DrawerLayout and the MaterialDrawerLayout have their own
-
-        glide = Glide.with(this)
 
         // Determine which of the three toolbars should be the supportActionBar (which hosts
         // the options menu).
@@ -1223,7 +1218,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
         val profiles: MutableList<IProfile> = uiState.accounts.map { acc ->
             ProfileDrawerItem().apply {
                 isSelected = acc.isActive
-                nameText = acc.displayName.emojify(acc.emojis, header, animateEmojis)
+                nameText = acc.displayName.emojify(glide, acc.emojis, header, animateEmojis)
                 iconUrl = acc.profilePictureUrl
                 isNameShown = true
                 identifier = acc.id

--- a/app/src/main/java/app/pachli/adapter/AccountViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/AccountViewHolder.kt
@@ -26,9 +26,11 @@ import app.pachli.core.ui.emojify
 import app.pachli.core.ui.loadAvatar
 import app.pachli.databinding.ItemAccountBinding
 import app.pachli.interfaces.AccountActionListener
+import com.bumptech.glide.RequestManager
 
 class AccountViewHolder(
     private val binding: ItemAccountBinding,
+    private val glide: RequestManager,
 ) : RecyclerView.ViewHolder(binding.root) {
     private lateinit var accountId: String
 
@@ -46,6 +48,7 @@ class AccountViewHolder(
         )
 
         val emojifiedName = account.name.emojify(
+            glide,
             account.emojis,
             binding.accountDisplayName,
             animateEmojis,
@@ -54,7 +57,7 @@ class AccountViewHolder(
 
         val avatarRadius = binding.accountAvatar.context.resources
             .getDimensionPixelSize(DR.dimen.avatar_radius_48dp)
-        loadAvatar(account.avatar, binding.accountAvatar, avatarRadius, animateAvatar)
+        loadAvatar(glide, account.avatar, binding.accountAvatar, avatarRadius, animateAvatar)
 
         binding.accountBotBadge.visible(showBotOverlay && account.bot)
     }

--- a/app/src/main/java/app/pachli/adapter/EmojiAdapter.kt
+++ b/app/src/main/java/app/pachli/adapter/EmojiAdapter.kt
@@ -23,10 +23,11 @@ import androidx.recyclerview.widget.RecyclerView
 import app.pachli.core.network.model.Emoji
 import app.pachli.core.ui.BindingHolder
 import app.pachli.databinding.ItemEmojiButtonBinding
-import com.bumptech.glide.Glide
+import com.bumptech.glide.RequestManager
 import java.util.Locale
 
 class EmojiAdapter(
+    private val glide: RequestManager,
     emojiList: List<Emoji>,
     private val onEmojiSelectedListener: OnEmojiSelectedListener,
     private val animate: Boolean,
@@ -47,12 +48,10 @@ class EmojiAdapter(
         val emojiImageView = holder.binding.root
 
         if (animate) {
-            Glide.with(emojiImageView)
-                .load(emoji.url)
+            glide.load(emoji.url)
                 .into(emojiImageView)
         } else {
-            Glide.with(emojiImageView)
-                .asBitmap()
+            glide.asBitmap()
                 .load(emoji.url)
                 .into(emojiImageView)
         }

--- a/app/src/main/java/app/pachli/adapter/FilterableStatusViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/FilterableStatusViewHolder.kt
@@ -28,11 +28,13 @@ import app.pachli.core.network.model.FilterAction as NetworkFilterAction
 import app.pachli.core.ui.SetStatusContent
 import app.pachli.databinding.ItemStatusWrapperBinding
 import app.pachli.interfaces.StatusActionListener
+import com.bumptech.glide.RequestManager
 
 open class FilterableStatusViewHolder<T : IStatusViewData>(
     private val binding: ItemStatusWrapperBinding,
+    glide: RequestManager,
     setStatusContent: SetStatusContent,
-) : StatusViewHolder<T>(binding.statusContainer, setStatusContent, binding.root) {
+) : StatusViewHolder<T>(binding.statusContainer, glide, setStatusContent, binding.root) {
     /** The filter that matched the status, null if the status is not being filtered. */
     var matchedFilter: Filter? = null
 

--- a/app/src/main/java/app/pachli/adapter/FollowRequestViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/FollowRequestViewHolder.kt
@@ -39,9 +39,11 @@ import app.pachli.core.ui.setClickableText
 import app.pachli.databinding.ItemFollowRequestBinding
 import app.pachli.interfaces.AccountActionListener
 import app.pachli.viewdata.NotificationViewData
+import com.bumptech.glide.RequestManager
 
 class FollowRequestViewHolder(
     private val binding: ItemFollowRequestBinding,
+    private val glide: RequestManager,
     private val accountActionListener: AccountActionListener,
     private val linkListener: LinkListener,
     private val showHeader: Boolean,
@@ -74,6 +76,7 @@ class FollowRequestViewHolder(
     ) {
         val wrappedName = account.name.unicodeWrap()
         val emojifiedName: CharSequence = wrappedName.emojify(
+            glide,
             account.emojis,
             itemView,
             animateEmojis,
@@ -91,7 +94,7 @@ class FollowRequestViewHolder(
                     wrappedName.length,
                     Spanned.SPAN_EXCLUSIVE_EXCLUSIVE,
                 )
-            }.emojify(account.emojis, itemView, animateEmojis)
+            }.emojify(glide, account.emojis, itemView, animateEmojis)
         }
         binding.notificationTextView.visible(showHeader)
         val formattedUsername = itemView.context.getString(DR.string.post_username_format, account.username)
@@ -102,11 +105,11 @@ class FollowRequestViewHolder(
             binding.accountNote.show()
 
             val emojifiedNote = account.note.parseAsMastodonHtml()
-                .emojify(account.emojis, binding.accountNote, animateEmojis)
+                .emojify(glide, account.emojis, binding.accountNote, animateEmojis)
             setClickableText(binding.accountNote, emojifiedNote, emptyList(), null, linkListener)
         }
         val avatarRadius = binding.avatar.context.resources.getDimensionPixelSize(DR.dimen.avatar_radius_48dp)
-        loadAvatar(account.avatar, binding.avatar, avatarRadius, animateAvatar)
+        loadAvatar(glide, account.avatar, binding.avatar, avatarRadius, animateAvatar)
         binding.avatarBadge.visible(showBotOverlay && account.bot)
     }
 

--- a/app/src/main/java/app/pachli/adapter/PollAdapter.kt
+++ b/app/src/main/java/app/pachli/adapter/PollAdapter.kt
@@ -28,6 +28,7 @@ import app.pachli.databinding.ItemPollBinding
 import app.pachli.viewdata.PollOptionViewData
 import app.pachli.viewdata.buildDescription
 import app.pachli.viewdata.calculatePercent
+import com.bumptech.glide.RequestManager
 import com.google.android.material.R
 import com.google.android.material.color.MaterialColors
 import com.mikepenz.iconics.typeface.library.googlematerial.GoogleMaterial
@@ -43,6 +44,7 @@ typealias ResultClickListener = () -> Unit
 // data from polls that have been edited, and the "shape" of that data is quite different (no
 // information about vote counts, poll IDs, etc).
 class PollAdapter(
+    private val glide: RequestManager,
     val options: List<PollOptionViewData>,
     private val votesCount: Int,
     private val votersCount: Int?,
@@ -131,20 +133,20 @@ class PollAdapter(
                 tintColor = MaterialColors.getColor(resultTextView, R.attr.colorPrimaryContainer)
                 textColor = MaterialColors.getColor(resultTextView, R.attr.colorOnPrimaryContainer)
                 itemText = buildDescription(option.title, percent, option.voted, resultTextView.context)
-                    .emojify(emojis, resultTextView, animateEmojis)
+                    .emojify(glide, emojis, resultTextView, animateEmojis)
             }
             displayMode == DisplayMode.RESULT || showVotes -> {
                 level = percent * 100
                 tintColor = MaterialColors.getColor(resultTextView, R.attr.colorSecondaryContainer)
                 textColor = MaterialColors.getColor(resultTextView, R.attr.colorOnSecondaryContainer)
                 itemText = buildDescription(option.title, percent, option.voted, resultTextView.context)
-                    .emojify(emojis, resultTextView, animateEmojis)
+                    .emojify(glide, emojis, resultTextView, animateEmojis)
             }
             else -> {
                 level = 0
                 tintColor = MaterialColors.getColor(resultTextView, R.attr.colorSecondaryContainer)
                 textColor = MaterialColors.getColor(resultTextView, android.R.attr.textColorPrimary)
-                itemText = option.title.emojify(emojis, radioButton, animateEmojis)
+                itemText = option.title.emojify(glide, emojis, radioButton, animateEmojis)
             }
         }
 

--- a/app/src/main/java/app/pachli/adapter/ReportNotificationViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/ReportNotificationViewHolder.kt
@@ -36,9 +36,11 @@ import app.pachli.databinding.ItemReportNotificationBinding
 import app.pachli.util.getRelativeTimeSpanString
 import app.pachli.viewdata.NotificationViewData
 import at.connyduck.sparkbutton.helpers.Utils
+import com.bumptech.glide.RequestManager
 
 class ReportNotificationViewHolder(
     private val binding: ItemReportNotificationBinding,
+    private val glide: RequestManager,
     private val notificationActionListener: NotificationActionListener,
 ) : NotificationsPagingAdapter.ViewHolder, RecyclerView.ViewHolder(binding.root) {
 
@@ -72,11 +74,13 @@ class ReportNotificationViewHolder(
         animateEmojis: Boolean,
     ) {
         val reporterName = reporter.name.unicodeWrap().emojify(
+            glide,
             reporter.emojis,
             binding.root,
             animateEmojis,
         )
         val reporteeName = report.targetAccount.toTimelineAccount().name.unicodeWrap().emojify(
+            glide,
             report.targetAccount.emojis,
             itemView,
             animateEmojis,
@@ -114,12 +118,14 @@ class ReportNotificationViewHolder(
         binding.notificationReporteeAvatar.setPaddingRelative(0, 0, padding, padding)
 
         loadAvatar(
+            glide,
             report.targetAccount.avatar,
             binding.notificationReporteeAvatar,
             itemView.context.resources.getDimensionPixelSize(DR.dimen.avatar_radius_36dp),
             animateAvatar,
         )
         loadAvatar(
+            glide,
             reporter.avatar,
             binding.notificationReporterAvatar,
             itemView.context.resources.getDimensionPixelSize(DR.dimen.avatar_radius_24dp),

--- a/app/src/main/java/app/pachli/adapter/StatusBaseViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/StatusBaseViewHolder.kt
@@ -57,7 +57,7 @@ import app.pachli.view.PreviewCardView
 import app.pachli.viewdata.PollViewData.Companion.from
 import at.connyduck.sparkbutton.SparkButton
 import at.connyduck.sparkbutton.helpers.Utils
-import com.bumptech.glide.Glide
+import com.bumptech.glide.RequestManager
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.color.MaterialColors
 import com.mikepenz.iconics.typeface.library.googlematerial.GoogleMaterial
@@ -66,6 +66,7 @@ import java.util.Date
 
 abstract class StatusBaseViewHolder<T : IStatusViewData> protected constructor(
     itemView: View,
+    protected val glide: RequestManager,
     protected val setStatusContent: SetStatusContent,
 ) : RecyclerView.ViewHolder(itemView) {
     object Key {
@@ -134,7 +135,7 @@ abstract class StatusBaseViewHolder<T : IStatusViewData> protected constructor(
         customEmojis: List<Emoji>?,
         statusDisplayOptions: StatusDisplayOptions,
     ) {
-        displayName.text = name.emojify(customEmojis, displayName, statusDisplayOptions.animateEmojis)
+        displayName.text = name.emojify(glide, customEmojis, displayName, statusDisplayOptions.animateEmojis)
     }
 
     protected fun setUsername(name: String) {
@@ -155,6 +156,7 @@ abstract class StatusBaseViewHolder<T : IStatusViewData> protected constructor(
         val expanded = viewData.isExpanded
         if (sensitive) {
             val emojiSpoiler = spoilerText.emojify(
+                glide,
                 viewData.actionable.emojis,
                 contentWarningDescription,
                 statusDisplayOptions.animateEmojis,
@@ -241,6 +243,7 @@ abstract class StatusBaseViewHolder<T : IStatusViewData> protected constructor(
 
         if (!sensitive || viewData.isExpanded) {
             setStatusContent(
+                glide,
                 this.content,
                 viewData.content,
                 statusDisplayOptions,
@@ -262,6 +265,7 @@ abstract class StatusBaseViewHolder<T : IStatusViewData> protected constructor(
                 }
 
                 pollView.bind(
+                    glide,
                     pollViewData,
                     emojis,
                     statusDisplayOptions,
@@ -294,8 +298,7 @@ abstract class StatusBaseViewHolder<T : IStatusViewData> protected constructor(
             avatar.setPaddingRelative(0, 0, 0, 0)
             if (statusDisplayOptions.showBotOverlay && isBot) {
                 avatarInset.visibility = View.VISIBLE
-                Glide.with(avatarInset)
-                    .load(DR.drawable.bot_badge)
+                glide.load(DR.drawable.bot_badge)
                     .into(avatarInset)
             } else {
                 avatarInset.visibility = View.GONE
@@ -307,6 +310,7 @@ abstract class StatusBaseViewHolder<T : IStatusViewData> protected constructor(
             avatarInset.visibility = View.VISIBLE
             avatarInset.background = null
             loadAvatar(
+                glide,
                 rebloggedUrl,
                 avatarInset,
                 avatarRadius24dp,
@@ -316,6 +320,7 @@ abstract class StatusBaseViewHolder<T : IStatusViewData> protected constructor(
             avatarRadius = avatarRadius36dp
         }
         loadAvatar(
+            glide,
             url,
             avatar,
             avatarRadius,
@@ -441,8 +446,7 @@ abstract class StatusBaseViewHolder<T : IStatusViewData> protected constructor(
         val placeholder = blurhash?.let { decodeBlurHash(it) } ?: mediaPreviewUnloaded
         if (TextUtils.isEmpty(previewUrl)) {
             imageView.removeFocalPoint()
-            Glide.with(imageView)
-                .load(placeholder)
+            glide.load(placeholder)
                 .centerInside()
                 .into(imageView)
             return
@@ -450,16 +454,14 @@ abstract class StatusBaseViewHolder<T : IStatusViewData> protected constructor(
 
         if (focus != null) { // If there is a focal point for this attachment:
             imageView.setFocalPoint(focus)
-            Glide.with(context)
-                .load(previewUrl)
+            glide.load(previewUrl)
                 .placeholder(placeholder)
                 .centerInside()
                 .addListener(imageView)
                 .into(imageView)
         } else {
             imageView.removeFocalPoint()
-            Glide.with(imageView)
-                .load(previewUrl)
+            glide.load(previewUrl)
                 .placeholder(placeholder)
                 .centerInside()
                 .into(imageView)
@@ -887,7 +889,7 @@ abstract class StatusBaseViewHolder<T : IStatusViewData> protected constructor(
             (!viewData.isCollapsible || !viewData.isCollapsed)
         ) {
             cardView.visibility = View.VISIBLE
-            cardView.bind(card, viewData.actionable.sensitive, statusDisplayOptions, false) { card, target ->
+            cardView.bind(glide, card, viewData.actionable.sensitive, statusDisplayOptions, false) { card, target ->
                 if (target == PreviewCardView.Target.BYLINE) {
                     card.authors?.firstOrNull()?.account?.id?.let {
                         context.startActivity(AccountActivityIntent(context, viewData.pachliAccountId, it))

--- a/app/src/main/java/app/pachli/adapter/StatusDetailedViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/StatusDetailedViewHolder.kt
@@ -21,14 +21,16 @@ import app.pachli.databinding.ItemStatusDetailedBinding
 import app.pachli.interfaces.StatusActionListener
 import app.pachli.util.description
 import app.pachli.util.icon
+import com.bumptech.glide.RequestManager
 import java.text.DateFormat
 import java.util.Locale
 
 class StatusDetailedViewHolder(
     private val binding: ItemStatusDetailedBinding,
+    glide: RequestManager,
     setStatusContent: SetStatusContent,
     private val openUrl: OpenUrlUseCase,
-) : StatusBaseViewHolder<StatusViewData>(binding.root, setStatusContent) {
+) : StatusBaseViewHolder<StatusViewData>(binding.root, glide, setStatusContent) {
 
     override fun setMetaData(
         viewData: StatusViewData,

--- a/app/src/main/java/app/pachli/adapter/StatusViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/StatusViewHolder.kt
@@ -35,12 +35,14 @@ import app.pachli.core.ui.emojify
 import app.pachli.databinding.ItemStatusBinding
 import app.pachli.interfaces.StatusActionListener
 import at.connyduck.sparkbutton.helpers.Utils
+import com.bumptech.glide.RequestManager
 
 open class StatusViewHolder<T : IStatusViewData>(
     private val binding: ItemStatusBinding,
+    glide: RequestManager,
     setStatusContent: SetStatusContent,
     root: View? = null,
-) : StatusBaseViewHolder<T>(root ?: binding.root, setStatusContent) {
+) : StatusBaseViewHolder<T>(root ?: binding.root, glide, setStatusContent) {
 
     override fun setupWithStatus(
         viewData: T,
@@ -82,7 +84,7 @@ open class StatusViewHolder<T : IStatusViewData>(
         val wrappedName: CharSequence = name.unicodeWrap()
         val boostedText: CharSequence = context.getString(R.string.post_boosted_format, wrappedName)
         val emojifiedText =
-            boostedText.emojify(accountEmoji, statusInfo, statusDisplayOptions.animateEmojis)
+            boostedText.emojify(glide, accountEmoji, statusInfo, statusDisplayOptions.animateEmojis)
         statusInfo.text = emojifiedText
         statusInfo.show()
     }

--- a/app/src/main/java/app/pachli/components/account/AccountActivity.kt
+++ b/app/src/main/java/app/pachli/components/account/AccountActivity.kt
@@ -92,7 +92,6 @@ import app.pachli.util.Error
 import app.pachli.util.Loading
 import app.pachli.util.Success
 import app.pachli.view.showMuteAccountDialog
-import com.bumptech.glide.Glide
 import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.chip.Chip
 import com.google.android.material.color.MaterialColors
@@ -249,7 +248,7 @@ class AccountActivity :
         binding.accountFollowsYouChip.hide()
 
         // setup the RecyclerView for the account fields
-        accountFieldAdapter = AccountFieldAdapter(this, animateEmojis)
+        accountFieldAdapter = AccountFieldAdapter(glide, this, animateEmojis)
         binding.accountFieldList.isNestedScrollingEnabled = false
         binding.accountFieldList.layoutManager = LinearLayoutManager(this)
         binding.accountFieldList.adapter = accountFieldAdapter
@@ -499,7 +498,7 @@ class AccountActivity :
 
         val usernameFormatted = getString(DR.string.post_username_format, account.username)
         binding.accountUsernameTextView.text = usernameFormatted
-        binding.accountDisplayNameTextView.text = account.name.emojify(account.emojis, binding.accountDisplayNameTextView, animateEmojis)
+        binding.accountDisplayNameTextView.text = account.name.emojify(glide, account.emojis, binding.accountDisplayNameTextView, animateEmojis)
 
         // Long press on username to copy it to clipboard
         for (view in listOf(binding.accountUsernameTextView, binding.accountDisplayNameTextView)) {
@@ -512,7 +511,7 @@ class AccountActivity :
             }
         }
 
-        val emojifiedNote = account.note.parseAsMastodonHtml().emojify(account.emojis, binding.accountNoteTextView, animateEmojis)
+        val emojifiedNote = account.note.parseAsMastodonHtml().emojify(glide, account.emojis, binding.accountNoteTextView, animateEmojis)
         setClickableText(binding.accountNoteTextView, emojifiedNote, emptyList(), null, this)
 
         accountFieldAdapter.fields = account.fields.orEmpty()
@@ -559,14 +558,14 @@ class AccountActivity :
         loadedAccount?.let { account ->
 
             loadAvatar(
+                glide,
                 account.avatar,
                 binding.accountAvatarImageView,
                 resources.getDimensionPixelSize(DR.dimen.avatar_radius_94dp),
                 animateAvatar,
             )
 
-            Glide.with(this)
-                .asBitmap()
+            glide.asBitmap()
                 .load(account.header)
                 .centerCrop()
                 .into(binding.accountHeaderImageView)
@@ -593,7 +592,7 @@ class AccountActivity :
      */
     private fun updateToolbar() {
         loadedAccount?.let { account ->
-            supportActionBar?.title = account.name.emojify(account.emojis, binding.accountToolbar, animateEmojis)
+            supportActionBar?.title = account.name.emojify(glide, account.emojis, binding.accountToolbar, animateEmojis)
             supportActionBar?.subtitle = String.format(getString(DR.string.post_username_format), account.username)
         }
     }
@@ -615,7 +614,7 @@ class AccountActivity :
 
             val avatarRadius = resources.getDimensionPixelSize(DR.dimen.avatar_radius_48dp)
 
-            loadAvatar(movedAccount.avatar, binding.accountMovedAvatar, avatarRadius, animateAvatar)
+            loadAvatar(glide, movedAccount.avatar, binding.accountMovedAvatar, avatarRadius, animateAvatar)
 
             binding.accountMovedText.text = getString(R.string.account_moved_description, movedAccount.name)
         }

--- a/app/src/main/java/app/pachli/components/account/AccountFieldAdapter.kt
+++ b/app/src/main/java/app/pachli/components/account/AccountFieldAdapter.kt
@@ -28,8 +28,10 @@ import app.pachli.core.ui.LinkListener
 import app.pachli.core.ui.emojify
 import app.pachli.core.ui.setClickableText
 import app.pachli.databinding.ItemAccountFieldBinding
+import com.bumptech.glide.RequestManager
 
 class AccountFieldAdapter(
+    private val glide: RequestManager,
     private val linkListener: LinkListener,
     private val animateEmojis: Boolean,
 ) : RecyclerView.Adapter<BindingHolder<ItemAccountFieldBinding>>() {
@@ -49,10 +51,10 @@ class AccountFieldAdapter(
         val nameTextView = holder.binding.accountFieldName
         val valueTextView = holder.binding.accountFieldValue
 
-        val emojifiedName = field.name.emojify(emojis, nameTextView, animateEmojis)
+        val emojifiedName = field.name.emojify(glide, emojis, nameTextView, animateEmojis)
         nameTextView.text = emojifiedName
 
-        val emojifiedValue = field.value.parseAsMastodonHtml().emojify(emojis, valueTextView, animateEmojis)
+        val emojifiedValue = field.value.parseAsMastodonHtml().emojify(glide, emojis, valueTextView, animateEmojis)
         setClickableText(valueTextView, emojifiedValue, emptyList(), null, linkListener)
 
         if (field.verifiedAt != null) {

--- a/app/src/main/java/app/pachli/components/account/media/AccountMediaFragment.kt
+++ b/app/src/main/java/app/pachli/components/account/media/AccountMediaFragment.kt
@@ -44,6 +44,7 @@ import app.pachli.core.navigation.ViewMediaActivityIntent
 import app.pachli.core.network.model.Attachment
 import app.pachli.core.ui.BackgroundMessage
 import app.pachli.databinding.FragmentTimelineBinding
+import com.bumptech.glide.Glide
 import com.google.android.material.color.MaterialColors
 import com.mikepenz.iconics.IconicsDrawable
 import com.mikepenz.iconics.typeface.library.googlematerial.GoogleMaterial
@@ -87,6 +88,7 @@ class AccountMediaFragment :
 
         adapter = AccountMediaGridAdapter(
             context = view.context,
+            glide = Glide.with(this),
             statusDisplayOptions = viewModel.statusDisplayOptions.value,
             onAttachmentClickListener = ::onAttachmentClick,
         )

--- a/app/src/main/java/app/pachli/components/account/media/AccountMediaGridAdapter.kt
+++ b/app/src/main/java/app/pachli/components/account/media/AccountMediaGridAdapter.kt
@@ -22,11 +22,12 @@ import app.pachli.core.ui.decodeBlurHash
 import app.pachli.databinding.ItemAccountMediaBinding
 import app.pachli.util.getFormattedDescription
 import app.pachli.util.iconResource
-import com.bumptech.glide.Glide
+import com.bumptech.glide.RequestManager
 import com.google.android.material.color.MaterialColors
 
 class AccountMediaGridAdapter(
     context: Context,
+    private val glide: RequestManager,
     statusDisplayOptions: StatusDisplayOptions,
     private val onAttachmentClickListener: (AttachmentViewData, View) -> Unit,
 ) : PagingDataAdapter<AttachmentViewData, BindingHolder<ItemAccountMediaBinding>>(
@@ -69,8 +70,7 @@ class AccountMediaGridAdapter(
 
                 val (placeholder, width, height) = item.attachment.placeholder(context, preview)
 
-                Glide.with(preview)
-                    .load(placeholder)
+                glide.load(placeholder)
                     .override(width, height)
                     .centerInside()
                     .into(preview)
@@ -85,8 +85,7 @@ class AccountMediaGridAdapter(
 
                 val (placeholder, _, _) = item.attachment.placeholder(context, preview)
 
-                Glide.with(preview)
-                    .asBitmap()
+                glide.asBitmap()
                     .load(item.attachment.previewUrl)
                     .placeholder(placeholder)
                     .into(preview)
@@ -99,8 +98,7 @@ class AccountMediaGridAdapter(
                 overlay.setBackgroundResource(0)
                 overlay.visible(item.attachment.type.isPlayable())
 
-                Glide.with(preview)
-                    .load(item.attachment.iconResource())
+                glide.load(item.attachment.iconResource())
                     .into(preview)
 
                 preview.contentDescription = item.attachment.getFormattedDescription(context)

--- a/app/src/main/java/app/pachli/components/accountlist/AccountListFragment.kt
+++ b/app/src/main/java/app/pachli/components/accountlist/AccountListFragment.kt
@@ -37,6 +37,7 @@ import app.pachli.core.activity.extensions.startActivityWithDefaultTransition
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
 import app.pachli.core.common.extensions.viewBinding
+import app.pachli.core.common.util.unsafeLazy
 import app.pachli.core.data.repository.AccountManager
 import app.pachli.core.navigation.AccountActivityIntent
 import app.pachli.core.navigation.AccountListActivityIntent.Kind
@@ -60,6 +61,7 @@ import app.pachli.databinding.FragmentAccountListBinding
 import app.pachli.interfaces.AccountActionListener
 import app.pachli.interfaces.AppBarLayoutHost
 import app.pachli.view.EndlessOnScrollListener
+import com.bumptech.glide.Glide
 import com.github.michaelbull.result.getOrElse
 import com.github.michaelbull.result.onFailure
 import com.github.michaelbull.result.onSuccess
@@ -99,6 +101,8 @@ class AccountListFragment :
 
     private var pachliAccountId by Delegates.notNull<Long>()
 
+    private val glide by unsafeLazy { Glide.with(this) }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         pachliAccountId = requireArguments().getLong(ARG_PACHLI_ACCOUNT_ID)
@@ -125,18 +129,19 @@ class AccountListFragment :
         val activeAccount = accountManager.activeAccount!!
 
         adapter = when (kind) {
-            BLOCKS -> BlocksAdapter(this, animateAvatar, animateEmojis, showBotOverlay)
-            MUTES -> MutesAdapter(this, animateAvatar, animateEmojis, showBotOverlay)
+            BLOCKS -> BlocksAdapter(glide, this, animateAvatar, animateEmojis, showBotOverlay)
+            MUTES -> MutesAdapter(glide, this, animateAvatar, animateEmojis, showBotOverlay)
             FOLLOW_REQUESTS -> {
                 val headerAdapter = FollowRequestsHeaderAdapter(
                     instanceName = activeAccount.domain,
                     accountLocked = activeAccount.locked,
                 )
-                val followRequestsAdapter = FollowRequestsAdapter(this, this, animateAvatar, animateEmojis, showBotOverlay)
+                val followRequestsAdapter = FollowRequestsAdapter(glide, this, this, animateAvatar, animateEmojis, showBotOverlay)
                 binding.recyclerView.adapter = ConcatAdapter(headerAdapter, followRequestsAdapter)
                 followRequestsAdapter
             }
-            else -> FollowAdapter(this, animateAvatar, animateEmojis, showBotOverlay)
+
+            else -> FollowAdapter(glide, this, animateAvatar, animateEmojis, showBotOverlay)
         }
         if (binding.recyclerView.adapter == null) {
             binding.recyclerView.adapter = adapter

--- a/app/src/main/java/app/pachli/components/accountlist/adapter/BlocksAdapter.kt
+++ b/app/src/main/java/app/pachli/components/accountlist/adapter/BlocksAdapter.kt
@@ -25,9 +25,11 @@ import app.pachli.core.ui.emojify
 import app.pachli.core.ui.loadAvatar
 import app.pachli.databinding.ItemBlockedUserBinding
 import app.pachli.interfaces.AccountActionListener
+import com.bumptech.glide.RequestManager
 
 /** Displays a list of blocked accounts. */
 class BlocksAdapter(
+    val glide: RequestManager,
     accountActionListener: AccountActionListener,
     animateAvatar: Boolean,
     animateEmojis: Boolean,
@@ -49,13 +51,13 @@ class BlocksAdapter(
         val binding = viewHolder.binding
         val context = binding.root.context
 
-        val emojifiedName = account.name.emojify(account.emojis, binding.blockedUserDisplayName, animateEmojis)
+        val emojifiedName = account.name.emojify(glide, account.emojis, binding.blockedUserDisplayName, animateEmojis)
         binding.blockedUserDisplayName.text = emojifiedName
         val formattedUsername = context.getString(DR.string.post_username_format, account.username)
         binding.blockedUserUsername.text = formattedUsername
 
         val avatarRadius = context.resources.getDimensionPixelSize(DR.dimen.avatar_radius_48dp)
-        loadAvatar(account.avatar, binding.blockedUserAvatar, avatarRadius, animateAvatar)
+        loadAvatar(glide, account.avatar, binding.blockedUserAvatar, avatarRadius, animateAvatar)
 
         binding.blockedUserBotBadge.visible(showBotOverlay && account.bot)
 

--- a/app/src/main/java/app/pachli/components/accountlist/adapter/FollowAdapter.kt
+++ b/app/src/main/java/app/pachli/components/accountlist/adapter/FollowAdapter.kt
@@ -21,9 +21,11 @@ import android.view.ViewGroup
 import app.pachli.adapter.AccountViewHolder
 import app.pachli.databinding.ItemAccountBinding
 import app.pachli.interfaces.AccountActionListener
+import com.bumptech.glide.RequestManager
 
 /** Displays either a follows or following list.  */
 class FollowAdapter(
+    val glide: RequestManager,
     accountActionListener: AccountActionListener,
     animateAvatar: Boolean,
     animateEmojis: Boolean,
@@ -37,7 +39,7 @@ class FollowAdapter(
 
     override fun createAccountViewHolder(parent: ViewGroup): AccountViewHolder {
         val binding = ItemAccountBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        return AccountViewHolder(binding)
+        return AccountViewHolder(binding, glide)
     }
 
     override fun onBindAccountViewHolder(viewHolder: AccountViewHolder, position: Int) {

--- a/app/src/main/java/app/pachli/components/accountlist/adapter/FollowRequestsAdapter.kt
+++ b/app/src/main/java/app/pachli/components/accountlist/adapter/FollowRequestsAdapter.kt
@@ -22,9 +22,11 @@ import app.pachli.adapter.FollowRequestViewHolder
 import app.pachli.core.ui.LinkListener
 import app.pachli.databinding.ItemFollowRequestBinding
 import app.pachli.interfaces.AccountActionListener
+import com.bumptech.glide.RequestManager
 
 /** Displays a list of follow requests with accept/reject buttons. */
 class FollowRequestsAdapter(
+    private val glide: RequestManager,
     accountActionListener: AccountActionListener,
     private val linkListener: LinkListener,
     animateAvatar: Boolean,
@@ -45,6 +47,7 @@ class FollowRequestsAdapter(
         )
         return FollowRequestViewHolder(
             binding,
+            glide,
             accountActionListener,
             linkListener,
             showHeader = false,

--- a/app/src/main/java/app/pachli/components/accountlist/adapter/MutesAdapter.kt
+++ b/app/src/main/java/app/pachli/components/accountlist/adapter/MutesAdapter.kt
@@ -27,9 +27,11 @@ import app.pachli.core.ui.emojify
 import app.pachli.core.ui.loadAvatar
 import app.pachli.databinding.ItemMutedUserBinding
 import app.pachli.interfaces.AccountActionListener
+import com.bumptech.glide.RequestManager
 
 /** Displays a list of muted accounts with mute/unmute account button and mute/unmute notifications switch */
 class MutesAdapter(
+    private val glide: RequestManager,
     accountActionListener: AccountActionListener,
     animateAvatar: Boolean,
     animateEmojis: Boolean,
@@ -55,14 +57,14 @@ class MutesAdapter(
 
         val mutingNotifications = mutingNotificationsMap[account.id]
 
-        val emojifiedName = account.name.emojify(account.emojis, binding.mutedUserDisplayName, animateEmojis)
+        val emojifiedName = account.name.emojify(glide, account.emojis, binding.mutedUserDisplayName, animateEmojis)
         binding.mutedUserDisplayName.text = emojifiedName
 
         val formattedUsername = context.getString(DR.string.post_username_format, account.username)
         binding.mutedUserUsername.text = formattedUsername
 
         val avatarRadius = context.resources.getDimensionPixelSize(DR.dimen.avatar_radius_48dp)
-        loadAvatar(account.avatar, binding.mutedUserAvatar, avatarRadius, animateAvatar)
+        loadAvatar(glide, account.avatar, binding.mutedUserAvatar, avatarRadius, animateAvatar)
 
         binding.mutedUserBotBadge.visible(showBotOverlay && account.bot)
 

--- a/app/src/main/java/app/pachli/components/announcements/AnnouncementAdapter.kt
+++ b/app/src/main/java/app/pachli/components/announcements/AnnouncementAdapter.kt
@@ -37,7 +37,7 @@ import app.pachli.core.ui.setClickableText
 import app.pachli.databinding.ItemAnnouncementBinding
 import app.pachli.util.equalByMinute
 import app.pachli.util.getRelativeTimeSpanString
-import com.bumptech.glide.Glide
+import com.bumptech.glide.RequestManager
 import com.google.android.material.chip.Chip
 import java.lang.ref.WeakReference
 
@@ -48,6 +48,7 @@ interface AnnouncementActionListener : LinkListener {
 }
 
 class AnnouncementAdapter(
+    private val glide: RequestManager,
     private var items: List<Announcement> = emptyList(),
     private val listener: AnnouncementActionListener,
     private val hideStatsInDetailedPosts: Boolean = false,
@@ -91,7 +92,7 @@ class AnnouncementAdapter(
         val chips = holder.binding.chipGroup
         val addReactionChip = holder.binding.addReactionChip
 
-        val emojifiedText: CharSequence = item.content.parseAsMastodonHtml().emojify(item.emojis, text, animateEmojis)
+        val emojifiedText: CharSequence = item.content.parseAsMastodonHtml().emojify(glide, item.emojis, text, animateEmojis)
 
         setClickableText(text, emojifiedText, item.mentions, item.tags, listener)
 
@@ -128,8 +129,7 @@ class AnnouncementAdapter(
                             span.contentDescription = reaction.name
                         }
                         spanBuilder.setSpan(span, 0, 1, 0)
-                        Glide.with(this)
-                            .asDrawable()
+                        glide.asDrawable()
                             .load(
                                 if (animateEmojis) {
                                     reaction.url

--- a/app/src/main/java/app/pachli/components/announcements/AnnouncementsActivity.kt
+++ b/app/src/main/java/app/pachli/components/announcements/AnnouncementsActivity.kt
@@ -101,7 +101,7 @@ class AnnouncementsActivity :
         val animateEmojis = sharedPreferencesRepository.animateEmojis
         val useAbsoluteTime = sharedPreferencesRepository.useAbsoluteTime
 
-        adapter = AnnouncementAdapter(emptyList(), this, hideStatsInDetailedPosts, animateEmojis, useAbsoluteTime)
+        adapter = AnnouncementAdapter(glide, emptyList(), this, hideStatsInDetailedPosts, animateEmojis, useAbsoluteTime)
 
         binding.announcementsList.adapter = adapter
 
@@ -133,7 +133,7 @@ class AnnouncementsActivity :
         }
 
         viewModel.emojis.observe(this) {
-            picker.adapter = EmojiAdapter(it, this, animateEmojis)
+            picker.adapter = EmojiAdapter(glide, it, this, animateEmojis)
         }
 
         viewModel.load()

--- a/app/src/main/java/app/pachli/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeActivity.kt
@@ -110,7 +110,6 @@ import app.pachli.util.highlightSpans
 import app.pachli.util.iconRes
 import app.pachli.util.modernLanguageCode
 import app.pachli.util.setDrawableTint
-import com.bumptech.glide.Glide
 import com.canhub.cropper.CropImage
 import com.canhub.cropper.CropImageContract
 import com.canhub.cropper.CropImageContractOptions
@@ -295,6 +294,7 @@ class ComposeActivity :
                 }
 
                 val mediaAdapter = MediaPreviewAdapter(
+                    glide = glide,
                     descriptionLimit = account.instanceInfo.maxMediaDescriptionChars,
                     onDescriptionChanged = this@ComposeActivity::onUpdateDescription,
                     onEditFocus = { item ->
@@ -456,19 +456,19 @@ class ComposeActivity :
             setReplyAvatar(this)
 
             binding.statusDisplayName.text =
-                displayName.emojify(emojis, binding.statusDisplayName, sharedPreferencesRepository.animateEmojis)
+                displayName.emojify(glide, emojis, binding.statusDisplayName, sharedPreferencesRepository.animateEmojis)
             binding.statusUsername.text = getString(app.pachli.core.designsystem.R.string.post_username_format, username)
 
             if (contentWarning.isEmpty()) {
                 binding.statusContentWarningDescription.hide()
             } else {
                 binding.statusContentWarningDescription.text =
-                    contentWarning.emojify(emojis, binding.statusContentWarningDescription, sharedPreferencesRepository.animateEmojis)
+                    contentWarning.emojify(glide, emojis, binding.statusContentWarningDescription, sharedPreferencesRepository.animateEmojis)
                 binding.statusContentWarningDescription.show()
             }
 
             binding.statusContent.text =
-                content.emojify(emojis, binding.statusContent, sharedPreferencesRepository.animateEmojis)
+                content.emojify(glide, emojis, binding.statusContent, sharedPreferencesRepository.animateEmojis)
         }
     }
 
@@ -476,14 +476,14 @@ class ComposeActivity :
         binding.statusAvatar.setPaddingRelative(0, 0, 0, 0)
         if (viewModel.statusDisplayOptions.value.showBotOverlay && inReplyTo.isBot) {
             binding.statusAvatarInset.visibility = View.VISIBLE
-            Glide.with(binding.statusAvatarInset)
-                .load(DR.drawable.bot_badge)
+            glide.load(DR.drawable.bot_badge)
                 .into(binding.statusAvatarInset)
         } else {
             binding.statusAvatarInset.visibility = View.GONE
         }
 
         loadAvatar(
+            glide,
             inReplyTo.avatarUrl,
             binding.statusAvatar,
             avatarRadius48dp,
@@ -519,6 +519,7 @@ class ComposeActivity :
 
         binding.composeEditField.setAdapter(
             ComposeAutoCompleteAdapter(
+                glide,
                 this,
                 sharedPreferencesRepository.animateAvatars,
                 sharedPreferencesRepository.animateEmojis,
@@ -735,6 +736,7 @@ class ComposeActivity :
         }
 
         loadAvatar(
+            glide,
             account.profilePictureUrl,
             binding.composeAvatar,
             avatarSize / 8,
@@ -1478,7 +1480,7 @@ class ComposeActivity :
     private fun setEmojiList(emojiList: List<Emoji>?) {
         if (emojiList != null) {
             val animateEmojis = sharedPreferencesRepository.animateEmojis
-            binding.emojiView.adapter = EmojiAdapter(emojiList, this@ComposeActivity, animateEmojis)
+            binding.emojiView.adapter = EmojiAdapter(glide, emojiList, this@ComposeActivity, animateEmojis)
             enableButton(binding.composeEmojiButton, true, emojiList.isNotEmpty())
         }
     }

--- a/app/src/main/java/app/pachli/components/compose/ComposeAutoCompleteAdapter.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeAutoCompleteAdapter.kt
@@ -34,10 +34,11 @@ import app.pachli.core.ui.emojify
 import app.pachli.core.ui.loadAvatar
 import app.pachli.databinding.ItemAutocompleteEmojiBinding
 import app.pachli.databinding.ItemAutocompleteHashtagBinding
-import com.bumptech.glide.Glide
+import com.bumptech.glide.RequestManager
 import kotlinx.coroutines.runBlocking
 
 class ComposeAutoCompleteAdapter(
+    private val glide: RequestManager,
     private val autocompletionProvider: AutocompletionProvider,
     private val animateAvatar: Boolean,
     private val animateEmojis: Boolean,
@@ -114,9 +115,15 @@ class ComposeAutoCompleteAdapter(
                 val accountResult = getItem(position) as AutocompleteResult.AccountResult
                 val account = accountResult.account
                 binding.username.text = context.getString(DR.string.post_username_format, account.username)
-                binding.displayName.text = account.name.emojify(account.emojis, binding.displayName, animateEmojis)
+                binding.displayName.text = account.name.emojify(
+                    glide,
+                    account.emojis,
+                    binding.displayName,
+                    animateEmojis,
+                )
                 val avatarRadius = context.resources.getDimensionPixelSize(DR.dimen.avatar_radius_42dp)
                 loadAvatar(
+                    glide,
                     account.avatar,
                     binding.avatar,
                     avatarRadius,
@@ -133,8 +140,7 @@ class ComposeAutoCompleteAdapter(
                 val emojiResult = getItem(position) as AutocompleteResult.EmojiResult
                 val (shortcode, url) = emojiResult.emoji
                 binding.shortcode.text = context.getString(R.string.emoji_shortcode_format, shortcode)
-                Glide.with(binding.preview)
-                    .load(url)
+                glide.load(url)
                     .into(binding.preview)
             }
         }

--- a/app/src/main/java/app/pachli/components/compose/MediaPreviewAdapter.kt
+++ b/app/src/main/java/app/pachli/components/compose/MediaPreviewAdapter.kt
@@ -42,7 +42,7 @@ import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
 import app.pachli.core.network.model.Attachment
 import app.pachli.databinding.ItemComposeMediaAttachmentBinding
-import com.bumptech.glide.Glide
+import com.bumptech.glide.RequestManager
 import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.get
@@ -100,6 +100,7 @@ typealias OnRemoveMediaListener = (item: QueuedMedia) -> Unit
  * media attachment.
  */
 class MediaPreviewAdapter(
+    private val glide: RequestManager,
     private val descriptionLimit: Int,
     private val onDescriptionChanged: OnDescriptionChangedListener,
     private val onEditFocus: OnEditFocusListener,
@@ -109,6 +110,7 @@ class MediaPreviewAdapter(
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AttachmentViewHolder {
         return AttachmentViewHolder(
             ItemComposeMediaAttachmentBinding.inflate(LayoutInflater.from(parent.context), parent, false),
+            glide,
             descriptionLimit,
             onDescriptionChanged = onDescriptionChanged,
             onMediaClick = ::showMediaPopup,
@@ -232,6 +234,7 @@ class MediaPreviewAdapter(
  */
 class AttachmentViewHolder(
     val binding: ItemComposeMediaAttachmentBinding,
+    private val glide: RequestManager,
     descriptionLimit: Int,
     private val onDescriptionChanged: OnDescriptionChangedListener,
     private val onMediaClick: (QueuedMedia, View) -> Unit,
@@ -290,19 +293,19 @@ class AttachmentViewHolder(
     private fun bindUri(item: QueuedMedia) = with(binding.media) {
         if (item.type == QueuedMedia.Type.AUDIO) {
             // TODO: Fancy waveform display?
+            glide.clear(this)
             setImageResource(R.drawable.ic_music_box_preview_24dp)
             return@with
         }
 
-        var glide = Glide.with(context)
-            .load(item.uri)
+        var request = glide.load(item.uri)
             .diskCacheStrategy(DiskCacheStrategy.NONE)
             .dontAnimate()
             .centerInside()
 
-        if (item.focus != null) glide = glide.addListener(this)
+        if (item.focus != null) request = request.addListener(this)
 
-        glide.into(this)
+        request.into(this)
 
         // Default Talkback behaviour reads out that this is a button with
         // options available. Enhance the experience by listing the options.

--- a/app/src/main/java/app/pachli/components/conversation/ConversationAdapter.kt
+++ b/app/src/main/java/app/pachli/components/conversation/ConversationAdapter.kt
@@ -34,8 +34,10 @@ import app.pachli.databinding.ItemConversationBinding
 import app.pachli.databinding.ItemConversationFilteredBinding
 import app.pachli.databinding.ItemStatusWrapperBinding
 import app.pachli.interfaces.StatusActionListener
+import com.bumptech.glide.RequestManager
 
 internal class ConversationAdapter(
+    private val glide: RequestManager,
     private var statusDisplayOptions: StatusDisplayOptions,
     private val setStatusContent: SetStatusContent,
     private val listener: StatusActionListener<ConversationViewData>,
@@ -80,12 +82,14 @@ internal class ConversationAdapter(
             ConversationViewKind.STATUS ->
                 ConversationViewHolder(
                     ItemConversationBinding.inflate(inflater, parent, false),
+                    glide,
                     setStatusContent,
                     listener,
                 )
             ConversationViewKind.STATUS_FILTERED ->
                 FilterableConversationStatusViewHolder(
                     ItemStatusWrapperBinding.inflate(inflater, parent, false),
+                    glide,
                     setStatusContent,
                     listener,
                 )
@@ -157,9 +161,10 @@ enum class ConversationViewKind {
  */
 class FilterableConversationStatusViewHolder internal constructor(
     binding: ItemStatusWrapperBinding,
+    glide: RequestManager,
     setStatusContent: SetStatusContent,
     private val listener: StatusActionListener<ConversationViewData>,
-) : ConversationAdapter.ViewHolder, FilterableStatusViewHolder<ConversationViewData>(binding, setStatusContent) {
+) : ConversationAdapter.ViewHolder, FilterableStatusViewHolder<ConversationViewData>(binding, glide, setStatusContent) {
     override fun bind(viewData: ConversationViewData, payloads: List<*>?, statusDisplayOptions: StatusDisplayOptions) {
         if (payloads.isNullOrEmpty()) {
             showStatusContent(true)

--- a/app/src/main/java/app/pachli/components/conversation/ConversationViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/conversation/ConversationViewHolder.kt
@@ -31,12 +31,14 @@ import app.pachli.core.ui.SetStatusContent
 import app.pachli.core.ui.loadAvatar
 import app.pachli.databinding.ItemConversationBinding
 import app.pachli.interfaces.StatusActionListener
+import com.bumptech.glide.RequestManager
 
 class ConversationViewHolder internal constructor(
     private val binding: ItemConversationBinding,
+    glide: RequestManager,
     setStatusContent: SetStatusContent,
     private val listener: StatusActionListener<ConversationViewData>,
-) : ConversationAdapter.ViewHolder, StatusBaseViewHolder<ConversationViewData>(binding.root, setStatusContent) {
+) : ConversationAdapter.ViewHolder, StatusBaseViewHolder<ConversationViewData>(binding.root, glide, setStatusContent) {
     private val avatars: Array<ImageView> = arrayOf(
         avatar,
         binding.statusAvatar1,
@@ -120,6 +122,7 @@ class ConversationViewHolder internal constructor(
         avatars.withIndex().forEach { views ->
             accounts.getOrNull(views.index)?.also { account ->
                 loadAvatar(
+                    glide,
                     account.avatar,
                     views.value,
                     avatarRadius48dp,

--- a/app/src/main/java/app/pachli/components/conversation/ConversationsFragment.kt
+++ b/app/src/main/java/app/pachli/components/conversation/ConversationsFragment.kt
@@ -45,6 +45,7 @@ import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
 import app.pachli.core.common.extensions.throttleFirst
 import app.pachli.core.common.extensions.viewBinding
+import app.pachli.core.common.util.unsafeLazy
 import app.pachli.core.data.repository.StatusDisplayOptionsRepository
 import app.pachli.core.eventhub.EventHub
 import app.pachli.core.model.AccountFilterDecision
@@ -66,6 +67,7 @@ import app.pachli.interfaces.ActionButtonActivity
 import app.pachli.interfaces.StatusActionListener
 import app.pachli.util.ListStatusAccessibilityDelegate
 import at.connyduck.sparkbutton.helpers.Utils
+import com.bumptech.glide.Glide
 import com.google.android.material.color.MaterialColors
 import com.google.android.material.divider.MaterialDividerItemDecoration
 import com.mikepenz.iconics.IconicsDrawable
@@ -153,6 +155,8 @@ class ConversationsFragment :
 
     override var pachliAccountId by Delegates.notNull<Long>()
 
+    private val glide by unsafeLazy { Glide.with(this) }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         pachliAccountId = requireArguments().getLong(ARG_PACHLI_ACCOUNT_ID)
@@ -175,7 +179,7 @@ class ConversationsFragment :
                 SetMastodonHtmlContent
             }
 
-            adapter = ConversationAdapter(statusDisplayOptions, setStatusContent, this@ConversationsFragment, accept)
+            adapter = ConversationAdapter(glide, statusDisplayOptions, setStatusContent, this@ConversationsFragment, accept)
 
             setupRecyclerView()
 

--- a/app/src/main/java/app/pachli/components/drafts/DraftMediaAdapter.kt
+++ b/app/src/main/java/app/pachli/components/drafts/DraftMediaAdapter.kt
@@ -26,10 +26,11 @@ import app.pachli.R
 import app.pachli.core.database.model.DraftAttachment
 import app.pachli.core.designsystem.R as DR
 import app.pachli.view.MediaPreviewImageView
-import com.bumptech.glide.Glide
+import com.bumptech.glide.RequestManager
 import com.bumptech.glide.load.engine.DiskCacheStrategy
 
 class DraftMediaAdapter(
+    private val glide: RequestManager,
     private val attachmentClick: () -> Unit,
 ) : ListAdapter<DraftAttachment, DraftMediaAdapter.DraftMediaViewHolder>(
     object : DiffUtil.ItemCallback<DraftAttachment>() {
@@ -58,17 +59,16 @@ class DraftMediaAdapter(
                 } else {
                     holder.imageView.clearFocus()
                 }
-                var glide = Glide.with(holder.itemView.context)
-                    .load(attachment.uri)
+                var request = glide.load(attachment.uri)
                     .diskCacheStrategy(DiskCacheStrategy.NONE)
                     .dontAnimate()
                     .centerInside()
 
                 if (attachment.focus != null) {
-                    glide = glide.addListener(holder.imageView)
+                    request = request.addListener(holder.imageView)
                 }
 
-                glide.into(holder.imageView)
+                request.into(holder.imageView)
             }
         }
     }

--- a/app/src/main/java/app/pachli/components/drafts/DraftsActivity.kt
+++ b/app/src/main/java/app/pachli/components/drafts/DraftsActivity.kt
@@ -71,7 +71,7 @@ class DraftsActivity : BaseActivity(), DraftActionListener {
 
         binding.draftsErrorMessageView.setup(BackgroundMessage.Empty(R.string.no_drafts))
 
-        val adapter = DraftsAdapter(this)
+        val adapter = DraftsAdapter(glide, this)
 
         binding.draftsRecyclerView.adapter = adapter
         binding.draftsRecyclerView.layoutManager = LinearLayoutManager(this)

--- a/app/src/main/java/app/pachli/components/drafts/DraftsAdapter.kt
+++ b/app/src/main/java/app/pachli/components/drafts/DraftsAdapter.kt
@@ -28,6 +28,7 @@ import app.pachli.core.common.extensions.visible
 import app.pachli.core.database.model.DraftEntity
 import app.pachli.core.ui.BindingHolder
 import app.pachli.databinding.ItemDraftBinding
+import com.bumptech.glide.RequestManager
 
 interface DraftActionListener {
     fun onOpenDraft(draft: DraftEntity)
@@ -35,6 +36,7 @@ interface DraftActionListener {
 }
 
 class DraftsAdapter(
+    private val glide: RequestManager,
     private val listener: DraftActionListener,
 ) : PagingDataAdapter<DraftEntity, BindingHolder<ItemDraftBinding>>(
     object : DiffUtil.ItemCallback<DraftEntity>() {
@@ -54,7 +56,7 @@ class DraftsAdapter(
         val viewHolder = BindingHolder(binding)
 
         binding.draftMediaPreview.layoutManager = LinearLayoutManager(binding.root.context, RecyclerView.HORIZONTAL, false)
-        binding.draftMediaPreview.adapter = DraftMediaAdapter {
+        binding.draftMediaPreview.adapter = DraftMediaAdapter(glide) {
             getItem(viewHolder.bindingAdapterPosition)?.let { draft ->
                 listener.onOpenDraft(draft)
             }

--- a/app/src/main/java/app/pachli/components/followedtags/FollowedTagsActivity.kt
+++ b/app/src/main/java/app/pachli/components/followedtags/FollowedTagsActivity.kt
@@ -27,6 +27,7 @@ import app.pachli.core.network.retrofit.MastodonApi
 import app.pachli.core.ui.ActionButtonScrollListener
 import app.pachli.databinding.ActivityFollowedTagsBinding
 import app.pachli.interfaces.HashtagActionListener
+import com.bumptech.glide.Glide
 import com.github.michaelbull.result.onFailure
 import com.github.michaelbull.result.onSuccess
 import com.google.android.material.divider.MaterialDividerItemDecoration
@@ -184,6 +185,7 @@ class FollowedTagsActivity :
             val autoCompleteTextView = layout.findViewById<AutoCompleteTextView>(R.id.hashtag)!!
             autoCompleteTextView.setAdapter(
                 ComposeAutoCompleteAdapter(
+                    Glide.with(this),
                     requireActivity() as FollowedTagsActivity,
                     animateAvatar = false,
                     animateEmojis = false,

--- a/app/src/main/java/app/pachli/components/notifications/FollowViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/notifications/FollowViewHolder.kt
@@ -35,9 +35,11 @@ import app.pachli.core.ui.loadAvatar
 import app.pachli.core.ui.setClickableText
 import app.pachli.databinding.ItemFollowBinding
 import app.pachli.viewdata.NotificationViewData
+import com.bumptech.glide.RequestManager
 
 class FollowViewHolder(
     private val binding: ItemFollowBinding,
+    private val glide: RequestManager,
     private val notificationActionListener: NotificationActionListener,
     private val linkListener: LinkListener,
 ) : NotificationsPagingAdapter.ViewHolder, RecyclerView.ViewHolder(binding.root) {
@@ -89,6 +91,7 @@ class FollowViewHolder(
         )
         val emojifiedMessage =
             wholeMessage.emojify(
+                glide,
                 account.emojis,
                 binding.notificationText,
                 animateEmojis,
@@ -97,6 +100,7 @@ class FollowViewHolder(
         val username = context.getString(DR.string.post_username_format, account.username)
         binding.notificationUsername.text = username
         loadAvatar(
+            glide,
             account.avatar,
             binding.notificationAvatar,
             avatarRadius42dp,
@@ -104,6 +108,7 @@ class FollowViewHolder(
         )
 
         val emojifiedNote = account.note.parseAsMastodonHtml().emojify(
+            glide,
             account.emojis,
             binding.notificationAccountNote,
             animateEmojis,

--- a/app/src/main/java/app/pachli/components/notifications/NotificationsFragment.kt
+++ b/app/src/main/java/app/pachli/components/notifications/NotificationsFragment.kt
@@ -73,6 +73,7 @@ import app.pachli.interfaces.StatusActionListener
 import app.pachli.util.ListStatusAccessibilityDelegate
 import app.pachli.viewdata.NotificationViewData
 import at.connyduck.sparkbutton.helpers.Utils
+import com.bumptech.glide.Glide
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.onFailure
 import com.github.michaelbull.result.onSuccess
@@ -167,6 +168,7 @@ class NotificationsFragment :
         }
 
         adapter = NotificationsPagingAdapter(
+            Glide.with(this),
             notificationDiffCallback,
             setStatusContent,
             statusActionListener = this,

--- a/app/src/main/java/app/pachli/components/notifications/NotificationsPagingAdapter.kt
+++ b/app/src/main/java/app/pachli/components/notifications/NotificationsPagingAdapter.kt
@@ -44,6 +44,7 @@ import app.pachli.databinding.ItemUnknownNotificationBinding
 import app.pachli.interfaces.AccountActionListener
 import app.pachli.interfaces.StatusActionListener
 import app.pachli.viewdata.NotificationViewData
+import com.bumptech.glide.RequestManager
 
 /** How to present the notification in the UI */
 enum class NotificationViewKind {
@@ -145,6 +146,7 @@ interface NotificationActionListener {
  * @param statusDisplayOptions
  */
 class NotificationsPagingAdapter(
+    private val glide: RequestManager,
     diffCallback: DiffUtil.ItemCallback<NotificationViewData>,
     private val setStatusContent: SetStatusContent,
     private val statusActionListener: StatusActionListener<NotificationViewData>,
@@ -185,6 +187,7 @@ class NotificationsPagingAdapter(
             NotificationViewKind.STATUS -> {
                 StatusViewHolder(
                     ItemStatusBinding.inflate(inflater, parent, false),
+                    glide,
                     setStatusContent,
                     statusActionListener,
                 )
@@ -192,6 +195,7 @@ class NotificationsPagingAdapter(
             NotificationViewKind.STATUS_FILTERED -> {
                 FilterableStatusViewHolder(
                     ItemStatusWrapperBinding.inflate(inflater, parent, false),
+                    glide,
                     setStatusContent,
                     statusActionListener,
                 )
@@ -206,6 +210,7 @@ class NotificationsPagingAdapter(
             NotificationViewKind.NOTIFICATION -> {
                 StatusNotificationViewHolder(
                     ItemStatusNotificationBinding.inflate(inflater, parent, false),
+                    glide,
                     setStatusContent,
                     statusActionListener,
                     notificationActionListener,
@@ -215,6 +220,7 @@ class NotificationsPagingAdapter(
             NotificationViewKind.FOLLOW -> {
                 FollowViewHolder(
                     ItemFollowBinding.inflate(inflater, parent, false),
+                    glide,
                     notificationActionListener,
                     statusActionListener,
                 )
@@ -222,6 +228,7 @@ class NotificationsPagingAdapter(
             NotificationViewKind.FOLLOW_REQUEST -> {
                 FollowRequestViewHolder(
                     ItemFollowRequestBinding.inflate(inflater, parent, false),
+                    glide,
                     accountActionListener,
                     statusActionListener,
                     showHeader = true,
@@ -230,6 +237,7 @@ class NotificationsPagingAdapter(
             NotificationViewKind.REPORT -> {
                 ReportNotificationViewHolder(
                     ItemReportNotificationBinding.inflate(inflater, parent, false),
+                    glide,
                     notificationActionListener,
                 )
             }

--- a/app/src/main/java/app/pachli/components/notifications/StatusNotificationViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/notifications/StatusNotificationViewHolder.kt
@@ -45,7 +45,7 @@ import app.pachli.interfaces.StatusActionListener
 import app.pachli.util.getRelativeTimeSpanString
 import app.pachli.viewdata.NotificationViewData
 import at.connyduck.sparkbutton.helpers.Utils
-import com.bumptech.glide.Glide
+import com.bumptech.glide.RequestManager
 import java.util.Date
 
 /**
@@ -60,6 +60,7 @@ import java.util.Date
  */
 internal class StatusNotificationViewHolder(
     private val binding: ItemStatusNotificationBinding,
+    private val glide: RequestManager,
     private val setStatusContent: SetStatusContent,
     private val statusActionListener: StatusActionListener<NotificationViewData>,
     private val notificationActionListener: NotificationActionListener,
@@ -146,7 +147,7 @@ internal class StatusNotificationViewHolder(
     }
 
     private fun setDisplayName(name: String, emojis: List<Emoji>?, animateEmojis: Boolean) {
-        val emojifiedName = name.emojify(emojis, binding.statusDisplayName, animateEmojis)
+        val emojifiedName = name.emojify(glide, emojis, binding.statusDisplayName, animateEmojis)
         binding.statusDisplayName.text = emojifiedName
     }
 
@@ -189,6 +190,7 @@ internal class StatusNotificationViewHolder(
     private fun setAvatar(statusAvatarUrl: String?, isBot: Boolean, animateAvatars: Boolean, showBotOverlay: Boolean) {
         binding.notificationStatusAvatar.setPaddingRelative(0, 0, 0, 0)
         loadAvatar(
+            glide,
             statusAvatarUrl,
             binding.notificationStatusAvatar,
             avatarRadius48dp,
@@ -196,8 +198,7 @@ internal class StatusNotificationViewHolder(
         )
         if (showBotOverlay && isBot) {
             binding.notificationNotificationAvatar.visibility = View.VISIBLE
-            Glide.with(binding.notificationNotificationAvatar)
-                .load(DR.drawable.bot_badge)
+            glide.load(DR.drawable.bot_badge)
                 .into(binding.notificationNotificationAvatar)
         } else {
             binding.notificationNotificationAvatar.visibility = View.GONE
@@ -208,6 +209,7 @@ internal class StatusNotificationViewHolder(
         val padding = Utils.dpToPx(binding.notificationStatusAvatar.context, 12)
         binding.notificationStatusAvatar.setPaddingRelative(0, 0, padding, padding)
         loadAvatar(
+            glide,
             statusAvatarUrl,
             binding.notificationStatusAvatar,
             avatarRadius36dp,
@@ -215,6 +217,7 @@ internal class StatusNotificationViewHolder(
         )
         binding.notificationNotificationAvatar.visibility = View.VISIBLE
         loadAvatar(
+            glide,
             notificationAvatarUrl,
             binding.notificationNotificationAvatar,
             avatarRadius24dp,
@@ -269,6 +272,7 @@ internal class StatusNotificationViewHolder(
             Spanned.SPAN_EXCLUSIVE_EXCLUSIVE,
         )
         val emojifiedText = str.emojify(
+            glide,
             viewData.account.emojis,
             binding.notificationTopText,
             statusDisplayOptions.animateEmojis,
@@ -347,6 +351,7 @@ internal class StatusNotificationViewHolder(
             binding.notificationContent.filters = NO_INPUT_FILTER
         }
         setStatusContent(
+            glide,
             binding.notificationContent,
             content,
             statusDisplayOptions,
@@ -357,6 +362,7 @@ internal class StatusNotificationViewHolder(
         )
 
         val emojifiedContentWarning: CharSequence = statusViewData.spoilerText.emojify(
+            glide,
             statusViewData.actionable.emojis,
             binding.notificationContentWarningDescription,
             statusDisplayOptions.animateEmojis,

--- a/app/src/main/java/app/pachli/components/notifications/StatusViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/notifications/StatusViewHolder.kt
@@ -26,12 +26,14 @@ import app.pachli.databinding.ItemStatusBinding
 import app.pachli.databinding.ItemStatusWrapperBinding
 import app.pachli.interfaces.StatusActionListener
 import app.pachli.viewdata.NotificationViewData
+import com.bumptech.glide.RequestManager
 
 internal class StatusViewHolder(
     binding: ItemStatusBinding,
+    glide: RequestManager,
     setStatusContent: SetStatusContent,
     private val statusActionListener: StatusActionListener<NotificationViewData>,
-) : NotificationsPagingAdapter.ViewHolder, StatusViewHolder<NotificationViewData>(binding, setStatusContent) {
+) : NotificationsPagingAdapter.ViewHolder, StatusViewHolder<NotificationViewData>(binding, glide, setStatusContent) {
 
     override fun bind(
         viewData: NotificationViewData,
@@ -64,9 +66,10 @@ internal class StatusViewHolder(
 
 class FilterableStatusViewHolder(
     binding: ItemStatusWrapperBinding,
+    glide: RequestManager,
     setStatusContent: SetStatusContent,
     private val statusActionListener: StatusActionListener<NotificationViewData>,
-) : NotificationsPagingAdapter.ViewHolder, FilterableStatusViewHolder<NotificationViewData>(binding, setStatusContent) {
+) : NotificationsPagingAdapter.ViewHolder, FilterableStatusViewHolder<NotificationViewData>(binding, glide, setStatusContent) {
     // Note: Identical to bind() in StatusViewHolder above
     override fun bind(
         viewData: NotificationViewData,

--- a/app/src/main/java/app/pachli/components/report/adapter/StatusViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/report/adapter/StatusViewHolder.kt
@@ -42,10 +42,12 @@ import app.pachli.util.StatusViewHelper.Companion.COLLAPSE_INPUT_FILTER
 import app.pachli.util.StatusViewHelper.Companion.NO_INPUT_FILTER
 import app.pachli.util.getRelativeTimeSpanString
 import app.pachli.viewdata.PollViewData
+import com.bumptech.glide.RequestManager
 import java.util.Date
 
 open class StatusViewHolder(
     private val binding: ItemReportStatusBinding,
+    private val glide: RequestManager,
     private val setStatusContent: SetStatusContent,
     private val statusDisplayOptions: StatusDisplayOptions,
     private val viewState: StatusViewState,
@@ -54,7 +56,7 @@ open class StatusViewHolder(
 ) : RecyclerView.ViewHolder(binding.root) {
 
     private val mediaViewHeight = itemView.context.resources.getDimensionPixelSize(DR.dimen.status_media_preview_height)
-    private val statusViewHelper = StatusViewHelper(itemView)
+    private val statusViewHelper = StatusViewHelper(glide, itemView)
     private val absoluteTimeFormatter = AbsoluteTimeFormatter()
 
     private val previewListener = object : StatusViewHelper.MediaPreviewListener {
@@ -117,7 +119,7 @@ open class StatusViewHolder(
                 binding.statusContentWarningButton.hide()
                 binding.statusContentWarningDescription.hide()
             } else {
-                val emojiSpoiler = viewdata.spoilerText.emojify(viewdata.status.emojis, binding.statusContentWarningDescription, statusDisplayOptions.animateEmojis)
+                val emojiSpoiler = viewdata.spoilerText.emojify(glide, viewdata.status.emojis, binding.statusContentWarningDescription, statusDisplayOptions.animateEmojis)
                 binding.statusContentWarningDescription.text = emojiSpoiler
                 binding.statusContentWarningDescription.show()
                 binding.statusContentWarningButton.show()
@@ -153,7 +155,7 @@ open class StatusViewHolder(
         listener: LinkListener,
     ) {
         if (expanded) {
-            setStatusContent(binding.statusContent, content, statusDisplayOptions, emojis, mentions, tags, listener)
+            setStatusContent(glide, binding.statusContent, content, statusDisplayOptions, emojis, mentions, tags, listener)
         } else {
             setClickableMentions(binding.statusContent, mentions, listener)
         }

--- a/app/src/main/java/app/pachli/components/report/adapter/StatusesAdapter.kt
+++ b/app/src/main/java/app/pachli/components/report/adapter/StatusesAdapter.kt
@@ -26,8 +26,10 @@ import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.data.model.StatusViewData
 import app.pachli.core.ui.SetStatusContent
 import app.pachli.databinding.ItemReportStatusBinding
+import com.bumptech.glide.RequestManager
 
 class StatusesAdapter(
+    private val glide: RequestManager,
     private val setStatusContent: SetStatusContent,
     private val statusDisplayOptions: StatusDisplayOptions,
     private val statusViewState: StatusViewState,
@@ -42,6 +44,7 @@ class StatusesAdapter(
         val binding = ItemReportStatusBinding.inflate(LayoutInflater.from(parent.context), parent, false)
         return StatusViewHolder(
             binding,
+            glide,
             setStatusContent,
             statusDisplayOptions,
             statusViewState,

--- a/app/src/main/java/app/pachli/components/report/fragments/ReportStatusesFragment.kt
+++ b/app/src/main/java/app/pachli/components/report/fragments/ReportStatusesFragment.kt
@@ -49,6 +49,7 @@ import app.pachli.core.network.model.Status
 import app.pachli.core.ui.SetMarkdownContent
 import app.pachli.core.ui.SetMastodonHtmlContent
 import app.pachli.databinding.FragmentReportStatusesBinding
+import com.bumptech.glide.Glide
 import com.google.android.material.color.MaterialColors
 import com.google.android.material.divider.MaterialDividerItemDecoration
 import com.google.android.material.snackbar.Snackbar
@@ -97,6 +98,7 @@ class ReportStatusesFragment :
         }
 
         adapter = StatusesAdapter(
+            Glide.with(this),
             setStatusContent,
             viewModel.statusDisplayOptions.value,
             viewModel.statusViewState,

--- a/app/src/main/java/app/pachli/components/search/SearchActivity.kt
+++ b/app/src/main/java/app/pachli/components/search/SearchActivity.kt
@@ -537,6 +537,7 @@ class SearchActivity :
 
                 dialogBinding.account.setAdapter(
                     ComposeAutoCompleteAdapter(
+                        glide,
                         this@SearchActivity,
                         animateAvatar = false,
                         animateEmojis = false,

--- a/app/src/main/java/app/pachli/components/search/adapter/SearchAccountsAdapter.kt
+++ b/app/src/main/java/app/pachli/components/search/adapter/SearchAccountsAdapter.kt
@@ -24,8 +24,15 @@ import app.pachli.adapter.AccountViewHolder
 import app.pachli.core.network.model.TimelineAccount
 import app.pachli.core.ui.LinkListener
 import app.pachli.databinding.ItemAccountBinding
+import com.bumptech.glide.RequestManager
 
-class SearchAccountsAdapter(private val linkListener: LinkListener, private val animateAvatars: Boolean, private val animateEmojis: Boolean, private val showBotOverlay: Boolean) :
+class SearchAccountsAdapter(
+    private val glide: RequestManager,
+    private val linkListener: LinkListener,
+    private val animateAvatars: Boolean,
+    private val animateEmojis: Boolean,
+    private val showBotOverlay: Boolean,
+) :
     PagingDataAdapter<TimelineAccount, AccountViewHolder>(ACCOUNT_COMPARATOR) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AccountViewHolder {
@@ -34,7 +41,7 @@ class SearchAccountsAdapter(private val linkListener: LinkListener, private val 
             parent,
             false,
         )
-        return AccountViewHolder(binding)
+        return AccountViewHolder(binding, glide)
     }
 
     override fun onBindViewHolder(holder: AccountViewHolder, position: Int) {
@@ -48,11 +55,9 @@ class SearchAccountsAdapter(private val linkListener: LinkListener, private val 
 
     companion object {
         val ACCOUNT_COMPARATOR = object : DiffUtil.ItemCallback<TimelineAccount>() {
-            override fun areContentsTheSame(oldItem: TimelineAccount, newItem: TimelineAccount): Boolean =
-                oldItem == newItem
+            override fun areContentsTheSame(oldItem: TimelineAccount, newItem: TimelineAccount): Boolean = oldItem == newItem
 
-            override fun areItemsTheSame(oldItem: TimelineAccount, newItem: TimelineAccount): Boolean =
-                oldItem.id == newItem.id
+            override fun areItemsTheSame(oldItem: TimelineAccount, newItem: TimelineAccount): Boolean = oldItem.id == newItem.id
         }
     }
 }

--- a/app/src/main/java/app/pachli/components/search/adapter/SearchStatusesAdapter.kt
+++ b/app/src/main/java/app/pachli/components/search/adapter/SearchStatusesAdapter.kt
@@ -26,8 +26,10 @@ import app.pachli.core.data.model.StatusViewData
 import app.pachli.core.ui.SetStatusContent
 import app.pachli.databinding.ItemStatusBinding
 import app.pachli.interfaces.StatusActionListener
+import com.bumptech.glide.RequestManager
 
 class SearchStatusesAdapter(
+    private val glide: RequestManager,
     private val setStatusContent: SetStatusContent,
     private val statusDisplayOptions: StatusDisplayOptions,
     private val statusListener: StatusActionListener<StatusViewData>,
@@ -36,6 +38,7 @@ class SearchStatusesAdapter(
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): StatusViewHolder<StatusViewData> {
         return StatusViewHolder(
             ItemStatusBinding.inflate(LayoutInflater.from(parent.context), parent, false),
+            glide,
             setStatusContent,
         )
     }

--- a/app/src/main/java/app/pachli/components/search/fragments/SearchAccountsFragment.kt
+++ b/app/src/main/java/app/pachli/components/search/fragments/SearchAccountsFragment.kt
@@ -23,6 +23,7 @@ import androidx.paging.PagingDataAdapter
 import app.pachli.components.search.adapter.SearchAccountsAdapter
 import app.pachli.core.network.model.TimelineAccount
 import app.pachli.core.preferences.SharedPreferencesRepository
+import com.bumptech.glide.Glide
 import com.google.android.material.divider.MaterialDividerItemDecoration
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -42,6 +43,7 @@ class SearchAccountsFragment : SearchFragment<TimelineAccount>() {
 
     override fun createAdapter(): PagingDataAdapter<TimelineAccount, *> {
         return SearchAccountsAdapter(
+            Glide.with(this),
             this,
             sharedPreferencesRepository.animateAvatars,
             sharedPreferencesRepository.animateEmojis,

--- a/app/src/main/java/app/pachli/components/search/fragments/SearchStatusesFragment.kt
+++ b/app/src/main/java/app/pachli/components/search/fragments/SearchStatusesFragment.kt
@@ -58,6 +58,7 @@ import app.pachli.core.ui.SetMarkdownContent
 import app.pachli.core.ui.SetMastodonHtmlContent
 import app.pachli.interfaces.StatusActionListener
 import app.pachli.view.showMuteAccountDialog
+import com.bumptech.glide.Glide
 import com.github.michaelbull.result.onFailure
 import com.github.michaelbull.result.onSuccess
 import com.google.android.material.divider.MaterialDividerItemDecoration
@@ -98,7 +99,7 @@ class SearchStatusesFragment : SearchFragment<StatusViewData>(), StatusActionLis
             MaterialDividerItemDecoration(requireContext(), MaterialDividerItemDecoration.VERTICAL),
         )
         binding.searchRecyclerView.layoutManager = LinearLayoutManager(binding.searchRecyclerView.context)
-        return SearchStatusesAdapter(setStatusContent, statusDisplayOptions, this)
+        return SearchStatusesAdapter(Glide.with(this), setStatusContent, statusDisplayOptions, this)
     }
 
     override fun onContentHiddenChange(viewData: StatusViewData, isShowingContent: Boolean) {

--- a/app/src/main/java/app/pachli/components/timeline/TimelineFragment.kt
+++ b/app/src/main/java/app/pachli/components/timeline/TimelineFragment.kt
@@ -82,6 +82,7 @@ import app.pachli.interfaces.AppBarLayoutHost
 import app.pachli.interfaces.StatusActionListener
 import app.pachli.util.ListStatusAccessibilityDelegate
 import at.connyduck.sparkbutton.helpers.Utils
+import com.bumptech.glide.Glide
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.onFailure
 import com.github.michaelbull.result.onSuccess
@@ -200,7 +201,7 @@ class TimelineFragment :
             SetMastodonHtmlContent
         }
 
-        adapter = TimelinePagingAdapter(setStatusContent, this, viewModel.statusDisplayOptions.value)
+        adapter = TimelinePagingAdapter(Glide.with(this), setStatusContent, this, viewModel.statusDisplayOptions.value)
 
         layoutManager = LinearLayoutManager(context)
 

--- a/app/src/main/java/app/pachli/components/timeline/TimelinePagingAdapter.kt
+++ b/app/src/main/java/app/pachli/components/timeline/TimelinePagingAdapter.kt
@@ -32,8 +32,10 @@ import app.pachli.core.ui.SetStatusContent
 import app.pachli.databinding.ItemStatusBinding
 import app.pachli.databinding.ItemStatusWrapperBinding
 import app.pachli.interfaces.StatusActionListener
+import com.bumptech.glide.RequestManager
 
 class TimelinePagingAdapter(
+    private val glide: RequestManager,
     private val setStatusContent: SetStatusContent,
     private val statusListener: StatusActionListener<StatusViewData>,
     var statusDisplayOptions: StatusDisplayOptions,
@@ -44,12 +46,14 @@ class TimelinePagingAdapter(
             VIEW_TYPE_STATUS_FILTERED -> {
                 FilterableStatusViewHolder<StatusViewData>(
                     ItemStatusWrapperBinding.inflate(inflater, viewGroup, false),
+                    glide,
                     setStatusContent,
                 )
             }
             VIEW_TYPE_STATUS -> {
                 StatusViewHolder<StatusViewData>(
                     ItemStatusBinding.inflate(inflater, viewGroup, false),
+                    glide,
                     setStatusContent,
                 )
             }

--- a/app/src/main/java/app/pachli/components/trending/TrendingLinkViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/trending/TrendingLinkViewHolder.kt
@@ -22,9 +22,11 @@ import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.network.model.TrendsLink
 import app.pachli.databinding.ItemTrendingLinkBinding
 import app.pachli.view.PreviewCardView
+import com.bumptech.glide.RequestManager
 
 class TrendingLinkViewHolder(
     private val binding: ItemTrendingLinkBinding,
+    private val glide: RequestManager,
     private val onClick: PreviewCardView.OnClickListener,
 ) : RecyclerView.ViewHolder(binding.root) {
     internal lateinit var link: TrendsLink
@@ -38,6 +40,6 @@ class TrendingLinkViewHolder(
     fun bind(link: TrendsLink, statusDisplayOptions: StatusDisplayOptions, showTimelineLink: Boolean) {
         this.link = link
 
-        binding.statusCardView.bind(link, sensitive = false, statusDisplayOptions, showTimelineLink, onClick)
+        binding.statusCardView.bind(glide, link, sensitive = false, statusDisplayOptions, showTimelineLink, onClick)
     }
 }

--- a/app/src/main/java/app/pachli/components/trending/TrendingLinksAdapter.kt
+++ b/app/src/main/java/app/pachli/components/trending/TrendingLinksAdapter.kt
@@ -26,6 +26,7 @@ import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.network.model.TrendsLink
 import app.pachli.databinding.ItemTrendingLinkBinding
 import app.pachli.view.PreviewCardView
+import com.bumptech.glide.RequestManager
 
 /**
  * @param statusDisplayOptions
@@ -34,6 +35,7 @@ import app.pachli.view.PreviewCardView
  * @param onViewLink
  */
 class TrendingLinksAdapter(
+    private val glide: RequestManager,
     statusDisplayOptions: StatusDisplayOptions,
     showTimelineLink: Boolean,
     private val onViewLink: PreviewCardView.OnClickListener,
@@ -59,6 +61,7 @@ class TrendingLinksAdapter(
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TrendingLinkViewHolder {
         return TrendingLinkViewHolder(
             ItemTrendingLinkBinding.inflate(LayoutInflater.from(parent.context)),
+            glide,
             onViewLink,
         )
     }

--- a/app/src/main/java/app/pachli/components/trending/TrendingLinksFragment.kt
+++ b/app/src/main/java/app/pachli/components/trending/TrendingLinksFragment.kt
@@ -55,6 +55,7 @@ import app.pachli.databinding.FragmentTrendingLinksBinding
 import app.pachli.interfaces.ActionButtonActivity
 import app.pachli.interfaces.AppBarLayoutHost
 import app.pachli.view.PreviewCardView.Target
+import com.bumptech.glide.Glide
 import com.google.android.material.color.MaterialColors
 import com.google.android.material.snackbar.Snackbar
 import com.mikepenz.iconics.IconicsDrawable
@@ -130,6 +131,7 @@ class TrendingLinksFragment :
         }
 
         trendingLinksAdapter = TrendingLinksAdapter(
+            Glide.with(this),
             viewModel.statusDisplayOptions.value,
             false,
             ::onOpenLink,

--- a/app/src/main/java/app/pachli/components/viewthread/ThreadAdapter.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/ThreadAdapter.kt
@@ -33,8 +33,10 @@ import app.pachli.databinding.ItemStatusBinding
 import app.pachli.databinding.ItemStatusDetailedBinding
 import app.pachli.databinding.ItemStatusWrapperBinding
 import app.pachli.interfaces.StatusActionListener
+import com.bumptech.glide.RequestManager
 
 class ThreadAdapter(
+    private val glide: RequestManager,
     private val statusDisplayOptions: StatusDisplayOptions,
     private val statusActionListener: StatusActionListener<StatusViewData>,
     private val setStatusContent: SetStatusContent,
@@ -47,18 +49,21 @@ class ThreadAdapter(
             VIEW_TYPE_STATUS -> {
                 StatusViewHolder(
                     ItemStatusBinding.inflate(inflater, parent, false),
+                    glide,
                     setStatusContent,
                 )
             }
             VIEW_TYPE_STATUS_FILTERED -> {
                 FilterableStatusViewHolder(
                     ItemStatusWrapperBinding.inflate(inflater, parent, false),
+                    glide,
                     setStatusContent,
                 )
             }
             VIEW_TYPE_STATUS_DETAILED -> {
                 StatusDetailedViewHolder(
                     ItemStatusDetailedBinding.inflate(inflater, parent, false),
+                    glide,
                     setStatusContent,
                     openUrl,
                 )

--- a/app/src/main/java/app/pachli/components/viewthread/ViewThreadFragment.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/ViewThreadFragment.kt
@@ -55,6 +55,7 @@ import app.pachli.databinding.FragmentViewThreadBinding
 import app.pachli.fragment.SFragment
 import app.pachli.interfaces.StatusActionListener
 import app.pachli.util.ListStatusAccessibilityDelegate
+import com.bumptech.glide.Glide
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.onFailure
 import com.github.michaelbull.result.onSuccess
@@ -102,7 +103,7 @@ class ViewThreadFragment :
             SetMastodonHtmlContent
         }
 
-        adapter = ThreadAdapter(viewModel.statusDisplayOptions.value, this, setStatusContent, openUrl)
+        adapter = ThreadAdapter(Glide.with(this), viewModel.statusDisplayOptions.value, this, setStatusContent, openUrl)
     }
 
     override fun onCreateView(

--- a/app/src/main/java/app/pachli/components/viewthread/edits/ViewEditsAdapter.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/edits/ViewEditsAdapter.kt
@@ -35,12 +35,13 @@ import app.pachli.core.ui.setClickableText
 import app.pachli.databinding.ItemStatusEditBinding
 import app.pachli.util.aspectRatios
 import app.pachli.viewdata.PollOptionViewData
-import com.bumptech.glide.Glide
+import com.bumptech.glide.RequestManager
 import com.google.android.material.color.MaterialColors
 import org.xml.sax.XMLReader
 
 class ViewEditsAdapter(
     context: Context,
+    private val glide: RequestManager,
     private val edits: List<StatusEdit>,
     private val animateEmojis: Boolean,
     private val useBlurhash: Boolean,
@@ -113,6 +114,7 @@ class ViewEditsAdapter(
             binding.statusEditContentWarningDescription.text = edit.spoilerText
                 .parseAsMastodonHtml(pachliTagHandler)
                 .emojify(
+                    glide,
                     edit.emojis,
                     binding.statusEditContentWarningDescription,
                     animateEmojis,
@@ -122,7 +124,7 @@ class ViewEditsAdapter(
         val emojifiedText = edit
             .content
             .parseAsMastodonHtml(pachliTagHandler)
-            .emojify(edit.emojis, binding.statusEditContent, animateEmojis)
+            .emojify(glide, edit.emojis, binding.statusEditContent, animateEmojis)
 
         setClickableText(binding.statusEditContent, emojifiedText, emptyList(), null, listener)
 
@@ -138,6 +140,7 @@ class ViewEditsAdapter(
             // binding.statusEditPollDescription.show()
 
             val pollAdapter = PollAdapter(
+                glide,
                 options = poll.options.map { PollOptionViewData.from(it) },
                 votesCount = 0,
                 votersCount = null,
@@ -183,8 +186,7 @@ class ViewEditsAdapter(
 
                 if (attachment.previewUrl.isNullOrEmpty()) {
                     imageView.removeFocalPoint()
-                    Glide.with(imageView)
-                        .load(placeholder)
+                    glide.load(placeholder)
                         .centerInside()
                         .into(imageView)
                 } else {
@@ -192,16 +194,14 @@ class ViewEditsAdapter(
 
                     if (focus != null) {
                         imageView.setFocalPoint(focus)
-                        Glide.with(imageView.context)
-                            .load(attachment.previewUrl)
+                        glide.load(attachment.previewUrl)
                             .placeholder(placeholder)
                             .centerInside()
                             .addListener(imageView)
                             .into(imageView)
                     } else {
                         imageView.removeFocalPoint()
-                        Glide.with(imageView)
-                            .load(attachment.previewUrl)
+                        glide.load(attachment.previewUrl)
                             .placeholder(placeholder)
                             .centerInside()
                             .into(imageView)

--- a/app/src/main/java/app/pachli/components/viewthread/edits/ViewEditsFragment.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/edits/ViewEditsFragment.kt
@@ -45,6 +45,7 @@ import app.pachli.core.ui.LinkListener
 import app.pachli.core.ui.emojify
 import app.pachli.core.ui.loadAvatar
 import app.pachli.databinding.FragmentViewEditsBinding
+import com.bumptech.glide.Glide
 import com.google.android.material.color.MaterialColors
 import com.google.android.material.divider.MaterialDividerItemDecoration
 import com.mikepenz.iconics.IconicsDrawable
@@ -136,8 +137,11 @@ class ViewEditsFragment :
                         binding.statusView.hide()
                         binding.initialProgressBar.hide()
 
+                        val glide = Glide.with(this@ViewEditsFragment)
+
                         binding.recyclerView.adapter = ViewEditsAdapter(
                             context = requireContext(),
+                            glide = glide,
                             edits = uiState.edits,
                             animateEmojis = animateEmojis,
                             useBlurhash = useBlurhash,
@@ -148,9 +152,14 @@ class ViewEditsFragment :
                         (binding.recyclerView.layoutManager as LinearLayoutManager).scrollToPosition(0)
 
                         val account = uiState.edits.first().account
-                        loadAvatar(account.avatar, binding.statusAvatar, avatarRadius, animateAvatars)
+                        loadAvatar(glide, account.avatar, binding.statusAvatar, avatarRadius, animateAvatars)
 
-                        binding.statusDisplayName.text = account.name.unicodeWrap().emojify(account.emojis, binding.statusDisplayName, animateEmojis)
+                        binding.statusDisplayName.text = account.name.unicodeWrap().emojify(
+                            glide,
+                            account.emojis,
+                            binding.statusDisplayName,
+                            animateEmojis,
+                        )
                         binding.statusUsername.text = account.username
                     }
                 }

--- a/app/src/main/java/app/pachli/util/StatusViewHelper.kt
+++ b/app/src/main/java/app/pachli/util/StatusViewHelper.kt
@@ -38,12 +38,15 @@ import app.pachli.view.MediaPreviewImageView
 import app.pachli.viewdata.PollViewData
 import app.pachli.viewdata.buildDescription
 import app.pachli.viewdata.calculatePercent
-import com.bumptech.glide.Glide
+import com.bumptech.glide.RequestManager
 import com.google.android.material.color.MaterialColors
 import java.text.NumberFormat
 import kotlin.math.min
 
-class StatusViewHelper(private val itemView: View) {
+class StatusViewHelper(
+    private val glide: RequestManager,
+    private val itemView: View,
+) {
     private val absoluteTimeFormatter = AbsoluteTimeFormatter()
 
     interface MediaPreviewListener {
@@ -110,8 +113,7 @@ class StatusViewHelper(private val itemView: View) {
             mediaPreviews[i].visibility = View.VISIBLE
 
             if (TextUtils.isEmpty(previewUrl)) {
-                Glide.with(mediaPreviews[i])
-                    .load(mediaPreviewUnloaded)
+                glide.load(mediaPreviewUnloaded)
                     .centerInside()
                     .into(mediaPreviews[i])
             } else {
@@ -124,8 +126,7 @@ class StatusViewHelper(private val itemView: View) {
                     if (focus != null) { // If there is a focal point for this attachment:
                         mediaPreviews[i].setFocalPoint(focus)
 
-                        Glide.with(mediaPreviews[i])
-                            .load(previewUrl)
+                        glide.load(previewUrl)
                             .placeholder(placeholder)
                             .centerInside()
                             .addListener(mediaPreviews[i])
@@ -133,8 +134,7 @@ class StatusViewHelper(private val itemView: View) {
                     } else {
                         mediaPreviews[i].removeFocalPoint()
 
-                        Glide.with(mediaPreviews[i])
-                            .load(previewUrl)
+                        glide.load(previewUrl)
                             .placeholder(placeholder)
                             .centerInside()
                             .into(mediaPreviews[i])
@@ -143,8 +143,10 @@ class StatusViewHelper(private val itemView: View) {
                     mediaPreviews[i].removeFocalPoint()
                     if (statusDisplayOptions.useBlurhash && attachment.blurhash != null) {
                         val blurhashBitmap = decodeBlurHash(context, attachment.blurhash!!)
+                        glide.clear(mediaPreviews[i])
                         mediaPreviews[i].setImageDrawable(blurhashBitmap)
                     } else {
+                        glide.clear(mediaPreviews[i])
                         mediaPreviews[i].setImageDrawable(mediaPreviewUnloaded)
                     }
                 }
@@ -327,7 +329,7 @@ class StatusViewHelper(private val itemView: View) {
                 val percent = calculatePercent(options[i].votesCount, poll.votersCount, poll.votesCount)
 
                 val pollOptionText = buildDescription(options[i].title, percent, options[i].voted, pollResults[i].context)
-                pollResults[i].text = pollOptionText.emojify(emojis, pollResults[i], animateEmojis)
+                pollResults[i].text = pollOptionText.emojify(glide, emojis, pollResults[i], animateEmojis)
                 pollResults[i].visibility = View.VISIBLE
 
                 val level = percent * 100

--- a/app/src/main/java/app/pachli/view/PollView.kt
+++ b/app/src/main/java/app/pachli/view/PollView.kt
@@ -43,6 +43,7 @@ import app.pachli.util.formatPollDuration
 import app.pachli.viewdata.PollViewData
 import app.pachli.viewdata.buildDescription
 import app.pachli.viewdata.calculatePercent
+import com.bumptech.glide.RequestManager
 import java.text.NumberFormat
 
 /**
@@ -78,6 +79,7 @@ class PollView @JvmOverloads constructor(
     }
 
     fun bind(
+        glide: RequestManager,
         pollViewData: PollViewData,
         emojis: List<Emoji>,
         statusDisplayOptions: StatusDisplayOptions,
@@ -110,6 +112,7 @@ class PollView @JvmOverloads constructor(
         }
 
         val adapter = PollAdapter(
+            glide = glide,
             options = options,
             votesCount = pollViewData.votesCount,
             votersCount = pollViewData.votersCount,

--- a/app/src/main/java/app/pachli/view/PreviewCardView.kt
+++ b/app/src/main/java/app/pachli/view/PreviewCardView.kt
@@ -37,7 +37,7 @@ import app.pachli.core.network.model.TrendsLink
 import app.pachli.core.ui.decodeBlurHash
 import app.pachli.core.ui.emojify
 import app.pachli.databinding.PreviewCardBinding
-import com.bumptech.glide.Glide
+import com.bumptech.glide.RequestManager
 import com.bumptech.glide.load.MultiTransformation
 import com.bumptech.glide.load.resource.bitmap.CenterCrop
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners
@@ -124,6 +124,7 @@ class PreviewCardView @JvmOverloads constructor(
      * @param listener
      */
     fun bind(
+        glide: RequestManager,
         card: PreviewCard,
         sensitive: Boolean,
         statusDisplayOptions: StatusDisplayOptions,
@@ -162,8 +163,7 @@ class PreviewCardView @JvmOverloads constructor(
                 setStartEndLayout()
             }.build()
 
-            val builder = Glide.with(cardImage.context)
-                .load(card.image)
+            val builder = glide.load(card.image)
                 .dontTransform()
             if (statusDisplayOptions.useBlurhash && !card.blurhash.isNullOrBlank()) {
                 builder
@@ -176,11 +176,11 @@ class PreviewCardView @JvmOverloads constructor(
             cardImage.show()
             cardImage.shapeAppearanceModel = setStartEndLayout().build()
 
-            Glide.with(cardImage.context)
-                .load(decodeBlurHash(cardImage.context, card.blurhash!!))
+            glide.load(decodeBlurHash(cardImage.context, card.blurhash!!))
                 .dontTransform()
                 .into(cardImage)
         } else {
+            glide.clear(cardImage)
             cardImage.hide()
         }
 
@@ -192,13 +192,13 @@ class PreviewCardView @JvmOverloads constructor(
         when {
             // Author has an account, link to that, with their avatar.
             author?.account != null -> {
-                val name = author.account?.name.unicodeWrap().emojify(author.account?.emojis, authorInfo, false)
+                val name = author.account?.name.unicodeWrap().emojify(glide, author.account?.emojis, authorInfo, false)
                 authorInfo.text = HtmlCompat.fromHtml(
                     authorInfo.context.getString(R.string.preview_card_byline_fediverse_account_fmt, name),
                     HtmlCompat.FROM_HTML_MODE_LEGACY,
                 )
 
-                Glide.with(authorInfo.context).load(author.account?.avatar).transform(bylineAvatarTransformation)
+                glide.load(author.account?.avatar).transform(bylineAvatarTransformation)
                     .placeholder(DR.drawable.avatar_default).into(bylineAvatarTarget)
                 authorInfo.show()
                 showBylineDivider = true

--- a/checks/src/main/java/app/pachli/lint/checks/GlideWithViewDetector.kt
+++ b/checks/src/main/java/app/pachli/lint/checks/GlideWithViewDetector.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2025 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.lint.checks
+
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.intellij.psi.PsiMethod
+import org.jetbrains.uast.UCallExpression
+
+class GlideWithViewDetector : Detector(), SourceCodeScanner {
+    override fun getApplicableMethodNames() = listOf(METHOD_WITH)
+
+    override fun visitMethodCall(context: JavaContext, node: UCallExpression, method: PsiMethod) {
+        if (!context.evaluator.isMemberInClass(method, CLASS_GLIDE)) return
+        if (method.name != METHOD_WITH) return
+        if (!context.evaluator.methodMatches(
+                method,
+                CLASS_GLIDE,
+                true,
+                "android.view.View",
+            )
+        ) {
+            return
+        }
+
+        context.report(
+            issue = ISSUE,
+            scope = node,
+            location = context.getCallLocation(node, includeReceiver = true, includeArguments = true),
+            message = "Use an activity or fragment, not a view.",
+        )
+    }
+
+    companion object {
+        private const val CLASS_GLIDE = "com.bumptech.glide.Glide"
+        private const val METHOD_WITH = "with"
+
+        val ISSUE = Issue.create(
+            id = "GlideWithViewDetector",
+            briefDescription = "Don't use `Glide.with(view)`, pass the activity or fragment",
+            explanation = """
+                `Glide.with(view)` always uses the activity's lifecycle, even if the view is displayed
+                by a fragment.
+
+                This means in-progress loads are not paused or cancelled when the fragment is stopped
+                or destroyed, only when the activity is destroyed.
+
+                Always call `Glide.with` with an explicit activity or fragment.
+
+                See https://github.com/bumptech/glide/issues/898
+            """,
+            category = Category.CORRECTNESS,
+            priority = 6,
+            severity = Severity.WARNING,
+            implementation = Implementation(
+                GlideWithViewDetector::class.java,
+                Scope.JAVA_FILE_SCOPE,
+            ),
+        )
+    }
+}

--- a/checks/src/main/java/app/pachli/lint/checks/LintRegistry.kt
+++ b/checks/src/main/java/app/pachli/lint/checks/LintRegistry.kt
@@ -11,6 +11,7 @@ class LintRegistry : IssueRegistry() {
             AndroidxToolbarDetector.ISSUE,
             ContextCompatGetDrawableDetector.ISSUE,
             DateDotTimeDetector.ISSUE,
+            GlideWithViewDetector.ISSUE,
             IntentDetector.ISSUE,
         )
 

--- a/checks/src/test/java/app/pachli/lint/checks/GlideWithViewDetectorTest.kt
+++ b/checks/src/test/java/app/pachli/lint/checks/GlideWithViewDetectorTest.kt
@@ -23,52 +23,52 @@ import com.android.tools.lint.detector.api.Detector
 import com.android.tools.lint.detector.api.Issue
 
 @Suppress("ktlint:standard:function-naming")
-class ContextCompatGetDrawableDetectorTest : LintDetectorTest() {
-    override fun getDetector(): Detector = ContextCompatGetDrawableDetector()
+class GlideWithViewDetectorTest : LintDetectorTest() {
+    override fun getDetector(): Detector = GlideWithViewDetector()
 
-    override fun getIssues(): List<Issue> = listOf(ContextCompatGetDrawableDetector.ISSUE)
+    override fun getIssues(): List<Issue> = listOf(GlideWithViewDetector.ISSUE)
 
-    fun `test Intent component constructor emits warning`() {
+    fun `test Glide with view emits warning`() {
         lint().files(
-            Context,
-            ContextCompat,
+            View,
+            Glide,
             kotlin(
                 """
                 package test.pkg
 
-                import android.content.Context
-                import androidx.core.content.ContextCompat
+                import android.view.View
+                import com.bumptech.glide.Glide
 
-                fun foo() = ContextCompat.getDrawable(Context(), 0)
+                val x = Glide.with(View())
             """,
             ).indented(),
         ).allowMissingSdk().testModes(TestMode.DEFAULT).run().expect(
-            """src/test/pkg/test.kt:6: Warning: Use AppCompatResources.getDrawable [ContextCompatGetDrawableDetector]
-fun foo() = ContextCompat.getDrawable(Context(), 0)
-            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            """src/test/pkg/test.kt:6: Warning: Use an activity or fragment, not a view. [GlideWithViewDetector]
+val x = Glide.with(View())
+        ~~~~~~~~~~~~~~~~~~
 0 errors, 1 warnings""",
         )
     }
 
     companion object Stubs {
-        /** Stub for `android.content.Context` */
-        private val Context = java(
+        /** Stub for `android.view.View` */
+        private val View = java(
             """
-            package android.content;
+            package android.view;
 
-            public class Context {}
+            public class View {}
             """,
         ).indented()
 
-        /** Stub for `androidx.core.content.ContextCompat` */
-        private val ContextCompat = java(
+        /** Stub for `com.bumptech.glide.Glide` */
+        private val Glide = java(
             """
-                package androidx.core.content;
+                package com.bumptech.glide;
 
-                import android.content.Context;
+                import android.view.View;
 
-                public class ContextCompat {
-                     public static void getDrawable(Context context, int resource) { return null; }
+                public class Glide {
+                     public static RequestManager with(View view) { return RequestManager(); }
                 }
             """,
         ).indented()

--- a/core/activity/build.gradle.kts
+++ b/core/activity/build.gradle.kts
@@ -52,7 +52,9 @@ dependencies {
     implementation(libs.bundles.androidx)
 
     // Loading avatars
-    implementation(libs.bundles.glide)
+    api(libs.bundles.glide)?.because("Exposes RequestManager type")
+    ksp(libs.glide.compiler)
+
     implementation(projects.core.database)
 
     // Crash reporting in orange (Pachli Current) builds only

--- a/core/activity/src/main/kotlin/app/pachli/core/activity/BaseActivity.kt
+++ b/core/activity/src/main/kotlin/app/pachli/core/activity/BaseActivity.kt
@@ -38,6 +38,7 @@ import androidx.lifecycle.lifecycleScope
 import app.pachli.core.activity.extensions.canOverrideActivityTransitions
 import app.pachli.core.activity.extensions.getTransitionKind
 import app.pachli.core.activity.extensions.startActivityWithDefaultTransition
+import app.pachli.core.common.util.unsafeLazy
 import app.pachli.core.data.repository.AccountManager
 import app.pachli.core.data.repository.Loadable
 import app.pachli.core.database.model.AccountEntity
@@ -48,6 +49,7 @@ import app.pachli.core.navigation.LoginActivityIntent
 import app.pachli.core.preferences.AppTheme
 import app.pachli.core.preferences.SharedPreferencesRepository
 import app.pachli.core.ui.ChooseAccountSuspendDialogFragment
+import com.bumptech.glide.Glide
 import com.google.android.material.color.MaterialColors
 import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.EntryPoint
@@ -79,6 +81,12 @@ abstract class BaseActivity : AppCompatActivity(), MenuProvider {
     interface SharedPreferencesRepositoryEntryPoint {
         fun sharedPreferencesRepository(): SharedPreferencesRepository
     }
+
+    /**
+     * Glide [RequestManager][com.bumptech.glide.RequestManager] that can be passed to
+     * anything that needs it scoped to this activity's lifecycle.
+     */
+    protected val glide by unsafeLazy { Glide.with(this) }
 
     override fun setTheme(@StyleRes themeId: Int) {
         activeThemeId = themeId

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/ChooseAccountSuspendDialogFragment.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/ChooseAccountSuspendDialogFragment.kt
@@ -40,6 +40,8 @@ import app.pachli.core.designsystem.R as DR
 import app.pachli.core.preferences.SharedPreferencesRepository
 import app.pachli.core.ui.ChooseAccountSuspendDialogFragment.Companion.newInstance
 import app.pachli.core.ui.databinding.ItemAutocompleteAccountBinding
+import com.bumptech.glide.Glide
+import com.bumptech.glide.RequestManager
 import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -79,6 +81,7 @@ open class ChooseAccountSuspendDialogFragment : AppCompatDialogFragment(), Suspe
 
         adapter = ChooseAccountAdapter(
             requireActivity(),
+            Glide.with(this),
             viewModel.animateAvatars,
             viewModel.animateEmojis,
         )
@@ -164,6 +167,7 @@ internal class ChooseAccountViewModel @Inject constructor(
  */
 class ChooseAccountAdapter(
     context: Context,
+    private val glide: RequestManager,
     private val animateAvatars: Boolean,
     private val animateEmojis: Boolean,
 ) : ArrayAdapter<PachliAccount>(context, R.layout.item_autocomplete_account) {
@@ -177,11 +181,11 @@ class ChooseAccountAdapter(
         val account = getItem(position) ?: return binding.root
 
         binding.username.text = account.entity.fullName
-        binding.displayName.text = account.entity.displayName.emojify(account.emojis, binding.displayName, animateEmojis)
+        binding.displayName.text = account.entity.displayName.emojify(glide, account.emojis, binding.displayName, animateEmojis)
         binding.avatarBadge.visibility = View.GONE // We never want to display the bot badge here
 
         val avatarRadius = context.resources.getDimensionPixelSize(DR.dimen.avatar_radius_42dp)
-        loadAvatar(account.entity.profilePictureUrl, binding.avatar, avatarRadius, animateAvatars)
+        loadAvatar(glide, account.entity.profilePictureUrl, binding.avatar, avatarRadius, animateAvatars)
 
         return binding.root
     }

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/CustomEmojiHelper.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/CustomEmojiHelper.kt
@@ -27,7 +27,7 @@ import android.text.style.ReplacementSpan
 import android.view.View
 import androidx.core.graphics.withSave
 import app.pachli.core.network.model.Emoji
-import com.bumptech.glide.Glide
+import com.bumptech.glide.RequestManager
 import com.bumptech.glide.request.target.CustomTarget
 import com.bumptech.glide.request.target.Target
 import com.bumptech.glide.request.transition.Transition
@@ -41,7 +41,7 @@ import java.util.regex.Pattern
  * @param view a reference to the a view the emojis will be shown in (should be the TextView, but parents of the TextView are also acceptable)
  * @return the text with the shortcodes replaced by EmojiSpans
 */
-fun CharSequence.emojify(emojis: List<Emoji>?, view: View, animate: Boolean): Spanned {
+fun CharSequence.emojify(glide: RequestManager, emojis: List<Emoji>?, view: View, animate: Boolean): Spanned {
     if (emojis.isNullOrEmpty()) {
         return SpannableStringBuilder.valueOf(this)
     }
@@ -59,8 +59,7 @@ fun CharSequence.emojify(emojis: List<Emoji>?, view: View, animate: Boolean): Sp
             val span = EmojiSpan(WeakReference(view))
 
             builder.setSpan(span, matcher.start(), matcher.end(), 0)
-            Glide.with(view)
-                .asDrawable()
+            glide.asDrawable()
                 .load(
                     if (animate) {
                         url

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/ImageLoadingHelper.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/ImageLoadingHelper.kt
@@ -25,7 +25,7 @@ import androidx.annotation.Px
 import androidx.core.graphics.drawable.toDrawable
 import app.pachli.core.common.util.BlurHashDecoder
 import app.pachli.core.designsystem.R as DR
-import com.bumptech.glide.Glide
+import com.bumptech.glide.RequestManager
 import com.bumptech.glide.load.MultiTransformation
 import com.bumptech.glide.load.Transformation
 import com.bumptech.glide.load.resource.bitmap.CenterCrop
@@ -34,6 +34,7 @@ import com.bumptech.glide.load.resource.bitmap.RoundedCorners
 private val centerCropTransformation = CenterCrop()
 
 fun loadAvatar(
+    glide: RequestManager,
     url: String?,
     imageView: ImageView,
     @Px radius: Int,
@@ -41,8 +42,7 @@ fun loadAvatar(
     transforms: List<Transformation<Bitmap>>? = null,
 ) {
     if (url.isNullOrBlank()) {
-        Glide.with(imageView)
-            .load(DR.drawable.avatar_default)
+        glide.load(DR.drawable.avatar_default)
             .into(imageView)
     } else {
         val multiTransformation = MultiTransformation(
@@ -54,14 +54,12 @@ fun loadAvatar(
         )
 
         if (animate) {
-            Glide.with(imageView)
-                .load(url)
+            glide.load(url)
                 .transform(multiTransformation)
                 .placeholder(DR.drawable.avatar_default)
                 .into(imageView)
         } else {
-            Glide.with(imageView)
-                .asBitmap()
+            glide.asBitmap()
                 .load(url)
                 .transform(multiTransformation)
                 .placeholder(DR.drawable.avatar_default)

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/SetStatusContent.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/SetStatusContent.kt
@@ -30,6 +30,7 @@ import app.pachli.core.network.model.HashTag
 import app.pachli.core.network.model.Status
 import app.pachli.core.network.parseAsMastodonHtml
 import app.pachli.core.ui.PreProcessMastodonHtml.processMarkdown
+import com.bumptech.glide.RequestManager
 import com.google.android.material.color.MaterialColors
 import com.mohamedrejeb.ksoup.entities.KsoupEntities
 import io.noties.markwon.AbstractMarkwonPlugin
@@ -46,13 +47,18 @@ import io.noties.markwon.syntax.SyntaxHighlightPlugin
 import io.noties.prism4j.Prism4j
 import io.noties.prism4j.annotations.PrismBundle
 
-/** Interface for setting the content of a status. */
+/**
+ * Interface for setting the content of a status.
+ *
+ * @see [SetStatusContent.invoke]
+ */
 interface SetStatusContent {
     /**
      * Processes [content] according to [statusDisplayOptions], embedding any [emojis],
      * [mentions], and [hashtags]. Clicks on these are sent to [listener]. Sets the
      * processed content as the [text][TextView.setText] on [textView].
      *
+     * @param glide RequestManager used to load images.
      * @param textView
      * @param content
      * @param statusDisplayOptions
@@ -62,6 +68,7 @@ interface SetStatusContent {
      * @param listener
      */
     operator fun invoke(
+        glide: RequestManager,
         textView: TextView,
         content: CharSequence,
         statusDisplayOptions: StatusDisplayOptions,
@@ -77,6 +84,7 @@ interface SetStatusContent {
  */
 object SetMastodonHtmlContent : SetStatusContent {
     override operator fun invoke(
+        glide: RequestManager,
         textView: TextView,
         content: CharSequence,
         statusDisplayOptions: StatusDisplayOptions,
@@ -86,7 +94,7 @@ object SetMastodonHtmlContent : SetStatusContent {
         listener: LinkListener,
     ) {
         val parsedContent = content.parseAsMastodonHtml()
-        val emojifiedText = parsedContent.emojify(emojis, textView, statusDisplayOptions.animateEmojis)
+        val emojifiedText = parsedContent.emojify(glide, emojis, textView, statusDisplayOptions.animateEmojis)
         setClickableText(textView, emojifiedText, mentions, hashtags, listener)
     }
 }
@@ -128,6 +136,7 @@ class SetMarkdownContent(context: Context) : SetStatusContent {
         .build()
 
     override operator fun invoke(
+        glide: RequestManager,
         textView: TextView,
         content: CharSequence,
         statusDisplayOptions: StatusDisplayOptions,
@@ -138,7 +147,7 @@ class SetMarkdownContent(context: Context) : SetStatusContent {
     ) {
         val spanned = markwon.toMarkdown(content.toString())
 
-        val emojifiedText = spanned.emojify(emojis, textView, statusDisplayOptions.animateEmojis)
+        val emojifiedText = spanned.emojify(glide, emojis, textView, statusDisplayOptions.animateEmojis)
 
         // This block does what setClickableText does.
         val spannableContent = markupHiddenUrls(textView, emojifiedText)

--- a/feature/intentrouter/build.gradle.kts
+++ b/feature/intentrouter/build.gradle.kts
@@ -40,6 +40,4 @@ dependencies {
         ?.because("Payload.Notification relies on the network type")
     implementation(projects.core.ui)
     implementation(libs.bundles.androidx)
-    implementation(libs.bundles.glide)
-        ?.because("Loading logo and avatar images")
 }

--- a/feature/lists/src/main/kotlin/app/pachli/feature/lists/AccountsInListFragment.kt
+++ b/feature/lists/src/main/kotlin/app/pachli/feature/lists/AccountsInListFragment.kt
@@ -48,6 +48,7 @@ import app.pachli.core.ui.emojify
 import app.pachli.core.ui.loadAvatar
 import app.pachli.feature.lists.databinding.FragmentAccountsInListBinding
 import app.pachli.feature.lists.databinding.ItemAccountInListBinding
+import com.bumptech.glide.Glide
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.get
 import com.github.michaelbull.result.mapBoth
@@ -249,11 +250,17 @@ class AccountsInListFragment : DialogFragment() {
 
         override fun onBindViewHolder(holder: BindingHolder<ItemAccountInListBinding>, position: Int) {
             val account = getItem(position)
-            holder.binding.displayName.text = account.name.emojify(account.emojis, holder.binding.displayName, animateEmojis)
+            val glide = Glide.with(this@AccountsInListFragment)
+            holder.binding.displayName.text = account.name.emojify(
+                glide,
+                account.emojis,
+                holder.binding.displayName,
+                animateEmojis,
+            )
             holder.binding.username.text = binding.root.context.getString(DR.string.post_username_format, account.username)
             holder.binding.avatarBadge.visible(account.bot)
             holder.binding.checkBox.isChecked = true
-            loadAvatar(account.avatar, holder.binding.avatar, radius, animateAvatar)
+            loadAvatar(glide, account.avatar, holder.binding.avatar, radius, animateAvatar)
         }
     }
 
@@ -290,9 +297,10 @@ class AccountsInListFragment : DialogFragment() {
         override fun onBindViewHolder(holder: BindingHolder<ItemAccountInListBinding>, position: Int) {
             val (account, inAList) = getItem(position)
 
-            holder.binding.displayName.text = account.name.emojify(account.emojis, holder.binding.displayName, animateEmojis)
+            val glide = Glide.with(this@AccountsInListFragment)
+            holder.binding.displayName.text = account.name.emojify(glide, account.emojis, holder.binding.displayName, animateEmojis)
             holder.binding.username.text = binding.root.context.getString(DR.string.post_username_format, account.username)
-            loadAvatar(account.avatar, holder.binding.avatar, radius, animateAvatar)
+            loadAvatar(glide, account.avatar, holder.binding.avatar, radius, animateAvatar)
             holder.binding.avatarBadge.visible(account.bot)
 
             with(holder.binding.checkBox) {

--- a/feature/login/build.gradle.kts
+++ b/feature/login/build.gradle.kts
@@ -41,7 +41,4 @@ dependencies {
 
     implementation(libs.bundles.androidx)
     implementation(libs.androidx.webkit)
-
-    // Loading the logo
-    implementation(libs.bundles.glide)
 }

--- a/feature/login/lint-baseline.xml
+++ b/feature/login/lint-baseline.xml
@@ -19,7 +19,7 @@
         errorLine2="                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/app/pachli/feature/login/LoginActivity.kt"
-            line="315"
+            line="313"
             column="22"/>
         <location
             file="src/main/res/values/strings.xml"
@@ -35,7 +35,7 @@
         errorLine2="                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/app/pachli/feature/login/LoginActivity.kt"
-            line="315"
+            line="313"
             column="22"/>
         <location
             file="src/main/res/values/strings.xml"

--- a/feature/login/src/main/kotlin/app/pachli/feature/login/LoginActivity.kt
+++ b/feature/login/src/main/kotlin/app/pachli/feature/login/LoginActivity.kt
@@ -43,7 +43,6 @@ import app.pachli.core.navigation.LoginActivityIntent
 import app.pachli.core.network.retrofit.MastodonApi
 import app.pachli.core.preferences.getNonNullString
 import app.pachli.feature.login.databinding.ActivityLoginBinding
-import com.bumptech.glide.Glide
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.onFailure
 import com.github.michaelbull.result.onSuccess
@@ -113,8 +112,7 @@ class LoginActivity : BaseActivity() {
         }
 
         if (BuildConfig.CUSTOM_LOGO_URL.isNotBlank()) {
-            Glide.with(binding.loginLogo)
-                .load(BuildConfig.CUSTOM_LOGO_URL)
+            glide.load(BuildConfig.CUSTOM_LOGO_URL)
                 .placeholder(null)
                 .into(binding.loginLogo)
         }

--- a/feature/suggestions/src/main/kotlin/app/pachli/feature/suggestions/SuggestionsAdapter.kt
+++ b/feature/suggestions/src/main/kotlin/app/pachli/feature/suggestions/SuggestionsAdapter.kt
@@ -42,6 +42,7 @@ import app.pachli.feature.suggestions.SuggestionViewHolder.ChangePayload
 import app.pachli.feature.suggestions.UiAction.NavigationAction
 import app.pachli.feature.suggestions.UiAction.SuggestionAction
 import app.pachli.feature.suggestions.databinding.ItemSuggestionBinding
+import com.bumptech.glide.RequestManager
 import java.time.Duration
 import java.time.Instant
 import kotlin.math.roundToInt
@@ -55,6 +56,7 @@ import kotlin.math.roundToInt
 // TODO: This is quite similar to AccountAdapter, see if some functionality can be
 // made common. See things like FollowRequestViewHolder.setupWithAccount as well.
 internal class SuggestionsAdapter(
+    private val glide: RequestManager,
     private var animateAvatars: Boolean,
     private var animateEmojis: Boolean,
     private var showBotOverlay: Boolean,
@@ -64,7 +66,7 @@ internal class SuggestionsAdapter(
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SuggestionViewHolder {
         val binding = ItemSuggestionBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        return SuggestionViewHolder(binding, accept)
+        return SuggestionViewHolder(binding, glide, accept)
     }
 
     fun setAnimateAvatars(animateAvatars: Boolean) {
@@ -119,6 +121,7 @@ internal class SuggestionsAdapter(
  */
 internal class SuggestionViewHolder(
     internal val binding: ItemSuggestionBinding,
+    private val glide: RequestManager,
     private val accept: (UiAction) -> Unit,
 ) : RecyclerView.ViewHolder(binding.root) {
     internal lateinit var viewData: SuggestionViewData
@@ -215,7 +218,7 @@ internal class SuggestionViewHolder(
 
     /** Binds the avatar image, respecting [animateAvatars]. */
     fun bindAvatar(viewData: SuggestionViewData, animateAvatars: Boolean) = with(binding) {
-        loadAvatar(viewData.suggestion.account.avatar, avatar, avatarRadius, animateAvatars)
+        loadAvatar(glide, viewData.suggestion.account.avatar, avatar, avatarRadius, animateAvatars)
     }
 
     /**
@@ -224,7 +227,12 @@ internal class SuggestionViewHolder(
      */
     fun bindAnimateEmojis(viewData: SuggestionViewData, animateEmojis: Boolean) = with(binding) {
         val account = viewData.suggestion.account
-        displayName.text = account.name.unicodeWrap().emojify(account.emojis, itemView, animateEmojis)
+        displayName.text = account.name.unicodeWrap().emojify(
+            glide,
+            account.emojis,
+            itemView,
+            animateEmojis,
+        )
 
         if (account.note.isBlank()) {
             @SuppressLint("SetTextI18n")
@@ -233,7 +241,7 @@ internal class SuggestionViewHolder(
         } else {
             accountNote.show()
             val emojifiedNote = account.note.parseAsMastodonHtml()
-                .emojify(account.emojis, accountNote, animateEmojis)
+                .emojify(glide, account.emojis, accountNote, animateEmojis)
 
             setClickableText(accountNote, emojifiedNote, emptyList(), null, linkListener)
         }

--- a/feature/suggestions/src/main/kotlin/app/pachli/feature/suggestions/SuggestionsFragment.kt
+++ b/feature/suggestions/src/main/kotlin/app/pachli/feature/suggestions/SuggestionsFragment.kt
@@ -59,6 +59,7 @@ import app.pachli.core.ui.makeIcon
 import app.pachli.feature.suggestions.UiAction.GetSuggestions
 import app.pachli.feature.suggestions.UiAction.NavigationAction
 import app.pachli.feature.suggestions.databinding.FragmentSuggestionsBinding
+import com.bumptech.glide.Glide
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.onFailure
 import com.github.michaelbull.result.onSuccess
@@ -120,6 +121,7 @@ class SuggestionsFragment :
         requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
 
         suggestionsAdapter = SuggestionsAdapter(
+            glide = Glide.with(this),
             animateAvatars = viewModel.uiState.value.animateAvatars,
             animateEmojis = viewModel.uiState.value.animateEmojis,
             showBotOverlay = viewModel.uiState.value.showBotOverlay,


### PR DESCRIPTION
Glide is lifecycle aware; when using `Glide.with(someContext)` Glide will pause any in-progress loads when the lifecycle associated with the context is stopped, and cancel the load if the lifecycle is destroyed.

Previous code used `Glide.with(someView)...` in a lot of places, causing Glide to use the view's context and lifecycle.

A view's context is the same as the context of the activity, even if the view is in a fragment inside an activity. So a load started like this would only be affected when the containing activity is stopped / destroyed, not when the fragment is stopped / destroyed.

Fix this by modifying adapters and viewholders to take an explicit `glide` parameter. This is created with the appropriate activity or fragment in the caller.

Add a lint detector for this to ensure it doesn't recur.