### PR TITLE
refactor: Move string/button_continue from app to core/ui

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -350,7 +350,6 @@
     <string name="confirmation_domain_unmuted">لم يعُد %s مخفيا</string>
     <string name="mute_domain_warning_dialog_ok">اخفِ كافة النطاق</string>
     <string name="pref_title_animate_gif_avatars">تنشيط الصور المتحركة GIF للحسابات</string>
-    <string name="button_continue">واصل</string>
     <string name="button_back">العودة</string>
     <string name="report_sent_success">تم الابلاغ عن @%s بنجاح</string>
     <string name="hint_additional_info">تعليقات إضافية</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -387,7 +387,6 @@
     <string name="create_poll_title">Апытанне</string>
     <string name="duration_1_day">1 дзень</string>
     <string name="duration_3_days">3 дні</string>
-    <string name="button_continue">Працягнуць</string>
     <plurals name="poll_timespan_minutes">
         <item quantity="one">Засталася %d хвіліна</item>
         <item quantity="few">Засталося %d хвіліны</item>

--- a/app/src/main/res/values-ber/strings.xml
+++ b/app/src/main/res/values-ber/strings.xml
@@ -13,7 +13,6 @@
     <string name="title_drafts">ⵉⵔⴻⵡⵡⴰⵢⴻⵏ</string>
     <string name="title_favourites">ⵉⵙⵎⴻⵏⵢⵉⴼⴻⵏ</string>
     <string name="button_back">ⵓⵖⴰⵍ</string>
-    <string name="button_continue">ⴽⴻⵎⵎⴻⵍ</string>
     <string name="filter_dialog_update_button">ⵍⵇⴻⵎ</string>
     <string name="filter_dialog_remove_button">ⴽⴽⴻⵙ</string>
     <string name="action_send_public">ⵊⴻⵡⵡⴻⵇ!</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -19,7 +19,6 @@
     <string name="hint_additional_info">Допълнителни коментари</string>
     <string name="report_sent_success">Успешно докладване на @%s</string>
     <string name="button_back">Назад</string>
-    <string name="button_continue">Продължаване</string>
     <plurals name="poll_timespan_seconds">
         <item quantity="one">Остава %d секунда</item>
         <item quantity="other">Остават %d секунди</item>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -291,7 +291,6 @@
     <string name="hint_additional_info">অতিরিক্ত মন্তব্যগুলি</string>
     <string name="report_sent_success">\'%s এ সফলভাবে রিপোর্ট করা হয়েছে\'</string>
     <string name="button_back">পিছাও</string>
-    <string name="button_continue">চালিয়ে যাও</string>
     <string name="poll_ended_created">আপনি তৈরি একটি নির্বাচন শেষ হয়েছে</string>
     <string name="poll_ended_voted">আপনি ভোট দিয়েছেন যে নির্বাচন এ সেটি শেষ হয়েছে</string>
     <string name="poll_vote">ভোট</string>

--- a/app/src/main/res/values-bn-rIN/strings.xml
+++ b/app/src/main/res/values-bn-rIN/strings.xml
@@ -294,7 +294,6 @@
     <string name="poll_vote">ভোট</string>
     <string name="poll_ended_voted">আপনি ভোট দিয়েছেন যে নির্বাচন এ সেটি শেষ হয়েছে</string>
     <string name="poll_ended_created">আপনি তৈরি একটি নির্বাচন শেষ হয়েছে</string>
-    <string name="button_continue">চালিয়ে যাও</string>
     <string name="button_back">পিছাও</string>
     <string name="report_sent_success">%s এ সফলভাবে রিপোর্ট করা হয়েছে</string>
     <string name="hint_additional_info">অতিরিক্ত মন্তব্যগুলি</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -301,7 +301,6 @@
     <string name="pref_title_alway_open_spoiler">Mostra sempre obertes les publicacions marcades amb avisos de contingut</string>
     <string name="filter_dialog_whole_word">Paraula sencera</string>
     <string name="description_poll">Enquesta amb opcions: %1$s, %2$s, %3$s, %4$s; %5$s</string>
-    <string name="button_continue">Continuar</string>
     <string name="button_back">Enrere</string>
     <string name="hint_additional_info">Comentaris addicionals</string>
     <string name="report_remote_instance">Reenviar a %s</string>

--- a/app/src/main/res/values-ckb/strings.xml
+++ b/app/src/main/res/values-ckb/strings.xml
@@ -231,7 +231,6 @@
     <string name="hint_additional_info">سەرنجەکانی زیاتر</string>
     <string name="report_sent_success">سەرکەوتووانە ڕاپۆرتکرا @%s</string>
     <string name="button_back">دواوە</string>
-    <string name="button_continue">بەردەوام بە</string>
     <plurals name="poll_timespan_seconds">
         <item quantity="one">%d چرکەی ماوەو</item>
         <item quantity="other">%d دووەم چەپ</item>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -324,7 +324,6 @@
     <string name="confirmation_domain_unmuted">Skrytí domény %s bylo zrušeno</string>
     <string name="mute_domain_warning">Jste si jistý/á, že chcete zablokovat vše z domény %s\? Z této domény neuvidíte obsah v žádné veřejné časové ose ani v oznámeních. Vaši sledující z této domény budou odstraněni.</string>
     <string name="mute_domain_warning_dialog_ok">Skrýt celou doménu</string>
-    <string name="button_continue">Pokračovat</string>
     <string name="button_back">Zpět</string>
     <string name="report_sent_success">\@%s byla/a úspěšně nahlášen/a</string>
     <string name="hint_additional_info">Další komentáře</string>

--- a/app/src/main/res/values-cy/strings.xml
+++ b/app/src/main/res/values-cy/strings.xml
@@ -364,7 +364,6 @@
     <string name="poll_vote">Pleidleisio</string>
     <string name="poll_ended_voted">Mae pôl rydych wedi pleidleisio ynddo wedi dod i ben</string>
     <string name="poll_ended_created">Mae pôl a greoch wedi dod i ben</string>
