### PR TITLE
fix: Show an account's emoji's when replying

### DIFF
--- a/core/navigation/src/main/kotlin/app/pachli/core/navigation/Navigation.kt
+++ b/core/navigation/src/main/kotlin/app/pachli/core/navigation/Navigation.kt
@@ -446,7 +446,7 @@ class ComposeActivityIntent(context: Context, pachliAccountId: Long, composeOpti
                         isBot = status.account.bot,
                         displayName = status.account.name,
                         username = status.account.localUsername,
-                        emojis = status.emojis,
+                        emojis = status.emojis + status.account.emojis.orEmpty(),
                         contentWarning = status.spoilerText,
                         content = status.content.parseAsMastodonHtml().toString(),
                     )


### PR DESCRIPTION
Previous code didn't include the account's emojis when replying, which meant the display name of the account being replied to might show emoji shortcodes instead of the images.

Fix this by including the account's emojis when constructing the `InReplyTo.Status` object.