### PR TITLE
build: Add -Xannotation-default-target=param-property compiler flag

### DIFF
--- a/build-logic/convention/src/main/kotlin/app/pachli/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/app/pachli/KotlinAndroid.kt
@@ -90,14 +90,17 @@ private fun Project.configureKotlin() {
             // Override by setting warningsAsErrors=true in your ~/.gradle/gradle.properties
             val warningsAsErrors: String? by project
             allWarningsAsErrors = warningsAsErrors.toBoolean()
-            freeCompilerArgs.addAll(
-                "-opt-in=kotlin.RequiresOptIn",
+            optIn.addAll(
+                "kotlin.RequiresOptIn",
                 // Enable experimental coroutines APIs, including Flow
-                "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
-                "-opt-in=kotlinx.coroutines.FlowPreview",
+                "kotlinx.coroutines.ExperimentalCoroutinesApi",
+                "kotlinx.coroutines.FlowPreview",
+            )
+            freeCompilerArgs.addAll(
                 // https://kotlinlang.org/docs/whatsnew1520.html#support-for-jspecify-nullness-annotations
                 "-Xtype-enhancement-improvements-strict-mode",
                 "-Xjspecify-annotations=strict",
+                "-Xannotation-default-target=param-property",
             )
         }
     }

--- a/tools/build.gradle.kts
+++ b/tools/build.gradle.kts
@@ -27,7 +27,8 @@ subprojects {
 
     tasks.named<KotlinCompilationTask<*>>("compileKotlin").configure {
         compilerOptions {
-            freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn")
+            optIn.addAll("kotlin.RequiresOptIn")
+            freeCompilerArgs.addAll("-Xannotation-default-target=param-property")
         }
     }
 


### PR DESCRIPTION
Applies annotations to params, properties, and backing fields.

See https://youtrack.jetbrains.com/issue/KT-73255.