### PR TITLE
change: Provide startActivityWith{Default}Transition for fragments

### DIFF
--- a/app/src/main/java/app/pachli/components/account/media/AccountMediaFragment.kt
+++ b/app/src/main/java/app/pachli/components/account/media/AccountMediaFragment.kt
@@ -35,6 +35,7 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout.OnRefreshListener
 import app.pachli.R
 import app.pachli.core.activity.OpenUrlUseCase
 import app.pachli.core.activity.RefreshableFragment
+import app.pachli.core.activity.extensions.startActivityWithDefaultTransition
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
 import app.pachli.core.common.extensions.viewBinding
@@ -178,9 +179,9 @@ class AccountMediaFragment :
                     val url = selected.attachment.url
                     ViewCompat.setTransitionName(view, url)
                     val options = ActivityOptionsCompat.makeSceneTransitionAnimation(requireActivity(), view, url)
-                    startActivity(intent, options.toBundle())
+                    startActivityWithDefaultTransition(intent, options.toBundle())
                 } else {
-                    startActivity(intent)
+                    startActivityWithDefaultTransition(intent)
                 }
             }
             Attachment.Type.UNKNOWN -> openUrl(selected.attachment.url)

--- a/app/src/main/java/app/pachli/components/conversation/ConversationsFragment.kt
+++ b/app/src/main/java/app/pachli/components/conversation/ConversationsFragment.kt
@@ -40,6 +40,7 @@ import app.pachli.adapter.StatusBaseViewHolder
 import app.pachli.components.preference.accountfilters.AccountConversationFiltersPreferenceDialogFragment
 import app.pachli.core.activity.ReselectableFragment
 import app.pachli.core.activity.extensions.TransitionKind
+import app.pachli.core.activity.extensions.startActivityWithDefaultTransition
 import app.pachli.core.activity.extensions.startActivityWithTransition
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
@@ -419,12 +420,12 @@ class ConversationsFragment :
 
     override fun onViewAccount(id: String) {
         val intent = AccountActivityIntent(requireContext(), pachliAccountId, id)
-        startActivity(intent)
+        startActivityWithDefaultTransition(intent)
     }
 
     override fun onViewTag(tag: String) {
         val intent = TimelineActivityIntent.hashtag(requireContext(), pachliAccountId, tag)
-        startActivity(intent)
+        startActivityWithTransition(intent, TransitionKind.SLIDE_FROM_END)
     }
 
     override fun removeItem(viewData: ConversationViewData) {

--- a/app/src/main/java/app/pachli/components/preference/AccountPreferencesFragment.kt
+++ b/app/src/main/java/app/pachli/components/preference/AccountPreferencesFragment.kt
@@ -32,6 +32,7 @@ import app.pachli.components.notifications.activeAccountNeedsPushScope
 import app.pachli.components.preference.accountfilters.AccountConversationFiltersPreferenceDialogFragment
 import app.pachli.components.preference.accountfilters.AccountNotificationFiltersPreferencesDialogFragment
 import app.pachli.core.activity.extensions.TransitionKind
+import app.pachli.core.activity.extensions.startActivityWithDefaultTransition
 import app.pachli.core.activity.extensions.startActivityWithTransition
 import app.pachli.core.common.util.unsafeLazy
 import app.pachli.core.data.repository.AccountManager
@@ -348,10 +349,10 @@ class AccountPreferencesFragment : PreferenceFragmentCompat() {
             val intent = Intent()
             intent.action = "android.settings.APP_NOTIFICATION_SETTINGS"
             intent.putExtra("android.provider.extra.APP_PACKAGE", BuildConfig.APPLICATION_ID)
-            requireActivity().startActivity(intent)
+            startActivityWithDefaultTransition(intent)
         } else {
             val intent = PreferencesActivityIntent(requireContext(), pachliAccountId, PreferenceScreen.NOTIFICATION)
-            requireActivity().startActivityWithTransition(intent, TransitionKind.SLIDE_FROM_END)
+            startActivityWithTransition(intent, TransitionKind.SLIDE_FROM_END)
         }
     }
 

