### PR TITLE
fix: Don't crash when receiving severed relationship notifications

### DIFF
--- a/app/src/main/java/app/pachli/viewdata/NotificationViewData.kt
+++ b/app/src/main/java/app/pachli/viewdata/NotificationViewData.kt
@@ -22,12 +22,14 @@ import app.pachli.core.data.model.StatusViewData
 import app.pachli.core.database.model.AccountEntity
 import app.pachli.core.database.model.NotificationData
 import app.pachli.core.database.model.NotificationEntity
+import app.pachli.core.database.model.NotificationRelationshipSeveranceEventEntity
 import app.pachli.core.database.model.NotificationReportEntity
 import app.pachli.core.database.model.TranslatedStatusEntity
 import app.pachli.core.database.model.TranslationState
 import app.pachli.core.model.AccountFilterDecision
 import app.pachli.core.model.FilterAction
 import app.pachli.core.network.model.RelationshipSeveranceEvent
+import app.pachli.core.network.model.RelationshipSeveranceEvent.Type
 import app.pachli.core.network.model.Status
 import app.pachli.core.network.model.TimelineAccount
 
@@ -101,7 +103,22 @@ data class NotificationViewData(
                 )
             },
             report = data.report,
-            relationshipSeveranceEvent = null,
+            relationshipSeveranceEvent = data.relationshipSeveranceEvent?.let {
+                RelationshipSeveranceEvent(
+                    id = it.serverId,
+                    type = when (it.type) {
+                        NotificationRelationshipSeveranceEventEntity.Type.DOMAIN_BLOCK -> Type.DOMAIN_BLOCK
+                        NotificationRelationshipSeveranceEventEntity.Type.USER_DOMAIN_BLOCK -> Type.USER_DOMAIN_BLOCK
+                        NotificationRelationshipSeveranceEventEntity.Type.ACCOUNT_SUSPENSION -> Type.ACCOUNT_SUSPENSION
+                        NotificationRelationshipSeveranceEventEntity.Type.UNKNOWN -> Type.UNKNOWN
+                    },
+                    purged = it.purged,
+                    targetName = it.targetName,
+                    followersCount = it.followersCount,
+                    followingCount = it.followingCount,
+                    createdAt = it.createdAt,
+                )
+            },
             isAboutSelf = isAboutSelf,
             accountFilterDecision = accountFilterDecision ?: AccountFilterDecision.None,
         )

--- a/app/src/main/res/layout/item_severed_relationships.xml
+++ b/app/src/main/res/layout/item_severed_relationships.xml
@@ -20,18 +20,21 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/notification_report"
-    android:layout_width="wrap_content"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
     android:paddingLeft="14dp"
-    android:paddingRight="14dp">
+    android:paddingRight="14dp"
+    android:paddingTop="8dp"
+    android:paddingBottom="8dp">
 
     <ImageView
         android:id="@+id/icon"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="28dp"
-        android:layout_marginTop="8dp"
+        app:layout_constraintEnd_toStartOf="@id/notification_top_text"
+        app:layout_constraintHorizontal_chainStyle="spread_inside"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:srcCompat="@drawable/ic_flag_24dp"
@@ -39,32 +42,34 @@
 
     <TextView
         android:id="@+id/notification_top_text"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="10dp"
-        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
         android:gravity="top"
         android:textColor="?android:textColorSecondary"
         android:textSize="?attr/status_text_medium"
-        app:layout_constrainedWidth="true"
+        app:layout_constrainedWidth="false"
         app:layout_constraintEnd_toStartOf="@id/datetime"
+        app:layout_constraintHorizontal_weight="1"
         app:layout_constraintStart_toEndOf="@+id/icon"
         app:layout_constraintTop_toTopOf="parent"
-        tools:text="Relationship with example.com severed"
-        tools:ignore="SelectableText" />
+        tools:ignore="SelectableText"
+        tools:text="You blocked mastodon.social" />
 
     <TextView
         android:id="@+id/datetime"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/notification_top_text"
         app:layout_constraintTop_toTopOf="@+id/notification_top_text"
