### PR TITLE
change: Improve type inference for unsafeLazy

### DIFF
--- a/core/common/src/main/kotlin/app/pachli/core/common/util/Lazy.kt
+++ b/core/common/src/main/kotlin/app/pachli/core/common/util/Lazy.kt
@@ -5,4 +5,4 @@ package app.pachli.core.common.util
  * to use if the initialization can never happen from multiple threads.
  */
 @Suppress("NOTHING_TO_INLINE")
-inline fun <T : Any> unsafeLazy(noinline initializer: () -> T): Lazy<T> = lazy(LazyThreadSafetyMode.NONE, initializer)
+inline fun <T> unsafeLazy(noinline initializer: () -> T): Lazy<T> = lazy(LazyThreadSafetyMode.NONE, initializer)


### PR DESCRIPTION
Previous code meant type inference didn't always work with `unsafeLazy` because it was generic over `<T : Any>`.

Make it generic over `<T>` (just like `lazy`) to fix this.