--- a/app/src/main/java/app/pachli/components/preference/PreferencesFragment.kt
+++ b/app/src/main/java/app/pachli/components/preference/PreferencesFragment.kt
@@ -40,6 +40,7 @@ import androidx.recyclerview.widget.DividerItemDecoration
 import app.pachli.R
 import app.pachli.components.notifications.getApplicationLabel
 import app.pachli.components.notifications.notificationMethod
+import app.pachli.core.activity.extensions.startActivityWithDefaultTransition
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
 import app.pachli.core.common.util.unsafeLazy
@@ -355,7 +356,7 @@ class PreferencesFragment : PreferenceFragmentCompat() {
                     setOnPreferenceClickListener {
                         distributorPkg?.let { pkg ->
                             context.packageManager.getLaunchIntentForPackage(pkg)?.also {
-                                startActivity(it)
+                                startActivityWithDefaultTransition(it)
                             }
                         }
 

--- a/app/src/main/java/app/pachli/components/report/fragments/ReportStatusesFragment.kt
+++ b/app/src/main/java/app/pachli/components/report/fragments/ReportStatusesFragment.kt
@@ -37,6 +37,7 @@ import app.pachli.components.report.ReportViewModel
 import app.pachli.components.report.Screen
 import app.pachli.components.report.adapter.AdapterHandler
 import app.pachli.components.report.adapter.StatusesAdapter
+import app.pachli.core.activity.extensions.startActivityWithDefaultTransition
 import app.pachli.core.common.extensions.viewBinding
 import app.pachli.core.common.extensions.visible
 import app.pachli.core.data.repository.AccountManager
@@ -120,9 +121,9 @@ class ReportStatusesFragment :
                         val url = actionable.attachments[idx].url
                         ViewCompat.setTransitionName(v, url)
                         val options = ActivityOptionsCompat.makeSceneTransitionAnimation(requireActivity(), v, url)
-                        startActivity(intent, options.toBundle())
+                        startActivityWithDefaultTransition(intent, options.toBundle())
                     } else {
-                        startActivity(intent)
+                        startActivityWithDefaultTransition(intent)
                     }
                 }
                 Attachment.Type.UNKNOWN -> {
@@ -234,11 +235,11 @@ class ReportStatusesFragment :
         return viewModel.isStatusChecked(id)
     }
 
-    override fun onViewAccount(id: String) = startActivity(
+    override fun onViewAccount(id: String) = startActivityWithDefaultTransition(
         AccountActivityIntent(requireContext(), pachliAccountId, id),
     )
 
-    override fun onViewTag(tag: String) = startActivity(
+    override fun onViewTag(tag: String) = startActivityWithDefaultTransition(
         TimelineActivityIntent.hashtag(requireContext(), pachliAccountId, tag),
     )
 

--- a/app/src/main/java/app/pachli/components/search/fragments/SearchStatusesFragment.kt
+++ b/app/src/main/java/app/pachli/components/search/fragments/SearchStatusesFragment.kt
@@ -141,9 +141,9 @@ class SearchStatusesFragment : SearchFragment<StatusViewData>(), StatusActionLis
                         view,
                         url,
                     )
-                    startActivity(intent, options.toBundle())
+                    startActivityWithDefaultTransition(intent, options.toBundle())
                 } else {
-                    startActivity(intent)
+                    startActivityWithDefaultTransition(intent)
                 }
             }
             Attachment.Type.UNKNOWN -> openUrl(actionable.attachments[attachmentIndex].url)
@@ -278,7 +278,7 @@ class SearchStatusesFragment : SearchFragment<StatusViewData>(), StatusActionLis
                         statusToShare.content
                     sendIntent.putExtra(Intent.EXTRA_TEXT, stringToShare)
                     sendIntent.type = "text/plain"
