### PR TITLE
feat: Pause video playback when swiping through media

### DIFF
--- a/app/src/main/java/app/pachli/fragment/ViewMediaFragment.kt
+++ b/app/src/main/java/app/pachli/fragment/ViewMediaFragment.kt
@@ -149,6 +149,14 @@ abstract class ViewMediaFragment : Fragment() {
     }
 
     /**
+     * Called when the fragment has been detached by the viewpager and is not visible.
+     *
+     * This is an opportunity to e.g., pause video playback, or possibly unload
+     * large resources.
+     */
+    open fun onDetachedFromWindow() = Unit
+
+    /**
      * Called when audio has become noisy (e.g., the user has removed headphones).
      *
      * If the fragment is playing media it should be paused.

--- a/app/src/main/java/app/pachli/fragment/ViewVideoFragment.kt
+++ b/app/src/main/java/app/pachli/fragment/ViewVideoFragment.kt
@@ -342,6 +342,10 @@ class ViewVideoFragment : ViewMediaFragment() {
         }
     }
 
+    override fun onDetachedFromWindow() {
+        player?.pause()
+    }
+
     override fun onAudioBecomingNoisy() {
         player?.pause()
     }

--- a/app/src/main/java/app/pachli/pager/ImagePagerAdapter.kt
+++ b/app/src/main/java/app/pachli/pager/ImagePagerAdapter.kt
@@ -2,6 +2,7 @@ package app.pachli.pager
 
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
+import androidx.viewpager2.adapter.FragmentViewHolder
 import app.pachli.ViewMediaAdapter
 import app.pachli.core.model.Attachment
 import app.pachli.fragment.ViewMediaFragment
@@ -34,6 +35,13 @@ class ImagePagerAdapter(
         } else {
             throw IllegalStateException()
         }
+    }
+
+    override fun onViewDetachedFromWindow(holder: FragmentViewHolder) {
+        super.onViewDetachedFromWindow(holder)
+        // Inform the fragment it is no longer visible so it can take appropriate
+        // action (e.g., pause playback).
+        fragments.getOrNull(holder.bindingAdapterPosition)?.get()?.onDetachedFromWindow()
     }
 
     override fun onAudioBecomingNoisy() {


### PR DESCRIPTION
Previous code didn't pause video playback when swiping through media. This isn't a problem on Mastodon where a status can't mix and match video and image attachments, but it is a problem from posts with other networks that can. If video was playing it would continue playing after the user swiped to a different attachment.

Fix this. Provide a new method, `onDetachedFromWindow`, that the media fragments can implement, and call this method from `ImagePagerAdapter` when `ViewPager2` detaches the fragment after a swipe. Pause the player when this happens.