### PR TITLE
feat: Show emojis grouped by category, and searchable

### DIFF
--- a/app/src/main/java/app/pachli/adapter/EmojiAdapter.kt
+++ b/app/src/main/java/app/pachli/adapter/EmojiAdapter.kt
@@ -1,4 +1,5 @@
-/* Copyright 2018 Conny Duck
+/*
+ * Copyright 2025 Pachli Association
  *
  * This file is a part of Pachli.
  *
@@ -18,53 +19,252 @@ package app.pachli.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import android.widget.Filter
+import android.widget.Filterable
 import androidx.appcompat.widget.TooltipCompat
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import app.pachli.adapter.EmojiListItem.CategoryItem
+import app.pachli.adapter.EmojiListItem.EmojiItem
 import app.pachli.core.model.Emoji
-import app.pachli.core.ui.BindingHolder
 import app.pachli.databinding.ItemEmojiButtonBinding
+import app.pachli.databinding.ItemEmojiCategoryBinding
 import com.bumptech.glide.RequestManager
 import java.util.Locale
 
-class EmojiAdapter(
-    private val glide: RequestManager,
-    emojiList: List<Emoji>,
-    private val onEmojiSelectedListener: OnEmojiSelectedListener,
-    private val animate: Boolean,
-) : RecyclerView.Adapter<BindingHolder<ItemEmojiButtonBinding>>() {
+/**
+ * Listener for clicks on emojis.
+ *
+ * @param shortcode Shortcode of the clicked emoji.
+ */
+typealias EmojiClickListener = (shortcode: String) -> Unit
 
