### PR TITLE
change: Rename code in ComposeActivity and related code

### DIFF
--- a/app/src/main/java/app/pachli/components/compose/ComposeViewModel.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeViewModel.kt
@@ -209,8 +209,8 @@ class ComposeViewModel @AssistedInject constructor(
 
     private val _media: MutableStateFlow<List<QueuedMedia>> = MutableStateFlow(emptyList())
     val media = _media.asStateFlow()
-    private val _closeConfirmation = MutableStateFlow(ConfirmationKind.NONE)
-    val closeConfirmationKind = _closeConfirmation.asStateFlow()
+    private val _closeConfirmationKind = MutableStateFlow(ConfirmationKind.NONE)
+    val closeConfirmationKind = _closeConfirmationKind.asStateFlow()
     private val _statusLength = MutableStateFlow(0)
     val statusLength = _statusLength.asStateFlow()
 
@@ -389,7 +389,7 @@ class ComposeViewModel @AssistedInject constructor(
     }
 
     private fun updateCloseConfirmation() {
-        _closeConfirmation.value = if (isDirty()) {
+        _closeConfirmationKind.value = if (isDirty()) {
             when (composeKind) {
                 ComposeKind.NEW -> if (isEmpty(content, effectiveContentWarning)) {
                     ConfirmationKind.NONE

--- a/app/src/main/java/app/pachli/components/compose/ComposeViewModel.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeViewModel.kt
@@ -210,7 +210,7 @@ class ComposeViewModel @AssistedInject constructor(
     private val _media: MutableStateFlow<List<QueuedMedia>> = MutableStateFlow(emptyList())
     val media = _media.asStateFlow()
     private val _closeConfirmation = MutableStateFlow(ConfirmationKind.NONE)
-    val closeConfirmation = _closeConfirmation.asStateFlow()
+    val closeConfirmationKind = _closeConfirmation.asStateFlow()
     private val _statusLength = MutableStateFlow(0)
     val statusLength = _statusLength.asStateFlow()
 

--- a/app/src/main/res/layout/activity_compose.xml
+++ b/app/src/main/res/layout/activity_compose.xml
@@ -343,7 +343,7 @@
             android:textColor="?android:textColorTertiary" />
 
         <TextView
-            android:id="@+id/actionPhotoPick"
+            android:id="@+id/action_add_media"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:gravity="center_vertical"
@@ -420,7 +420,7 @@
         android:paddingBottom="4dp">
 
         <ImageButton
-            android:id="@+id/composeAddMediaButton"
+            android:id="@+id/compose_add_attachment_button"
             style="@style/AppImageButton"
             android:layout_width="36dp"
             android:layout_height="36dp"
@@ -431,7 +431,7 @@
             app:tooltipText="@string/action_add_media" />
 
         <ImageButton
-            android:id="@+id/composeToggleVisibilityButton"
+            android:id="@+id/compose_change_visibility_button"
             style="@style/AppImageButton"
             android:layout_width="36dp"
             android:layout_height="36dp"
@@ -443,7 +443,7 @@
             tools:src="@drawable/ic_public_24dp" />
 
         <ImageButton
-            android:id="@+id/composeHideMediaButton"
+            android:id="@+id/compose_mark_sensitive_button"
             style="@style/AppImageButton"
             android:layout_width="36dp"
             android:layout_height="36dp"


### PR DESCRIPTION
`ComposeActivity` had variables, functions, and view IDs that didn't accurately reflect what they did, making it more difficult to read the code.

Rename many of them to be clearer.

While here:

- Add documentation comments to many functions.
- Early return from some functions, instead of nested `if` statements.
- Remove unused function parameters.