### PR TITLE
fix: Show playback controls on video fragments after the first

### DIFF
--- a/app/src/main/java/app/pachli/pager/ImagePagerAdapter.kt
+++ b/app/src/main/java/app/pachli/pager/ImagePagerAdapter.kt
@@ -37,6 +37,16 @@ class ImagePagerAdapter(
         }
     }
 
+    override fun onBindViewHolder(holder: FragmentViewHolder, position: Int, payloads: List<Any?>) {
+        super.onBindViewHolder(holder, position, payloads)
+
+        // We might be binding a new fragment after the transition completed. If so,
+        // make sure to call the fragment's `onTransitionEnd` so it can start
+        // immediately. Otherwise the fragment hangs waiting for the transition
+        // to complete.
+        if (transitionComplete) fragments.getOrNull(position)?.get()?.onTransitionEnd()
+    }
+
     override fun onViewDetachedFromWindow(holder: FragmentViewHolder) {
         super.onViewDetachedFromWindow(holder)
         // Inform the fragment it is no longer visible so it can take appropriate


### PR DESCRIPTION
Previous code only notified the first fragment the transition ended, which meant that any subsequent fragments that showed video would never show the media controls -- they were waiting for a transition to complete that had already completed but they didn't know about.

Fix that by notifying the fragment every time it is bound.