### PR TITLE
fix: Prevent visual "stutter" when first showing playback controls

### DIFF
--- a/app/src/main/java/app/pachli/fragment/ViewVideoFragment.kt
+++ b/app/src/main/java/app/pachli/fragment/ViewVideoFragment.kt
@@ -246,9 +246,15 @@ class ViewVideoFragment : ViewMediaFragment() {
                         transitionComplete?.let {
                             viewLifecycleOwner.lifecycleScope.launch {
                                 it.await()
+                                // Work-around visual glitch by only setting useController here instead
+                                // of in the layout.  Otherwise a "blank" controller (just playback
+                                // buttons) is displayed while media is loading / preparing, and is then
+                                // replaced with the final controller.
+                                binding.videoView.useController = true
                                 player?.play()
+                                // Show controller *after* playback starts, otherwise the show timeout
+                                // is ignored.
                                 binding.videoView.showController()
-                                binding.videoView.controllerAutoShow = true
                             }
                         }
                     }

--- a/app/src/main/res/layout/fragment_view_video.xml
+++ b/app/src/main/res/layout/fragment_view_video.xml
@@ -32,7 +32,7 @@
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:use_controller="true"
+        app:use_controller="false"
         app:controller_layout_id="@layout/pachli_exo_player_control_view"
         app:show_previous_button="false"
         app:show_next_button="false"


### PR DESCRIPTION
Playback controls can appear before the media is ready and the controller is configured. They're then replaced (which moves them up the screen) with correct controls, so the UI appears to "stutter" as this happens.

Work around this by only setting `useController` when the media is ready to start.