### PR TITLE
fix: Reduce network calls when filtering notifications

### DIFF
--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/notifications/NotificationsRepository.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/notifications/NotificationsRepository.kt
@@ -45,6 +45,7 @@ import app.pachli.core.model.Timeline
 import app.pachli.core.network.model.Status
 import app.pachli.core.network.model.TimelineAccount
 import app.pachli.core.network.model.asModel
+import app.pachli.core.network.model.asNetworkModel
 import app.pachli.core.network.retrofit.MastodonApi
 import com.github.michaelbull.result.onSuccess
 import javax.inject.Inject
@@ -73,10 +74,11 @@ class NotificationsRepository @Inject constructor(
     private val remoteKeyTimelineId = Timeline.Notifications.remoteKeyTimelineId
 
     /**
+     * @param excludeTypes Types to filter from the results.
      * @return Notifications for [pachliAccountId].
      */
     @OptIn(ExperimentalPagingApi::class)
-    suspend fun notifications(pachliAccountId: Long): Flow<PagingData<NotificationData>> {
+    suspend fun notifications(pachliAccountId: Long, excludeTypes: Set<Notification.Type>): Flow<PagingData<NotificationData>> {
         factory = InvalidatingPagingSourceFactory { notificationDao.pagingSource(pachliAccountId) }
 
         // Room is row-keyed, not item-keyed. Find the user's REFRESH key, then find the
@@ -98,6 +100,7 @@ class NotificationsRepository @Inject constructor(
                 remoteKeyDao,
                 notificationDao,
                 statusDao,
+                excludeTypes.asNetworkModel(),
             ),
             pagingSourceFactory = factory!!,
         ).flow

--- a/core/network/src/main/kotlin/app/pachli/core/network/model/AccountWarning.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/AccountWarning.kt
@@ -81,11 +81,4 @@ data class AccountWarning(
             UNKNOWN -> app.pachli.core.model.AccountWarning.Action.UNKNOWN
         }
     }
-
-    fun asModel() = app.pachli.core.model.AccountWarning(
-        id = id,
-        action = action.asModel(),
-        text = text,
-        createdAt = createdAt,
-    )
 }

--- a/core/network/src/main/kotlin/app/pachli/core/network/model/AccountWarning.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/AccountWarning.kt
@@ -68,17 +68,5 @@ data class AccountWarning(
         /** Unknown action. */
         @Default
         UNKNOWN,
-
-        ;
-
-        fun asModel() = when (this) {
-            NONE -> app.pachli.core.model.AccountWarning.Action.NONE
-            DISABLE -> app.pachli.core.model.AccountWarning.Action.DISABLE
-            MARK_STATUSES_AS_SENSITIVE -> app.pachli.core.model.AccountWarning.Action.MARK_STATUSES_AS_SENSITIVE
-            DELETE_STATUSES -> app.pachli.core.model.AccountWarning.Action.DELETE_STATUSES
-            SILENCE -> app.pachli.core.model.AccountWarning.Action.SILENCE
-            SUSPEND -> app.pachli.core.model.AccountWarning.Action.SUSPEND
-            UNKNOWN -> app.pachli.core.model.AccountWarning.Action.UNKNOWN
-        }
     }
 }

--- a/core/network/src/main/kotlin/app/pachli/core/network/model/Notification.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/Notification.kt
@@ -144,3 +144,21 @@ data class Notification(
         relationshipSeveranceEvent = relationshipSeveranceEvent?.asModel(),
     )
 }
+
+fun app.pachli.core.model.Notification.Type.asNetworkModel() = when (this) {
+    app.pachli.core.model.Notification.Type.UNKNOWN -> Notification.Type.UNKNOWN
+    app.pachli.core.model.Notification.Type.MENTION -> Notification.Type.MENTION
+    app.pachli.core.model.Notification.Type.REBLOG -> Notification.Type.REBLOG
+    app.pachli.core.model.Notification.Type.FAVOURITE -> Notification.Type.FAVOURITE
+    app.pachli.core.model.Notification.Type.FOLLOW -> Notification.Type.FOLLOW
+    app.pachli.core.model.Notification.Type.FOLLOW_REQUEST -> Notification.Type.FOLLOW_REQUEST
+    app.pachli.core.model.Notification.Type.POLL -> Notification.Type.POLL
+    app.pachli.core.model.Notification.Type.STATUS -> Notification.Type.STATUS
+    app.pachli.core.model.Notification.Type.SIGN_UP -> Notification.Type.SIGN_UP
+    app.pachli.core.model.Notification.Type.UPDATE -> Notification.Type.UPDATE
+    app.pachli.core.model.Notification.Type.REPORT -> Notification.Type.REPORT
+    app.pachli.core.model.Notification.Type.SEVERED_RELATIONSHIPS -> Notification.Type.SEVERED_RELATIONSHIPS
+    app.pachli.core.model.Notification.Type.MODERATION_WARNING -> Notification.Type.MODERATION_WARNING
+}
+
+fun Iterable<app.pachli.core.model.Notification.Type>.asNetworkModel() = map { it.asNetworkModel() }

--- a/core/network/src/main/kotlin/app/pachli/core/network/retrofit/MastodonApi.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/retrofit/MastodonApi.kt
@@ -166,7 +166,7 @@ interface MastodonApi {
         /** Maximum number of results to return. Defaults to 15, max is 30 */
         @Query("limit") limit: Int? = null,
         /** Types to excludes from the results */
-        @Query("exclude_types[]") excludes: Set<Notification.Type>? = null,
+        @Query("exclude_types[]") excludes: Iterable<Notification.Type>? = null,
         /** Include notifications filtered by the user's notifications filter policy. */
         @Query("include_filtered") includeFiltered: Boolean = true,
     ): ApiResult<List<Notification>>


### PR DESCRIPTION
Previously, all notifications were fetched from the server and filtering
was performed client side.

If the user selected a type of notification that was not present in a
page then then the next page would be fetched. If it was not present in
that page the next page would be fetched, and so on, until enough
notifications of that type had been fetched from the server.

If the notification type was rare (e.g., a moderation action) this could
end up paging through all the user's notifications with very few results,
burning through API quota and causing the notification fetch to take a
very long time.

The UI was also very jumpy while this happened.

Fix this, pass the set of notification types to filter down to
`NotificationsRemoteMediator` and pass that as an API parameter. The
results are returned much faster, and without UI jumping.