### PR TITLE
fix: Show the account's username (includes domain) when replying

### DIFF
--- a/core/navigation/src/main/kotlin/app/pachli/core/navigation/Navigation.kt
+++ b/core/navigation/src/main/kotlin/app/pachli/core/navigation/Navigation.kt
@@ -445,7 +445,7 @@ class ComposeActivityIntent(context: Context, pachliAccountId: Long, composeOpti
                         avatarUrl = status.account.avatar,
                         isBot = status.account.bot,
                         displayName = status.account.name,
-                        username = status.account.localUsername,
+                        username = status.account.username,
                         emojis = status.emojis + status.account.emojis.orEmpty(),
                         contentWarning = status.spoilerText,
                         content = status.content.parseAsMastodonHtml().toString(),


### PR DESCRIPTION
Previous code displayed the account's local part in the UI when replying.

Change to use `username` -- for local accounts this is still just the local part, for remote accounts it will include the domain. This is consistent with how handles are displayed in timelines.