-    <string name="button_continue">Parhau</string>
     <string name="button_back">Nôl</string>
     <string name="hint_additional_info">Sylwadau ychwanegol</string>
     <string name="pref_main_nav_position">Prif lleoliad y panel llywio</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -310,7 +310,6 @@
     <string name="pref_title_animate_gif_avatars">GIF-Profilbilder animieren</string>
     <string name="filter_dialog_whole_word">Ganzes Wort</string>
     <string name="filter_dialog_whole_word_description">Wenn das Wort oder die Formulierung nur aus Buchstaben oder Zahlen besteht, tritt der Filter nur dann in Kraft, wenn er exakt dieser Zeichenfolge entspricht</string>
-    <string name="button_continue">Weiter</string>
     <string name="button_back">Zurück</string>
     <string name="report_sent_success">\@%s wurde erfolgreich gemeldet</string>
     <string name="hint_additional_info">Zusätzliche Anmerkungen</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -312,7 +312,6 @@
     <string name="mute_domain_warning">Ĉu vi certas ke vi volas tute bloki %s\? Vi ne vidos enhavon de tiu domajno en publika tempolinio aŭ en viaj sciigoj. Viaj sekvantoj el tiu domajno estos forigitaj.</string>
     <string name="mute_domain_warning_dialog_ok">Kaŝi la tutan domajnon</string>
     <string name="description_poll">Balotenketo kun elektoj: %1$s, %2$s, %3$s, %4$s, %5$s</string>
-    <string name="button_continue">Daŭrigi</string>
     <string name="button_back">Reveni</string>
     <string name="report_sent_success">\@%s sukcese signalita</string>
     <string name="hint_additional_info">Pliaj komentoj</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -331,7 +331,6 @@
     <string name="filter_dialog_whole_word">Toda palabra</string>
     <string name="filter_dialog_whole_word_description">Cuando la palabra o frase sea solo alfanumérica, solo se aplicará si coincide con toda la palabra</string>
     <string name="description_poll">Encuesta con opciones: %1$s, %2$s, %3$s, %4$s; %5$s</string>
-    <string name="button_continue">Continuar</string>
     <string name="button_back">Atrás</string>
     <string name="report_sent_success">\@%s reportado satisfactoriamente</string>
     <string name="hint_additional_info">Comentarios adicionales</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -324,7 +324,6 @@
         <item quantity="one">Segundu %d geratzen da</item>
         <item quantity="other">%d segundu geratzen da</item>
     </plurals>
-    <string name="button_continue">Jarraitu</string>
     <string name="button_back">Itzuli</string>
     <string name="report_sent_success">\@%s jakinarazi duzu arrakastaz</string>
     <string name="hint_additional_info">Iruzkin gehigarriak</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -311,7 +311,6 @@
         <item quantity="one">%d دقیقه مانده</item>
         <item quantity="other">%d دقیقه مانده</item>
     </plurals>
-    <string name="button_continue">ادامه</string>
     <string name="button_back">بازگشت</string>
     <string name="report_sent_success">‫@%s با موفّقیت گزارش شد</string>
     <string name="hint_additional_info">نظرهای اضافی</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -69,7 +69,6 @@
     <string name="create_poll_title">Kysely</string>
     <string name="title_accounts">Tilit</string>
     <string name="button_back">Takaisin</string>
-    <string name="button_continue">Jatka</string>
     <string name="poll_vote">Äänestä</string>
     <string name="poll_info_closed">suljettu</string>
     <string name="notifications_apply_filter">Suodatin</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -325,7 +325,6 @@
     <string name="action_mute_domain">Masquer %s</string>
     <string name="confirmation_domain_unmuted">%s n’est plus masqué·e</string>
     <string name="mute_domain_warning_dialog_ok">Masquer le domaine entier</string>
-    <string name="button_continue">Continuer</string>
     <string name="button_back">Retour</string>
     <string name="report_sent_success">\@%s signalé avec succès</string>
     <string name="hint_additional_info">Commentaires additionnels</string>

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -356,7 +356,6 @@
         <item quantity="many">D\'imigh %d soicindí</item>
         <item quantity="other">D\'imigh %d soicindí</item>
     </plurals>
-    <string name="button_continue">Lean ar aghaidh</string>
     <string name="button_back">Ar ais</string>
     <string name="report_sent_success">Tuairiscíodh go rathúil @%s</string>
     <string name="hint_additional_info">Tuairimí Breise</string>

--- a/app/src/main/res/values-gd/strings.xml
+++ b/app/src/main/res/values-gd/strings.xml
@@ -108,7 +108,6 @@
     <string name="hint_additional_info">Beachdan a bharrachd</string>
     <string name="report_sent_success">Chaidh do gearan air @%s a chlàradh</string>
     <string name="button_back">Air ais</string>
-    <string name="button_continue">Air adhart</string>
     <plurals name="poll_timespan_seconds">
         <item quantity="one">Tha %d diog air fhàgail</item>
         <item quantity="two">Tha %d dhiog air fhàgail</item>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -123,7 +123,6 @@
     <string name="hint_additional_info">Comentarios adicionais</string>
     <string name="report_sent_success">Denuncia feita sobre @%s</string>
     <string name="button_back">Atrás</string>
-    <string name="button_continue">Continuar</string>
     <plurals name="poll_timespan_seconds">
         <item quantity="one">queda %d segundo</item>
         <item quantity="other">quedan %d segundos</item>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -39,7 +39,6 @@
     <string name="create_poll_title">पोल</string>
     <string name="title_accounts">खाता</string>
     <string name="button_back">पीछे</string>
-    <string name="button_continue">जारी रखें</string>
     <string name="poll_vote">वोट</string>
     <string name="poll_info_closed">बन्द है</string>
     <string name="compose_shortcut_short_label">लिखें</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -323,7 +323,6 @@
         <item quantity="one">%d másodperc maradt</item>
         <item quantity="other">%d másodperc maradt</item>
     </plurals>
