### PR TITLE
fix: Start-align "Vote" button's position

### DIFF
--- a/app/src/main/res/layout/status_poll.xml
+++ b/app/src/main/res/layout/status_poll.xml
@@ -40,6 +40,7 @@
         android:text="@string/poll_vote"
         android:textSize="?attr/status_text_medium"
         app:layout_constraintEnd_toStartOf="@+id/status_poll_show_results"
+        app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintHorizontal_chainStyle="spread_inside"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/status_poll_options"


### PR DESCRIPTION
If the "Show votes" button is hidden (e.g., because no one has voted on the poll) the constraint layout default behaviour is to centre the "Vote" button, which is not it's normal position.

Set an explicit horizontal bias to fix this.