### PR TITLE
refactor: Move more IO code to Dispatchers.IO

### DIFF
--- a/app/src/main/java/app/pachli/ViewMediaActivity.kt
+++ b/app/src/main/java/app/pachli/ViewMediaActivity.kt
@@ -92,14 +92,14 @@ import okio.buffer
 import okio.sink
 import timber.log.Timber
 
-/** Errors that can occur downloading a URL to share. */
-sealed interface DownloadUrlToShareError : PachliError {
+/** Errors that can occur downloading a URL. */
+sealed interface DownloadUrlError : PachliError {
     /** ApiError occurred downloading the media. */
     @JvmInline
-    value class Api(private val error: ApiError) : DownloadUrlToShareError, PachliError by error
+    value class Api(private val error: ApiError) : DownloadUrlError, PachliError by error
 
     /** Call to getExternalFilesDir failed / returned null. */
-    data object GetExternalFilesDirError : DownloadUrlToShareError {
+    data object GetExternalFilesDirError : DownloadUrlError {
         override val resourceId = R.string.error_share_media
         override val formatArgs = null
         override val cause = null
@@ -368,13 +368,13 @@ class ViewMediaActivity : BaseActivity(), MediaActionsListener {
      *
      * @return If successful, a [Pair] where the first item is the file's MIME type
      * and the second item is the [File] the [url] was downloaded to. Otherwise, the
-     * [DownloadUrlToShareError] that occurred downloading the file.
+     * [DownloadUrlError] that occurred downloading the file.
      */
-    private suspend fun downloadUrlToTempFile(url: String): Result<Pair<String?, File>, DownloadUrlToShareError> = withContext(Dispatchers.IO) {
+    private suspend fun downloadUrlToTempFile(url: String): Result<Pair<String?, File>, DownloadUrlError> = withContext(Dispatchers.IO) {
         val directory = applicationContext.getExternalFilesDir(null)
         if (directory == null || !(directory.exists())) {
             Timber.e("Error obtaining directory to save temporary media.")
-            return@withContext Err(DownloadUrlToShareError.GetExternalFilesDirError)
+            return@withContext Err(DownloadUrlError.GetExternalFilesDirError)
         }
 
         val mimeTypeMap = MimeTypeMap.getSingleton()
@@ -395,7 +395,7 @@ class ViewMediaActivity : BaseActivity(), MediaActionsListener {
                 }
             }
             .map { Pair(mimeType, file) }
-            .mapError { DownloadUrlToShareError.Api(ApiError.from(call.request(), it)) }
+            .mapError { DownloadUrlError.Api(ApiError.from(call.request(), it)) }
     }
 
     companion object {

--- a/app/src/main/java/app/pachli/ViewMediaActivity.kt
+++ b/app/src/main/java/app/pachli/ViewMediaActivity.kt
@@ -92,14 +92,14 @@ import okio.buffer
 import okio.sink
 import timber.log.Timber
 
-/** Errors that can occur downloading a URL. */
-sealed interface DownloadUrlError : PachliError {
+/** Errors that can occur downloading a URL to share. */
+sealed interface DownloadUrlToShareError : PachliError {
     /** ApiError occurred downloading the media. */
     @JvmInline
-    value class Api(private val error: ApiError) : DownloadUrlError, PachliError by error
+    value class Api(private val error: ApiError) : DownloadUrlToShareError, PachliError by error
 
     /** Call to getExternalFilesDir failed / returned null. */
-    data object GetExternalFilesDirError : DownloadUrlError {
+    data object GetExternalFilesDirError : DownloadUrlToShareError {
         override val resourceId = R.string.error_share_media
         override val formatArgs = null
         override val cause = null
@@ -283,11 +283,13 @@ class ViewMediaActivity : BaseActivity(), MediaActionsListener {
     private fun downloadMedia() {
         val url = imageUrl ?: attachmentViewData!![binding.viewPager.currentItem].attachment.url
         Toast.makeText(applicationContext, resources.getString(R.string.download_image, url), Toast.LENGTH_SHORT).show()
-        downloadUrlUseCase(
-            url,
-            accountManager.activeAccount!!.fullName,
-            owningUsername,
-        )
+        lifecycleScope.launch {
+            downloadUrlUseCase(
+                url,
+                accountManager.activeAccount!!.fullName,
+                owningUsername,
+            )
+        }
     }
 
     private fun requestDownloadMedia() {
@@ -368,13 +370,13 @@ class ViewMediaActivity : BaseActivity(), MediaActionsListener {
      *
      * @return If successful, a [Pair] where the first item is the file's MIME type
      * and the second item is the [File] the [url] was downloaded to. Otherwise, the
-     * [DownloadUrlError] that occurred downloading the file.
+     * [DownloadUrlToShareError] that occurred downloading the file.
      */
-    private suspend fun downloadUrlToTempFile(url: String): Result<Pair<String?, File>, DownloadUrlError> = withContext(Dispatchers.IO) {
+    private suspend fun downloadUrlToTempFile(url: String): Result<Pair<String?, File>, DownloadUrlToShareError> = withContext(Dispatchers.IO) {
         val directory = applicationContext.getExternalFilesDir(null)
         if (directory == null || !(directory.exists())) {
             Timber.e("Error obtaining directory to save temporary media.")
-            return@withContext Err(DownloadUrlError.GetExternalFilesDirError)
+            return@withContext Err(DownloadUrlToShareError.GetExternalFilesDirError)
         }
 
         val mimeTypeMap = MimeTypeMap.getSingleton()
@@ -395,7 +397,7 @@ class ViewMediaActivity : BaseActivity(), MediaActionsListener {
                 }
             }
             .map { Pair(mimeType, file) }
-            .mapError { DownloadUrlError.Api(ApiError.from(call.request(), it)) }
+            .mapError { DownloadUrlToShareError.Api(ApiError.from(call.request(), it)) }
     }
 
     companion object {

--- a/app/src/main/java/app/pachli/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeActivity.kt
@@ -133,10 +133,12 @@ import java.util.Locale
 import javax.inject.Inject
 import kotlin.math.max
 import kotlin.math.min
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import timber.log.Timber
 
 /**
@@ -214,9 +216,9 @@ class ComposeActivity :
         val uriNew = result.uriContent
         if (result.isSuccessful && uriNew != null) {
             viewModel.cropImageItemOld?.let { itemOld ->
-                val size = getMediaSize(contentResolver, uriNew)
-
                 lifecycleScope.launch {
+                    val size = getMediaSize(contentResolver, uriNew)
+
                     viewModel.addMediaToQueue(
                         itemOld.type,
                         uriNew,
@@ -352,7 +354,7 @@ class ComposeActivity :
                             viewModel.updateFocus(item.localId, newFocus)
                         }
                     },
-                    onEditImage = this@ComposeActivity::editImageInQueue,
+                    onEditImage = { lifecycleScope.launch { editImageInQueue(it) } },
                     onRemoveMedia = this@ComposeActivity::removeMediaFromQueue,
                 )
 
@@ -746,7 +748,7 @@ class ComposeActivity :
 
         binding.actionPhotoTake.visible(Intent(MediaStore.ACTION_IMAGE_CAPTURE).resolveActivity(packageManager) != null)
 
-        binding.actionPhotoTake.setOnClickListener { initiateCameraApp() }
+        binding.actionPhotoTake.setOnClickListener { lifecycleScope.launch { initiateCameraApp() } }
         binding.actionAddMedia.setOnClickListener { onAddMediaClick() }
         binding.addPollTextActionTextView.setOnClickListener { onAddPollClick() }
 
@@ -1327,19 +1329,19 @@ class ComposeActivity :
         }
     }
 
-    private fun initiateCameraApp() {
+    private suspend fun initiateCameraApp() = withContext(Dispatchers.IO) {
         addAttachmentBehavior.state = BottomSheetBehavior.STATE_COLLAPSED
 
         val photoFile: File = try {
-            createNewImageFile(this)
+            createNewImageFile(this@ComposeActivity)
         } catch (_: IOException) {
             displayTransientMessage(R.string.error_media_upload_opening)
-            return
+            return@withContext
         }
 
         // Continue only if the File was successfully created
         photoUploadUri = FileProvider.getUriForFile(
-            this,
+            this@ComposeActivity,
             BuildConfig.APPLICATION_ID + ".fileprovider",
             photoFile,
         )?.also {
@@ -1367,7 +1369,7 @@ class ComposeActivity :
         }
     }
 
-    private fun editImageInQueue(item: QueuedMedia) {
+    private suspend fun editImageInQueue(item: QueuedMedia) {
         // If input image is lossless, output image should be lossless.
         // Currently the only supported lossless format is png.
         val mimeType: String? = contentResolver.getType(item.uri)

--- a/app/src/main/java/app/pachli/components/search/fragments/SearchStatusesFragment.kt
+++ b/app/src/main/java/app/pachli/components/search/fragments/SearchStatusesFragment.kt
@@ -382,7 +382,9 @@ class SearchStatusesFragment : SearchFragment<StatusViewData>(), StatusActionLis
     private fun downloadAllMedia(status: Status) {
         Toast.makeText(context, R.string.downloading_media, Toast.LENGTH_SHORT).show()
         for ((_, url) in status.attachments) {
-            downloadUrlUseCase(url, viewModel.activeAccount!!.fullName, status.actionableStatus.account.username)
+            lifecycleScope.launch {
+                downloadUrlUseCase(url, viewModel.activeAccount!!.fullName, status.actionableStatus.account.username)
+            }
         }
     }
 

--- a/app/src/main/java/app/pachli/fragment/SFragment.kt
+++ b/app/src/main/java/app/pachli/fragment/SFragment.kt
@@ -556,11 +556,13 @@ abstract class SFragment<T : IStatusViewData> : Fragment(), StatusActionListener
         Toast.makeText(context, R.string.downloading_media, Toast.LENGTH_SHORT).show()
 
         status.attachments.forEach {
-            downloadUrlUseCase(
-                it.url,
-                accountManager.activeAccount!!.fullName,
-                status.actionableStatus.account.username,
-            )
+            lifecycleScope.launch {
+                downloadUrlUseCase(
+                    it.url,
+                    accountManager.activeAccount!!.fullName,
+                    status.actionableStatus.account.username,
+                )
+            }
         }
     }
 

--- a/app/src/main/java/app/pachli/util/MediaUtils.kt
+++ b/app/src/main/java/app/pachli/util/MediaUtils.kt
@@ -28,6 +28,8 @@ import java.io.FileNotFoundException
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 /**
  * Helper methods for obtaining and resizing media files
@@ -42,15 +44,15 @@ const val MEDIA_SIZE_UNKNOWN = -1L
  *
  * @return the size of the media in bytes or {@link MediaUtils#MEDIA_SIZE_UNKNOWN}
  */
-fun getMediaSize(contentResolver: ContentResolver, uri: Uri?): Long {
-    uri ?: return MEDIA_SIZE_UNKNOWN
+suspend fun getMediaSize(contentResolver: ContentResolver, uri: Uri?): Long = withContext(Dispatchers.IO) {
+    uri ?: return@withContext MEDIA_SIZE_UNKNOWN
 
     var mediaSize = MEDIA_SIZE_UNKNOWN
     val cursor: Cursor?
     try {
         cursor = contentResolver.query(uri, null, null, null, null)
     } catch (e: SecurityException) {
-        return MEDIA_SIZE_UNKNOWN
+        return@withContext MEDIA_SIZE_UNKNOWN
     }
     if (cursor != null) {
         val sizeIndex = cursor.getColumnIndex(OpenableColumns.SIZE)
@@ -58,7 +60,7 @@ fun getMediaSize(contentResolver: ContentResolver, uri: Uri?): Long {
         mediaSize = cursor.getLong(sizeIndex)
         cursor.close()
     }
-    return mediaSize
+    return@withContext mediaSize
 }
 
 @Throws(FileNotFoundException::class)

--- a/core/domain/src/main/kotlin/app/pachli/core/domain/DownloadUrlUseCase.kt
+++ b/core/domain/src/main/kotlin/app/pachli/core/domain/DownloadUrlUseCase.kt
@@ -29,6 +29,8 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 /**
  * Downloads a URL respecting the user's preferences.
@@ -53,9 +55,9 @@ class DownloadUrlUseCase @Inject constructor(
      * @param sender Username of the account supplying the URL. May or may not
      * start with an "@", one is prepended to the download directory if missing.
      */
-    operator fun invoke(url: String, recipient: String, sender: String) {
+    suspend operator fun invoke(url: String, recipient: String, sender: String): Unit = withContext(Dispatchers.IO) {
         val uri = url.toUri()
-        val filename = uri.lastPathSegment ?: return
+        val filename = uri.lastPathSegment ?: return@withContext
         val downloadManager = context.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
         val request = DownloadManager.Request(uri)
 


### PR DESCRIPTION
Previous code did a lot of UI work on whatever happened to be the
active dispatcher. Refactor to run the work explicitly on `Dispatchers.IO`
to ensure it's off the main thread.