-        tools:text="14h"
-        tools:ignore="SelectableText" />
+        tools:ignore="SelectableText"
+        tools:text="14h" />
 
     <TextView
         android:id="@+id/notification_followers_count"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
         android:hyphenationFrequency="full"
@@ -72,14 +77,15 @@
         android:lineSpacingMultiplier="1.1"
         android:textColor="?android:textColorTertiary"
         android:textSize="?attr/status_text_medium"
-        app:layout_constraintStart_toStartOf="@+id/notification_top_text"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="@id/notification_top_text"
         app:layout_constraintTop_toBottomOf="@+id/notification_top_text"
-        tools:text="2 followers"
-        tools:ignore="SelectableText" />
+        tools:ignore="SelectableText"
+        tools:text="2 followers" />
 
     <TextView
         android:id="@+id/notification_following_count"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
         android:hyphenationFrequency="full"
@@ -87,24 +93,9 @@
         android:lineSpacingMultiplier="1.1"
         android:textColor="?android:textColorTertiary"
         android:textSize="?attr/status_text_medium"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="@+id/notification_top_text"
         app:layout_constraintTop_toBottomOf="@+id/notification_followers_count"
-        tools:text="2 following"
-        tools:ignore="SelectableText" />
-
-    <TextView
-        android:id="@+id/notification_category"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
-        android:hyphenationFrequency="full"
-        android:importantForAccessibility="no"
-        android:lineSpacingMultiplier="1.1"
-        android:paddingBottom="10dp"
-        android:textColor="?android:textColorTertiary"
-        android:textSize="?attr/status_text_medium"
-        app:layout_constraintStart_toStartOf="@+id/notification_top_text"
-        app:layout_constraintTop_toBottomOf="@id/notification_following_count"
-        tools:text="@string/notification_severed_relationships_domain_block_body"
-        tools:ignore="SelectableText" />
+        tools:ignore="SelectableText"
+        tools:text="2 following" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -586,5 +586,4 @@
     <string name="reaction_name_and_count">%1$s %2$d</string>
     <string name="announcement_date">%1$s %2$s</string>
     <string name="announcement_date_updated">(Aktualisiert: %1$s)</string>
-    <string name="notification_severed_relationships_user_domain_block_body">Du hast die Domain blockiert</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -602,11 +602,6 @@
     <string name="action_add_to_tab_success">Se ha añadido \'%1$s\' a pestañas</string>
     <string name="action_remove_tab">Quitar pestaña</string>
     <string name="action_manage_tabs">Gestionar pestañas</string>
-    <string name="notification_severed_relationships_domain_block_body">Un moderador suspendió el dominio</string>
-    <string name="notification_severed_relationships_user_domain_block_body">Bloqueaste el dominio</string>
-    <string name="notification_severed_relationships_account_suspension_body">Un moderador suspendió la cuenta</string>
-    <string name="notification_severed_relationships_unknown_body">Motivo desconocido</string>
-    <string name="notification_severed_relationships_format">Se rompió la relación con &lt;b&gt;%1$s&lt;/b&gt;</string>
     <string name="notification_severed_relationships_name">Relaciones rotas</string>
     <string name="notification_severed_relationships_description">Notificaciones sobre relaciones rotas</string>
     <string name="poll_show_votes">Mostrar votos</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -594,11 +594,6 @@
     <string name="action_add_to_tab_success">\'%1$s\' lisätty välilehtiin</string>
     <string name="action_manage_tabs">Hallinnoi välilehtiä</string>
     <string name="action_remove_tab">Poista välilehti</string>
