### PR TITLE
refactor: Push responsibility for followup account actions down to TimelineCases

### DIFF
--- a/app/src/main/java/app/pachli/components/accountlist/AccountListFragment.kt
+++ b/app/src/main/java/app/pachli/components/accountlist/AccountListFragment.kt
@@ -61,6 +61,7 @@ import app.pachli.core.ui.extensions.applyDefaultWindowInsets
 import app.pachli.databinding.FragmentAccountListBinding
 import app.pachli.interfaces.AccountActionListener
 import app.pachli.interfaces.AppBarLayoutHost
+import app.pachli.usecase.TimelineCases
 import app.pachli.view.EndlessOnScrollListener
 import com.bumptech.glide.Glide
 import com.github.michaelbull.result.getOrElse
@@ -89,6 +90,9 @@ class AccountListFragment :
 
     @Inject
     lateinit var sharedPreferencesRepository: SharedPreferencesRepository
+
+    @Inject
+    lateinit var timelineCases: TimelineCases
 
     private val binding by viewBinding(FragmentAccountListBinding::bind)
 
@@ -189,9 +193,9 @@ class AccountListFragment :
     override fun onMute(mute: Boolean, id: String, position: Int, notifications: Boolean) {
         viewLifecycleOwner.lifecycleScope.launch {
             if (!mute) {
-                api.unmuteAccount(id)
+                timelineCases.unmuteAccount(pachliAccountId, id)
             } else {
-                api.muteAccount(id, notifications)
+                timelineCases.muteAccount(pachliAccountId, id, notifications)
             }
                 .onSuccess { onMuteSuccess(mute, id, position, notifications) }
                 .onFailure { onMuteFailure(mute, id, notifications) }
@@ -232,9 +236,9 @@ class AccountListFragment :
     override fun onBlock(block: Boolean, id: String, position: Int) {
         viewLifecycleOwner.lifecycleScope.launch {
             if (block) {
-                api.blockAccount(id)
+                timelineCases.blockAccount(pachliAccountId, id)
             } else {
-                api.unblockAccount(id)
+                timelineCases.unblockAccount(pachliAccountId, id)
             }
                 .onSuccess { onBlockSuccess(block, id, position) }
                 .onFailure { onBlockFailure(block, id, it.throwable) }

--- a/app/src/main/java/app/pachli/components/search/SearchViewModel.kt
+++ b/app/src/main/java/app/pachli/components/search/SearchViewModel.kt
@@ -330,7 +330,7 @@ class SearchViewModel @Inject constructor(
 
     fun muteAccount(accountId: String, notifications: Boolean, duration: Int?) {
         viewModelScope.launch {
-            timelineCases.mute(activeAccount!!.id, accountId, notifications, duration)
+            timelineCases.muteAccount(activeAccount!!.id, accountId, notifications, duration)
         }
     }
 
@@ -342,7 +342,7 @@ class SearchViewModel @Inject constructor(
 
     fun blockAccount(accountId: String) {
         viewModelScope.launch {
-            timelineCases.block(activeAccount!!.id, accountId)
+            timelineCases.blockAccount(activeAccount!!.id, accountId)
         }
     }
 

--- a/app/src/main/java/app/pachli/fragment/SFragment.kt
+++ b/app/src/main/java/app/pachli/fragment/SFragment.kt
@@ -392,7 +392,7 @@ abstract class SFragment<T : IStatusViewData> : Fragment(), StatusActionListener
     private fun onMute(accountId: String, accountUsername: String) {
         showMuteAccountDialog(this.requireActivity(), accountUsername) { notifications: Boolean?, duration: Int? ->
             lifecycleScope.launch {
-                timelineCases.mute(pachliAccountId, accountId, notifications == true, duration)
+                timelineCases.muteAccount(pachliAccountId, accountId, notifications == true, duration)
             }
         }
     }
@@ -402,7 +402,7 @@ abstract class SFragment<T : IStatusViewData> : Fragment(), StatusActionListener
             .setMessage(getString(R.string.dialog_block_warning, accountUsername))
             .setPositiveButton(android.R.string.ok) { _: DialogInterface?, _: Int ->
                 lifecycleScope.launch {
-                    timelineCases.block(pachliAccountId, accountId)
+                    timelineCases.blockAccount(pachliAccountId, accountId)
                 }
             }
             .setNegativeButton(android.R.string.cancel, null)

--- a/app/src/main/java/app/pachli/usecase/TimelineCases.kt
+++ b/app/src/main/java/app/pachli/usecase/TimelineCases.kt
@@ -18,6 +18,8 @@ package app.pachli.usecase
 
 import app.pachli.core.common.di.ApplicationScope
 import app.pachli.core.data.model.StatusViewData
+import app.pachli.core.data.repository.AccountManager
+import app.pachli.core.data.repository.StatusActionError
 import app.pachli.core.data.repository.StatusRepository
 import app.pachli.core.database.dao.RemoteKeyDao
 import app.pachli.core.database.dao.TranslatedStatusDao
@@ -27,14 +29,16 @@ import app.pachli.core.database.model.TranslationState
 import app.pachli.core.database.model.toEntity
 import app.pachli.core.eventhub.BlockEvent
 import app.pachli.core.eventhub.EventHub
-import app.pachli.core.eventhub.MuteConversationEvent
 import app.pachli.core.eventhub.MuteEvent
 import app.pachli.core.eventhub.StatusDeletedEvent
+import app.pachli.core.eventhub.UnfollowEvent
+import app.pachli.core.model.Status
 import app.pachli.core.model.translation.TranslatedStatus
 import app.pachli.core.network.model.DeletedStatus
 import app.pachli.core.network.model.Relationship
-import app.pachli.core.network.model.Status
 import app.pachli.core.network.retrofit.MastodonApi
+import app.pachli.core.network.retrofit.apiresult.ApiError
+import app.pachli.core.network.retrofit.apiresult.ApiResponse
 import app.pachli.core.network.retrofit.apiresult.ApiResult
 import app.pachli.translation.TranslationService
 import app.pachli.translation.TranslatorError
@@ -56,26 +60,117 @@ class TimelineCases @Inject constructor(
     private val translatedStatusDao: TranslatedStatusDao,
     private val translationService: TranslationService,
     private val remoteKeyDao: RemoteKeyDao,
+    private val accountManager: AccountManager,
     @ApplicationScope private val externalScope: CoroutineScope,
 ) {
-    suspend fun muteConversation(pachliAccountId: Long, statusId: String, mute: Boolean): ApiResult<Status> {
-        return if (mute) {
-            mastodonApi.muteConversation(statusId)
-        } else {
-            mastodonApi.unmuteConversation(statusId)
-        }.onSuccess {
-            eventHub.dispatch(MuteConversationEvent(pachliAccountId, statusId, mute))
-        }
+    suspend fun muteConversation(pachliAccountId: Long, statusId: String, mute: Boolean): Result<Status, StatusActionError.Mute> {
+        return statusRepository.mute(pachliAccountId, statusId, mute)
     }
 
-    suspend fun mute(pachliAccountId: Long, statusId: String, notifications: Boolean, duration: Int?) {
-        mastodonApi.muteAccount(statusId, notifications, duration)
-            .onSuccess { eventHub.dispatch(MuteEvent(pachliAccountId, statusId)) }
+    /**
+     * Sends a follow request for [accountId] to the server for [pachliAccountId].
+     *
+     * On success:
+     *
+     * - The following relationship is added to [AccountManager].
+     *
+     * @param pachliAccountId
+     * @param accountId ID of account to follow.
+     * @param showReblogs If true, show reblogs from this account. Null uses server default.
+     * @param notify If true, receive notifications when this account posts. Null uses server default.
+     */
+    suspend fun followAccount(pachliAccountId: Long, accountId: String, showReblogs: Boolean? = null, notify: Boolean? = null): ApiResult<Relationship> {
+        return mastodonApi.followAccount(accountId, showReblogs, notify)
+            .onSuccess { accountManager.followAccount(pachliAccountId, accountId) }
     }
 
-    suspend fun block(pachliAccountId: Long, accountId: String) {
-        mastodonApi.blockAccount(accountId)
+    /**
+     * Unfollow [accountId].
+     *
+     * On success:
+     *
+     * - The following relationship is removed from [AccountManager].
+     * - [UnfollowEvent] is dispatched.
+     *
+     * @param pachliAccountId
+     * @param accountID ID of the account to unfollow.
+     */
+    suspend fun unfollowAccount(pachliAccountId: Long, accountId: String): ApiResult<Relationship> {
+        return mastodonApi.unfollowAccount(accountId)
+            .onSuccess {
+                accountManager.unfollowAccount(pachliAccountId, accountId)
+                eventHub.dispatch(UnfollowEvent(pachliAccountId, accountId))
+            }
+    }
+
+    /**
+     * Subscribe to [accountId].
+     *
+     * @param pachliAccountId
+     * @param accountId ID of the account to subscribe to.
+     */
+    suspend fun subscribeAccount(pachliAccountId: Long, accountId: String): ApiResult<Relationship> {
+        return mastodonApi.subscribeAccount(accountId)
+    }
+
+    /**
+     * Unsubscribe from [accountId].
+     *
+     * @param pachliAccountId
+     * @param accountId ID of the account to unsubscribe from.
+     */
+    suspend fun unsubscribeAccount(pachliAccountId: Long, accountId: String): ApiResult<Relationship> {
+        return mastodonApi.unsubscribeAccount(accountId)
+    }
+
+    /**
+     * Mute [accountId].
+     *
+     * On success:
+     *
+     * - [MuteEvent] is dispatched.
+     *
+     * @param pachliAccountId
+     * @param accountId ID of the account to mute.
+     */
+    suspend fun muteAccount(pachliAccountId: Long, accountId: String, notifications: Boolean? = null, duration: Int? = null): Result<ApiResponse<Relationship>, ApiError> {
+        return mastodonApi.muteAccount(accountId, notifications, duration)
+            .onSuccess { eventHub.dispatch(MuteEvent(pachliAccountId, accountId)) }
+    }
+
+    /**
+     * Unmute [accountId].
+     *
+     * @param pachliAccountId
+     * @param accountId ID of the account to unmute.
+     */
+    suspend fun unmuteAccount(pachliAccountId: Long, accountId: String): ApiResult<Relationship> {
+        return mastodonApi.unmuteAccount(accountId)
+    }
+
+    /**
+     * Block [accountId].
+     *
+     * On success:
+     *
+     * - [BlockEvent] is dispatched.
+     *
+     * @param pachliAccountId
+     * @param accountId ID of the account to block.
+     */
+    suspend fun blockAccount(pachliAccountId: Long, accountId: String): Result<ApiResponse<Relationship>, ApiError> {
+        return mastodonApi.blockAccount(accountId)
             .onSuccess { eventHub.dispatch(BlockEvent(pachliAccountId, accountId)) }
+    }
+
+    /**
+     * Unblock [accountId].
+     *
+     * @param pachliAccountId
+     * @param accountId ID of the account to unblock.
+     */
+    suspend fun unblockAccount(pachliAccountId: Long, accountId: String): ApiResult<Relationship> {
+        return mastodonApi.unblockAccount(accountId)
     }
 
     suspend fun delete(statusId: String): ApiResult<DeletedStatus> {

--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/AccountManager.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/AccountManager.kt
@@ -483,7 +483,7 @@ class AccountManager @Inject constructor(
 
             transactionProvider {
                 followingAccountDao.deleteAllForAccount(account.id)
-                followingAccountDao.insert(following)
+                followingAccountDao.upsert(following)
             }
 
             return@async Ok(following)
@@ -803,7 +803,7 @@ class AccountManager @Inject constructor(
 
     // -- Following
     suspend fun followAccount(pachliAccountId: Long, serverId: String) {
-        followingAccountDao.insert(FollowingAccountEntity(pachliAccountId, serverId))
+        followingAccountDao.upsert(FollowingAccountEntity(pachliAccountId, serverId))
     }
 
     suspend fun unfollowAccount(pachliAccountId: Long, serverId: String) {

--- a/core/database/src/main/kotlin/app/pachli/core/database/dao/FollowingAccountDao.kt
+++ b/core/database/src/main/kotlin/app/pachli/core/database/dao/FollowingAccountDao.kt
@@ -19,9 +19,9 @@ package app.pachli.core.database.dao
 
 import androidx.room.Dao
 import androidx.room.Delete
-import androidx.room.Insert
 import androidx.room.Query
 import androidx.room.TypeConverters
+import androidx.room.Upsert
 import app.pachli.core.database.Converters
 import app.pachli.core.database.model.FollowingAccountEntity
 
@@ -37,11 +37,11 @@ WHERE pachliAccountId = :accountId
     )
     suspend fun deleteAllForAccount(accountId: Long)
 
-    @Insert
-    suspend fun insert(accounts: List<FollowingAccountEntity>)
+    @Upsert
+    suspend fun upsert(accounts: List<FollowingAccountEntity>)
 
-    @Insert
-    suspend fun insert(account: FollowingAccountEntity)
+    @Upsert
+    suspend fun upsert(account: FollowingAccountEntity)
 
     @Delete
     suspend fun delete(account: FollowingAccountEntity)

--- a/core/database/src/test/kotlin/app/pachli/core/database/dao/AccountEntityForeignKeyTest.kt
+++ b/core/database/src/test/kotlin/app/pachli/core/database/dao/AccountEntityForeignKeyTest.kt
@@ -285,7 +285,7 @@ class AccountEntityForeignKeyTest {
             pachliAccountId = pachliAccountId,
             serverId = "2",
         )
-        followingAccountDao.insert(followingAccount)
+        followingAccountDao.upsert(followingAccount)
 
         // Check everything is as expected.
         assertThat(followingAccountDao.loadAllForAccount(pachliAccountId)).containsExactly(followingAccount)


### PR DESCRIPTION
Previous code performed account actions (following, unfollowing, blocking, etc) in a number of different places. Some places called the relevant methods in `AccountManager` and sent the appropriate events, other places didn't.

Make this consistent (and probably fix some bugs) by pushing the responsibility into `TimelineCases`, and calling those functions from code closer to the UI.