### PR TITLE
fix: Don't crash when receiving severed relationship notifications

### DIFF
--- a/app/src/main/java/app/pachli/viewdata/NotificationViewData.kt
+++ b/app/src/main/java/app/pachli/viewdata/NotificationViewData.kt
@@ -22,12 +22,14 @@ import app.pachli.core.data.model.StatusViewData
 import app.pachli.core.database.model.AccountEntity
 import app.pachli.core.database.model.NotificationData
 import app.pachli.core.database.model.NotificationEntity
+import app.pachli.core.database.model.NotificationRelationshipSeveranceEventEntity
 import app.pachli.core.database.model.NotificationReportEntity
 import app.pachli.core.database.model.TranslatedStatusEntity
 import app.pachli.core.database.model.TranslationState
 import app.pachli.core.model.AccountFilterDecision
 import app.pachli.core.model.FilterAction
 import app.pachli.core.network.model.RelationshipSeveranceEvent
+import app.pachli.core.network.model.RelationshipSeveranceEvent.Type
 import app.pachli.core.network.model.Status
 import app.pachli.core.network.model.TimelineAccount
 
@@ -101,7 +103,22 @@ data class NotificationViewData(
                 )
             },
             report = data.report,
-            relationshipSeveranceEvent = null,
+            relationshipSeveranceEvent = data.relationshipSeveranceEvent?.let {
+                RelationshipSeveranceEvent(
+                    id = it.serverId,
+                    type = when (it.type) {
+                        NotificationRelationshipSeveranceEventEntity.Type.DOMAIN_BLOCK -> Type.DOMAIN_BLOCK
+                        NotificationRelationshipSeveranceEventEntity.Type.USER_DOMAIN_BLOCK -> Type.USER_DOMAIN_BLOCK
+                        NotificationRelationshipSeveranceEventEntity.Type.ACCOUNT_SUSPENSION -> Type.ACCOUNT_SUSPENSION
+                        NotificationRelationshipSeveranceEventEntity.Type.UNKNOWN -> Type.UNKNOWN
+                    },
+                    purged = it.purged,
+                    targetName = it.targetName,
+                    followersCount = it.followersCount,
+                    followingCount = it.followingCount,
+                    createdAt = it.createdAt,
+                )
+            },
             isAboutSelf = isAboutSelf,
             accountFilterDecision = accountFilterDecision ?: AccountFilterDecision.None,
         )

--- a/app/src/main/res/layout/item_severed_relationships.xml
+++ b/app/src/main/res/layout/item_severed_relationships.xml
@@ -20,18 +20,21 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/notification_report"
-    android:layout_width="wrap_content"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
     android:paddingLeft="14dp"
-    android:paddingRight="14dp">
+    android:paddingRight="14dp"
+    android:paddingTop="8dp"
+    android:paddingBottom="8dp">
 
     <ImageView
         android:id="@+id/icon"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="28dp"
-        android:layout_marginTop="8dp"
+        app:layout_constraintEnd_toStartOf="@id/notification_top_text"
+        app:layout_constraintHorizontal_chainStyle="spread_inside"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:srcCompat="@drawable/ic_flag_24dp"
@@ -39,32 +42,34 @@
 
     <TextView
         android:id="@+id/notification_top_text"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="10dp"
-        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
         android:gravity="top"
         android:textColor="?android:textColorSecondary"
         android:textSize="?attr/status_text_medium"
-        app:layout_constrainedWidth="true"
+        app:layout_constrainedWidth="false"
         app:layout_constraintEnd_toStartOf="@id/datetime"
+        app:layout_constraintHorizontal_weight="1"
         app:layout_constraintStart_toEndOf="@+id/icon"
         app:layout_constraintTop_toTopOf="parent"
-        tools:text="Relationship with example.com severed"
-        tools:ignore="SelectableText" />
+        tools:ignore="SelectableText"
+        tools:text="You blocked mastodon.social" />
 
     <TextView
         android:id="@+id/datetime"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/notification_top_text"
         app:layout_constraintTop_toTopOf="@+id/notification_top_text"