-                    startActivity(Intent.createChooser(sendIntent, resources.getText(R.string.send_post_content_to)))
+                    startActivityWithDefaultTransition(Intent.createChooser(sendIntent, resources.getText(R.string.send_post_content_to)))
                     return@setOnMenuItemClickListener true
                 }
                 R.id.post_share_link -> {
@@ -286,7 +286,7 @@ class SearchStatusesFragment : SearchFragment<StatusViewData>(), StatusActionLis
                     sendIntent.action = Intent.ACTION_SEND
                     sendIntent.putExtra(Intent.EXTRA_TEXT, statusUrl)
                     sendIntent.type = "text/plain"
-                    startActivity(Intent.createChooser(sendIntent, resources.getText(R.string.send_post_link_to)))
+                    startActivityWithDefaultTransition(Intent.createChooser(sendIntent, resources.getText(R.string.send_post_link_to)))
                     return@setOnMenuItemClickListener true
                 }
                 R.id.status_copy_link -> {
@@ -401,7 +401,7 @@ class SearchStatusesFragment : SearchFragment<StatusViewData>(), StatusActionLis
     }
 
     private fun openReportPage(accountId: String, accountUsername: String, statusId: String) {
-        startActivity(ReportActivityIntent(requireContext(), this.pachliAccountId, accountId, accountUsername, statusId))
+        startActivityWithDefaultTransition(ReportActivityIntent(requireContext(), this.pachliAccountId, accountId, accountUsername, statusId))
     }
 
     // TODO: Identical to the same function in SFragment.kt
@@ -450,7 +450,7 @@ class SearchStatusesFragment : SearchFragment<StatusViewData>(), StatusActionLis
                                     kind = ComposeOptions.ComposeKind.NEW,
                                 ),
                             )
-                            startActivity(intent)
+                            startActivityWithDefaultTransition(intent)
                         }.onFailure { error ->
                             Timber.w("error deleting status: %s", error)
                             Toast.makeText(context, app.pachli.core.ui.R.string.error_generic, Toast.LENGTH_SHORT).show()
@@ -478,7 +478,7 @@ class SearchStatusesFragment : SearchFragment<StatusViewData>(), StatusActionLis
                     poll = status.poll?.toNewPoll(status.createdAt),
                     kind = ComposeOptions.ComposeKind.EDIT_POSTED,
                 )
-                startActivity(ComposeActivityIntent(requireContext(), pachliAccountId, composeOptions))
+                startActivityWithDefaultTransition(ComposeActivityIntent(requireContext(), pachliAccountId, composeOptions))
             }.onFailure {
                 Snackbar.make(
                     requireView(),

--- a/app/src/main/java/app/pachli/components/trending/TrendingLinksFragment.kt
+++ b/app/src/main/java/app/pachli/components/trending/TrendingLinksFragment.kt
@@ -41,6 +41,8 @@ import app.pachli.components.trending.viewmodel.TrendingLinksViewModel
 import app.pachli.core.activity.OpenUrlUseCase
 import app.pachli.core.activity.RefreshableFragment
 import app.pachli.core.activity.ReselectableFragment
+import app.pachli.core.activity.extensions.TransitionKind
+import app.pachli.core.activity.extensions.startActivityWithTransition
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
 import app.pachli.core.common.extensions.viewBinding
@@ -275,7 +277,10 @@ class TrendingLinksFragment :
             Target.CARD -> openUrl(card.url)
             Target.IMAGE -> openUrl(card.url)
             Target.BYLINE -> card.authors?.firstOrNull()?.account?.id?.let {
-                startActivity(AccountActivityIntent(requireContext(), pachliAccountId, it))
+                startActivityWithTransition(
+                    AccountActivityIntent(requireContext(), pachliAccountId, it),
+                    TransitionKind.SLIDE_FROM_END,
+                )
             }
 
             Target.TIMELINE_LINK -> {
@@ -285,7 +290,7 @@ class TrendingLinksFragment :
                     card.url,
                     card.title,
                 )
-                startActivity(intent)
+                startActivityWithTransition(intent, TransitionKind.SLIDE_FROM_END)
             }
         }
     }