-    private val emojiList: List<Emoji> = emojiList.filter { emoji -> emoji.visibleInPicker == null || emoji.visibleInPicker!! }
-        .sortedBy { it.shortcode.lowercase(Locale.ROOT) }
+/**
+ * Items that can be be displayed in the list of emojis.
+ *
+ * @property id Unique identifier for this item.
+ */
+sealed interface EmojiListItem {
+    val id: String
 
-    override fun getItemCount() = emojiList.size
+    /**
+     * A wrapped emoji.
+     *
+     * The emoji's [shortcode] is used as the [id]
+     */
+    @JvmInline
+    value class EmojiItem(private val emoji: Emoji) : EmojiListItem {
+        override val id: String
+            get() = emoji.shortcode
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BindingHolder<ItemEmojiButtonBinding> {
-        val binding = ItemEmojiButtonBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        return BindingHolder(binding)
+        val shortcode: String
+            get() = emoji.shortcode
+
+        val category: String?
+            get() = emoji.category
+
+        val url: String
+            get() = emoji.url
     }
 
-    override fun onBindViewHolder(holder: BindingHolder<ItemEmojiButtonBinding>, position: Int) {
-        val emoji = emojiList[position]
-        val emojiImageView = holder.binding.root
-
-        if (animate) {
-            glide.load(emoji.url)
-                .into(emojiImageView)
-        } else {
-            glide.asBitmap()
-                .load(emoji.url)
-                .into(emojiImageView)
-        }
-
-        emojiImageView.setOnClickListener {
-            onEmojiSelectedListener.onEmojiSelected(emoji.shortcode)
-        }
-
-        emojiImageView.contentDescription = emoji.shortcode
-        TooltipCompat.setTooltipText(emojiImageView, emoji.shortcode)
+    /**
+     * An emoji category.
+     *
+     * The [title] is used as the [id].
+     */
+    data class CategoryItem(val title: String) : EmojiListItem {
+        override val id = title
     }
 }
 
-interface OnEmojiSelectedListener {
-    fun onEmojiSelected(shortcode: String)
+/** Interface that viewholders for [EmojiListItem] must implement. */
+private interface EmojiViewHolder<T : EmojiListItem> {
+    fun bind(viewData: T)
+}
+
+/**
+ * Filterable adapter to display a list of emojis, sorted by [shortcode][Emoji.shortcode]
+ * and grouped by sorted [category][Emoji.category].
+ *
+ * The filter is applied to the emoji's [shortcode][Emoji.shortcode] and
+ * [category][Emoji.category].
+ *
+ * @property glide
+ * @property animate True if emojis should be animated.
+ * @property labelNoCategory Text label to use if an Emoji's [category][Emoji.category]
+ * is null.
+ * @property onClick
+ */
+class EmojiAdapter(
+    private val glide: RequestManager,
+    initialEmojis: List<Emoji>,
+    private val animate: Boolean,
+    private val labelNoCategory: String,
+    private val onClick: EmojiClickListener,
+) : ListAdapter<EmojiListItem, RecyclerView.ViewHolder>(diffCallback), Filterable {
+
+    /**
+     * Converts initialEmojis (a list of emojis with no categories) to a list
+     * with a mix of [CategoryItem] and [EmojiItem]. This is the unfiltered list,
+     * used whenever there is no filter constraint.
+     *
+     * The list is sorted by category name, and within each category by emoji
+     * shortcode.
+     */
+    private val emojiItems: List<EmojiListItem> = initialEmojis.filter { emoji -> emoji.visibleInPicker == null || emoji.visibleInPicker!! }
+        .map { EmojiItem(it) }
+        .groupBy { it.category ?: labelNoCategory }
+        .toSortedMap { k1, k2 -> k1.compareTo(k2, ignoreCase = true) }
+        .flatMap {
+            buildList {
+                add(CategoryItem(it.key))
+                addAll(it.value.sortedBy { it.shortcode.lowercase(Locale.ROOT) })
+            }
+        }
+
+    /**
+     * Filters emojis by category and shortcode. Any empty categories that occur
+     * after filtering are also removed.
+     */
+    private val filter = object : Filter() {
+        private val unfilteredItems = FilterResults().apply { values = emojiItems }
+
+        override fun performFiltering(constraint: CharSequence?): FilterResults? {
+            val query = constraint?.trim()
+            if (query.isNullOrBlank()) return unfilteredItems
+
+            // Filter in two passes. This first pass removes any items with a
+            // shortcode or category that don't match. All headings are retained.
+            val filteredEmojis = emojiItems.filter {
+                it is CategoryItem ||
+                    it is EmojiItem &&
+                    (
+                        it.shortcode.contains(query, ignoreCase = true) ||
+                            (it.category ?: labelNoCategory).contains(query, ignoreCase = true) == true
+                        )
+            }
+
+            // Second pass removes category headings that have no emojis in the category.
+            val final = buildList {
+                var prevItem: EmojiListItem? = null
+                filteredEmojis.forEach {
+                    if (prevItem == null) {
+                        prevItem = it
+                    } else {
+                        // Previous item was a category heading, and this is an item
+                        // in the category -- add the heading.
+                        if (prevItem is CategoryItem && it is EmojiItem) add(prevItem)
+
+                        // This is an emoji. Irrespective of the previous item, add it.
+                        if (it is EmojiItem) add(it)
+                        prevItem = it
+                    }
+                }
+                // Reached the end of the list. If the final item was an emoji then add it.
+                if (prevItem is EmojiItem) add(prevItem)
+            }
+
+            return FilterResults().apply { values = final }
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        override fun publishResults(constraint: CharSequence?, results: FilterResults?) {
+            submitList(results?.values as? List<EmojiListItem>)
+        }
+    }
+
+    init {
+        submitList(emojiItems)
+    }
+
+    override fun getFilter() = filter
+
+    override fun getItemViewType(position: Int): Int {
+        return when (getItem(position)) {
+            is CategoryItem -> app.pachli.R.layout.item_emoji_category
+            is EmojiItem -> app.pachli.R.layout.item_emoji_button
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        return when (viewType) {
+            app.pachli.R.layout.item_emoji_category -> EmojiCategoryViewHolder(ItemEmojiCategoryBinding.inflate(inflater, parent, false))
+            app.pachli.R.layout.item_emoji_button -> EmojiItemViewHolder(glide, ItemEmojiButtonBinding.inflate(inflater, parent, false), animate, onClick)
+            else -> throw IllegalStateException("incorrect viewType: $viewType")
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        getItem(position)?.let {
+            when (it) {
+                is CategoryItem -> (holder as EmojiViewHolder<CategoryItem>).bind(it)
+                is EmojiItem -> (holder as EmojiViewHolder<EmojiItem>).bind(it)
+            }
+        }
+    }
+
+    companion object {
+        val diffCallback = object : DiffUtil.ItemCallback<EmojiListItem>() {
+            override fun areItemsTheSame(oldItem: EmojiListItem, newItem: EmojiListItem) = oldItem == newItem
+
+            override fun areContentsTheSame(oldItem: EmojiListItem, newItem: EmojiListItem) = oldItem.id == newItem.id
+        }
+    }
+}
+
+/**
+ * Viewholder for an [EmojiItem].
+ *
+ * Loads the emoji with [glide], animated according to [animate].
+ *
+ * Long-pressing the emoji shows a tooltip with the emoji's shortcode.
+ *
+ * Clicking the emoji calls [onClick].
+ *
+ * @property glide
+ * @property binding
+ * @property animate
+ * @property onClick
+ */
+class EmojiItemViewHolder(
+    val glide: RequestManager,
+    val binding: ItemEmojiButtonBinding,
+    val animate: Boolean,
+    val onClick: EmojiClickListener,
+) : EmojiViewHolder<EmojiItem>, RecyclerView.ViewHolder(binding.root) {
+    // Inline classes can't be marked lateinit, so this must be nullable
+    var emoji: EmojiItem? = null
+
+    init {
+        binding.root.setOnClickListener { emoji?.let { onClick(it.shortcode) } }
+    }
+
+    override fun bind(viewData: EmojiItem) {
+        with(binding.root) {
+            emoji = viewData
+
+            if (animate) {
+                glide.load(viewData.url).into(this)
+            } else {
+                glide.asBitmap().load(viewData.url).into(this)
+            }
+
+            contentDescription = viewData.shortcode
+            TooltipCompat.setTooltipText(this, viewData.shortcode)
+        }
+    }
+}
+
+/**
+ * Viewholder for a [CategoryItem].
+ *
+ * Displays the category text.
+ */
+class EmojiCategoryViewHolder(val binding: ItemEmojiCategoryBinding) : EmojiViewHolder<CategoryItem>, RecyclerView.ViewHolder(binding.root) {
+    override fun bind(viewData: CategoryItem) {
+        binding.text1.text = viewData.title
+    }
 }

--- a/app/src/main/java/app/pachli/components/announcements/AnnouncementsActivity.kt
+++ b/app/src/main/java/app/pachli/components/announcements/AnnouncementsActivity.kt
@@ -27,7 +27,6 @@ import androidx.core.view.MenuProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import app.pachli.R
 import app.pachli.adapter.EmojiAdapter
-import app.pachli.adapter.OnEmojiSelectedListener
 import app.pachli.core.activity.ViewUrlActivity
 import app.pachli.core.activity.extensions.startActivityWithDefaultTransition
 import app.pachli.core.common.extensions.hide
@@ -54,7 +53,6 @@ import dagger.hilt.android.AndroidEntryPoint
 class AnnouncementsActivity :
     ViewUrlActivity(),
     AnnouncementActionListener,
-    OnEmojiSelectedListener,
     MenuProvider {
 
     private val viewModel: AnnouncementsViewModel by viewModels()
@@ -133,7 +131,15 @@ class AnnouncementsActivity :
         }
 
         viewModel.emojis.observe(this) {
-            picker.adapter = EmojiAdapter(glide, it, this, animateEmojis)
+            picker.adapter = EmojiAdapter(
+                glide,
+                it,
+                animateEmojis,
+                getString(R.string.label_emoji_no_category),
+            ) {
+                viewModel.addReaction(currentAnnouncementId!!, it)
+                pickerDialog.dismiss()
+            }
         }
 
         viewModel.load()
@@ -171,11 +177,6 @@ class AnnouncementsActivity :
     override fun openReactionPicker(announcementId: String, target: View) {
         currentAnnouncementId = announcementId
         pickerDialog.showAsDropDown(target)
-    }
-
-    override fun onEmojiSelected(shortcode: String) {
-        viewModel.addReaction(currentAnnouncementId!!, shortcode)
-        pickerDialog.dismiss()
     }
 
     override fun addReaction(announcementId: String, name: String) {

--- a/app/src/main/java/app/pachli/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeActivity.kt
@@ -66,7 +66,6 @@ import app.pachli.BuildConfig
 import app.pachli.R
 import app.pachli.adapter.EmojiAdapter
 import app.pachli.adapter.LocaleAdapter
-import app.pachli.adapter.OnEmojiSelectedListener
 import app.pachli.components.compose.ComposeViewModel.ConfirmationKind
 import app.pachli.components.compose.dialog.makeFocusDialog
 import app.pachli.components.compose.dialog.showAddPollDialog
@@ -146,8 +145,6 @@ class ComposeActivity :
     BaseActivity(),
     ComposeVisibilityListener,
     ComposeAutoCompleteAdapter.AutocompletionProvider,
-    OnEmojiSelectedListener,
-
     OnReceiveContentListener,
     ComposeScheduleView.OnTimeSetListener {
 
@@ -670,7 +667,7 @@ class ComposeActivity :
         visibilityBehavior = BottomSheetBehavior.from(binding.composeOptionsBottomSheet)
         addAttachmentBehavior = BottomSheetBehavior.from(binding.addMediaBottomSheet)
         scheduleBehavior = BottomSheetBehavior.from(binding.composeScheduleView)
-        emojiBehavior = BottomSheetBehavior.from(binding.emojiView)
+        emojiBehavior = BottomSheetBehavior.from(binding.emojiPickerBottomSheet)
 
         val bottomSheetCallback = object : BottomSheetBehavior.BottomSheetCallback() {
             override fun onStateChanged(bottomSheet: View, newState: Int) {
@@ -1554,13 +1551,16 @@ class ComposeActivity :
         return viewModel.searchAutocompleteSuggestions(token)
     }
 
-    override fun onEmojiSelected(shortcode: String) {
-        replaceTextAtCaret(":$shortcode: ")
-    }
-
     private fun bindEmojiList(emojiList: List<Emoji>) {
         val animateEmojis = sharedPreferencesRepository.animateEmojis
-        binding.emojiView.adapter = EmojiAdapter(glide, emojiList, this@ComposeActivity, animateEmojis)
+        val emojiAdapter = EmojiAdapter(
+            glide,
+            emojiList,
+            animateEmojis,
+            getString(R.string.label_emoji_no_category),
+        ) { replaceTextAtCaret(":$it: ") }
+        binding.emojiView.adapter = emojiAdapter
+        binding.emojiFilter.editText?.doAfterTextChanged { emojiAdapter.filter.filter(it) }
         enableButton(binding.composeEmojiButton, true, emojiList.isNotEmpty())
     }
 

--- a/app/src/main/java/app/pachli/view/EmojiPicker.kt
+++ b/app/src/main/java/app/pachli/view/EmojiPicker.kt
@@ -1,17 +1,72 @@
+/*
+ * Copyright 2025 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
 package app.pachli.view
 
 import android.content.Context
 import android.util.AttributeSet
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import at.connyduck.sparkbutton.helpers.Utils
 
 class EmojiPicker @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
 ) : RecyclerView(context, attrs) {
+    /**
+     * Layout manager for the grid. Initial span count is 1, the actual span count is
+     * determined in [onMeasure].
+     */
+    val gridLayoutManager = GridLayoutManager(context, 1, GridLayoutManager.VERTICAL, false)
+
+    /** Width of an [app.pachli.databinding.ItemEmojiButtonBinding] in pixels. */
+    val pxSpanWidth = Utils.dpToPx(context, 48)
+
+    /**
+     * Determines the size of each span based on the item's view type.
+     *
+     * [Headers][app.pachli.databinding.ItemEmojiHeaderBinding] take the full
+     * width of the layout, everything else uses one span.
+     */
+    val spanSizeLookup = object : GridLayoutManager.SpanSizeLookup() {
+        override fun getSpanSize(position: Int): Int {
+            return when (adapter?.getItemViewType(position)) {
+                app.pachli.R.layout.item_emoji_category -> gridLayoutManager.spanCount
+                else -> 1
+            }
+        }
+    }.apply {
+        isSpanIndexCacheEnabled = true
+        isSpanGroupIndexCacheEnabled = true
+    }
 
     init {
         clipToPadding = false
-        layoutManager = GridLayoutManager(context, 3, GridLayoutManager.HORIZONTAL, false)
+        gridLayoutManager.spanSizeLookup = spanSizeLookup
+        layoutManager = gridLayoutManager
+    }
+
+    /**
+     * Computes the number of spans to show based on the width of the view and
+     * width of each span.
+     */
+    override fun onMeasure(widthSpec: Int, heightSpec: Int) {
+        super.onMeasure(widthSpec, heightSpec)
+        val spanCount = 1.coerceAtLeast((measuredWidth / pxSpanWidth).toInt())
+        gridLayoutManager.spanCount = spanCount
     }
 }

--- a/app/src/main/res/layout/activity_compose.xml
+++ b/app/src/main/res/layout/activity_compose.xml
@@ -363,10 +363,11 @@
             android:textColor="?android:textColorTertiary" />
     </LinearLayout>
 
-    <app.pachli.view.EmojiPicker
-        android:id="@+id/emojiView"
+    <LinearLayout
+        android:id="@+id/emojiPickerBottomSheet"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:orientation="vertical"
         android:background="?attr/colorSurface"
         android:elevation="12dp"
         android:paddingStart="16dp"
@@ -375,7 +376,29 @@
         android:paddingBottom="60dp"
         app:behavior_hideable="true"
         app:behavior_peekHeight="0dp"
-        app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior" />
+        app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
+
+        <app.pachli.view.EmojiPicker
+            android:id="@+id/emojiView"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:scrollbars="vertical" />
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/emojiFilter"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_search_emojis"
+            style="@style/AppTextInput"
+            app:endIconMode="clear_text"
+            app:endIconContentDescription="@string/clear_text_end_icon_content_description">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+        </com.google.android.material.textfield.TextInputLayout>
+    </LinearLayout>
 
     <app.pachli.components.compose.view.ComposeOptionsView
         android:id="@+id/composeOptionsBottomSheet"

--- a/app/src/main/res/layout/item_emoji_category.xml
+++ b/app/src/main/res/layout/item_emoji_category.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2024 Pachli Association
+  ~
+  ~ This file is a part of Pachli.
+  ~
+  ~ This program is free software; you can redistribute it and/or modify it under the terms of the
+  ~ GNU General Public License as published by the Free Software Foundation; either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+  ~ the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+  ~ Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License along with Pachli; if not,
+  ~ see <http://www.gnu.org/licenses>.
+  -->
+
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@android:id/text1"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="bottom"
+    android:paddingTop="8dp"
+    android:textAppearance="?android:attr/textAppearanceListItemSmall"
+    android:focusable="false"
+    tools:ignore="SelectableText"
+    tools:text="Category" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -235,6 +235,7 @@
     <string name="hint_display_name">Display name</string>
     <string name="hint_note">Bio</string>
     <string name="hint_search">Search…</string>
+    <string name="hint_search_emojis">Search emojis…</string>
     <string name="hint_description">Description</string>
     <string name="hint_media_description_missing">Media should have a description.</string>
     <string name="search_no_results">No results</string>
@@ -426,6 +427,7 @@
     <string name="action_compose_shortcut">Compose</string>
     <string name="error_no_custom_emojis">Your instance %s does not have any custom emojis</string>
     <string name="emoji_style">Emoji style</string>
+    <string name="label_emoji_no_category">No category</string>
     <string name="system_default">System default</string>
     <string name="download_fonts">You\'ll need to download these emoji sets first</string>
     <string name="expand_collapse_all_posts">Expand/Collapse all posts</string>

--- a/core/model/src/main/kotlin/app/pachli/core/model/Emoji.kt
+++ b/core/model/src/main/kotlin/app/pachli/core/model/Emoji.kt
@@ -29,4 +29,5 @@ data class Emoji(
     val url: String,
     @Json(name = "static_url") val staticUrl: String,
     @Json(name = "visible_in_picker") val visibleInPicker: Boolean?,
+    val category: String? = null,
 ) : Parcelable

--- a/core/network/src/main/kotlin/app/pachli/core/network/model/Emoji.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/Emoji.kt
@@ -25,12 +25,14 @@ data class Emoji(
     val url: String,
     @Json(name = "static_url") val staticUrl: String,
     @Json(name = "visible_in_picker") val visibleInPicker: Boolean?,
+    val category: String? = null,
 ) {
     fun asModel() = app.pachli.core.model.Emoji(
         shortcode = shortcode,
         url = url,
         staticUrl = staticUrl,
         visibleInPicker = visibleInPicker,
+        category = category,
     )
 }
 


### PR DESCRIPTION
Previous code presented emojis as a flat list, sorted by emoji shortcode. On servers with many emojis this was difficult to find the one you wanted, and emojis from different categories were mixed together.

Fix this.

Display emojis grouped by category, with an additional view for the category header. Provide a `TextView` to allow the user to search the emojis by shortcode or category, filtering the list to just the matched entries. Scroll the list vertically instead of horizontally, with scrollbars.

Fixes #1226