### PR TITLE
fix: Improve colours when compose buttons are enabled

### DIFF
--- a/app/src/main/java/app/pachli/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeActivity.kt
@@ -1229,15 +1229,11 @@ class ComposeActivity :
 
     private fun enableButton(button: ImageButton, clickable: Boolean, colorActive: Boolean) {
         button.isEnabled = clickable
-        setDrawableTint(
-            this,
-            button.drawable,
-            if (colorActive) {
-                android.R.attr.textColorTertiary
-            } else {
-                DR.attr.textColorDisabled
-            },
-        )
+        if (colorActive) {
+            setDrawableTint(this, button.drawable, android.R.attr.textColorTertiary)
+        } else {
+            button.drawable.clearColorFilter()
+        }
     }
 
     private fun enablePollButton(enable: Boolean) {


### PR DESCRIPTION
Previous colour choice was not visible in dark mode. Instead of explicitly setting a colour, clear the colour filter, which will fall back to whatever the default "disabled" colour is.