### PR TITLE
fix: Don't crash on older devices loading role chip resources

### DIFF
--- a/core/ui/src/main/kotlin/app/pachli/core/ui/ProfileChip.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/ProfileChip.kt
@@ -20,6 +20,7 @@ package app.pachli.core.ui
 import android.content.Context
 import android.util.AttributeSet
 import android.util.TypedValue
+import androidx.core.content.res.use
 import androidx.core.view.updatePadding
 import app.pachli.core.designsystem.R as DR
 import com.google.android.material.R


### PR DESCRIPTION
try-with-resources and `use` doesn't work on a `TypedArray`, the desugaring works on `AutoClose`, not the `AutoClosable` that Kotlin uses.

This crashes with:

```
java.lang.ClassCastException: android.content.res.TypedArray cannot be cast to java.lang.AutoCloseable
```

The fix is to import `androidx.core.content.res.use`, which overrides `use` from the Kotlin stdlib and does the right thing.