-    <string name="notification_severed_relationships_domain_block_body">Moderaattori esti verkkotunnuksen</string>
-    <string name="notification_severed_relationships_format">Yhteys katkaistu: &lt;b&gt;%1$s&lt;/b&gt;</string>
-    <string name="notification_severed_relationships_user_domain_block_body">Estit verkkotunnuksen</string>
-    <string name="notification_severed_relationships_account_suspension_body">Moderaattori esti tilin</string>
-    <string name="notification_severed_relationships_unknown_body">Tuntematon syy</string>
     <string name="error_filter_missing_keyword">Tarvitaan vähintään yksi avainsana tai lauseke</string>
     <string name="error_filter_missing_context">Tarvitaan vähintään yksi suodatettava asia</string>
     <string name="error_filter_missing_title">Otsikko vaaditaan</string>

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -554,10 +554,6 @@
     <string name="ui_error_reblog_fmt">Theip ar threisiú an phoist: %1$s</string>
     <string name="ui_error_vote_fmt">Theip ar vótáil sa phobalbhreith: %1$s</string>
     <string name="ui_error_filter_v1_load_fmt">Níorbh fhéidir scagairí a luchtú: %1$s</string>
-    <string name="notification_severed_relationships_domain_block_body">Chuir modhnóir an fearann ar fionraí</string>
-    <string name="notification_severed_relationships_user_domain_block_body">Chuir tú bac ar an bhfearann</string>
-    <string name="notification_severed_relationships_account_suspension_body">Chuir modhnóir an cuntas ar fionraí</string>
-    <string name="notification_severed_relationships_unknown_body">Cúis anaithnid</string>
     <string name="notification_header_report_format">%s tuairiscithe %s</string>
     <plurals name="notification_summary_report_format">
         <item quantity="one">%1$s · %2$d post ceangailte</item>
@@ -653,7 +649,6 @@
     <string name="search_operator_sensitive_dialog_title">Poist le hábhar íogair</string>
     <string name="search_operator_where_dialog_public">Poist phoiblí</string>
     <string name="search_operator_where_dialog_public_hint">Poist phoiblí, inchuardaithe ar a dtugtar an freastalaí</string>
-    <string name="notification_severed_relationships_format">Scaradh an gaol le &lt;b&gt;%1$s&lt;/b&gt;</string>
     <string name="action_share_account_link">Comhroinn nasc chuig an gcuntas</string>
     <string name="pref_title_show_self_boosts_description">Duine éigin ag cur lena bpost féin</string>
     <string name="notification_prune_cache">Cothabháil taisce…</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -559,17 +559,12 @@
     <string name="action_suggestions">Contas suxeridas</string>
     <string name="title_public_trending">En voga</string>
     <string name="title_public_trending_links">Ligazóns populares</string>
-    <string name="notification_severed_relationships_format">Cortouse a relación con &lt;b&gt;%1$s&lt;/b&gt;</string>
-    <string name="notification_severed_relationships_domain_block_body">A moderación suspendeu o dominio</string>
-    <string name="notification_severed_relationships_unknown_body">Razón descoñecida</string>
     <string name="action_translate">Traducir</string>
     <string name="action_translate_undo">Non traducir</string>
     <string name="poll_show_votes">Ver votos</string>
     <string name="action_filter_search">Filtrar a busca</string>
     <string name="notification_severed_relationships_name">Relacións perdidas</string>
     <string name="compose_schedule_date_time_fmt">%1$s %2$s</string>
-    <string name="notification_severed_relationships_user_domain_block_body">Bloqueaches o dominio</string>
-    <string name="notification_severed_relationships_account_suspension_body">A moderación suspendeu a conta</string>
     <string name="title_public_trending_statuses">Publicacións populares</string>
     <string name="title_tab_public_trending_hashtags">Cancelos</string>
     <string name="title_tab_public_trending_links">Ligazóns</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -256,8 +256,6 @@
     <plurals name="notification_severed_relationships_summary_followers_fmt">
         <item quantity="other">%1$s pengikut di hapus</item>
     </plurals>
