### PR TITLE
fix: Prevent NPE where *TimelineViewModel.repository might be null

### DIFF
--- a/app/src/main/java/app/pachli/components/timeline/TimelineFragment.kt
+++ b/app/src/main/java/app/pachli/components/timeline/TimelineFragment.kt
@@ -126,7 +126,7 @@ class TimelineFragment :
     //
     // If the navigation library was being used this would happen automatically, so this
     // workaround can be removed when that change happens.
-    private val viewModel: TimelineViewModel<out Any> by lazy {
+    private val viewModel: TimelineViewModel<out Any, out TimelineRepository<out Any>> by lazy {
         if (timeline == Timeline.Home) {
             viewModels<CachedTimelineViewModel>(
                 extrasProducer = {

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/CachedTimelineViewModel.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/CachedTimelineViewModel.kt
@@ -51,14 +51,14 @@ import kotlinx.coroutines.launch
 @HiltViewModel
 class CachedTimelineViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    private val repository: CachedTimelineRepository,
+    repository: CachedTimelineRepository,
     timelineCases: TimelineCases,
     eventHub: EventHub,
     accountManager: AccountManager,
     statusDisplayOptionsRepository: StatusDisplayOptionsRepository,
     sharedPreferencesRepository: SharedPreferencesRepository,
     statusRepository: StatusRepository,
-) : TimelineViewModel<TimelineStatusWithAccount>(
+) : TimelineViewModel<TimelineStatusWithAccount, CachedTimelineRepository>(
     savedStateHandle,
     timelineCases,
     eventHub,

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelineViewModel.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelineViewModel.kt
@@ -60,14 +60,14 @@ import kotlinx.coroutines.launch
 @HiltViewModel
 class NetworkTimelineViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    private val repository: NetworkTimelineRepository,
+    repository: NetworkTimelineRepository,
     timelineCases: TimelineCases,
     eventHub: EventHub,
     accountManager: AccountManager,
     statusDisplayOptionsRepository: StatusDisplayOptionsRepository,
     sharedPreferencesRepository: SharedPreferencesRepository,
     statusRepository: StatusRepository,
-) : TimelineViewModel<Status>(
+) : TimelineViewModel<Status, NetworkTimelineRepository>(
     savedStateHandle,
     timelineCases,
     eventHub,

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/TimelineViewModel.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/TimelineViewModel.kt
@@ -303,12 +303,12 @@ sealed interface UiError {
     }
 }
 
-abstract class TimelineViewModel<T : Any>(
+abstract class TimelineViewModel<T : Any, R : TimelineRepository<T>>(
     savedStateHandle: SavedStateHandle,
     protected val timelineCases: TimelineCases,
     private val eventHub: EventHub,
     protected val accountManager: AccountManager,
-    private val repository: TimelineRepository<T>,
+    protected val repository: R,
     statusDisplayOptionsRepository: StatusDisplayOptionsRepository,
     private val sharedPreferencesRepository: SharedPreferencesRepository,
     protected val statusRepository: StatusRepository,


### PR DESCRIPTION
Previous code could crash in e.g,. `NetworkTimelineViewModel` at a call site like this:

```kotlin
override fun handleFavEvent(favEvent: FavoriteEvent) {
    viewModelScope.launch {
        repository.updateActionableStatusById(favEvent.statusId) {
            it.copy(favourited = favEvent.favourite)
        }
    }
}
```

where `repository` was null.

This happened because `repository` was a property of `NetworkTimelineViewModel` but `handleFavEvent` (or other functions) could be called by a flow collector running in `TimelineViewModel.init`.

So `NetworkTimelineViewModel.handleFavEvent` might be called before `NetworkTimelineViewModel` was fully constructed, and `repository` was null at that point.

Fix this by exposing `TimelineViewModel.repository` to subclasses. To make this work the subclass has to pass the concrete type of the repository as a type parameter to `TimelineViewModel`