-    <string name="button_continue">Folytatás</string>
     <string name="button_back">Vissza</string>
     <string name="report_sent_success">\@%s sikeresen bejelentettük</string>
     <string name="hint_additional_info">Egyéb megjegyzések</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -305,7 +305,6 @@
     <string name="poll_vote">Greiða atkvæði</string>
     <string name="poll_ended_voted">Könnun sem þú tókst þátt í er lokið</string>
     <string name="poll_ended_created">Könnuninni þinni er lokið</string>
-    <string name="button_continue">Halda áfram</string>
     <string name="button_back">Til baka</string>
     <string name="report_sent_success">Tókst að kæra @%s</string>
     <string name="hint_additional_info">Aðrar athugasemdir</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -354,7 +354,6 @@
         <item quantity="many">%d secondi rimasti</item>
         <item quantity="other">%d secondi rimasti</item>
     </plurals>
-    <string name="button_continue">Continua</string>
     <string name="button_back">Indietro</string>
     <string name="report_sent_success">Segnalato @%s con successo</string>
     <string name="hint_additional_info">Altri commenti</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -330,7 +330,6 @@
     <string name="report_description_1">通報をサーバーのモデレーターに送信します。以下にこのアカウントを通報理由を入力できます:</string>
     <string name="failed_fetch_posts">投稿を取得できませんでした</string>
     <string name="button_back">戻る</string>
-    <string name="button_continue">続ける</string>
     <string name="compose_shortcut_short_label">投稿</string>
     <string name="compose_shortcut_long_label">投稿する</string>
     <string name="list">リスト</string>

--- a/app/src/main/res/values-kab/strings.xml
+++ b/app/src/main/res/values-kab/strings.xml
@@ -159,7 +159,6 @@
         <item quantity="one">%d n tasdidt id yugran</item>
         <item quantity="other">%d n tisdidin id yugran</item>
     </plurals>
-    <string name="button_continue">Kemmel</string>
     <string name="button_back">Uɣal</string>
     <string name="failed_report">Tella-d tuccḍa deg cetki</string>
     <string name="failed_search">Tucḍa n unadi</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -316,7 +316,6 @@
     <plurals name="poll_timespan_seconds">
         <item quantity="other">%d초 남음</item>
     </plurals>
-    <string name="button_continue">다음</string>
     <string name="button_back">이전</string>
     <string name="report_sent_success">\@%s를 신고하였습니다</string>
     <string name="hint_additional_info">부가 설명</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -124,7 +124,6 @@
     <string name="notifications_clear">Notīrīt</string>
     <string name="notifications_apply_filter">Filtrēt</string>
     <string name="filter_apply">Pielietot</string>
-    <string name="button_continue">Turpināt</string>
     <string name="button_back">Atpakaļ</string>
     <string name="hint_additional_info">Papildu komentāri</string>
     <string name="poll_info_closed">noslēgusies</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -114,7 +114,6 @@
     <string name="pref_title_thread_filter_keywords">സംഭാഷണങ്ങൾ</string>
     <string name="label_quick_reply">മറുപടി…</string>
     <string name="action_reject">നിരസിക്കുക</string>
-    <string name="button_continue">തുടരുക</string>
     <string name="pref_title_timelines">സമയരേഖകൾ</string>
     <string name="pref_title_proxy_settings">പ്രോക്സി</string>
     <string name="pref_title_notification_alerts">മുന്നറിയിപ്പുകൾ</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -308,7 +308,6 @@
     <string name="compose_preview_image_description">Handlinger for bilde %s</string>
     <string name="pref_title_animate_gif_avatars">Animer GIF-avatarer</string>
     <string name="description_poll">Avstemming med valg: %1$s, %2$s, %3$s, %4$s; %5$s</string>
-    <string name="button_continue">Fortsett</string>
     <string name="button_back">Tilbake</string>
     <string name="report_sent_success">\@%s er rapportert</string>
     <string name="hint_additional_info">Flere kommentarer</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -321,7 +321,6 @@
         <item quantity="one">%d seconde over</item>
         <item quantity="other">%d seconden over</item>
     </plurals>
-    <string name="button_continue">Doorgaan</string>
     <string name="button_back">Terug</string>
     <string name="report_sent_success">Het rapporteren van @%s is geslaagd</string>
     <string name="hint_additional_info">Extra opmerkingen</string>

--- a/app/src/main/res/values-nn/strings.xml
+++ b/app/src/main/res/values-nn/strings.xml
@@ -495,7 +495,6 @@
     <string name="poll_show_votes">Syn røyster</string>
     <string name="poll_ended_voted">Ei avstemming du har røysta i er avslutta</string>
     <string name="poll_ended_created">Ei avstemming du har laga er avslutta</string>
-    <string name="button_continue">Fortsett</string>
     <string name="button_back">Tilbake</string>
     <string name="report_sent_success">Rapporterte @%s</string>
     <string name="hint_additional_info">Vidare kommentar</string>

--- a/app/src/main/res/values-oc/strings.xml
+++ b/app/src/main/res/values-oc/strings.xml
@@ -315,7 +315,6 @@
     <string name="compose_preview_image_description">Accions per l’imatge %s</string>
     <string name="pref_title_animate_gif_avatars">Activar l’animacion dels avatars</string>
     <string name="description_poll">Sondatge amb opcion : %1$s, %2$s, %3$s, %4$s; %5$s</string>
-    <string name="button_continue">Contunhar</string>
     <string name="button_back">Tornar</string>
     <string name="report_sent_success">\@%s corrèctament senhalat</string>
     <string name="hint_additional_info">Comentaris suplementaris</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -340,7 +340,6 @@
         <item quantity="many">Zostało %d sekund</item>
         <item quantity="other">Zostało %d sekund</item>
     </plurals>
