### PR TITLE
fix: Delete cached notifications when deleting server notifications

### DIFF
--- a/app/src/main/java/app/pachli/components/conversation/ConversationsRemoteMediator.kt
+++ b/app/src/main/java/app/pachli/components/conversation/ConversationsRemoteMediator.kt
@@ -50,10 +50,6 @@ class ConversationsRemoteMediator(
 
         val conversations = conversationsResponse.body.filterNot { it.lastStatus == null }
 
-        if (conversations.isEmpty()) {
-            return MediatorResult.Success(endOfPaginationReached = loadType != LoadType.REFRESH)
-        }
-
         transactionProvider {
             if (loadType == LoadType.REFRESH) {
                 conversationsDao.deleteForAccount(pachliAccountId)

--- a/app/src/main/java/app/pachli/components/notifications/NotificationsFragment.kt
+++ b/app/src/main/java/app/pachli/components/notifications/NotificationsFragment.kt
@@ -340,6 +340,9 @@ class NotificationsFragment :
                     }
                     adapter.refresh()
                 }
+
+                is UiActionSuccess.ClearNotifications -> adapter.refresh()
+
                 else -> { /* nothing to do */ }
             }
         }
@@ -394,6 +397,12 @@ class NotificationsFragment :
         }
         menu.findItem(R.id.action_edit_notification_filter)?.apply {
             icon = makeIcon(requireContext(), GoogleMaterial.Icon.gmd_tune, IconicsSize.dp(20))
+        }
+    }
+
+    override fun onPrepareMenu(menu: Menu) {
+        menu.findItem(R.id.action_clear_notifications)?.apply {
+            isEnabled = adapter.itemCount != 0
         }
     }
 