-    <string name="notification_severed_relationships_format">Hubungan dengan <b>%1$s</b> terputus</string>
-    <string name="notification_severed_relationships_domain_block_body">Moderator menangguhkan domain tersebut</string>
     <string name="pref_title_notification_filter_follow_requests">ikuti diminta</string>
     <plurals name="notification_severed_relationships_summary_following_fmt">
         <item quantity="other">%1$s akun yang kamu ikuti telah dihapus</item>
@@ -269,9 +267,6 @@
     <string name="pref_summary_http_proxy_missing">&lt;tidak diatur&gt;</string>
     <string name="action_filter_search">Filter pencarian</string>
     <string name="action_suggestions">Akun yang disarankan</string>
-    <string name="notification_severed_relationships_user_domain_block_body">Kamu memblokir domain</string>
-    <string name="notification_severed_relationships_account_suspension_body">Moderator menangguhkan akun tersebut</string>
-    <string name="notification_severed_relationships_unknown_body">Alasan yang tidak diketahui</string>
     <string name="action_refresh_account">Refresh akun</string>
     <string name="mute_domain_warning">Apakah Anda yakin ingin memblokir semua %s? Anda tidak akan melihat konten dari domain tersebut di timeline publik atau notifikasi Anda. Pengikut Anda dari domain tersebut akan dihapus.</string>
     <string name="pref_title_timeline_filters">Filter</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -503,8 +503,6 @@
     <string name="pref_account_conversation_filters_label_limited_by_server">… satura pārraudzītāju ierobežots</string>
     <string name="pref_account_notification_filters_label_limited_by_server">… satura pārraudzītāju ierobežots</string>
     <string name="title_tab_public_trending_hashtags">Tēmturi</string>
-    <string name="notification_severed_relationships_domain_block_body">Satura pārraudzītājs apturēja domēnu</string>
-    <string name="notification_severed_relationships_account_suspension_body">Satura pārraudzītājs apturēja kontu</string>
     <string name="account_filter_placeholder_type_mention_fmt">Lietotājs @<b>%1s</b> pieminēja Tevi</string>
     <string name="action_send_private_content_description">Nosūtīt tikai sekotājiem paredzētu ierakstu</string>
     <string name="action_send_direct_content_description">Nosūtīt tiešu ziņu</string>
@@ -513,14 +511,11 @@
     <string name="search_operator_where_dialog_library_hint">Tavi ieraksti, pastiprinājumi, izlase, grāmatzīmes un ieraksti, kuros Tevi @piemin</string>
     <string name="account_filter_placeholder_label_limited_by_server">Atlasīts jo: <b>satura pārraudzītāju ierobežots</b></string>
     <string name="title_tab_public_trending_statuses">Ieraksti</string>
-    <string name="notification_severed_relationships_user_domain_block_body">Tu liedzi domēnu</string>
-    <string name="notification_severed_relationships_unknown_body">Nezināms iemesls</string>
     <plurals name="notification_severed_relationships_summary_following_fmt">
         <item quantity="zero">Noņemti %1$s kontu, kuriem seko</item>
         <item quantity="one">Noņemts %1$s konts, kuram seko</item>
         <item quantity="other">Noņemti %1$s konti, kuriem seko</item>
     </plurals>
-    <string name="notification_severed_relationships_format">Pārrauta saikne ar <b>%1$s</b></string>
     <string name="pref_title_show_self_boosts_description">Kāds, kurs pats pastiprina savu ierakstu</string>
     <string name="action_translate">Tulkot</string>
     <string name="action_translate_undo">Atsaukt tulkošanu</string>

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -35,7 +35,6 @@
     <string name="notification_subscription_format">%s ပိုစ့်တင်သည်</string>
     <string name="notification_update_format">%s သည်၎င်းတို့၌ပိုစ့်ကိုပြုပြင်ခဲ့သည်</string>
     <string name="notification_report_format">%s သို့တိုင်ကြားမှုများ</string>