--- a/app/src/main/java/app/pachli/fragment/SFragment.kt
+++ b/app/src/main/java/app/pachli/fragment/SFragment.kt
@@ -40,7 +40,9 @@ import app.pachli.core.activity.BaseActivity
 import app.pachli.core.activity.BottomSheetActivity
 import app.pachli.core.activity.OpenUrlUseCase
 import app.pachli.core.activity.PostLookupFallbackBehavior
+import app.pachli.core.activity.extensions.TransitionKind
 import app.pachli.core.activity.extensions.startActivityWithDefaultTransition
+import app.pachli.core.activity.extensions.startActivityWithTransition
 import app.pachli.core.data.model.IStatusViewData
 import app.pachli.core.data.repository.AccountManager
 import app.pachli.core.data.repository.ServerRepository
@@ -109,12 +111,9 @@ abstract class SFragment<T : IStatusViewData> : Fragment(), StatusActionListener
 
     protected abstract val pachliAccountId: Long
 
+    @Deprecated("Use startActivityWithTransition or startActivityWithDefaultTransition")
     override fun startActivity(intent: Intent) {
-        if (intent.component?.className?.startsWith("app.pachli.") == true) {
-            requireActivity().startActivityWithDefaultTransition(intent)
-        } else {
-            super.startActivity(intent)
-        }
+        super.startActivity(intent)
     }
 
     override fun onAttach(context: Context) {
@@ -202,7 +201,7 @@ abstract class SFragment<T : IStatusViewData> : Fragment(), StatusActionListener
         )
 
         val intent = ComposeActivityIntent(requireContext(), pachliAccountId, composeOptions)