-    <string name="button_continue">Kontynuuj</string>
     <string name="button_back">Wstecz</string>
     <string name="report_sent_success">Zgłoszenie @%s powiodło się</string>
     <string name="hint_additional_info">Dodatkowe komentarze</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -323,7 +323,6 @@
     </plurals>
     <string name="pref_title_animate_gif_avatars">Animar avatares com GIF</string>
     <string name="description_poll">Enquete com as opções: %1$s, %2$s, %3$s, %4$s; %5$s</string>
-    <string name="button_continue">Continuar</string>
     <string name="button_back">Voltar</string>
     <string name="report_sent_success">\@%s denunciado com sucesso</string>
     <string name="hint_additional_info">Comentários adicionais</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -373,7 +373,6 @@
         <item quantity="many">%d segundos restantes</item>
         <item quantity="other">%d segundos restantes</item>
     </plurals>
-    <string name="button_continue">Continuar</string>
     <string name="button_back">Retroceder</string>
     <string name="report_sent_success">\@%s denunciado com sucesso</string>
     <string name="hint_additional_info">Comentários adicionais</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -329,7 +329,6 @@
     <string name="poll_vote">Голосовать</string>
     <string name="poll_ended_voted">Опрос, в котором вы приняли участие, завершился</string>
     <string name="poll_ended_created">Созданный вами опрос завершился</string>
-    <string name="button_continue">Продолжить</string>
     <string name="button_back">Назад</string>
     <string name="hint_additional_info">Дополнительные комментарии</string>
     <string name="title_domain_mutes">Скрытые домены</string>

--- a/app/src/main/res/values-sa/strings.xml
+++ b/app/src/main/res/values-sa/strings.xml
@@ -312,7 +312,6 @@
     <string name="hint_additional_info">अन्याः टिप्पण्यः</string>
     <string name="report_sent_success">साफल्येनाऽऽवेदनं दत्तमस्य @%s</string>
     <string name="button_back">पूर्वम्</string>
-    <string name="button_continue">निरन्तरम्</string>
     <plurals name="poll_timespan_seconds">
         <item quantity="one">%d क्षणम्</item>
         <item quantity="other">%d क्षणे</item>

--- a/app/src/main/res/values-si/strings.xml
+++ b/app/src/main/res/values-si/strings.xml
@@ -134,7 +134,6 @@
     <string name="abbreviated_in_years">වර්. %d කින්</string>
     <string name="restart_emoji">මෙම වෙනස්කම් යෙදීමට ඔබ ටුස්කි නැවත ඇරඹිය යුතුය</string>
     <string name="action_edit">සංස්කරණය</string>
-    <string name="button_continue">ඉදිරියට</string>
     <string name="pref_title_post_filter">කාලරේඛාව පෙරීම</string>
     <string name="conversation_more_recipients">%1$s, %2$s සහ තවත් %3$d</string>
     <string name="pref_title_timelines">කාලරේඛා</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -350,7 +350,6 @@
     <string name="abbreviated_in_seconds">za %ds</string>
     <string name="follows_you">Sleduje ťa</string>
     <string name="add_poll_choice">Pridať voľbu</string>
-    <string name="button_continue">Pokračovať</string>
     <string name="poll_allow_multiple_choices">Viacero možností</string>
     <string name="poll_new_choice_hint">Možnosť %d</string>
     <string name="accessibility_talking_about_tag">%1$d ľudí diskutuje o hashtagu %2$s</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -314,7 +314,6 @@
     </plurals>
     <string name="pref_title_animate_gif_avatars">Animirane podobe GIF</string>
     <string name="description_poll">Anketa z izbiro: %1$s, %2$s, %3$s, %4$s; %5$s</string>
-    <string name="button_continue">Nadaljuj</string>
     <string name="button_back">Nazaj</string>
     <string name="report_sent_success">\@%s je uspešno prijavljen</string>
     <string name="hint_additional_info">Dodatni komentarji</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -327,7 +327,6 @@
     <string name="confirmation_domain_unmuted">%s inte tystad längre</string>
     <string name="mute_domain_warning">Är du säker på att du vill blockera allt från %s\? Du kommer inte kunna se något innehåll från denna domän i publika tidslinjer eller i dina notifieringar. Dina följare på domänen kommer inte att bli borttagna.</string>
     <string name="mute_domain_warning_dialog_ok">Dölj hela domänen</string>
-    <string name="button_continue">Fortsätt</string>
     <string name="button_back">Tillbaka</string>
     <string name="report_sent_success">Anmälan av @%s har lyckats</string>
     <string name="hint_additional_info">Ytterligare kommentarer</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -308,7 +308,6 @@
         <item quantity="one">%d இரண்டாவது இடது</item>
         <item quantity="other">%d விநாடிகள் எஞ்சியுள்ளன</item>
     </plurals>
-    <string name="button_continue">தொடரவும்</string>
     <string name="button_back">பின்</string>
     <string name="hint_additional_info">கூடுதல் கருத்துகள்</string>
     <string name="report_description_1">அறிக்கை உங்கள் சேவையக மதிப்பீட்டாளருக்கு அனுப்பப்படும். இந்த கணக்கை நீங்கள் ஏன் கீழே புகாரளிக்கிறீர்கள் என்பதற்கான விளக்கத்தை நீங்கள் வழங்கலாம்:</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -20,7 +20,6 @@
     <string name="hint_additional_info">ความคิดเห็นเพิ่มเติม</string>
     <string name="report_sent_success">รายงาน @%s เรียบร้อยแล้ว</string>
     <string name="button_back">ย้อนกลับ</string>
-    <string name="button_continue">ต่อไป</string>
     <plurals name="poll_timespan_seconds">
         <item quantity="other">เหลืออีก %d วินาที</item>
     </plurals>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -313,7 +313,6 @@
         <item quantity="one">%d saniye kaldı</item>
         <item quantity="other">%d saniyeler kaldı</item>
     </plurals>
-    <string name="button_continue">Devam</string>
     <string name="button_back">Geri</string>
     <string name="report_sent_success">\@%s başarıyla bildirildi</string>
     <string name="hint_additional_info">Ek Yorumlar</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -173,7 +173,6 @@
     <string name="hint_additional_info">Додаткові коментарі</string>
     <string name="report_sent_success">Звіт @%s надіслано</string>
     <string name="button_back">Назад</string>
