### PR TITLE
build: Add a lint check for TypedArray.use

### DIFF
--- a/checks/src/main/java/app/pachli/lint/checks/LintRegistry.kt
+++ b/checks/src/main/java/app/pachli/lint/checks/LintRegistry.kt
@@ -13,6 +13,7 @@ class LintRegistry : IssueRegistry() {
             DateDotTimeDetector.ISSUE,
             GlideWithViewDetector.ISSUE,
             IntentDetector.ISSUE,
+            TypedArrayUseDetector.ISSUE,
         )
 
     override val api: Int

--- a/checks/src/main/java/app/pachli/lint/checks/TypedArrayUseDetector.kt
+++ b/checks/src/main/java/app/pachli/lint/checks/TypedArrayUseDetector.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.lint.checks
+
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.LintFix
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.intellij.psi.PsiMethod
+import org.jetbrains.uast.UCallExpression
+
+class TypedArrayUseDetector : Detector(), SourceCodeScanner {
+    override fun getApplicableMethodNames() = listOf(METHOD_USE)
+
+    private val fix = LintFix.create()
+        .name("Replace with `androidx.core.content.res.use`")
+        .replace()
+        .text("use")
+        .with("use")
+        .imports("androidx.core.content.res.use")
+        .independent(true)
+        .build()
+
+    override fun visitMethodCall(context: JavaContext, node: UCallExpression, method: PsiMethod) {
+        if (node.receiverType?.canonicalText != CLASS_TYPED_ARRAY) return
+        if (method.name != METHOD_USE) return
+        if (node.resolve()?.containingClass?.qualifiedName == CLASS_USE) return
+
+        context.report(
+            issue = ISSUE,
+            scope = node,
+            location = context.getCallLocation(node, includeReceiver = false, includeArguments = false),
+            message = "Import `androidx.core.content.res.use`",
+            quickfixData = fix,
+        )
+    }
+
+    companion object {
+        private const val CLASS_TYPED_ARRAY = "android.content.res.TypedArray"
+        private const val METHOD_USE = "use"
+        private const val CLASS_USE = "androidx.core.content.res.TypedArrayKt"
+
+        val ISSUE = Issue.create(
+            id = "TypedArrayUseDetector",
+            briefDescription = "Don't use `kotlin.use`, use `androidx.core.content.res.use`",
+            explanation = """
+                TypedArray implements AutoCloseable but doesn't have a desugared `close` on older devices,
+                and will cause a class cast exception at runtime on older devices.
+                See https://issuetracker.google.com/issues/262851206
+            """,
+            category = Category.CORRECTNESS,
+            priority = 6,
+            severity = Severity.FATAL,
+            implementation = Implementation(
+                TypedArrayUseDetector::class.java,
+                Scope.JAVA_FILE_SCOPE,
+            ),
+        )
+    }
+}

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/ProfileChip.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/ProfileChip.kt
@@ -50,8 +50,8 @@ open class ProfileChip @JvmOverloads constructor(
 ) : Chip(context, attrs, defStyleAttr) {
     init {
         isChipIconVisible = true
-        setChipStrokeWidthResource(app.pachli.core.designsystem.R.dimen.profile_badge_stroke_width)
-        setChipIconSizeResource(app.pachli.core.designsystem.R.dimen.profile_badge_icon_size)
+        setChipStrokeWidthResource(DR.dimen.profile_badge_stroke_width)
+        setChipIconSizeResource(DR.dimen.profile_badge_icon_size)
 
         val textSize = context.obtainStyledAttributes(null, intArrayOf(DR.attr.status_text_small)).use {
             it.getDimension(0, -1f)
@@ -64,10 +64,10 @@ open class ProfileChip @JvmOverloads constructor(
         setEnsureMinTouchTargetSize(false)
 
         // Reset some defaults
-        setIconStartPaddingResource(app.pachli.core.designsystem.R.dimen.profile_badge_icon_start_padding)
-        setIconEndPaddingResource(app.pachli.core.designsystem.R.dimen.profile_badge_icon_end_padding)
-        setChipMinHeightResource(app.pachli.core.designsystem.R.dimen.profile_badge_min_height)
-        minHeight = resources.getDimensionPixelSize(app.pachli.core.designsystem.R.dimen.profile_badge_min_height)
+        setIconStartPaddingResource(DR.dimen.profile_badge_icon_start_padding)
+        setIconEndPaddingResource(DR.dimen.profile_badge_icon_end_padding)
+        setChipMinHeightResource(DR.dimen.profile_badge_min_height)
+        minHeight = resources.getDimensionPixelSize(DR.dimen.profile_badge_min_height)
         updatePadding(top = 0, bottom = 0)
     }
 }


### PR DESCRIPTION
`TypedArray` implements `AutoCloseable`, but doesn't have a desugared `close` implementation on older devices. This causes a runtime exception on older Android devices.

Typically this is triggered by using the `kotlin.use` extension method on something that returns a `TypedArray`.

The fix is to call `androidx.core.content.res.use` instead, which can normally be done simply by adding the import for it.

Add a lint check to detect this and suggest the change.

While I'm here, simplify the resource references in ProfileChip.kt.