-    <string name="notification_severed_relationships_unknown_body">အမျိုးအမည်မသိသောအကြောင်းပြချက်</string>
     <plurals name="notification_summary_report_format">
         <item quantity="other">%1$s မှ %2$d အထိပိုစ့်များပါဝင်သည်</item>
     </plurals>
@@ -88,9 +87,6 @@
     <string name="post_content_show_less">ဖြန့်မည်</string>
     <string name="footer_empty">ဘာမှမရှိ။ ရီဖလက်ရှ်လုပ်ရန်အောက်သို့ဆွဲပါ!</string>
     <string name="notification_follow_format">%s မှသင့်အားစောင့်ကြည့်ခြင်းစတင်သည်</string>
-    <string name="notification_severed_relationships_user_domain_block_body">သင် ဒိုမိန်းအားဘလော့ခ်ထားသည်</string>
-    <string name="notification_severed_relationships_domain_block_body">မော်ဒရေတာတစ်ဦးမှ ဒိုမိန်းအားကန့်သတ်ထားသည်</string>
-    <string name="notification_severed_relationships_account_suspension_body">မော်ဒရေတာတစ်ဦးမှ အကောင့်အား ကန့်သတ်ထားသည်</string>
     <string name="notification_header_report_format">%s မှ %s အားတိုင်ကြားထားသည်</string>
     <string name="report_username_format">\@%s အားတိုင်ကြားမည်</string>
     <string name="action_quick_reply">အမြန်ပြန်စာ</string>
@@ -156,7 +152,6 @@
     <string name="pref_summary_content_filters">သင့်ဆာဗာသည် အကြောင်းအရာစစ်ထုတ်မှုကိုမထောက်ပံ့ပါ</string>
     <string name="pref_title_browser_settings">ဘရောက်ဇာ</string>
     <string name="pref_title_custom_tabs">ဘရောက်ဇာ custom တဘ်များကိုသုံးမည်</string>
-    <string name="notification_severed_relationships_format"><b>%1$s</b> နှင့်ဆက်ဆံရေးစတင်သည်</string>
     <string name="action_report">တိုင်ကြားမည်</string>
     <string name="action_view_preferences">ပြင်ဆင်စရာများ</string>
     <string name="action_view_mutes">ကန့်သတ်ထားသောအသုံးပြုသူ</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -560,7 +560,6 @@
     <string name="title_public_trending_links">Trendende lenker</string>
     <string name="title_tab_public_trending_hashtags">Emneknagger</string>
     <string name="title_tab_public_trending_links">Lenker</string>
-    <string name="notification_severed_relationships_domain_block_body">En moderator suspenderte instansen</string>
     <string name="poll_show_votes">Vis stemminger</string>
     <string name="compose_warn_language_dialog_title">Kontroller språket til innlegget</string>
     <string name="compose_warn_language_dialog_fmt">Språket til innlegget er %1$s men det kan skje at du har skrevet innlegget på %2$s.</string>
@@ -568,8 +567,6 @@
     <string name="error_media_uploader_upload_not_found_fmt">Mediaopplasting med ID %1$s finnes ikke</string>
     <string name="ui_error_translate_status_fmt">Oversettelse mislyktes: %1$s</string>
     <string name="ui_error_filter_v1_load_fmt">Å laste inn filtere mislyktes: %1$s</string>
-    <string name="notification_severed_relationships_account_suspension_body">En moderator suspenderte kontoen</string>
-    <string name="notification_severed_relationships_user_domain_block_body">Du blokkerte instansen</string>
     <string name="action_translate">Oversett</string>
     <string name="action_translate_undo">Angre oversetting</string>
     <string name="pref_summary_content_filters">Serveren din støtter ikke filtere</string>
@@ -586,8 +583,6 @@
     <string name="title_public_trending">Trendende</string>
     <string name="title_public_trending_statuses">Trendende innlegg</string>
     <string name="title_tab_public_trending_statuses">Innlegg</string>