-        requireActivity().startActivity(intent)
+        startActivityWithTransition(intent, TransitionKind.SLIDE_FROM_END)
     }
 
     /**
@@ -281,7 +280,7 @@ abstract class SFragment<T : IStatusViewData> : Fragment(), StatusActionListener
                         )
                         putExtra(Intent.EXTRA_SUBJECT, statusUrl)
                     }
-                    startActivity(
+                    startActivityWithDefaultTransition(
                         Intent.createChooser(
                             sendIntent,
                             resources.getText(R.string.send_post_content_to),
@@ -295,7 +294,7 @@ abstract class SFragment<T : IStatusViewData> : Fragment(), StatusActionListener
                         putExtra(Intent.EXTRA_TEXT, statusUrl)
                         type = "text/plain"
                     }
-                    startActivity(
+                    startActivityWithDefaultTransition(
                         Intent.createChooser(
                             sendIntent,
                             resources.getText(R.string.send_post_link_to),
@@ -432,9 +431,9 @@ abstract class SFragment<T : IStatusViewData> : Fragment(), StatusActionListener
                         view,
                         url,
                     )
-                    startActivity(intent, options.toBundle())
+                    startActivityWithDefaultTransition(intent, options.toBundle())
                 } else {
-                    startActivity(intent)
+                    startActivityWithDefaultTransition(intent)
                 }
             }
             Attachment.Type.UNKNOWN -> openUrl(attachment.url)
@@ -442,11 +441,14 @@ abstract class SFragment<T : IStatusViewData> : Fragment(), StatusActionListener
     }
 
     protected fun viewTag(tag: String) {
-        startActivity(TimelineActivityIntent.hashtag(requireContext(), pachliAccountId, tag))
+        startActivityWithTransition(
+            TimelineActivityIntent.hashtag(requireContext(), pachliAccountId, tag),
+            TransitionKind.SLIDE_FROM_END,
+        )
     }
 
     private fun openReportPage(accountId: String, accountUsername: String, statusId: String) {
-        startActivity(ReportActivityIntent(requireContext(), pachliAccountId, accountId, accountUsername, statusId))
+        startActivityWithDefaultTransition(ReportActivityIntent(requireContext(), pachliAccountId, accountId, accountUsername, statusId))
     }
 
     private fun showConfirmDeleteDialog(viewData: T) {
@@ -498,7 +500,10 @@ abstract class SFragment<T : IStatusViewData> : Fragment(), StatusActionListener
                             poll = sourceStatus.poll?.toNewPoll(sourceStatus.createdAt),
                             kind = ComposeOptions.ComposeKind.NEW,
                         )
-                        startActivity(ComposeActivityIntent(requireContext(), pachliAccountId, composeOptions))
+                        startActivityWithTransition(
+                            ComposeActivityIntent(requireContext(), pachliAccountId, composeOptions),
+                            TransitionKind.SLIDE_FROM_END,
+                        )
                     }
                         .onFailure {
                             Timber.w("error deleting status: %s", it)
@@ -527,7 +532,10 @@ abstract class SFragment<T : IStatusViewData> : Fragment(), StatusActionListener
                     poll = status.poll?.toNewPoll(status.createdAt),
                     kind = ComposeOptions.ComposeKind.EDIT_POSTED,
                 )
-                startActivity(ComposeActivityIntent(requireContext(), pachliAccountId, composeOptions))
+                startActivityWithTransition(
+                    ComposeActivityIntent(requireContext(), pachliAccountId, composeOptions),
+                    TransitionKind.SLIDE_FROM_END,
+                )
             }
                 .onFailure {
                     Snackbar.make(

--- a/core/activity/src/main/kotlin/app/pachli/core/activity/extensions/FragmentExtensions.kt
+++ b/core/activity/src/main/kotlin/app/pachli/core/activity/extensions/FragmentExtensions.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.core.activity.extensions
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import app.pachli.core.activity.BaseActivity
+
+fun Fragment.startActivityWithDefaultTransition(intent: Intent, options: Bundle? = null) {
+    val activity = requireActivity() as? BaseActivity
+
+    if (activity != null && intent.forPachliComponent) {
+        activity.startActivityWithDefaultTransition(intent, options)
+    } else {
+        startActivity(intent, options)
+    }
+}
+
+/**
+ * Starts the activity in [intent].
+ *
+ * If the activity is a Pachli activity then [transitionKind] is included in the intent and
+ * used as the open/close transition.
+ *
+ * See [BaseActivity.onCreate] for the other half of this code.
+ */
+fun Fragment.startActivityWithTransition(intent: Intent, transitionKind: TransitionKind, options: Bundle? = null) {
+    val activity = requireActivity() as? BaseActivity
+
+    if (activity != null && intent.forPachliComponent) {
+        activity.startActivityWithTransition(intent, transitionKind, options)
+    } else {
+        startActivity(intent, options)
+    }
+}

--- a/core/activity/src/main/kotlin/app/pachli/core/activity/extensions/IntentExtensions.kt
+++ b/core/activity/src/main/kotlin/app/pachli/core/activity/extensions/IntentExtensions.kt
@@ -22,7 +22,7 @@ import android.os.Build
 import androidx.annotation.AnimRes
 import app.pachli.core.designsystem.R as DR
 
-const val EXTRA_TRANSITION_KIND = "transition_kind"
+const val EXTRA_TRANSITION_KIND = "app.pachli.core.activity.extensions.EXTRA_TRANSITION_KIND"
 
 /**
  * The type of transition and animation resources to use when opening and closing
@@ -69,3 +69,7 @@ fun Intent.getTransitionKind(): TransitionKind? {
         getSerializableExtra(EXTRA_TRANSITION_KIND) as? TransitionKind
     }
 }
+
+/** True if [Intent] is for a Pachli component, false otherwise. */
+val Intent.forPachliComponent: Boolean
+    get() = this.component?.className?.startsWith("app.pachli") == true


### PR DESCRIPTION
Allows all fragments to use this functionality, not just SFragment.

Use a slide transition when replying, editing, or viewing tags.