### PR TITLE
feat: Replace Local timeline with Trending in default tabs

### DIFF
--- a/core/database/src/main/kotlin/app/pachli/core/database/model/AccountEntity.kt
+++ b/core/database/src/main/kotlin/app/pachli/core/database/model/AccountEntity.kt
@@ -157,6 +157,6 @@ data class AccountEntity(
 fun defaultTabs() = listOf(
     Timeline.Home,
     Timeline.Notifications,
-    Timeline.PublicLocal,
+    Timeline.TrendingStatuses,
     Timeline.Conversations,
 )


### PR DESCRIPTION
This is likely to give the user a better initial experience, as the set of trending statuses is probably more interesting than the unfiltered "Local" stream.