### PR TITLE
fix: Don't crash with network activity on the main thread sharing media

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -897,4 +897,6 @@
     <string name="export_preferences_ok_fmt">Preferences exported to %1$s</string>
     <string name="error_export_preferences_fmt">Could not export preferences to %1$s: %2$s</string>
     <string name="error_import_preferences_fmt">Could not import preferences from %1$s: %2$s</string>
+
+    <string name="error_share_media">no directory to save temporary media exists</string>
 </resources>


### PR DESCRIPTION
Previous code made the network request on `Dispatchers.IO`, but then read the response body on `Dispatchers.Main`. If the response was large and the body hadn't been fully read in the request this could cause a crash with a `NetworkOnMainThreadException`.

Fix this by splitting the "share" operation in to `shareMedia` which runs on the main thread and manages the UI, and `downloadUrlToTempFile` which performs all the disk and network operations on `Dispatchers.IO`.