### PR TITLE
refactor: Don't destructure large classes

### DIFF
--- a/app/src/main/java/app/pachli/adapter/StatusBaseViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/StatusBaseViewHolder.kt
@@ -151,7 +151,7 @@ abstract class StatusBaseViewHolder<T : IStatusViewData> protected constructor(
         statusDisplayOptions: StatusDisplayOptions,
         listener: StatusActionListener<T>,
     ) {
-        val spoilerText = viewData.spoilerText
+        val spoilerText = viewData.actionable.spoilerText
         val sensitive = !TextUtils.isEmpty(spoilerText)
         val expanded = viewData.isExpanded
         if (sensitive) {
@@ -222,7 +222,11 @@ abstract class StatusBaseViewHolder<T : IStatusViewData> protected constructor(
         statusDisplayOptions: StatusDisplayOptions,
         listener: StatusActionListener<T>,
     ) {
-        val (_, _, _, _, _, _, _, _, _, emojis, _, _, _, _, _, _, _, _, _, _, mentions, tags, _, _, _, poll) = viewData.actionable
+        val emojis = viewData.actionable.emojis
+        val mentions = viewData.actionable.mentions
+        val tags = viewData.actionable.tags
+        val poll = viewData.actionable.poll
+
         when (viewData.translationState) {
             TranslationState.SHOW_ORIGINAL -> translationProvider?.hide()
             TranslationState.TRANSLATING -> {
@@ -334,7 +338,9 @@ abstract class StatusBaseViewHolder<T : IStatusViewData> protected constructor(
         statusDisplayOptions: StatusDisplayOptions,
         listener: StatusActionListener<T>,
     ) {
-        val (_, _, _, _, _, _, _, createdAt, editedAt) = viewData.actionable
+        val createdAt = viewData.actionable.createdAt
+        val editedAt = viewData.actionable.editedAt
+
         var timestampText: String
         timestampText = if (statusDisplayOptions.useAbsoluteTime) {
             absoluteTimeFormatter.format(createdAt, true)
@@ -690,7 +696,7 @@ abstract class StatusBaseViewHolder<T : IStatusViewData> protected constructor(
         if (payloads == null) {
             val actionable = viewData.actionable
             setDisplayName(actionable.account.name, actionable.account.emojis, statusDisplayOptions)
-            setUsername(viewData.username)
+            setUsername(actionable.account.username)
             setMetaData(viewData, statusDisplayOptions, listener)
             setIsReply(actionable.inReplyToId != null)
             setReplyCount(actionable.repliesCount, statusDisplayOptions.showStatsInline)
@@ -769,7 +775,17 @@ abstract class StatusBaseViewHolder<T : IStatusViewData> protected constructor(
 
     /** Creates and sets the content description for the status. */
     private fun setContentDescriptionForStatus(viewData: T, statusDisplayOptions: StatusDisplayOptions) {
-        val (_, _, account, _, _, _, _, createdAt, editedAt, _, reblogsCount, favouritesCount, _, reblogged, favourited, bookmarked, sensitive, _, visibility) = viewData.actionable
+        val account = viewData.actionable.account
+        val createdAt = viewData.actionable.createdAt
+        val editedAt = viewData.actionable.editedAt
+        val reblogsCount = viewData.actionable.reblogsCount
+        val favouritesCount = viewData.actionable.favouritesCount
+        val reblogged = viewData.actionable.reblogged
+        val favourited = viewData.actionable.favourited
+        val bookmarked = viewData.actionable.bookmarked
+        val sensitive = viewData.actionable.sensitive
+        val visibility = viewData.actionable.visibility
+        val spoilerText = viewData.actionable.spoilerText
 
         // Build the content description using a string builder instead of a string resource
         // as there are many places where optional ";" and "," are needed.
@@ -798,7 +814,7 @@ abstract class StatusBaseViewHolder<T : IStatusViewData> protected constructor(
 
             // Content is optional, and hidden if there are spoilers or the status is
             // marked sensitive, and it has not been expanded.
-            if (TextUtils.isEmpty(viewData.spoilerText) || !sensitive || viewData.isExpanded) {
+            if (TextUtils.isEmpty(spoilerText) || !sensitive || viewData.isExpanded) {
                 append(viewData.content.parseAsMastodonHtml(), ", ")
             }
 
@@ -820,7 +836,7 @@ abstract class StatusBaseViewHolder<T : IStatusViewData> protected constructor(
 
             getReblogDescription(context, viewData)?.let { append(", ", it) }
 
-            append(", ", viewData.username)
+            append(", ", viewData.actionable.account.username)
 
             if (reblogged) {
                 append(", ", context.getString(R.string.description_post_reblogged))
@@ -879,7 +895,11 @@ abstract class StatusBaseViewHolder<T : IStatusViewData> protected constructor(
     ) {
         cardView ?: return
 
-        val (_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, sensitive, _, _, attachments, _, _, _, _, _, poll, card) = viewData.actionable
+        val sensitive = viewData.actionable.sensitive
+        val attachments = viewData.actionable.attachments
+        val poll = viewData.actionable.poll
+        val card = viewData.actionable.card
+
         if (cardViewMode !== CardViewMode.NONE &&
             attachments.isEmpty() &&
             poll == null &&
@@ -946,11 +966,10 @@ abstract class StatusBaseViewHolder<T : IStatusViewData> protected constructor(
 
         /** @return "Content warning: {spoilerText}", for use in a content description. */
         private fun getContentWarningDescription(context: Context, status: IStatusViewData): String? {
-            return if (!TextUtils.isEmpty(status.spoilerText)) {
-                context.getString(R.string.description_post_cw, status.spoilerText)
-            } else {
-                null
-            }
+            val spoilerText = status.actionable.spoilerText
+            if (spoilerText.isEmpty()) return null
+
+            return context.getString(R.string.description_post_cw, status.spoilerText)
         }
     }
 }

--- a/app/src/main/java/app/pachli/adapter/StatusDetailedViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/StatusDetailedViewHolder.kt
@@ -37,7 +37,11 @@ class StatusDetailedViewHolder(
         statusDisplayOptions: StatusDisplayOptions,
         listener: StatusActionListener<StatusViewData>,
     ) {
-        val (_, _, _, _, _, _, _, createdAt, editedAt, _, _, _, _, _, _, _, _, _, visibility, _, _, _, app) = viewData.actionable
+        val createdAt = viewData.actionable.createdAt
+        val editedAt = viewData.actionable.editedAt
+        val visibility = viewData.actionable.visibility
+        val app = viewData.actionable.application
+
         val visibilityIcon = visibility.icon(metaInfo)
         val visibilityString = visibility.description(context)
         val sb = SpannableStringBuilder(visibilityString)
@@ -125,7 +129,8 @@ class StatusDetailedViewHolder(
             listener,
         ) // Always show card for detailed status
         if (payloads == null) {
-            val (_, _, _, _, _, _, _, _, _, _, reblogsCount, favouritesCount) = uncollapsedViewdata.actionable
+            val reblogsCount = uncollapsedViewdata.actionable.reblogsCount
+            val favouritesCount = uncollapsedViewdata.actionable.favouritesCount
             if (!statusDisplayOptions.hideStatsInDetailedView) {
                 setReblogAndFavCount(viewData, reblogsCount, favouritesCount, listener)
             } else {

--- a/app/src/main/java/app/pachli/components/account/media/AccountMediaGridAdapter.kt
+++ b/app/src/main/java/app/pachli/components/account/media/AccountMediaGridAdapter.kt
@@ -83,7 +83,7 @@ class AccountMediaGridAdapter(
                 overlay.setBackgroundResource(0)
                 overlay.visible(item.attachment.type.isPlayable())
 
-                val (placeholder, _, _) = item.attachment.placeholder(context, preview)
+                val placeholder = item.attachment.placeholder(context, preview).first
 
                 glide.asBitmap()
                     .load(item.attachment.previewUrl)

--- a/app/src/main/java/app/pachli/components/compose/ComposeAutoCompleteAdapter.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeAutoCompleteAdapter.kt
@@ -112,8 +112,7 @@ class ComposeAutoCompleteAdapter(
 
         when (val binding = view.tag) {
             is ItemAutocompleteAccountBinding -> {
-                val accountResult = getItem(position) as AutocompleteResult.AccountResult
-                val account = accountResult.account
+                val account = (getItem(position) as AutocompleteResult.AccountResult).account
                 binding.username.text = context.getString(DR.string.post_username_format, account.username)
                 binding.displayName.text = account.name.emojify(
                     glide,
@@ -137,11 +136,9 @@ class ComposeAutoCompleteAdapter(
                 binding.usage7d.text = formatNumber(result.usage7d.toLong(), 10000)
             }
             is ItemAutocompleteEmojiBinding -> {
-                val emojiResult = getItem(position) as AutocompleteResult.EmojiResult
-                val (shortcode, url) = emojiResult.emoji
-                binding.shortcode.text = context.getString(R.string.emoji_shortcode_format, shortcode)
-                glide.load(url)
-                    .into(binding.preview)
+                val emoji = (getItem(position) as AutocompleteResult.EmojiResult).emoji
+                binding.shortcode.text = context.getString(R.string.emoji_shortcode_format, emoji.shortcode)
+                glide.load(emoji.url).into(binding.preview)
             }
         }
         return view

--- a/app/src/main/java/app/pachli/components/conversation/ConversationViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/conversation/ConversationViewHolder.kt
@@ -46,7 +46,13 @@ class ConversationViewHolder internal constructor(
     )
 
     override fun bind(viewData: ConversationViewData, payloads: List<*>?, statusDisplayOptions: StatusDisplayOptions) {
-        val (_, _, account, inReplyToId, _, _, _, _, _, _, _, _, _, _, favourited, bookmarked, sensitive, _, _, attachments) = viewData.status
+        val account = viewData.actionable.account
+        val inReplyToId = viewData.actionable.inReplyToId
+        val favourited = viewData.actionable.favourited
+        val bookmarked = viewData.actionable.bookmarked
+        val sensitive = viewData.actionable.sensitive
+        val attachments = viewData.actionable.attachments
+
         if (payloads.isNullOrEmpty()) {
             setupCollapsedState(viewData, listener)
             setDisplayName(account.name, account.emojis, statusDisplayOptions)

--- a/app/src/main/java/app/pachli/components/notifications/NotificationHelper.kt
+++ b/app/src/main/java/app/pachli/components/notifications/NotificationHelper.kt
@@ -391,7 +391,11 @@ private fun getStatusReplyIntent(
 ): PendingIntent {
     val status = body.status!!
     val inReplyToId = status.id
-    val (_, _, account1, _, _, _, _, _, _, _, _, _, _, _, _, _, _, contentWarning, replyVisibility, _, mentions) = status.actionableStatus
+    val account1 = status.actionableStatus.account
+    val contentWarning = status.actionableStatus.spoilerText
+    val replyVisibility = status.actionableStatus.visibility
+    val mentions = status.actionableStatus.mentions
+
     var mentionedUsernames: MutableList<String?> = ArrayList()
     mentionedUsernames.add(account1.username)
     for ((_, _, username) in mentions) {
@@ -426,7 +430,12 @@ private fun getStatusComposeIntent(
     account: AccountEntity,
 ): PendingIntent {
     val status = body.status!!
-    val (_, _, account1, _, _, _, _, _, _, _, _, _, _, _, _, _, _, contentWarning, replyVisibility, _, mentions, _, _, _, _, _, _, language) = status.actionableStatus
+    val account1 = status.actionableStatus.account
+    val contentWarning = status.actionableStatus.spoilerText
+    val replyVisibility = status.actionableStatus.visibility
+    val mentions = status.actionableStatus.mentions
+    val language = status.actionableStatus.language
+
     val mentionedUsernames: MutableSet<String> = LinkedHashSet()
     mentionedUsernames.add(account1.username)
     for ((_, _, mentionedUsername) in mentions) {

--- a/app/src/main/java/app/pachli/components/notifications/StatusNotificationViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/notifications/StatusNotificationViewHolder.kt
@@ -89,7 +89,8 @@ internal class StatusNotificationViewHolder(
                 showNotificationContent(false)
             } else {
                 showNotificationContent(true)
-                val (_, _, account, _, _, _, _, createdAt) = statusViewData.actionable
+                val account = statusViewData.actionable.account
+                val createdAt = statusViewData.actionable.createdAt
                 setDisplayName(account.name, account.emojis, statusDisplayOptions.animateEmojis)
                 setUsername(account.username)
                 setCreatedAt(createdAt, statusDisplayOptions.useAbsoluteTime)

--- a/app/src/main/java/app/pachli/util/ListStatusAccessibilityDelegate.kt
+++ b/app/src/main/java/app/pachli/util/ListStatusAccessibilityDelegate.kt
@@ -56,13 +56,13 @@ class ListStatusAccessibilityDelegate<T : IStatusViewData>(
                 if (status.statusViewData == null) return
             }
 
-            if (status.spoilerText.isNotEmpty()) {
+            val actionable = status.actionable
+            if (actionable.spoilerText.isNotEmpty()) {
                 info.addAction(if (status.isExpanded) collapseCwAction else expandCwAction)
             }
 
             info.addAction(replyAction)
 
-            val actionable = status.actionable
             if (actionable.rebloggingAllowed()) {
                 info.addAction(if (actionable.reblogged) unreblogAction else reblogAction)
             }


### PR DESCRIPTION
Destructuring (`val (_, _, x, y, _, _, z, _, _) = someObject`) is dangerous, because if the order of the properties in `someObject` change without changing the types you have a runtime bug instead of a compile time error.

Replace this with explicit variable creation and assignment for each used property. Noticed some places where the actionable status is the correct choice, update those call sites.