-    <string name="button_continue">Продовжити</string>
     <plurals name="poll_timespan_seconds">
         <item quantity="one">Залишилася %d секунда</item>
         <item quantity="few">Залишилося %d секунди</item>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -37,7 +37,6 @@
     <string name="action_logout">Đăng xuất</string>
     <string name="action_send_public">ĐĂNG</string>
     <string name="button_back">Quay lại</string>
-    <string name="button_continue">Tiếp tục</string>
     <string name="filter_dialog_update_button">Cập nhật</string>
     <string name="filter_dialog_remove_button">Xóa</string>
     <string name="action_send">ĐĂNG</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -333,7 +333,6 @@
     <string name="description_poll">使用以下选项创建投票：%1$s，%2$s，%3$s，%4$s；%5$s</string>
     <string name="select_list_title">选择列表</string>
     <string name="list">列表</string>
-    <string name="button_continue">继续</string>
     <string name="button_back">返回</string>
     <string name="report_sent_success">成功举报 @%s</string>
     <string name="hint_additional_info">附加留言</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -397,7 +397,6 @@
     <string name="hint_additional_info">額外的評論</string>
     <string name="report_sent_success">成功回報 @%s</string>
     <string name="button_back">返回</string>
-    <string name="button_continue">繼續</string>
     <plurals name="poll_info_people">
         <item quantity="other">%s 人</item>
     </plurals>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -333,7 +333,6 @@
     <string name="filter_dialog_whole_word_description">如果關鍵字或短語僅為字母或數字，則只有在匹配整個單詞時才會應用</string>
     <string name="description_poll">使用以下選項創建投票：%1$s, %2$s, %3$s, %4$s; %5$s</string>
     <string name="compose_preview_image_description">圖片 %s 的動作</string>
-    <string name="button_continue">繼續</string>
     <string name="button_back">返回</string>
     <string name="report_sent_success">成功回報 @%s</string>
     <string name="hint_additional_info">附加留言</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -547,7 +547,6 @@
         <item quantity="one">%d second left</item>
         <item quantity="other">%d seconds left</item>
     </plurals>
-    <string name="button_continue">Continue</string>
     <string name="button_back">Back</string>
     <string name="report_sent_success">Successfully reported @%s</string>
     <string name="hint_additional_info">Additional comments</string>

--- a/core/ui/src/main/res/values-ar/strings.xml
+++ b/core/ui/src/main/res/values-ar/strings.xml
@@ -15,4 +15,5 @@
     <string name="title_links_dialog">الروابط</string>
     <string name="title_hashtags_dialog">الوسوم</string>
     <string name="title_mentions_dialog">الإشارات</string>
+    <string name="button_continue">واصل</string>
 </resources>

--- a/core/ui/src/main/res/values-be/strings.xml
+++ b/core/ui/src/main/res/values-be/strings.xml
@@ -15,4 +15,5 @@
     <string name="title_links_dialog">Спасылкі</string>
     <string name="title_hashtags_dialog">Хэштэгі</string>
     <string name="title_mentions_dialog">Згадкі</string>
+    <string name="button_continue">Працягнуць</string>
 </resources>

--- a/core/ui/src/main/res/values-ber/strings.xml
+++ b/core/ui/src/main/res/values-ber/strings.xml
@@ -2,4 +2,5 @@
 <resources>
     <string name="error_generic">ⵝⴻⵍⵍⴰ ⴷ ⵝⵓⵛⴹⴰ.</string>
     <string name="action_view_profile">ⴰⵎⴻⵖⵏⵓ</string>
+    <string name="button_continue">ⴽⴻⵎⵎⴻⵍ</string>
 </resources>

--- a/core/ui/src/main/res/values-bg/strings.xml
+++ b/core/ui/src/main/res/values-bg/strings.xml
@@ -13,4 +13,5 @@
     <string name="title_links_dialog">Връзки</string>
     <string name="title_hashtags_dialog">Хаштагове</string>
     <string name="title_mentions_dialog">Споменавания</string>
+    <string name="button_continue">Продължаване</string>
 </resources>

--- a/core/ui/src/main/res/values-bn-rBD/strings.xml
+++ b/core/ui/src/main/res/values-bn-rBD/strings.xml
@@ -13,4 +13,5 @@
     <string name="title_links_dialog">লিংকসমূহ</string>
     <string name="title_hashtags_dialog">হ্যাশট্যাগ</string>
     <string name="title_mentions_dialog">উল্লেখসমূহ</string>
+    <string name="button_continue">চালিয়ে যাও</string>
 </resources>

--- a/core/ui/src/main/res/values-bn-rIN/strings.xml
+++ b/core/ui/src/main/res/values-bn-rIN/strings.xml
@@ -13,4 +13,5 @@
     <string name="title_links_dialog">লিংকসমূহ</string>
     <string name="title_hashtags_dialog">হ্যাশট্যাগ</string>
     <string name="title_mentions_dialog">উল্লেখসমূহ</string>
+    <string name="button_continue">চালিয়ে যাও</string>
 </resources>

--- a/core/ui/src/main/res/values-ca/strings.xml
+++ b/core/ui/src/main/res/values-ca/strings.xml
@@ -15,4 +15,5 @@
     <string name="title_links_dialog">Enllaç</string>
     <string name="title_hashtags_dialog">Hashtags</string>
     <string name="title_mentions_dialog">Mencions</string>
+    <string name="button_continue">Continuar</string>
 </resources>

--- a/core/ui/src/main/res/values-ckb/strings.xml
+++ b/core/ui/src/main/res/values-ckb/strings.xml
@@ -13,4 +13,5 @@
     <string name="title_links_dialog">بەستەرەکان</string>
     <string name="title_hashtags_dialog">هاشتاگی</string>
     <string name="title_mentions_dialog">ئاماژەکان</string>
+    <string name="button_continue">بەردەوام بە</string>
 </resources>

