### PR TITLE
fix: Don't crash when managing accounts on older API devices

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -923,9 +923,9 @@
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/account_selector` with a theme that also paints a background (inferred theme is `@android:style/Theme.Holo`)"
-        errorLine1="    android:background=&quot;@color/account_selector&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `?colorSurface` with a theme that also paints a background (inferred theme is `@android:style/Theme.Holo`)"
+        errorLine1="    android:background=&quot;?colorSurface&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/item_pachli_account.xml"
             line="29"

--- a/feature/manageaccounts/lint-baseline.xml
+++ b/feature/manageaccounts/lint-baseline.xml
@@ -3,9 +3,9 @@
 
     <issue
         id="Overdraw"
-        message="Possible overdraw: Root element paints background `@color/account_selector` with a theme that also paints a background (inferred theme is `@android:style/Theme.Holo`)"
-        errorLine1="    android:background=&quot;@color/account_selector&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Possible overdraw: Root element paints background `?colorSurface` with a theme that also paints a background (inferred theme is `@android:style/Theme.Holo`)"
+        errorLine1="    android:background=&quot;?colorSurface&quot;"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/layout/item_pachli_account.xml"
             line="29"

--- a/feature/manageaccounts/src/main/res/color/account_selector.xml
+++ b/feature/manageaccounts/src/main/res/color/account_selector.xml
@@ -17,5 +17,5 @@
 
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_activated="true" android:color="?attr/colorSecondaryContainer"/>
-    <item android:color="?attr/colorSurface"/>
+    <item android:color="@android:color/transparent" />
 </selector>

--- a/feature/manageaccounts/src/main/res/layout/item_pachli_account.xml
+++ b/feature/manageaccounts/src/main/res/layout/item_pachli_account.xml
@@ -26,7 +26,8 @@
     android:paddingStart="?android:attr/listPreferredItemPaddingStart"
     android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
     android:paddingBottom="8dp"
-    android:background="@color/account_selector"
+    android:background="?colorSurface"
+    android:backgroundTint="@color/account_selector"
     tools:ignore="SelectableText">
 
     <TextView


### PR DESCRIPTION
API 24 devices (at least, possibly some newer API levels) don't want `android:background` to be a color statelist, crashing because the XML resource inflater expects to find a drawable instead of a colour.

Work around this by setting the colour to the surface colour, and using the statelist as the background tint.