### PR TITLE
feat: Speed up account switching if the user has no account filters

### DIFF
--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/AccountManager.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/AccountManager.kt
@@ -520,7 +520,18 @@ class AccountManager @Inject constructor(
         // TODO: Add a capability for announcements.
         deferAnnouncements.await().orElse { Ok(emptyList()) }.bind()
 
-        deferFollowing.await().bind()
+        // Fetching the user's list of followed accounts may take some time if they
+        // follow a lot of accounts. This information is only used when filtering
+        // notifications and conversations, and only if the user has set the
+        // relevant options.
+        //
+        // If the options are set then wait for the API calls to complete. Otherwise
+        // this can happen in the background.
+        if (account.notificationAccountFilterNotFollowed != FilterAction.NONE ||
+            account.conversationAccountFilterNotFollowed != FilterAction.NONE
+        ) {
+            deferFollowing.await().bind()
+        }
     }
 
     /**

--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/PachliAccount.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/PachliAccount.kt
@@ -39,7 +39,7 @@ import io.github.z4kn4fein.semver.Version
  * @param server Details about the account's server.
  * @param contentFilters Account's content filters.
  * @param announcements Announcements from the account's server.
- * @param following Accounts this account is following
+ * @param following Accounts this account is following.
  */
 // TODO: Still not sure if it's better to have one class that contains everything,
 // or provide dedicated functions that return specific flows for the different


### PR DESCRIPTION
Previous code always fetched the user's list of followed accounts as part of refreshing the local account data when loading the app or switching accounts.

This may take a lot of time, and is only necessary if the user has the notification or conversation account filters set to filter accounts the user is not following.

Change this so the fetch still happens, but only blocks the refresh if the user has one of those filter options set. Otherwise the fetch happens in the background.

See https://github.com/pachli/pachli-android/issues/1556