### PR TITLE
fix: Show large/zoomed images with padding to avoid insets

### DIFF
--- a/app/src/main/java/app/pachli/fragment/ViewImageFragment.kt
+++ b/app/src/main/java/app/pachli/fragment/ViewImageFragment.kt
@@ -36,6 +36,8 @@ import app.pachli.R
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.viewBinding
 import app.pachli.core.common.extensions.visible
+import app.pachli.core.ui.extensions.InsetType
+import app.pachli.core.ui.extensions.applyWindowInsets
 import app.pachli.databinding.FragmentViewImageBinding
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.DataSource
@@ -86,6 +88,12 @@ class ViewImageFragment : ViewMediaFragment() {
     @SuppressLint("ClickableViewAccessibility")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        binding.photoView.applyWindowInsets(
+            InsetType.PADDING,
+            InsetType.PADDING,
+            InsetType.PADDING,
+            InsetType.PADDING,
+        )
 
         val singleTapDetector = GestureDetector(
             requireContext(),


### PR DESCRIPTION
Previously you could zoom in on an image and it would appear edge-to-edge in immersive mode and you can scroll around. But the edge of the image might still appear under the camera cutouts in the display.

Add padding; the image can still be scrolled under the camera cutout, but the edge of the image can be moved away from it completely.