### PR TITLE
fix: Display poll previews correctly

### DIFF
--- a/app/src/main/java/app/pachli/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeActivity.kt
@@ -37,7 +37,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.AdapterView
 import android.widget.ImageButton
-import android.widget.LinearLayout
 import android.widget.PopupMenu
 import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
@@ -1007,13 +1006,6 @@ class ComposeActivity :
     }
 
     private fun setupPollView() {
-        val margin = resources.getDimensionPixelSize(DR.dimen.compose_media_preview_margin)
-        val marginBottom = resources.getDimensionPixelSize(DR.dimen.compose_media_preview_margin_bottom)
-
-        val layoutParams = LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT)
-        layoutParams.setMargins(margin, margin, margin, marginBottom)
-        binding.pollPreview.layoutParams = layoutParams
-
         binding.pollPreview.setOnClickListener {
             val popup = PopupMenu(this, binding.pollPreview)
             val editId = 1

--- a/app/src/main/res/layout/activity_compose.xml
+++ b/app/src/main/res/layout/activity_compose.xml
@@ -307,8 +307,9 @@
 
             <app.pachli.components.compose.view.PollPreviewView
                 android:id="@+id/pollPreview"
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/compose_media_preview_margin"
                 app:layout_constraintTop_toBottomOf="@id/composeMediaPreviewBar"
                 android:minWidth="@dimen/poll_preview_min_width"
                 android:visibility="gone"


### PR DESCRIPTION
Poll previews had their layout params overwritten, which meant they were laid out at the top of the view, overlapping the content.

Fix this.