--- a/core/ui/src/main/res/values-cs/strings.xml
+++ b/core/ui/src/main/res/values-cs/strings.xml
@@ -14,4 +14,5 @@
     <string name="title_links_dialog">Odkazy</string>
     <string name="title_hashtags_dialog">Hashtagy</string>
     <string name="title_mentions_dialog">Zmínky</string>
+    <string name="button_continue">Pokračovat</string>
 </resources>

--- a/core/ui/src/main/res/values-cy/strings.xml
+++ b/core/ui/src/main/res/values-cy/strings.xml
@@ -15,4 +15,5 @@
     <string name="title_links_dialog">Dolenni</string>
     <string name="title_hashtags_dialog">Hashnodau</string>
     <string name="title_mentions_dialog">Crybwylliadau</string>
+    <string name="button_continue">Parhau</string>
 </resources>

--- a/core/ui/src/main/res/values-de/strings.xml
+++ b/core/ui/src/main/res/values-de/strings.xml
@@ -15,4 +15,5 @@
     <string name="title_links_dialog">Links</string>
     <string name="title_hashtags_dialog">Hashtags</string>
     <string name="title_mentions_dialog">Erwähnungen</string>
+    <string name="button_continue">Weiter</string>
 </resources>

--- a/core/ui/src/main/res/values-eo/strings.xml
+++ b/core/ui/src/main/res/values-eo/strings.xml
@@ -14,4 +14,5 @@
     <string name="title_links_dialog">Ligiloj</string>
     <string name="title_hashtags_dialog">Kradvortoj</string>
     <string name="title_mentions_dialog">Mencioj</string>
+    <string name="button_continue">Daŭrigi</string>
 </resources>

--- a/core/ui/src/main/res/values-es/strings.xml
+++ b/core/ui/src/main/res/values-es/strings.xml
@@ -17,4 +17,5 @@
     <string name="item_copied">Texto copiado</string>
     <string name="action_copy_item">Copiar ítem</string>
     <string name="title_mentions_dialog">Menciones</string>
+    <string name="button_continue">Continuar</string>
 </resources>

--- a/core/ui/src/main/res/values-eu/strings.xml
+++ b/core/ui/src/main/res/values-eu/strings.xml
@@ -13,4 +13,5 @@
     <string name="title_links_dialog">Estekak</string>
     <string name="title_hashtags_dialog">Traolak</string>
     <string name="title_mentions_dialog">Aipamenak</string>
+    <string name="button_continue">Jarraitu</string>
 </resources>

--- a/core/ui/src/main/res/values-fa/strings.xml
+++ b/core/ui/src/main/res/values-fa/strings.xml
@@ -15,4 +15,5 @@
     <string name="title_links_dialog">پیوندها</string>
     <string name="title_hashtags_dialog">برچسب‌ها</string>
     <string name="title_mentions_dialog">اشاره‌ها</string>
+    <string name="button_continue">ادامه</string>
 </resources>

--- a/core/ui/src/main/res/values-fi/strings.xml
+++ b/core/ui/src/main/res/values-fi/strings.xml
@@ -17,4 +17,5 @@
     <string name="item_copied">Teksti kopioitu</string>
     <string name="action_copy_item">Kopioi kohde</string>
     <string name="title_mentions_dialog">Maininnat</string>
+    <string name="button_continue">Jatka</string>
 </resources>

--- a/core/ui/src/main/res/values-fr/strings.xml
+++ b/core/ui/src/main/res/values-fr/strings.xml
@@ -15,4 +15,5 @@
     <string name="title_links_dialog">Liens</string>
     <string name="title_hashtags_dialog">Hashtags</string>
     <string name="title_mentions_dialog">Mentions</string>
+    <string name="button_continue">Continuer</string>
 </resources>

--- a/core/ui/src/main/res/values-ga/strings.xml
+++ b/core/ui/src/main/res/values-ga/strings.xml
@@ -17,4 +17,5 @@
     <string name="item_copied">Cóipeáladh téacs</string>
     <string name="action_copy_item">Cóipeáil mír</string>
     <string name="title_mentions_dialog">Tráchtanna</string>
+    <string name="button_continue">Lean ar aghaidh</string>
 </resources>

--- a/core/ui/src/main/res/values-gd/strings.xml
+++ b/core/ui/src/main/res/values-gd/strings.xml
@@ -15,4 +15,5 @@
     <string name="title_links_dialog">Ceanglaichean</string>
     <string name="title_hashtags_dialog">Tagaichean hais</string>
     <string name="title_mentions_dialog">Iomraidhean</string>
+    <string name="button_continue">Air adhart</string>
 </resources>

--- a/core/ui/src/main/res/values-gl/strings.xml
+++ b/core/ui/src/main/res/values-gl/strings.xml
@@ -15,4 +15,5 @@
     <string name="title_links_dialog">Ligazóns</string>
     <string name="title_hashtags_dialog">Cancelos</string>
     <string name="title_mentions_dialog">Mencións</string>
+    <string name="button_continue">Continuar</string>
 </resources>

--- a/core/ui/src/main/res/values-hi/strings.xml
+++ b/core/ui/src/main/res/values-hi/strings.xml
@@ -12,4 +12,5 @@
     <string name="title_links_dialog">लिंक</string>
     <string name="title_hashtags_dialog">हैशटैग</string>
     <string name="title_mentions_dialog">ज़िक्र</string>
+    <string name="button_continue">जारी रखें</string>
 </resources>

--- a/core/ui/src/main/res/values-hu/strings.xml
+++ b/core/ui/src/main/res/values-hu/strings.xml
@@ -15,4 +15,5 @@
     <string name="title_links_dialog">Linkek</string>
     <string name="title_hashtags_dialog">Hashtagek</string>
     <string name="title_mentions_dialog">Említések</string>
+    <string name="button_continue">Folytatás</string>
 </resources>