@@ -596,7 +605,7 @@ class NotificationsFragment :
 
     private fun clearNotifications() {
         binding.swipeRefreshLayout.isRefreshing = false
-        viewModel.accept(FallibleUiAction.ClearNotifications)
+        viewModel.accept(FallibleUiAction.ClearNotifications(pachliAccountId))
     }
 
     private fun showFilterDialog() {

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/CachedTimelineRemoteMediator.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/CachedTimelineRemoteMediator.kt
@@ -99,19 +99,15 @@ class CachedTimelineRemoteMediator(
             val statuses = response.body
 
             Timber.d("%d - # statuses loaded", statuses.size)
-
-            // This request succeeded with no new data, and pagination ends (unless this is a
-            // REFRESH, which must always set endOfPaginationReached to false).
-            if (statuses.isEmpty()) {
-                return@transactionProvider MediatorResult.Success(endOfPaginationReached = loadType != LoadType.REFRESH)
+            if (statuses.isNotEmpty()) {
+                Timber.d("  %s..%s", statuses.first().id, statuses.last().id)
             }
-
-            Timber.d("  %s..%s", statuses.first().id, statuses.last().id)
 
             val links = Links.from(response.headers["link"])
 
             when (loadType) {
                 LoadType.REFRESH -> {
+                    remoteKeyDao.deletePrevNext(pachliAccountId, remoteKeyTimelineId)
                     timelineDao.deleteAllStatusesForAccountOnTimeline(
                         pachliAccountId,
                         TimelineStatusEntity.Kind.Home,
@@ -162,7 +158,13 @@ class CachedTimelineRemoteMediator(
             }
             insertStatuses(pachliAccountId, statuses)
 
-            MediatorResult.Success(endOfPaginationReached = false)
+            val endOfPagination = when (loadType) {
+                LoadType.REFRESH -> statuses.isEmpty() || (links.prev == null && links.next == null)
+                LoadType.PREPEND -> statuses.isEmpty() || links.prev == null
+                LoadType.APPEND -> statuses.isEmpty() || links.next == null
+            }
+
+            MediatorResult.Success(endOfPaginationReached = endOfPagination)
         }
     }
 

--- a/app/src/test/java/app/pachli/components/notifications/NotificationsViewModelTestClearNotifications.kt
+++ b/app/src/test/java/app/pachli/components/notifications/NotificationsViewModelTestClearNotifications.kt
@@ -45,24 +45,24 @@ class NotificationsViewModelTestClearNotifications : NotificationsViewModelTestB
         mastodonApi.stub { onBlocking { clearNotifications() } doReturn success(Unit) }
 
         // When
-        viewModel.accept(FallibleUiAction.ClearNotifications)
+        viewModel.accept(FallibleUiAction.ClearNotifications(pachliAccountId))
 
         // Then
-        verify(notificationsRepository).clearNotifications()
+        verify(notificationsRepository).clearNotifications(pachliAccountId)
     }
 
     @Test
     fun `clearing notifications fails && emits UiError`() = runTest {
         // Given
-        notificationsRepository.stub { onBlocking { clearNotifications() } doReturn failure() }
+        notificationsRepository.stub { onBlocking { clearNotifications(pachliAccountId) } doReturn failure() }
 
         viewModel.uiResult.test {
             // When
-            viewModel.accept(FallibleUiAction.ClearNotifications)
+            viewModel.accept(FallibleUiAction.ClearNotifications(pachliAccountId))
 
             // Then
             val item = awaitItem().getError() as? UiError.ClearNotifications
-            assertThat(item?.action).isEqualTo(FallibleUiAction.ClearNotifications)
+            assertThat(item?.action).isEqualTo(FallibleUiAction.ClearNotifications(pachliAccountId))
         }
     }
 }

--- a/app/src/test/java/app/pachli/components/timeline/CachedTimelineRemoteMediatorTest.kt
+++ b/app/src/test/java/app/pachli/components/timeline/CachedTimelineRemoteMediatorTest.kt
@@ -190,7 +190,7 @@ class CachedTimelineRemoteMediatorTest {
         val result = runBlocking { remoteMediator.load(LoadType.REFRESH, state) }
 
         assertTrue(result is RemoteMediator.MediatorResult.Success)
-        assertEquals(false, (result as RemoteMediator.MediatorResult.Success).endOfPaginationReached)
+        assertEquals(true, (result as RemoteMediator.MediatorResult.Success).endOfPaginationReached)
 
         db.assertStatuses(
             listOf(

--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/notifications/NotificationsRepository.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/notifications/NotificationsRepository.kt
@@ -38,6 +38,7 @@ import app.pachli.core.database.model.RemoteKeyEntity
 import app.pachli.core.database.model.RemoteKeyEntity.RemoteKeyKind
 import app.pachli.core.model.AccountFilterDecision
 import app.pachli.core.model.FilterAction
+import app.pachli.core.model.Timeline
 import app.pachli.core.network.model.Notification
 import app.pachli.core.network.retrofit.MastodonApi
 import com.github.michaelbull.result.onSuccess
@@ -64,6 +65,8 @@ class NotificationsRepository @Inject constructor(
 ) {
     private var factory: InvalidatingPagingSourceFactory<Int, NotificationData>? = null
 
+    private val remoteKeyTimelineId = Timeline.Notifications.remoteKeyTimelineId
+
     /**
      * @return Notifications for [pachliAccountId].
      */
@@ -73,7 +76,7 @@ class NotificationsRepository @Inject constructor(
 
         // Room is row-keyed, not item-keyed. Find the user's REFRESH key, then find the
         // row of the notification with that ID, and use that as the Pager's initialKey.
-        val initialKey = remoteKeyDao.remoteKeyForKind(pachliAccountId, RKE_TIMELINE_ID, RemoteKeyKind.REFRESH)?.key
+        val initialKey = remoteKeyDao.remoteKeyForKind(pachliAccountId, remoteKeyTimelineId, RemoteKeyKind.REFRESH)?.key
         val row = initialKey?.let { notificationDao.getNotificationRowNumber(pachliAccountId, it) }
 
         return Pager(
@@ -108,7 +111,7 @@ class NotificationsRepository @Inject constructor(
     suspend fun saveRefreshKey(pachliAccountId: Long, key: String?) = externalScope.async {
         Timber.d("saveRefreshKey: $key")
         remoteKeyDao.upsert(
-            RemoteKeyEntity(pachliAccountId, RKE_TIMELINE_ID, RemoteKeyKind.REFRESH, key),
+            RemoteKeyEntity(pachliAccountId, remoteKeyTimelineId, RemoteKeyKind.REFRESH, key),
         )
     }.await()
 
@@ -118,15 +121,20 @@ class NotificationsRepository @Inject constructor(
      * should fetch the latest notifications.
      */
     suspend fun getRefreshKey(pachliAccountId: Long): String? = externalScope.async {
-        remoteKeyDao.getRefreshKey(pachliAccountId, RKE_TIMELINE_ID)
+        remoteKeyDao.getRefreshKey(pachliAccountId, remoteKeyTimelineId)
     }.await()
 
     /**
      * Clears (deletes) all notifications from the server. Invalidates the repository
      * if successful.
+     *
+     * @param pachliAccountId
      */
-    suspend fun clearNotifications() = externalScope.async {
-        return@async mastodonApi.clearNotifications().onSuccess { invalidate() }
+    suspend fun clearNotifications(pachliAccountId: Long) = externalScope.async {
+        return@async mastodonApi.clearNotifications().onSuccess {
+            remoteKeyDao.delete(pachliAccountId, remoteKeyTimelineId)
+            notificationDao.deleteAllNotificationsForAccount(pachliAccountId)
+        }
     }.await()
 
     /**
@@ -186,8 +194,6 @@ class NotificationsRepository @Inject constructor(
 
     companion object {
         private const val PAGE_SIZE = 30
-
-        internal const val RKE_TIMELINE_ID = "NOTIFICATIONS"
     }
 }
 


### PR DESCRIPTION
Previously, when the user decided to clear all notifications they were deleted from the server but the local cache was not cleared (because the remote mediator returned early if they were no results on a refresh), so Pachli continued to show the (now deleted) notifications.

Fix that -- always delete the notifications.

While I'm here, make the "enabled" state of the "Clear notifications" menu item contingent on whether there are any notifications available to delete, and update CachedTimelineRemoteMediator and ConversationsRemoteMediator to behave the same.

Fixes #1582