-        tools:text="14h"
-        tools:ignore="SelectableText" />
+        tools:ignore="SelectableText"
+        tools:text="14h" />
 
     <TextView
         android:id="@+id/notification_followers_count"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
         android:hyphenationFrequency="full"
@@ -72,14 +77,15 @@
         android:lineSpacingMultiplier="1.1"
         android:textColor="?android:textColorTertiary"
         android:textSize="?attr/status_text_medium"
-        app:layout_constraintStart_toStartOf="@+id/notification_top_text"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="@id/notification_top_text"
         app:layout_constraintTop_toBottomOf="@+id/notification_top_text"
-        tools:text="2 followers"
-        tools:ignore="SelectableText" />
+        tools:ignore="SelectableText"
+        tools:text="2 followers" />
 
     <TextView
         android:id="@+id/notification_following_count"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
         android:hyphenationFrequency="full"
@@ -87,24 +93,9 @@
         android:lineSpacingMultiplier="1.1"
         android:textColor="?android:textColorTertiary"
         android:textSize="?attr/status_text_medium"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="@+id/notification_top_text"
         app:layout_constraintTop_toBottomOf="@+id/notification_followers_count"
-        tools:text="2 following"
-        tools:ignore="SelectableText" />
-
-    <TextView
-        android:id="@+id/notification_category"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
-        android:hyphenationFrequency="full"
-        android:importantForAccessibility="no"
-        android:lineSpacingMultiplier="1.1"
-        android:paddingBottom="10dp"
-        android:textColor="?android:textColorTertiary"
-        android:textSize="?attr/status_text_medium"
-        app:layout_constraintStart_toStartOf="@+id/notification_top_text"
-        app:layout_constraintTop_toBottomOf="@id/notification_following_count"
-        tools:text="@string/notification_severed_relationships_domain_block_body"
-        tools:ignore="SelectableText" />
+        tools:ignore="SelectableText"
+        tools:text="2 following" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -105,13 +105,17 @@
     <string name="notification_severed_relationships_user_domain_block_body">You blocked the domain</string>
     <string name="notification_severed_relationships_account_suspension_body">A moderator suspended the account</string>
     <string name="notification_severed_relationships_unknown_body">Unknown reason</string>
+    <string name="notification_severed_relationships_domain_block_fmt">An admin of %1$s blocked &lt;b>%2$s&lt;/b></string>
+    <string name="notification_severed_relationships_user_domain_block_fmt">You blocked &lt;b>%1$s&lt;/b></string>
+    <string name="notification_severed_relationships_account_suspension_fmt">An admin of %1$s blocked &lt;b>%2$s&lt;/b></string>
+    <string name="notification_severed_relationships_unknown_fmt">&lt;b>%1$s&lt;/b> is blocked (unknown reason)</string>
     <plurals name="notification_severed_relationships_summary_followers_fmt">
-        <item quantity="one">%1$s follower removed</item>
-        <item quantity="other">%1$s followers removed</item>
+        <item quantity="one">%1$s follower removed.</item>
+        <item quantity="other">%1$s followers removed.</item>
     </plurals>
     <plurals name="notification_severed_relationships_summary_following_fmt">
-        <item quantity="one">%1$s account you follow removed</item>
-        <item quantity="other">%1$s accounts you follow removed</item>
+        <item quantity="one">%1$s account you follow removed.</item>
+        <item quantity="other">%1$s accounts you follow removed.</item>
     </plurals>
     <string name="notification_unknown">Unknown notification type</string>
     <string name="notification_header_report_format">%s reported %s</string>


### PR DESCRIPTION
The code to wire up the severed relationship information was inadvertently missing, resulting in an NPE if the notification timeline included a severed relationship notification.

Fix that.

While I'm here, improve the UI. Simplify two messages into one, and ensure the view constraints are correct.

Fixes #1569