-    <string name="notification_severed_relationships_format">Brøt forholdet med &lt;b&gt;%1$s&lt;/b&gt;</string>
-    <string name="notification_severed_relationships_unknown_body">Ukjent årsak</string>
     <string name="label_image">Bild</string>
     <string name="pref_title_font_family">Skriftfamilie</string>
     <string name="notification_severed_relationships_name">Brutte forhold</string>

--- a/app/src/main/res/values-nn/strings.xml
+++ b/app/src/main/res/values-nn/strings.xml
@@ -68,10 +68,6 @@
     </plurals>
     <string name="notification_update_format">%s redigerte innlegget sitt</string>
     <string name="notification_report_format">Ny rapport på %s</string>
-    <string name="notification_severed_relationships_format">Braut forholdet med &lt;b&gt;%1$s&lt;/b&gt;</string>
-    <string name="notification_severed_relationships_domain_block_body">Ein moderator suspenderte instansen</string>
-    <string name="notification_severed_relationships_account_suspension_body">Ein moderator suspenderte kontoen</string>
-    <string name="notification_severed_relationships_unknown_body">Ukjend årsak</string>
     <string name="notification_header_report_format">%s rapporterte %s</string>
     <plurals name="notification_summary_report_format">
         <item quantity="other">%1$s · %2$d innlegg lagt ved</item>
@@ -162,7 +158,6 @@
     <string name="error_media_upload_type">Den filtypen kan ikkje lastast opp.</string>
     <string name="error_media_upload_opening">Den filen kunne ikkje verte opna.</string>
     <string name="error_following_hashtags_unsupported">Denne instansen støttar ikkje fylging av emneknaggar.</string>
-    <string name="notification_severed_relationships_user_domain_block_body">Du blokkerte instansen</string>
     <plurals name="notification_severed_relationships_summary_following_fmt">
         <item quantity="one">%1$s konto du fylgjer vart fjerna</item>
         <item quantity="other">%1$s kontoar du fylgjer vart fjerna</item>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -546,8 +546,6 @@
     <string name="action_add">Dodaj</string>
     <string name="pref_ui_text_size">Rozmiar tekstu interfejsu</string>
     <string name="notification_listenable_worker_description">Powiadomienia gdy Pachli działa w tle</string>
-    <string name="notification_severed_relationships_account_suspension_body">Konto zawieszone przez osobę moderującą</string>
-    <string name="notification_severed_relationships_unknown_body">Nieznany powód</string>
     <plurals name="notification_severed_relationships_summary_following_fmt">
         <item quantity="one">%1$s konto, które obserwujesz usunięto</item>
         <item quantity="few">%1$s konta, które obserwujesz usunięto</item>
@@ -560,7 +558,6 @@
         <item quantity="many">%1$s kont obserwujących usunięto</item>
         <item quantity="other">%1$s kont obserwujących usunięto</item>
     </plurals>
-    <string name="notification_severed_relationships_format">Relacja z <b>%1$s</b> została przerwana</string>
     <string name="notification_unknown">Nieznany typ powiadomienia</string>
     <string name="manage_lists">Zarządzaj listami</string>
     <string name="pref_summary_content_filters">Twój serwer nie wspiera filtrów treści</string>
@@ -575,8 +572,6 @@
     <string name="action_translate_undo">Pokaż oryginał</string>
     <string name="confirmation_hashtag_unmuted">Cofnięto ukrycie #%s</string>
     <string name="status_filter_placeholder_label_format">Zastosowano filtr: <b>%1$s</b></string>
