### PR TITLE
fix: Use properly scoped Glide in more places

### DIFF
--- a/app/src/main/java/app/pachli/adapter/ReportNotificationViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/ReportNotificationViewHolder.kt
@@ -74,7 +74,7 @@ class ReportNotificationViewHolder(
         animateAvatar: Boolean,
         animateEmojis: Boolean,
     ) {
-        binding.notificationTopText.updateEmojiTargets {
+        binding.notificationTopText.updateEmojiTargets(glide) {
             val reporterName = reporter.name.unicodeWrap().emojify(glide, reporter.emojis, animateEmojis)
             val reporteeName = report.targetAccount.displayName.unicodeWrap().emojify(glide, report.targetAccount.emojis, animateEmojis)
 

--- a/app/src/main/java/app/pachli/components/announcements/AnnouncementAdapter.kt
+++ b/app/src/main/java/app/pachli/components/announcements/AnnouncementAdapter.kt
@@ -110,7 +110,7 @@ class AnnouncementAdapter(
         // hide button if announcement badge limit is already reached
         addReactionChip.visible(item.reactions.size < 8)
 
-        chips.clearEmojiTargets()
+        chips.clearEmojiTargets(glide)
         val targets = ArrayList<Target<Drawable>>(item.reactions.size)
 
         item.reactions.forEachIndexed { i, reaction ->
@@ -174,7 +174,7 @@ class AnnouncementAdapter(
     }
 
     override fun onViewRecycled(holder: BindingHolder<ItemAnnouncementBinding>) {
-        holder.binding.chipGroup.clearEmojiTargets()
+        holder.binding.chipGroup.clearEmojiTargets(glide)
     }
 
     override fun getItemCount() = items.size

--- a/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -53,6 +53,7 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
                 add("testImplementation", project(":core:testing"))
                 add("androidTestImplementation", kotlin("test"))
                 add("androidTestImplementation", project(":core:testing"))
+                add("lintChecks", project(":checks"))
             }
         }
     }

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/CustomEmojiHelper.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/CustomEmojiHelper.kt
@@ -28,7 +28,6 @@ import android.widget.TextView
 import androidx.core.graphics.withSave
 import androidx.core.text.toSpannable
 import app.pachli.core.model.Emoji
-import com.bumptech.glide.Glide
 import com.bumptech.glide.RequestManager
 import com.bumptech.glide.request.target.CustomTarget
 import com.bumptech.glide.request.target.Target
@@ -42,7 +41,7 @@ import com.bumptech.glide.request.transition.Transition
  * @return the text with the shortcodes replaced by EmojiSpans
  */
 fun CharSequence.emojify(glide: RequestManager, emojis: List<Emoji>?, view: View, animate: Boolean): CharSequence {
-    return view.updateEmojiTargets {
+    return view.updateEmojiTargets(glide) {
         emojify(glide, emojis, animate)
     }
 }
@@ -78,8 +77,8 @@ class EmojiTargetScope<T : View>(val view: T) {
     }
 }
 
-inline fun <T : View, R> T.updateEmojiTargets(body: EmojiTargetScope<T>.() -> R): R {
-    clearEmojiTargets()
+inline fun <T : View, R> T.updateEmojiTargets(glide: RequestManager, body: EmojiTargetScope<T>.() -> R): R {
+    clearEmojiTargets(glide)
     val scope = EmojiTargetScope(this)
     val result = body(scope)
     setEmojiTargets(scope.targets)
@@ -87,11 +86,10 @@ inline fun <T : View, R> T.updateEmojiTargets(body: EmojiTargetScope<T>.() -> R)
 }
 
 @Suppress("UNCHECKED_CAST")
-fun View.clearEmojiTargets() {
+fun View.clearEmojiTargets(glide: RequestManager) {
     getTag(R.id.custom_emoji_targets_tag)?.let { tag ->
         val targets = tag as List<Target<Drawable>>
-        val requestManager = Glide.with(this)
-        targets.forEach { requestManager.clear(it) }
+        targets.forEach { glide.clear(it) }
         setTag(R.id.custom_emoji_targets_tag, null)
     }
 }

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/emoji/EmojiPickerView.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/emoji/EmojiPickerView.kt
@@ -17,6 +17,7 @@
 
 package app.pachli.core.ui.emoji
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
@@ -47,6 +48,8 @@ class EmojiPickerView @JvmOverloads constructor(
     /** Text string to use as the label for when [Emoji.category] is null. */
     private val labelNoCategory = context.getString(R.string.label_emoji_no_category)
 
+    // Using Glide.with like this in a View subclass is OK.
+    @SuppressLint("GlideWithViewDetector")
     private val adapter = EmojiAdapter(Glide.with(this), labelNoCategory)
 
     var emojis: List<Emoji> = emptyList()


### PR DESCRIPTION
Custom lint checks weren't being applied to modules other than :app, so the detector to check for appropriate use of `Glide.with()` wasn't running over the other modules.

Fix that, and update a couple of call sites where a properly scoped `RequestManager` could be passed down.