### PR TITLE
fix: Don't crash when showing dialog to choose a push provider

### DIFF
--- a/app/src/main/java/app/pachli/components/notifications/PushNotificationHelper.kt
+++ b/app/src/main/java/app/pachli/components/notifications/PushNotificationHelper.kt
@@ -76,7 +76,7 @@ fun activeAccountNeedsPushScope(accountManager: AccountManager) = accountManager
  * Otherwise, show the user list of distributors and allows them to choose one. Returns
  * their choice, unless they cancelled the dialog, in which case return null.
  *
- * @param context
+ * @param context This must by an Activity context so it can be used to show a dialog.
  * @param usePreviousDistributor
  */
 suspend fun chooseUnifiedPushDistributor(context: Context, usePreviousDistributor: Boolean = true): String? {

--- a/app/src/main/java/app/pachli/components/notifications/domain/EnableAllNotificationsUseCase.kt
+++ b/app/src/main/java/app/pachli/components/notifications/domain/EnableAllNotificationsUseCase.kt
@@ -26,13 +26,17 @@ import app.pachli.core.domain.notifications.DisablePushNotificationsForAccountUs
 import app.pachli.core.domain.notifications.NotificationConfig
 import app.pachli.core.domain.notifications.hasPushScope
 import app.pachli.core.preferences.SharedPreferencesRepository
-import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.android.qualifiers.ActivityContext
+import dagger.hilt.android.scopes.ActivityScoped
 import javax.inject.Inject
 import org.unifiedpush.android.connector.UnifiedPush
 import timber.log.Timber
 
+// The context is used to launch dialogs (see chooseUnifiedPushDistributor) so should
+// be a context with an activity so the correct resources are found.
+@ActivityScoped
 class EnableAllNotificationsUseCase @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @ActivityContext private val context: Context,
     private val accountManager: AccountManager,
     private val sharedPreferencesRepository: SharedPreferencesRepository,
     private val disablePushNotificationsForAccount: DisablePushNotificationsForAccountUseCase,


### PR DESCRIPTION
Had a user report of a crash with the following stack trace:

```
android.content.res.Resources$NotFoundException: Resource ID #0x0
at android.content.res.ResourcesImpl.getValue(ResourcesImpl.java:285)
at android.content.res.Resources.loadXmlResourceParser(Resources.java:2570)
at android.content.res.Resources.getLayout(Resources.java:1285)
at android.view.LayoutInflater.inflate(LayoutInflater.java:460)
at android.view.LayoutInflater.inflate(LayoutInflater.java:413)
at androidx.appcompat.app.AlertDialog$Builder.create(SourceFile:145)
at app.pachli.components.notifications.PushNotificationHelperKt.a(SourceFile:239)
...
```

That's the dialog creation in `chooseUnifiedPushDistributor()`.

That *might* be because the context used to launch the dialog is an `ApplicationContext` (based on online research).

Change the context to an `ActivityContext` to see if that prevents the crash.