### PR TITLE
feat: Parse Instants from servers that don't include the timezone

### DIFF
--- a/core/network/src/main/kotlin/app/pachli/core/network/json/InstantJsonAdapter.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/json/InstantJsonAdapter.kt
@@ -24,15 +24,41 @@ import com.squareup.moshi.JsonReader.Token.NULL
 import com.squareup.moshi.JsonWriter
 import com.squareup.moshi.ToJson
 import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeFormatterBuilder
+import java.time.format.DateTimeParseException
 
 class InstantJsonAdapter : JsonAdapter<Instant?>() {
+    var fmt: DateTimeFormatter = DateTimeFormatterBuilder()
+        .append(DateTimeFormatter.ISO_DATE_TIME)
+        .optionalStart().appendOffsetId()
+        .toFormatter().withZone(ZoneOffset.UTC)
+
+    /**
+     * Parse an [Instant] from JSON.
+     *
+     * Handles the case where the incoming JSON date might not include the
+     * timezone (missing from some buggy servers). Fallback to parsing as
+     * [LocalDateTime] and then converting that to an [Instant].
+     */
     @FromJson
     override fun fromJson(reader: JsonReader): Instant? {
         if (reader.peek() == NULL) {
             return reader.nextNull()
         }
         val string = reader.nextString()
-        return Instant.parse(string)
+        val parsed = fmt.parseBest(string, Instant::from, LocalDateTime::from)
+        return when (parsed) {
+            is Instant -> parsed
+            is LocalDateTime -> Instant.from(parsed)
+            else -> {
+                // Shouldn't happen, parseBest should already have thrown rather
+                // than return an unexpected class.
+                throw (DateTimeParseException("unexpected class from parseBest, $parsed", string, 0))
+            }
+        }
     }
 
     @ToJson

--- a/core/network/src/main/kotlin/app/pachli/core/network/json/LenientRfc3339DateJsonAdapter.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/json/LenientRfc3339DateJsonAdapter.kt
@@ -17,11 +17,13 @@
 
 package app.pachli.core.network.json
 
+import com.squareup.moshi.FromJson
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.JsonDataException
 import com.squareup.moshi.JsonReader
 import com.squareup.moshi.JsonReader.Token.NULL
 import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.ToJson
 import java.util.Calendar
 import java.util.Date
 import java.util.GregorianCalendar
@@ -84,6 +86,7 @@ import timber.log.Timber
 class LenientRfc3339DateJsonAdapter : JsonAdapter<Date>() {
     /** The underlying deserialization logic is thread-safe and does not require synchronization. **/
     @Throws(IOException::class)
+    @FromJson
     override fun fromJson(reader: JsonReader): Date? {
         if (reader.peek() == NULL) {
             return reader.nextNull()
@@ -94,6 +97,7 @@ class LenientRfc3339DateJsonAdapter : JsonAdapter<Date>() {
 
     /*** The underlying serialization logic is thread-safe and does not require synchronization. **/
     @Throws(IOException::class)
+    @ToJson
     override fun toJson(writer: JsonWriter, value: Date?) {
         if (value == null) {
             writer.nullValue()

--- a/core/network/src/test/kotlin/app/pachli/core/network/json/Rfc3339DateTest.kt
+++ b/core/network/src/test/kotlin/app/pachli/core/network/json/Rfc3339DateTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.core.network.json
+
+import com.google.common.truth.Truth.assertThat
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.adapter
+import java.time.Instant
+import java.util.Date
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+/**
+ * Tests [InstantJsonAdapter] and [LenientRfc3339DateJsonAdapter]. They should both
+ * parse the same JSON date strings the same way.
+ */
+@RunWith(Parameterized::class)
+@OptIn(ExperimentalStdlibApi::class)
+class Rfc3339DateTest(private val testData: TestData) {
+    /**
+     * Data for each test.
+     *
+     * @param name Test name.
+     * @param json JSON string as input for the test.
+     */
+    data class TestData(val name: String, val json: String)
+
+    private val moshi = Moshi.Builder()
+        .add(InstantJsonAdapter())
+        .add(LenientRfc3339DateJsonAdapter())
+        .build()
+
+    companion object {
+        /** Expected [Instant] value after parsing [TestData.json]. */
+        private val wantInstant = Instant.parse("1994-11-05T13:15:30.000Z")
+
+        /** Expected [Date] value after parsing [TestData.json]. */
+        private val wantDate = Date.from(wantInstant)
+
+        @Parameterized.Parameters(name = "{0}")
+        @JvmStatic
+        fun data(): Iterable<TestData> {
+            return listOf(
+                TestData(
+                    "RFC3339 date",
+                    "\"1994-11-05T13:15:30.000Z\"",
+                ),
+                TestData(
+                    "RFC3339 without subsecond precision",
+                    "\"1994-11-05T13:15:30Z\"",
+                ),
+                TestData(
+                    "RFC3339 with timezone as offset",
+                    "\"1994-11-05T16:15:30+03:00\"",
+                ),
+                TestData(
+                    "RFC3339 with missing timezone",
+                    "\"1994-11-05T13:15:30\"",
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun dateParses() {
+        assertThat(moshi.adapter<Date>().fromJson(testData.json)).isEqualTo(wantDate)
+    }
+
+    @Test
+    fun instantParses() {
+        assertThat(moshi.adapter<Instant>().fromJson(testData.json)).isEqualTo(wantInstant)
+    }
+}


### PR DESCRIPTION
Some servers don't include the (mandatory) timezone information. This was already supported by `LenientRfc3339DateJsonAdapter` when parsing to a `Date`, support it when parsing to an `Instant` too.

Test both adapters with the same data and ensure they return the same results for the same input.