-    <string name="notification_severed_relationships_user_domain_block_body">Domena zablokowana przez ciebie</string>
-    <string name="notification_severed_relationships_domain_block_body">Domena zawieszona przez osobę moderującą</string>
     <string name="notification_prune_cache">Zarządzanie cache…</string>
     <string name="conversation_0_recipients">Brak innych uczestników</string>
     <string name="action_manage_tabs">Zarządzaj kartami</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -161,9 +161,6 @@
     <string name="notification_reblog_format">%s zdieľal/a tvoj príspevok</string>
     <string name="notification_follow_format">%s ťa sleduje</string>
     <string name="notification_follow_request_format">%s ťa požiadal o sledovanie</string>
-    <string name="notification_severed_relationships_format">Vzťah s <b>%1$s</b> bol prerušený</string>
-    <string name="notification_severed_relationships_domain_block_body">Moderátor pozastavil doménu</string>
-    <string name="notification_severed_relationships_user_domain_block_body">Zablokoval/a si doménu</string>
     <string name="action_delete_conversation">Vymazať konverzáciu</string>
     <string name="action_share_account_username">Zdieľať používateľské meno účtu</string>
     <string name="action_discard">Zahodiť zmeny</string>
@@ -185,8 +182,6 @@
     </plurals>
     <string name="account_filter_placeholder_type_favourite_fmt">\@<b>%1s</b> si obľúbil/a tvoj príspevok</string>
     <string name="pref_title_bot_overlay">Zobraziť indikátor botov</string>
-    <string name="notification_severed_relationships_unknown_body">Neznámy dôvod</string>
-    <string name="notification_severed_relationships_account_suspension_body">Moderátor pozastavil účet</string>
     <string name="action_post_failed">Nahrávanie zlyhalo</string>
     <string name="action_post_failed_show_drafts">Zobraziť koncepty</string>
     <string name="action_unmute">Zrušiť stíšenie</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -597,8 +597,6 @@
     <string name="action_filter_search">Filtrera sökningen</string>
     <string name="search_operator_attachment_dialog_audio_label">Ljud</string>
     <string name="action_suggestions">Föreslagna konton</string>
-    <string name="notification_severed_relationships_domain_block_body">En moderator blockerade instansen</string>
-    <string name="notification_severed_relationships_user_domain_block_body">Du blockerade instansen</string>
     <string name="search_operator_attachment_dialog_image_label">Bilder</string>
     <string name="pref_notification_up_distributor_none">Ingen</string>
     <string name="search_operator_attachment_none">Inget</string>
@@ -617,8 +615,6 @@
     <string name="search_operator_attachment_kind_image_label">bilder</string>
     <string name="search_operator_date_dialog_today">I dag</string>
     <string name="search_operator_attachment_kind_video_label">video</string>
-    <string name="notification_severed_relationships_account_suspension_body">En moderator blockerade kontot</string>
-    <string name="notification_severed_relationships_unknown_body">Okänd anledning</string>
     <string name="error_prepare_media_io_fmt">%1$s</string>
     <string name="search_operator_attachment_kind_audio_label">ljud</string>
     <string name="search_operator_language_checked_fmt">%1$s</string>
@@ -637,7 +633,6 @@
     <string name="pref_notification_up_distributor_name_fmt">%1$s. Tryck för att öppna</string>
     <string name="compose_schedule_date_time_fmt">%1$s %2$s</string>
     <string name="pref_title_notification_battery_optimisation">Batterioptimering</string>
-    <string name="notification_severed_relationships_format">Bröt förhållandet med <b>%1$s</b></string>
     <string name="conversation_0_recipients">Inga andra deltagare</string>
     <string name="manage_lists">Hantera listor</string>
     <string name="pref_labs_reverse_home_timeline_on_summary">Äldst inlägg först</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -469,10 +469,6 @@
     <string name="account_filter_placeholder_label_limited_by_server">வடிகட்டப்பட்டது: <b> உங்கள் மதிப்பீட்டாளர்களால் வரையறுக்கப்பட்டுள்ளது </b></string>
     <string name="ui_error_bookmark_fmt">புக்மார்க்கிங் இடுகை தோல்வியுற்றது: %1$s</string>
     <string name="ui_error_reblog_fmt">போச்டிங் போச்ட் தோல்வியுற்றது: %1$s</string>