--- a/core/ui/src/main/res/values-is/strings.xml
+++ b/core/ui/src/main/res/values-is/strings.xml
@@ -15,4 +15,5 @@
     <string name="title_links_dialog">Tenglar</string>
     <string name="title_hashtags_dialog">Myllumerki</string>
     <string name="title_mentions_dialog">Tilvísanir</string>
+    <string name="button_continue">Halda áfram</string>
 </resources>

--- a/core/ui/src/main/res/values-it/strings.xml
+++ b/core/ui/src/main/res/values-it/strings.xml
@@ -15,4 +15,5 @@
     <string name="title_links_dialog">Collegamenti</string>
     <string name="title_hashtags_dialog">Hashtag</string>
     <string name="title_mentions_dialog">Menzioni</string>
+    <string name="button_continue">Continua</string>
 </resources>

--- a/core/ui/src/main/res/values-ja/strings.xml
+++ b/core/ui/src/main/res/values-ja/strings.xml
@@ -15,4 +15,5 @@
     <string name="title_links_dialog">リンク</string>
     <string name="title_hashtags_dialog">ハッシュタグ</string>
     <string name="title_mentions_dialog">返信</string>
+    <string name="button_continue">続ける</string>
 </resources>

--- a/core/ui/src/main/res/values-kab/strings.xml
+++ b/core/ui/src/main/res/values-kab/strings.xml
@@ -13,4 +13,5 @@
     <string name="title_links_dialog">Iseɣwan</string>
     <string name="title_hashtags_dialog">Ihacṭagen</string>
     <string name="title_mentions_dialog">Tibdarin</string>
+    <string name="button_continue">Kemmel</string>
 </resources>

--- a/core/ui/src/main/res/values-ko/strings.xml
+++ b/core/ui/src/main/res/values-ko/strings.xml
@@ -13,4 +13,5 @@
     <string name="title_links_dialog">링크</string>
     <string name="title_hashtags_dialog">해시태그</string>
     <string name="title_mentions_dialog">멘션</string>
+    <string name="button_continue">다음</string>
 </resources>

--- a/core/ui/src/main/res/values-lv/strings.xml
+++ b/core/ui/src/main/res/values-lv/strings.xml
@@ -17,4 +17,5 @@
     <string name="title_mentions_dialog">Pieminējumi</string>
     <string name="action_copy_item">Kopēt vienuma tekstu</string>
     <string name="item_copied">Teksts nokopēts</string>
+    <string name="button_continue">Turpināt</string>
 </resources>

--- a/core/ui/src/main/res/values-ml/strings.xml
+++ b/core/ui/src/main/res/values-ml/strings.xml
@@ -10,4 +10,5 @@
     <string name="action_mentions">സൂചനകൾ</string>
     <string name="title_links_dialog">ലിങ്കുകൾ</string>
     <string name="title_mentions_dialog">സൂചനകൾ</string>
+    <string name="button_continue">തുടരുക</string>
 </resources>

--- a/core/ui/src/main/res/values-nb-rNO/strings.xml
+++ b/core/ui/src/main/res/values-nb-rNO/strings.xml
@@ -15,4 +15,5 @@
     <string name="title_links_dialog">Lenker</string>
     <string name="title_hashtags_dialog">Stikkord</string>
     <string name="title_mentions_dialog">Nevnelser</string>
+    <string name="button_continue">Fortsett</string>
 </resources>

--- a/core/ui/src/main/res/values-nl/strings.xml
+++ b/core/ui/src/main/res/values-nl/strings.xml
@@ -15,4 +15,5 @@
     <string name="title_links_dialog">Links</string>
     <string name="title_hashtags_dialog">Hashtags</string>
     <string name="title_mentions_dialog">Vermeldingen</string>
+    <string name="button_continue">Doorgaan</string>
 </resources>

--- a/core/ui/src/main/res/values-nn/strings.xml
+++ b/core/ui/src/main/res/values-nn/strings.xml
@@ -17,4 +17,5 @@
     <string name="item_copied">Tekst kopiert</string>
     <string name="action_copy_item">Kopier oppføring</string>
     <string name="title_mentions_dialog">Nemningar</string>
+    <string name="button_continue">Fortsett</string>
 </resources>

--- a/core/ui/src/main/res/values-oc/strings.xml
+++ b/core/ui/src/main/res/values-oc/strings.xml
@@ -15,4 +15,5 @@
     <string name="title_links_dialog">Ligams</string>
     <string name="title_hashtags_dialog">Etiquetas</string>
     <string name="title_mentions_dialog">Mencions</string>
+    <string name="button_continue">Contunhar</string>
 </resources>

--- a/core/ui/src/main/res/values-pl/strings.xml
+++ b/core/ui/src/main/res/values-pl/strings.xml
@@ -17,4 +17,5 @@
     <string name="title_mentions_dialog">Wzmianki</string>
     <string name="item_copied">Skopiowano tekst</string>
     <string name="action_copy_item">Skopiuj element</string>
+    <string name="button_continue">Kontynuuj</string>
 </resources>

--- a/core/ui/src/main/res/values-pt-rBR/strings.xml
+++ b/core/ui/src/main/res/values-pt-rBR/strings.xml
@@ -15,4 +15,5 @@
     <string name="title_links_dialog">Links</string>
     <string name="title_hashtags_dialog">Hashtags</string>
     <string name="title_mentions_dialog">Menções</string>
+    <string name="button_continue">Continuar</string>
 </resources>

--- a/core/ui/src/main/res/values-pt-rPT/strings.xml
+++ b/core/ui/src/main/res/values-pt-rPT/strings.xml
@@ -14,4 +14,5 @@
     <string name="title_links_dialog">Hiperligações</string>
     <string name="title_hashtags_dialog">Hashtags</string>
     <string name="title_mentions_dialog">Menções</string>
+    <string name="button_continue">Continuar</string>
 </resources>

--- a/core/ui/src/main/res/values-ru/strings.xml
+++ b/core/ui/src/main/res/values-ru/strings.xml
@@ -13,4 +13,5 @@
     <string name="title_links_dialog">Ссылки</string>
     <string name="title_hashtags_dialog">Хэштеги</string>
     <string name="title_mentions_dialog">Упоминания</string>
