### PR TITLE
fix: Don't crash unregistering AudioBecomingNoisyReceiver

### DIFF
--- a/app/src/main/java/app/pachli/fragment/ViewMediaFragment.kt
+++ b/app/src/main/java/app/pachli/fragment/ViewMediaFragment.kt
@@ -149,6 +149,13 @@ abstract class ViewMediaFragment : Fragment() {
     }
 
     /**
+     * Called when audio has become noisy (e.g., the user has removed headphones).
+     *
+     * If the fragment is playing media it should be paused.
+     */
+    open fun onAudioBecomingNoisy() = Unit
+
+    /**
      * Called by the fragment adapter to notify the fragment that the shared
      * element transition has been completed.
      */

--- a/app/src/main/java/app/pachli/pager/ImagePagerAdapter.kt
+++ b/app/src/main/java/app/pachli/pager/ImagePagerAdapter.kt
@@ -36,6 +36,10 @@ class ImagePagerAdapter(
         }
     }
 
+    override fun onAudioBecomingNoisy() {
+        fragments.forEach { it?.get()?.onAudioBecomingNoisy() }
+    }
+
     /**
      * Called by the hosting activity to notify the adapter that the shared element
      * transition to the first displayed item in the adapter has completed.


### PR DESCRIPTION
Previously the `AudioBecomingNoisyReceiver` was registered in the fragment playing the video.

This works for statuses from Mastodon which can only have a single video attached. However, statuses from other networks may have multiple videos attached. The receiver would be registered by each video playing fragment and then unregistered when they pause/stop. Because the receiver is a singleton the second attempt to unregister it (if the status has two or more video attachments) would crash.

Fix this by moving the broadcast receiver to `ViewMediaActivity`. Implement the receiver as lifecycle observer so it can register/unregister itself without needing to modify `ViewMediaActivity` beyond instantiating the object.

Update `ViewMediaAdapter` to include an `onAudioBecomingNoisy` method to call on receipt of the broadcast.

Update `ImagePagerAdapter` to implement `onAudioBecomingNoisy` and call an identically named method on each fragment.

Implement `onAudioBecomingNoisy` in `ViewVideoFragment` and pause the player.