### PR TITLE
refactor: Implement StatusRepository in other repositories

### DIFF
--- a/app/src/main/java/app/pachli/components/conversation/ConversationsRepository.kt
+++ b/app/src/main/java/app/pachli/components/conversation/ConversationsRepository.kt
@@ -23,6 +23,8 @@ import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import app.pachli.core.common.di.ApplicationScope
+import app.pachli.core.data.repository.OfflineFirstStatusRepository
+import app.pachli.core.data.repository.StatusRepository
 import app.pachli.core.database.dao.ConversationsDao
 import app.pachli.core.database.dao.StatusDao
 import app.pachli.core.database.dao.TimelineDao
@@ -45,7 +47,8 @@ class ConversationsRepository @Inject constructor(
     private val conversationsDao: ConversationsDao,
     private val statusDao: StatusDao,
     private val timelineDao: TimelineDao,
-) {
+    statusRepository: OfflineFirstStatusRepository,
+) : StatusRepository by statusRepository {
     private var factory: InvalidatingPagingSourceFactory<Int, ConversationData>? = null
 
     @OptIn(ExperimentalPagingApi::class)

--- a/app/src/main/java/app/pachli/components/conversation/ConversationsViewModel.kt
+++ b/app/src/main/java/app/pachli/components/conversation/ConversationsViewModel.kt
@@ -23,7 +23,6 @@ import androidx.paging.filter
 import androidx.paging.map
 import app.pachli.core.data.repository.AccountManager
 import app.pachli.core.data.repository.PachliAccount
-import app.pachli.core.data.repository.StatusRepository
 import app.pachli.core.database.dao.ConversationsDao
 import app.pachli.core.database.model.ConversationData
 import app.pachli.core.model.AccountFilterDecision
@@ -54,10 +53,9 @@ import kotlinx.coroutines.launch
 class ConversationsViewModel @AssistedInject constructor(
     private val repository: ConversationsRepository,
     private val conversationsDao: ConversationsDao,
-    private val accountManager: AccountManager,
+    accountManager: AccountManager,
     private val api: MastodonApi,
     sharedPreferencesRepository: SharedPreferencesRepository,
-    private val statusRepository: StatusRepository,
     @Assisted val pachliAccountId: Long,
 ) : ViewModel() {
     private val accountFlow = accountManager.getPachliAccountFlow(pachliAccountId)
@@ -196,7 +194,7 @@ class ConversationsViewModel @AssistedInject constructor(
      */
     fun favourite(favourite: Boolean, lastStatusId: String) {
         viewModelScope.launch {
-            statusRepository.favourite(pachliAccountId, lastStatusId, favourite)
+            repository.favourite(pachliAccountId, lastStatusId, favourite)
         }
     }
 
@@ -205,7 +203,7 @@ class ConversationsViewModel @AssistedInject constructor(
      */
     fun bookmark(bookmark: Boolean, lastStatusId: String) {
         viewModelScope.launch {
-            statusRepository.bookmark(pachliAccountId, lastStatusId, bookmark)
+            repository.bookmark(pachliAccountId, lastStatusId, bookmark)
         }
     }
 
@@ -214,7 +212,7 @@ class ConversationsViewModel @AssistedInject constructor(
      */
     fun muteConversation(muted: Boolean, lastStatusId: String) {
         viewModelScope.launch {
-            statusRepository.mute(pachliAccountId, lastStatusId, muted)
+            repository.mute(pachliAccountId, lastStatusId, muted)
         }
     }
 
@@ -223,25 +221,25 @@ class ConversationsViewModel @AssistedInject constructor(
      */
     fun voteInPoll(choices: List<Int>, lastStatusId: String, pollId: String) {
         viewModelScope.launch {
-            statusRepository.voteInPoll(pachliAccountId, lastStatusId, pollId, choices)
+            repository.voteInPoll(pachliAccountId, lastStatusId, pollId, choices)
         }
     }
 
     fun expandHiddenStatus(pachliAccountId: Long, expanded: Boolean, lastStatusId: String) {
         viewModelScope.launch {
-            statusRepository.setExpanded(pachliAccountId, lastStatusId, expanded)
+            repository.setExpanded(pachliAccountId, lastStatusId, expanded)
         }
     }
 
     fun collapseLongStatus(pachliAccountId: Long, collapsed: Boolean, lastStatusId: String) {
         viewModelScope.launch {
-            statusRepository.setContentCollapsed(pachliAccountId, lastStatusId, collapsed)
+            repository.setContentCollapsed(pachliAccountId, lastStatusId, collapsed)
         }
     }
 
     fun showContent(pachliAccountId: Long, showingHiddenContent: Boolean, lastStatusId: String) {
         viewModelScope.launch {
-            statusRepository.setContentShowing(pachliAccountId, lastStatusId, showingHiddenContent)
+            repository.setContentShowing(pachliAccountId, lastStatusId, showingHiddenContent)
         }
     }
 

--- a/app/src/main/java/app/pachli/components/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/app/pachli/components/notifications/NotificationsViewModel.kt
@@ -30,9 +30,9 @@ import app.pachli.core.common.extensions.throttleFirst
 import app.pachli.core.data.model.ContentFilterModel
 import app.pachli.core.data.model.StatusViewData
 import app.pachli.core.data.repository.AccountManager
+import app.pachli.core.data.repository.OfflineFirstStatusRepository
 import app.pachli.core.data.repository.PachliAccount
 import app.pachli.core.data.repository.StatusDisplayOptionsRepository
-import app.pachli.core.data.repository.StatusRepository
 import app.pachli.core.data.repository.notifications.NotificationsRepository
 import app.pachli.core.database.model.AccountEntity
 import app.pachli.core.eventhub.BlockEvent
@@ -393,7 +393,7 @@ class NotificationsViewModel @AssistedInject constructor(
     private val eventHub: EventHub,
     statusDisplayOptionsRepository: StatusDisplayOptionsRepository,
     private val sharedPreferencesRepository: SharedPreferencesRepository,
-    private val statusRepository: StatusRepository,
+    private val statusRepository: OfflineFirstStatusRepository,
     @Assisted val pachliAccountId: Long,
 ) : ViewModel() {
     private val accountFlow = accountManager.getPachliAccountFlow(pachliAccountId)
@@ -669,18 +669,21 @@ class NotificationsViewModel @AssistedInject constructor(
         .onStart { emit(null) }
 
     private fun onContentCollapsed(action: InfallibleUiAction.SetContentCollapsed) {
-        repository.setContentCollapsed(action.pachliAccountId, action.statusViewData, action.isCollapsed)
-        repository.invalidate()
+        viewModelScope.launch {
+            repository.setContentCollapsed(action.pachliAccountId, action.statusViewData.actionableId, action.isCollapsed)
+        }
     }
 
     private fun onShowingContent(action: InfallibleUiAction.SetShowingContent) {
-        repository.setShowingContent(action.pachliAccountId, action.statusViewData, action.isShowingContent)
-        repository.invalidate()
+        viewModelScope.launch {
+            repository.setContentShowing(action.pachliAccountId, action.statusViewData.actionableId, action.isShowingContent)
+        }
     }
 
     private fun onExpanded(action: InfallibleUiAction.SetExpanded) {
-        repository.setExpanded(action.pachliAccountId, action.statusViewData, action.isExpanded)
-        repository.invalidate()
+        viewModelScope.launch {
+            repository.setExpanded(action.pachliAccountId, action.statusViewData.actionableId, action.isExpanded)
+        }
     }
 
     private fun onClearContentFilter(action: InfallibleUiAction.ClearContentFilter) {

--- a/app/src/main/java/app/pachli/components/search/SearchViewModel.kt
+++ b/app/src/main/java/app/pachli/components/search/SearchViewModel.kt
@@ -36,8 +36,8 @@ import app.pachli.components.search.adapter.SearchPagingSourceFactory
 import app.pachli.core.data.model.StatusViewData
 import app.pachli.core.data.repository.AccountManager
 import app.pachli.core.data.repository.Loadable
+import app.pachli.core.data.repository.OfflineFirstStatusRepository
 import app.pachli.core.data.repository.ServerRepository
-import app.pachli.core.data.repository.StatusRepository
 import app.pachli.core.database.model.AccountEntity
 import app.pachli.core.model.DeletedStatus
 import app.pachli.core.model.Poll
@@ -86,7 +86,7 @@ class SearchViewModel @Inject constructor(
     private val mastodonApi: MastodonApi,
     private val timelineCases: TimelineCases,
     private val accountManager: AccountManager,
-    private val statusRepository: StatusRepository,
+    private val statusRepository: OfflineFirstStatusRepository,
     serverRepository: ServerRepository,
 ) : ViewModel() {
 

--- a/app/src/main/java/app/pachli/components/timeline/CachedTimelineRepository.kt
+++ b/app/src/main/java/app/pachli/components/timeline/CachedTimelineRepository.kt
@@ -25,6 +25,8 @@ import androidx.paging.PagingData
 import app.pachli.components.timeline.TimelineRepository.Companion.PAGE_SIZE
 import app.pachli.components.timeline.viewmodel.CachedTimelineRemoteMediator
 import app.pachli.core.common.di.ApplicationScope
+import app.pachli.core.data.repository.OfflineFirstStatusRepository
+import app.pachli.core.data.repository.StatusRepository
 import app.pachli.core.database.dao.RemoteKeyDao
 import app.pachli.core.database.dao.StatusDao
 import app.pachli.core.database.dao.TimelineDao
@@ -60,7 +62,8 @@ class CachedTimelineRepository @Inject constructor(
     private val translatedStatusDao: TranslatedStatusDao,
     private val statusDao: StatusDao,
     @ApplicationScope private val externalScope: CoroutineScope,
-) : TimelineRepository<TimelineStatusWithAccount> {
+    statusRepository: OfflineFirstStatusRepository,
+) : TimelineRepository<TimelineStatusWithAccount>, StatusRepository by statusRepository {
     private var factory: InvalidatingPagingSourceFactory<Int, TimelineStatusWithAccount>? = null
 
     /** @return flow of Mastodon [TimelineStatusWithAccount. */

--- a/app/src/main/java/app/pachli/components/timeline/NetworkTimelineRepository.kt
+++ b/app/src/main/java/app/pachli/components/timeline/NetworkTimelineRepository.kt
@@ -26,6 +26,8 @@ import app.pachli.components.timeline.TimelineRepository.Companion.PAGE_SIZE
 import app.pachli.components.timeline.viewmodel.NetworkTimelinePagingSource
 import app.pachli.components.timeline.viewmodel.NetworkTimelineRemoteMediator
 import app.pachli.components.timeline.viewmodel.PageCache
+import app.pachli.core.data.repository.OfflineFirstStatusRepository
+import app.pachli.core.data.repository.StatusRepository
 import app.pachli.core.database.dao.RemoteKeyDao
 import app.pachli.core.database.model.RemoteKeyEntity.RemoteKeyKind
 import app.pachli.core.model.Status
@@ -72,7 +74,8 @@ import timber.log.Timber
 class NetworkTimelineRepository @Inject constructor(
     private val mastodonApi: MastodonApi,
     private val remoteKeyDao: RemoteKeyDao,
-) : TimelineRepository<Status> {
+    private val statusRepository: OfflineFirstStatusRepository,
+) : TimelineRepository<Status>, StatusRepository by statusRepository {
     private val pageCache = PageCache()
 
     private var factory: InvalidatingPagingSourceFactory<String, Status>? = null

--- a/app/src/main/java/app/pachli/components/timeline/TimelineRepository.kt
+++ b/app/src/main/java/app/pachli/components/timeline/TimelineRepository.kt
@@ -19,6 +19,7 @@ package app.pachli.components.timeline
 
 import androidx.paging.PagingData
 import androidx.paging.PagingSource
+import app.pachli.core.data.repository.StatusRepository
 import app.pachli.core.model.Timeline
 import kotlinx.coroutines.flow.Flow
 
@@ -26,7 +27,7 @@ import kotlinx.coroutines.flow.Flow
  * Common interface for a repository that provides a [PagingData] timeline of items
  * of type [T].
  */
-interface TimelineRepository<T : Any> {
+interface TimelineRepository<T : Any> : StatusRepository {
     /** @return Flow of [T] for [pachliAccountId] and [kind]. */
     suspend fun getStatusStream(pachliAccountId: Long, kind: Timeline): Flow<PagingData<T>>
 

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/CachedTimelineViewModel.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/CachedTimelineViewModel.kt
@@ -26,7 +26,6 @@ import app.pachli.components.timeline.CachedTimelineRepository
 import app.pachli.core.data.model.StatusViewData
 import app.pachli.core.data.repository.AccountManager
 import app.pachli.core.data.repository.StatusDisplayOptionsRepository
-import app.pachli.core.data.repository.StatusRepository
 import app.pachli.core.database.model.TimelineStatusWithAccount
 import app.pachli.core.eventhub.BookmarkEvent
 import app.pachli.core.eventhub.EventHub
@@ -57,7 +56,6 @@ class CachedTimelineViewModel @Inject constructor(
     accountManager: AccountManager,
     statusDisplayOptionsRepository: StatusDisplayOptionsRepository,
     sharedPreferencesRepository: SharedPreferencesRepository,
-    statusRepository: StatusRepository,
 ) : TimelineViewModel<TimelineStatusWithAccount, CachedTimelineRepository>(
     savedStateHandle,
     timelineCases,
@@ -66,7 +64,6 @@ class CachedTimelineViewModel @Inject constructor(
     repository,
     statusDisplayOptionsRepository,
     sharedPreferencesRepository,
-    statusRepository,
 ) {
     override val statuses = pachliAccountFlow.distinctUntilChangedBy { it.id }.flatMapLatest { pachliAccount ->
         repository.getStatusStream(pachliAccount.id, timeline).map { pagingData ->
@@ -122,44 +119,41 @@ class CachedTimelineViewModel @Inject constructor(
 
     override fun onChangeExpanded(isExpanded: Boolean, statusViewData: StatusViewData) {
         viewModelScope.launch {
-            statusRepository.setExpanded(statusViewData.pachliAccountId, statusViewData.id, isExpanded)
-            repository.invalidate(statusViewData.pachliAccountId)
+            repository.setExpanded(statusViewData.pachliAccountId, statusViewData.id, isExpanded)
         }
     }
 
     override fun onChangeContentShowing(isShowing: Boolean, statusViewData: StatusViewData) {
         viewModelScope.launch {
-            statusRepository.setContentShowing(statusViewData.pachliAccountId, statusViewData.id, isShowing)
-            repository.invalidate(statusViewData.pachliAccountId)
+            repository.setContentShowing(statusViewData.pachliAccountId, statusViewData.id, isShowing)
         }
     }
 
     override fun onContentCollapsed(isCollapsed: Boolean, statusViewData: StatusViewData) {
         viewModelScope.launch {
-            statusRepository.setContentCollapsed(statusViewData.pachliAccountId, statusViewData.id, isCollapsed)
-            repository.invalidate(statusViewData.pachliAccountId)
+            repository.setContentCollapsed(statusViewData.pachliAccountId, statusViewData.id, isCollapsed)
         }
     }
 
-    override suspend fun onBookmark(action: FallibleStatusAction.Bookmark) = statusRepository.bookmark(
+    override suspend fun onBookmark(action: FallibleStatusAction.Bookmark) = repository.bookmark(
         action.statusViewData.pachliAccountId,
         action.statusViewData.actionableId,
         action.state,
     )
 
-    override suspend fun onFavourite(action: FallibleStatusAction.Favourite) = statusRepository.favourite(
+    override suspend fun onFavourite(action: FallibleStatusAction.Favourite) = repository.favourite(
         action.statusViewData.pachliAccountId,
         action.statusViewData.actionableId,
         action.state,
     )
 
-    override suspend fun onReblog(action: FallibleStatusAction.Reblog) = statusRepository.reblog(
+    override suspend fun onReblog(action: FallibleStatusAction.Reblog) = repository.reblog(
         action.statusViewData.pachliAccountId,
         action.statusViewData.actionableId,
         action.state,
     )
 
-    override suspend fun onVoteInPoll(action: FallibleStatusAction.VoteInPoll) = statusRepository.voteInPoll(
+    override suspend fun onVoteInPoll(action: FallibleStatusAction.VoteInPoll) = repository.voteInPoll(
         action.statusViewData.pachliAccountId,
         action.statusViewData.actionableId,
         action.poll.id,

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/TimelineViewModel.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/TimelineViewModel.kt
@@ -311,7 +311,6 @@ abstract class TimelineViewModel<T : Any, R : TimelineRepository<T>>(
     protected val repository: R,
     statusDisplayOptionsRepository: StatusDisplayOptionsRepository,
     private val sharedPreferencesRepository: SharedPreferencesRepository,
-    protected val statusRepository: StatusRepository,
 ) : ViewModel() {
     /**
      * The account to load statuses for. Receiving [InfallibleUiAction.LoadPachliAccount]

--- a/app/src/main/java/app/pachli/components/viewthread/ViewThreadViewModel.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/ViewThreadViewModel.kt
@@ -25,7 +25,6 @@ import app.pachli.core.data.model.StatusViewData
 import app.pachli.core.data.repository.AccountManager
 import app.pachli.core.data.repository.Loadable
 import app.pachli.core.data.repository.StatusDisplayOptionsRepository
-import app.pachli.core.data.repository.StatusRepository
 import app.pachli.core.database.dao.TimelineDao
 import app.pachli.core.database.model.AccountEntity
 import app.pachli.core.database.model.TranslationState
@@ -79,7 +78,6 @@ class ViewThreadViewModel @Inject constructor(
     private val timelineDao: TimelineDao,
     private val repository: CachedTimelineRepository,
     statusDisplayOptionsRepository: StatusDisplayOptionsRepository,
-    private val statusRepository: StatusRepository,
     private val timelineCases: TimelineCases,
 ) : ViewModel() {
     // TODO: For consistency with other fragments the UiState should not include
@@ -182,8 +180,8 @@ class ViewThreadViewModel @Inject constructor(
             } else {
                 Timber.d("Loaded status from network")
                 val statusCall = async { api.status(id) }
-                val existingViewData = statusRepository.getStatusViewData(account.id, id)
-                val existingTranslation = statusRepository.getTranslation(account.id, id)
+                val existingViewData = repository.getStatusViewData(account.id, id)
+                val existingTranslation = repository.getTranslation(account.id, id)
 
                 val status = statusCall.await().getOrElse { error ->
                     _uiResult.value = Err(ThreadError.Api(error))
@@ -311,7 +309,7 @@ class ViewThreadViewModel @Inject constructor(
                 reblog = it.reblog?.copy(reblogged = reblog),
             )
         }
-        statusRepository.reblog(status.pachliAccountId, status.actionableId, reblog).onFailure {
+        repository.reblog(status.pachliAccountId, status.actionableId, reblog).onFailure {
             updateStatus(status.id) { it }
             Timber.d("Failed to reblog status: %s: %s", status.actionableId, it)
         }
@@ -324,7 +322,7 @@ class ViewThreadViewModel @Inject constructor(
                 favouritesCount = it.favouritesCount + 1,
             )
         }
-        statusRepository.favourite(status.pachliAccountId, status.actionableId, favorite).onFailure {
+        repository.favourite(status.pachliAccountId, status.actionableId, favorite).onFailure {
             updateStatus(status.id) { it }
             Timber.d("Failed to favourite status: %s: %s", status.actionableId, it)
         }
@@ -332,7 +330,7 @@ class ViewThreadViewModel @Inject constructor(
 
     fun bookmark(bookmark: Boolean, status: StatusViewData) = viewModelScope.launch {
         updateStatus(status.id) { it.copy(bookmarked = bookmark) }
-        statusRepository.bookmark(status.pachliAccountId, status.actionableId, bookmark).onFailure {
+        repository.bookmark(status.pachliAccountId, status.actionableId, bookmark).onFailure {
             updateStatus(status.id) { it }
             Timber.d("Failed to bookmark status: %s: %s", status.actionableId, it)
         }
@@ -344,7 +342,7 @@ class ViewThreadViewModel @Inject constructor(
             status.copy(poll = votedPoll)
         }
 
-        statusRepository.voteInPoll(status.pachliAccountId, status.actionableId, poll.id, choices)
+        repository.voteInPoll(status.pachliAccountId, status.actionableId, poll.id, choices)
             .onFailure {
                 Timber.d("Failed to vote in poll: %s: %s", status.actionableId, it)
                 updateStatus(status.id) { it.copy(poll = poll) }
@@ -374,7 +372,7 @@ class ViewThreadViewModel @Inject constructor(
             )
         }
         viewModelScope.launch {
-            statusRepository.setExpanded(status.pachliAccountId, status.id, expanded)
+            repository.setExpanded(status.pachliAccountId, status.id, expanded)
         }
     }
 
@@ -383,7 +381,7 @@ class ViewThreadViewModel @Inject constructor(
             viewData.copy(isShowingContent = isShowing)
         }
         viewModelScope.launch {
-            statusRepository.setContentShowing(status.pachliAccountId, status.id, isShowing)
+            repository.setContentShowing(status.pachliAccountId, status.id, isShowing)
         }
     }
 
@@ -392,7 +390,7 @@ class ViewThreadViewModel @Inject constructor(
             viewData.copy(isCollapsed = isCollapsed)
         }
         viewModelScope.launch {
-            statusRepository.setContentCollapsed(status.pachliAccountId, status.id, isCollapsed)
+            repository.setContentCollapsed(status.pachliAccountId, status.id, isCollapsed)
         }
     }
 
@@ -510,7 +508,7 @@ class ViewThreadViewModel @Inject constructor(
             viewData.copy(translationState = TranslationState.SHOW_ORIGINAL)
         }
         viewModelScope.launch {
-            statusRepository.setTranslationState(statusViewData.pachliAccountId, statusViewData.id, TranslationState.SHOW_ORIGINAL)
+            repository.setTranslationState(statusViewData.pachliAccountId, statusViewData.id, TranslationState.SHOW_ORIGINAL)
         }
     }
 

--- a/app/src/main/java/app/pachli/fragment/SFragment.kt
+++ b/app/src/main/java/app/pachli/fragment/SFragment.kt
@@ -44,8 +44,8 @@ import app.pachli.core.activity.extensions.startActivityWithDefaultTransition
 import app.pachli.core.activity.extensions.startActivityWithTransition
 import app.pachli.core.data.model.IStatusViewData
 import app.pachli.core.data.repository.AccountManager
+import app.pachli.core.data.repository.OfflineFirstStatusRepository
 import app.pachli.core.data.repository.ServerRepository
-import app.pachli.core.data.repository.StatusRepository
 import app.pachli.core.database.model.AccountEntity
 import app.pachli.core.database.model.TranslationState
 import app.pachli.core.domain.DownloadUrlUseCase
@@ -86,7 +86,7 @@ abstract class SFragment<T : IStatusViewData> : Fragment(), StatusActionListener
     lateinit var accountManager: AccountManager
 
     @Inject
-    lateinit var statusRepository: StatusRepository
+    lateinit var statusRepository: OfflineFirstStatusRepository
 
     @Inject
     lateinit var timelineCases: TimelineCases

--- a/app/src/main/java/app/pachli/usecase/TimelineCases.kt
+++ b/app/src/main/java/app/pachli/usecase/TimelineCases.kt
@@ -19,8 +19,8 @@ package app.pachli.usecase
 import app.pachli.core.common.di.ApplicationScope
 import app.pachli.core.data.model.StatusViewData
 import app.pachli.core.data.repository.AccountManager
+import app.pachli.core.data.repository.OfflineFirstStatusRepository
 import app.pachli.core.data.repository.StatusActionError
-import app.pachli.core.data.repository.StatusRepository
 import app.pachli.core.database.dao.RemoteKeyDao
 import app.pachli.core.database.dao.TranslatedStatusDao
 import app.pachli.core.database.model.RemoteKeyEntity
@@ -56,7 +56,7 @@ import timber.log.Timber
 class TimelineCases @Inject constructor(
     private val mastodonApi: MastodonApi,
     private val eventHub: EventHub,
-    private val statusRepository: StatusRepository,
+    private val statusRepository: OfflineFirstStatusRepository,
     private val translatedStatusDao: TranslatedStatusDao,
     private val translationService: TranslationService,
     private val remoteKeyDao: RemoteKeyDao,

--- a/app/src/test/java/app/pachli/components/notifications/NotificationsViewModelTestBase.kt
+++ b/app/src/test/java/app/pachli/components/notifications/NotificationsViewModelTestBase.kt
@@ -22,8 +22,8 @@ import app.pachli.PachliApplication
 import app.pachli.core.data.repository.AccountManager
 import app.pachli.core.data.repository.AccountPreferenceDataStore
 import app.pachli.core.data.repository.ContentFiltersRepository
+import app.pachli.core.data.repository.OfflineFirstStatusRepository
 import app.pachli.core.data.repository.StatusDisplayOptionsRepository
-import app.pachli.core.data.repository.StatusRepository
 import app.pachli.core.data.repository.notifications.NotificationsRepository
 import app.pachli.core.database.dao.AccountDao
 import app.pachli.core.eventhub.EventHub
@@ -96,7 +96,7 @@ abstract class NotificationsViewModelTestBase {
     lateinit var statusDisplayOptionsRepository: StatusDisplayOptionsRepository
 
     @Inject
-    lateinit var statusRepository: StatusRepository
+    lateinit var statusRepository: OfflineFirstStatusRepository
 
     @Inject
     lateinit var accountDao: AccountDao

--- a/app/src/test/java/app/pachli/components/timeline/CachedTimelineViewModelTestBase.kt
+++ b/app/src/test/java/app/pachli/components/timeline/CachedTimelineViewModelTestBase.kt
@@ -24,8 +24,8 @@ import app.pachli.components.timeline.viewmodel.CachedTimelineViewModel
 import app.pachli.components.timeline.viewmodel.TimelineViewModel
 import app.pachli.core.data.repository.AccountManager
 import app.pachli.core.data.repository.ContentFiltersRepository
+import app.pachli.core.data.repository.OfflineFirstStatusRepository
 import app.pachli.core.data.repository.StatusDisplayOptionsRepository
-import app.pachli.core.data.repository.StatusRepository
 import app.pachli.core.eventhub.EventHub
 import app.pachli.core.model.Timeline
 import app.pachli.core.network.di.test.DEFAULT_INSTANCE_V2
@@ -97,7 +97,7 @@ abstract class CachedTimelineViewModelTestBase {
     lateinit var statusDisplayOptionsRepository: StatusDisplayOptionsRepository
 
     @Inject
-    lateinit var statusRepository: StatusRepository
+    lateinit var statusRepository: OfflineFirstStatusRepository
 
     @Inject
     lateinit var moshi: Moshi
@@ -173,7 +173,6 @@ abstract class CachedTimelineViewModelTestBase {
             accountManager,
             statusDisplayOptionsRepository,
             sharedPreferencesRepository,
-            statusRepository,
         )
     }
 }

--- a/app/src/test/java/app/pachli/components/timeline/NetworkTimelineViewModelTestBase.kt
+++ b/app/src/test/java/app/pachli/components/timeline/NetworkTimelineViewModelTestBase.kt
@@ -23,8 +23,8 @@ import app.pachli.components.timeline.viewmodel.NetworkTimelineViewModel
 import app.pachli.components.timeline.viewmodel.TimelineViewModel
 import app.pachli.core.data.repository.AccountManager
 import app.pachli.core.data.repository.ContentFiltersRepository
+import app.pachli.core.data.repository.OfflineFirstStatusRepository
 import app.pachli.core.data.repository.StatusDisplayOptionsRepository
-import app.pachli.core.data.repository.StatusRepository
 import app.pachli.core.database.dao.StatusDao
 import app.pachli.core.database.dao.TranslatedStatusDao
 import app.pachli.core.eventhub.EventHub
@@ -92,7 +92,7 @@ abstract class NetworkTimelineViewModelTestBase {
     lateinit var statusDisplayOptionsRepository: StatusDisplayOptionsRepository
 
     @Inject
-    lateinit var statusRepository: StatusRepository
+    lateinit var statusRepository: OfflineFirstStatusRepository
 
     @Inject
     lateinit var statusDao: StatusDao
@@ -169,7 +169,6 @@ abstract class NetworkTimelineViewModelTestBase {
             accountManager,
             statusDisplayOptionsRepository,
             sharedPreferencesRepository,
-            statusRepository,
         )
     }
 }

--- a/app/src/test/java/app/pachli/components/viewthread/ViewThreadViewModelTest.kt
+++ b/app/src/test/java/app/pachli/components/viewthread/ViewThreadViewModelTest.kt
@@ -6,8 +6,8 @@ import app.pachli.PachliApplication
 import app.pachli.components.compose.HiltTestApplication_Application
 import app.pachli.components.timeline.CachedTimelineRepository
 import app.pachli.core.data.repository.AccountManager
+import app.pachli.core.data.repository.OfflineFirstStatusRepository
 import app.pachli.core.data.repository.StatusDisplayOptionsRepository
-import app.pachli.core.data.repository.StatusRepository
 import app.pachli.core.database.dao.TimelineDao
 import app.pachli.core.eventhub.BookmarkEvent
 import app.pachli.core.eventhub.EventHub
@@ -92,7 +92,7 @@ class ViewThreadViewModelTest {
     lateinit var statusDisplayOptionsRepository: StatusDisplayOptionsRepository
 
     @Inject
-    lateinit var statusRepository: StatusRepository
+    lateinit var statusRepository: OfflineFirstStatusRepository
 
     private lateinit var viewModel: ViewThreadViewModel
 
@@ -154,7 +154,7 @@ class ViewThreadViewModelTest {
             .onSuccess { accountManager.refresh(it) }
 
         val cachedTimelineRepository: CachedTimelineRepository = mock {
-            onBlocking { getStatusViewData(anyLong(), any()) } doReturn emptyMap()
+            onBlocking { getStatusViewData(anyLong(), any<List<String>>()) } doReturn emptyMap()
             onBlocking { getStatusTranslations(anyLong(), any()) } doReturn emptyMap()
         }
 
@@ -165,7 +165,6 @@ class ViewThreadViewModelTest {
             timelineDao,
             cachedTimelineRepository,
             statusDisplayOptionsRepository,
-            statusRepository,
             timelineCases,
         )
     }

--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/OfflineFirstStatusRepository.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/OfflineFirstStatusRepository.kt
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2025 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.core.data.repository
+
+import app.pachli.core.common.di.ApplicationScope
+import app.pachli.core.database.dao.StatusDao
+import app.pachli.core.database.dao.TranslatedStatusDao
+import app.pachli.core.database.di.TransactionProvider
+import app.pachli.core.database.model.StatusViewDataContentCollapsed
+import app.pachli.core.database.model.StatusViewDataContentShowing
+import app.pachli.core.database.model.StatusViewDataExpanded
+import app.pachli.core.database.model.StatusViewDataTranslationState
+import app.pachli.core.database.model.TranslationState
+import app.pachli.core.eventhub.BookmarkEvent
+import app.pachli.core.eventhub.EventHub
+import app.pachli.core.eventhub.FavoriteEvent
+import app.pachli.core.eventhub.MuteConversationEvent
+import app.pachli.core.eventhub.PinEvent
+import app.pachli.core.eventhub.PollVoteEvent
+import app.pachli.core.eventhub.ReblogEvent
+import app.pachli.core.model.Poll
+import app.pachli.core.model.Status
+import app.pachli.core.network.retrofit.MastodonApi
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.map
+import com.github.michaelbull.result.mapEither
+import com.github.michaelbull.result.mapError
+import com.github.michaelbull.result.onFailure
+import com.github.michaelbull.result.onSuccess
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+
+/**
+ * Repository for managing actions on statuses ([bookmark], etc).
+ *
+ * Operations are generally performed locally first so the UI updates quickly,
+ * then sent to the server, and if they fail the local operation is undone.
+ *
+ * This should not be used by anything other than other repositories. Those
+ * repositories should inject this and implement [StatusRepository] by
+ * delegating to this repository.
+ *
+ * ```kotlin
+ * class SomeOtherRepository @Inject constructor(
+ *     statusRepository: OfflineFirstStatusRepository,
+ *     // ...
+ * ) : StatusRepository by statusRepository { /* ... */ }
+ */
+class OfflineFirstStatusRepository @Inject constructor(
+    @ApplicationScope private val externalScope: CoroutineScope,
+    private val mastodonApi: MastodonApi,
+    private val transactionProvider: TransactionProvider,
+    private val statusDao: StatusDao,
+    private val translatedStatusDao: TranslatedStatusDao,
+    private val eventHub: EventHub,
+) : StatusRepository {
+    override suspend fun bookmark(
+        pachliAccountId: Long,
+        statusId: String,
+        bookmarked: Boolean,
+    ): Result<Status, StatusActionError.Bookmark> = externalScope.async {
+        transactionProvider {
+            statusDao.setBookmarked(pachliAccountId, statusId, bookmarked)
+            if (bookmarked) {
+                mastodonApi.bookmarkStatus(statusId)
+            } else {
+                mastodonApi.unbookmarkStatus(statusId)
+            }
+                .onSuccess { eventHub.dispatch(BookmarkEvent(statusId, bookmarked)) }
+                .onFailure { statusDao.setBookmarked(pachliAccountId, statusId, !bookmarked) }
+                .mapEither({ it.body.asModel() }, { StatusActionError.Bookmark(it) })
+        }
+    }.await()
+
+    override suspend fun favourite(
+        pachliAccountId: Long,
+        statusId: String,
+        favourited: Boolean,
+    ): Result<Status, StatusActionError.Favourite> = externalScope.async {
+        transactionProvider {
+            statusDao.setFavourited(pachliAccountId, statusId, favourited)
+            if (favourited) {
+                mastodonApi.favouriteStatus(statusId)
+            } else {
+                mastodonApi.unfavouriteStatus(statusId)
+            }
+                .onSuccess { eventHub.dispatch(FavoriteEvent(statusId, favourited)) }
+                .onFailure { statusDao.setFavourited(pachliAccountId, statusId, !favourited) }
+                .mapEither({ it.body.asModel() }, { StatusActionError.Favourite(it) })
+        }
+    }.await()
+
+    override suspend fun reblog(
+        pachliAccountId: Long,
+        statusId: String,
+        reblogged: Boolean,
+    ): Result<Status, StatusActionError.Reblog> = externalScope.async {
+        transactionProvider {
+            statusDao.setReblogged(pachliAccountId, statusId, reblogged)
+            if (reblogged) {
+                mastodonApi.reblogStatus(statusId)
+            } else {
+                mastodonApi.unreblogStatus(statusId)
+            }
+                .onSuccess { eventHub.dispatch(ReblogEvent(statusId, reblogged)) }
+                .onFailure { statusDao.setReblogged(pachliAccountId, statusId, !reblogged) }
+                .mapEither({ it.body.asModel() }, { StatusActionError.Reblog(it) })
+        }
+    }.await()
+
+    override suspend fun mute(
+        pachliAccountId: Long,
+        statusId: String,
+        muted: Boolean,
+    ): Result<Status, StatusActionError.Mute> = externalScope.async {
+        statusDao.setMuted(pachliAccountId, statusId, muted)
+        return@async if (muted) {
+            mastodonApi.muteConversation(statusId)
+        } else {
+            mastodonApi.unmuteConversation(statusId)
+        }
+            .onSuccess { eventHub.dispatch(MuteConversationEvent(pachliAccountId, statusId, muted)) }
+            .onFailure { statusDao.setMuted(pachliAccountId, statusId, !muted) }
+            .mapEither({ it.body.asModel() }, { StatusActionError.Mute(it) })
+    }.await()
+
+    override suspend fun pin(
+        pachliAccountId: Long,
+        statusId: String,
+        pinned: Boolean,
+    ): Result<Status, StatusActionError.Pin> = externalScope.async {
+        statusDao.setPinned(pachliAccountId, statusId, pinned)
+        return@async if (pinned) {
+            mastodonApi.pinStatus(statusId)
+        } else {
+            mastodonApi.unpinStatus(statusId)
+        }
+            .onSuccess { eventHub.dispatch(PinEvent(statusId, pinned)) }
+            .onFailure { statusDao.setPinned(pachliAccountId, statusId, !pinned) }
+            .mapEither({ it.body.asModel() }, { StatusActionError.Pin(it) })
+    }.await()
+
+    override suspend fun voteInPoll(
+        pachliAccountId: Long,
+        statusId: String,
+        pollId: String,
+        choices: List<Int>,
+    ): Result<Poll, StatusActionError.VoteInPoll> = externalScope.async {
+        transactionProvider {
+            val poll = statusDao.getStatus(pachliAccountId, statusId)?.poll
+            poll?.let {
+                statusDao.setPoll(pachliAccountId, statusId, poll.votedCopy(choices))
+            }
+
+            mastodonApi.voteInPoll(pollId, choices)
+                .map { it.body.asModel() }
+                .onSuccess { poll ->
+                    statusDao.setPoll(pachliAccountId, statusId, poll)
+                    eventHub.dispatch(PollVoteEvent(statusId, poll))
+                }
+                .onFailure { poll?.let { statusDao.setPoll(pachliAccountId, statusId, it) } }
+                .mapError { StatusActionError.VoteInPoll(it) }
+        }
+    }.await()
+
+    override suspend fun setExpanded(pachliAccountId: Long, statusId: String, expanded: Boolean) {
+        statusDao.setExpanded(
+            StatusViewDataExpanded(
+                pachliAccountId = pachliAccountId,
+                serverId = statusId,
+                expanded = expanded,
+            ),
+        )
+    }
+
+    override suspend fun setContentShowing(pachliAccountId: Long, statusId: String, contentShowing: Boolean) {
+        statusDao.setContentShowing(
+            StatusViewDataContentShowing(
+                pachliAccountId = pachliAccountId,
+                serverId = statusId,
+                contentShowing = contentShowing,
+            ),
+        )
+    }
+
+    override suspend fun setContentCollapsed(pachliAccountId: Long, statusId: String, contentCollapsed: Boolean) {
+        statusDao.setContentCollapsed(
+            StatusViewDataContentCollapsed(
+                pachliAccountId = pachliAccountId,
+                serverId = statusId,
+                contentCollapsed = contentCollapsed,
+            ),
+        )
+    }
+
+    override suspend fun setTranslationState(pachliAccountId: Long, statusId: String, translationState: TranslationState) {
+        statusDao.setTranslationState(
+            StatusViewDataTranslationState(
+                pachliAccountId = pachliAccountId,
+                serverId = statusId,
+                translationState = translationState,
+            ),
+        )
+    }
+
+    override suspend fun getStatusViewData(pachliAccountId: Long, statusId: String) = statusDao.getStatusViewData(pachliAccountId, statusId)
+
+    override suspend fun getTranslation(pachliAccountId: Long, statusId: String) = translatedStatusDao.getTranslation(pachliAccountId, statusId)
+}

--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/notifications/NotificationsRepository.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/notifications/NotificationsRepository.kt
@@ -23,7 +23,7 @@ import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import app.pachli.core.common.di.ApplicationScope
-import app.pachli.core.data.model.StatusViewData
+import app.pachli.core.data.repository.OfflineFirstStatusRepository
 import app.pachli.core.data.repository.StatusRepository
 import app.pachli.core.database.dao.NotificationDao
 import app.pachli.core.database.dao.RemoteKeyDao
@@ -67,8 +67,8 @@ class NotificationsRepository @Inject constructor(
     private val notificationDao: NotificationDao,
     private val remoteKeyDao: RemoteKeyDao,
     private val statusDao: StatusDao,
-    private val statusRepository: StatusRepository,
-) {
+    statusRepository: OfflineFirstStatusRepository,
+) : StatusRepository by statusRepository {
     private var factory: InvalidatingPagingSourceFactory<Int, NotificationData>? = null
 
     private val remoteKeyTimelineId = Timeline.Notifications.remoteKeyTimelineId
@@ -174,30 +174,6 @@ class NotificationsRepository @Inject constructor(
                 accountFilterDecision,
             ),
         )
-    }
-
-    /**
-     * Saves a copy of [statusViewData] with [StatusViewData.isCollapsed] set to
-     * [isCollapsed].
-     */
-    fun setContentCollapsed(pachliAccountId: Long, statusViewData: StatusViewData, isCollapsed: Boolean) = externalScope.launch {
-        statusRepository.setContentCollapsed(pachliAccountId, statusViewData.id, isCollapsed)
-    }
-
-    /**
-     * Saves a copy of [statusViewData] with [StatusViewData.isShowingContent] set to
-     * [isShowingContent].
-     */
-    fun setShowingContent(pachliAccountId: Long, statusViewData: StatusViewData, isShowingContent: Boolean) = externalScope.launch {
-        statusRepository.setContentShowing(pachliAccountId, statusViewData.id, isShowingContent)
-    }
-
-    /**
-     * Saves a copy of [statusViewData] with [StatusViewData.isExpanded] set to
-     * [isExpanded].
-     */
-    fun setExpanded(pachliAccountId: Long, statusViewData: StatusViewData, isExpanded: Boolean) = externalScope.launch {
-        statusRepository.setExpanded(pachliAccountId, statusViewData.id, isExpanded)
     }
 
     companion object {

--- a/core/data/src/test/kotlin/app/pachli/core/data/repository/StatusRepositoryTest.kt
+++ b/core/data/src/test/kotlin/app/pachli/core/data/repository/StatusRepositoryTest.kt
@@ -77,7 +77,7 @@ class StatusRepositoryTest {
     @Inject
     lateinit var eventHub: EventHub
 
-    private lateinit var statusRepository: StatusRepository
+    private lateinit var statusRepository: OfflineFirstStatusRepository
 
     private val statusId = "1234"
 
@@ -86,7 +86,7 @@ class StatusRepositoryTest {
         hilt.inject()
         reset(mastodonApi)
 
-        statusRepository = StatusRepository(
+        statusRepository = OfflineFirstStatusRepository(
             externalScope,
             mastodonApi,
             transactionProvider,


### PR DESCRIPTION
Previous code that operated on timelines and statuses generally injected a repository for the timeline and `StatusRepository`, then had to remember which repository to use for which operation. In some cases the timeline repository included methods that just wrapped those in `StatusRepository`.

Simplify this. Now the goal is that viewmodels work with a single repository for the timeline they operate on. The `StatusRepository` methods have been moved to an interface, implemented by `OfflineFirstStatusRepository`.

The timeline repositories inject `OfflineFirstStatusRepository` as a constructor parameter and implement `StatusRepository` by delegating to the injected `OfflineFirstStatusRepository`.

Most viewmodels have been updated to do this. Some legacy ones which don't have a specific timeline repository are left unchanged. When those are converted `StatusRepository` can be marked internal to `core.data`.