+    <string name="button_continue">Продолжить</string>
 </resources>

--- a/core/ui/src/main/res/values-sa/strings.xml
+++ b/core/ui/src/main/res/values-sa/strings.xml
@@ -14,4 +14,5 @@
     <string name="title_links_dialog">जालस्थलानि</string>
     <string name="title_hashtags_dialog">निश्रेणिचिह्नशीर्षकाः</string>
     <string name="title_mentions_dialog">उल्लेखाः</string>
+    <string name="button_continue">निरन्तरम्</string>
 </resources>

--- a/core/ui/src/main/res/values-si/strings.xml
+++ b/core/ui/src/main/res/values-si/strings.xml
@@ -9,4 +9,5 @@
     <string name="action_mentions">සඳැහුම්</string>
     <string name="title_links_dialog">සබැඳි</string>
     <string name="title_mentions_dialog">සඳැහුම්</string>
+    <string name="button_continue">ඉදිරියට</string>
 </resources>

--- a/core/ui/src/main/res/values-sk/strings.xml
+++ b/core/ui/src/main/res/values-sk/strings.xml
@@ -17,4 +17,5 @@
     <string name="url_domain_notifier">" (🔗 %s)"</string>
     <string name="item_copied">Text skopírovaný</string>
     <string name="action_copy_item">Kopírovať položku</string>
+    <string name="button_continue">Pokračovať</string>
 </resources>

--- a/core/ui/src/main/res/values-sl/strings.xml
+++ b/core/ui/src/main/res/values-sl/strings.xml
@@ -13,4 +13,5 @@
     <string name="title_links_dialog">Povezave</string>
     <string name="title_hashtags_dialog">Ključniki</string>
     <string name="title_mentions_dialog">Omembe</string>
+    <string name="button_continue">Nadaljuj</string>
 </resources>

--- a/core/ui/src/main/res/values-sv/strings.xml
+++ b/core/ui/src/main/res/values-sv/strings.xml
@@ -15,4 +15,5 @@
     <string name="title_links_dialog">Länkar</string>
     <string name="title_hashtags_dialog">Hashtaggar</string>
     <string name="title_mentions_dialog">Omnämnanden</string>
+    <string name="button_continue">Fortsätt</string>
 </resources>

--- a/core/ui/src/main/res/values-ta/strings.xml
+++ b/core/ui/src/main/res/values-ta/strings.xml
@@ -5,4 +5,5 @@
     <string name="action_retry">மீண்டும் முயற்சி</string>
     <string name="action_view_profile">சுயவிவரம்</string>
     <string name="action_more">மேலும்</string>
+    <string name="button_continue">தொடரவும்</string>
 </resources>

--- a/core/ui/src/main/res/values-th/strings.xml
+++ b/core/ui/src/main/res/values-th/strings.xml
@@ -13,4 +13,5 @@
     <string name="title_links_dialog">ลิงก์</string>
     <string name="title_hashtags_dialog">แฮชแท็ก</string>
     <string name="title_mentions_dialog">โต้ตอบ</string>
+    <string name="button_continue">ต่อไป</string>
 </resources>

--- a/core/ui/src/main/res/values-tr/strings.xml
+++ b/core/ui/src/main/res/values-tr/strings.xml
@@ -15,4 +15,5 @@
     <string name="title_links_dialog">Bağlantılar</string>
     <string name="title_hashtags_dialog">Etiketler</string>
     <string name="title_mentions_dialog">Bahsedenler</string>
+    <string name="button_continue">Devam</string>
 </resources>

--- a/core/ui/src/main/res/values-uk/strings.xml
+++ b/core/ui/src/main/res/values-uk/strings.xml
@@ -15,4 +15,5 @@
     <string name="title_links_dialog">Посилання</string>
     <string name="title_hashtags_dialog">Хештеги</string>
     <string name="title_mentions_dialog">Згадки</string>
+    <string name="button_continue">Продовжити</string>
 </resources>

--- a/core/ui/src/main/res/values-vi/strings.xml
+++ b/core/ui/src/main/res/values-vi/strings.xml
@@ -15,4 +15,5 @@
     <string name="title_links_dialog">Links</string>
     <string name="title_hashtags_dialog">Hashtag</string>
     <string name="title_mentions_dialog">Lượt nhắc tới</string>
+    <string name="button_continue">Tiếp tục</string>
 </resources>

--- a/core/ui/src/main/res/values-zh-rCN/strings.xml
+++ b/core/ui/src/main/res/values-zh-rCN/strings.xml
@@ -15,4 +15,5 @@
     <string name="title_links_dialog">链接</string>
     <string name="title_hashtags_dialog">话题</string>
     <string name="title_mentions_dialog">提及</string>
+    <string name="button_continue">继续</string>
 </resources>

--- a/core/ui/src/main/res/values-zh-rHK/strings.xml
+++ b/core/ui/src/main/res/values-zh-rHK/strings.xml
@@ -14,4 +14,5 @@
     <string name="title_hashtags_dialog">話題</string>
     <string name="action_refresh">重新整理</string>
     <string name="title_mentions_dialog">提及</string>
+    <string name="button_continue">繼續</string>
 </resources>

--- a/core/ui/src/main/res/values-zh-rTW/strings.xml
+++ b/core/ui/src/main/res/values-zh-rTW/strings.xml
@@ -15,4 +15,5 @@
     <string name="title_hashtags_dialog">話題</string>
     <string name="action_refresh">重新整理</string>
     <string name="title_mentions_dialog">提及</string>
+    <string name="button_continue">繼續</string>
 </resources>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -17,4 +17,5 @@
     <string name="item_copied">Text copied</string>
     <string name="action_copy_item">Copy item</string>
     <string name="title_mentions_dialog">Mentions</string>
+    <string name="button_continue">Continue</string>
 </resources>


### PR DESCRIPTION
Part of the account router change, moved to its own PR.