-    <string name="notification_severed_relationships_domain_block_body">ஒரு மதிப்பீட்டாளர் டொமைனை இடைநீக்கம் செய்தார்</string>
-    <string name="notification_severed_relationships_format"><b>%1$s </b> உடன் உறவு துண்டிக்கப்பட்டது</string>
-    <string name="notification_severed_relationships_unknown_body">தெரியாத காரணம்</string>
-    <string name="notification_severed_relationships_account_suspension_body">ஒரு மதிப்பீட்டாளர் கணக்கை இடைநீக்கம் செய்தார்</string>
     <string name="action_view_bookmarks">புக்மார்க்குகள்</string>
     <string name="action_open_media_n">திறந்த மீடியா #%d</string>
     <string name="pref_summary_http_proxy_invalid">&lt;செல்லாத&gt;</string>
@@ -631,7 +627,6 @@
     <string name="post_content_show_more">விரிவாக்கு</string>
     <string name="post_edited">திருத்தப்பட்ட %s</string>
     <string name="notification_subscription_format">%s இப்போது இடுகையிடப்பட்டது</string>
-    <string name="notification_severed_relationships_user_domain_block_body">நீங்கள் டொமைனைத் தடுத்தீர்கள்</string>
     <string name="action_view_domain_mutes">மறைக்கப்பட்ட களங்கள்</string>
     <string name="send_account_link_to">கணக்கு முகவரி ஐப் பகிரவும்…</string>
     <string name="send_account_username_to">கணக்கு பயனர்பெயரைப் பகிரவும்…</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -100,18 +100,17 @@
     <string name="notification_subscription_format">%s just posted</string>
     <string name="notification_update_format">%s edited their post</string>
     <string name="notification_report_format">New report on %s</string>
-    <string name="notification_severed_relationships_format">Relationship with &lt;b>%1$s&lt;/b> severed</string>
-    <string name="notification_severed_relationships_domain_block_body">A moderator suspended the domain</string>
-    <string name="notification_severed_relationships_user_domain_block_body">You blocked the domain</string>
-    <string name="notification_severed_relationships_account_suspension_body">A moderator suspended the account</string>
-    <string name="notification_severed_relationships_unknown_body">Unknown reason</string>
+    <string name="notification_severed_relationships_domain_block_fmt">An admin of %1$s blocked &lt;b>%2$s&lt;/b></string>
+    <string name="notification_severed_relationships_user_domain_block_fmt">You blocked &lt;b>%1$s&lt;/b></string>
+    <string name="notification_severed_relationships_account_suspension_fmt">An admin of %1$s blocked &lt;b>%2$s&lt;/b></string>
+    <string name="notification_severed_relationships_unknown_fmt">&lt;b>%1$s&lt;/b> is blocked (unknown reason)</string>
     <plurals name="notification_severed_relationships_summary_followers_fmt">
-        <item quantity="one">%1$s follower removed</item>
-        <item quantity="other">%1$s followers removed</item>
+        <item quantity="one">%1$s follower removed.</item>
+        <item quantity="other">%1$s followers removed.</item>
     </plurals>
     <plurals name="notification_severed_relationships_summary_following_fmt">
-        <item quantity="one">%1$s account you follow removed</item>
-        <item quantity="other">%1$s accounts you follow removed</item>
+        <item quantity="one">%1$s account you follow removed.</item>
+        <item quantity="other">%1$s accounts you follow removed.</item>
     </plurals>
     <string name="notification_unknown">Unknown notification type</string>
     <string name="notification_header_report_format">%s reported %s</string>


### PR DESCRIPTION
The code to wire up the severed relationship information was inadvertently missing, resulting in an NPE if the notification timeline included a severed relationship notification.

Fix that.

While I'm here, improve the UI. Simplify two messages into one, and ensure the view constraints are correct.

Fixes #1569