### PR TITLE
fix: Show animated avatars at correct size in timelines

### DIFF
--- a/app/src/main/java/app/pachli/adapter/StatusBaseViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/StatusBaseViewHolder.kt
@@ -314,7 +314,6 @@ abstract class StatusBaseViewHolder<T : IStatusViewData> protected constructor(
                 avatarInset,
                 avatarRadius24dp,
                 statusDisplayOptions.animateAvatars,
-                null,
             )
             avatarRadius = avatarRadius36dp
         }

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/ImageLoadingHelper.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/ImageLoadingHelper.kt
@@ -47,9 +47,9 @@ fun loadAvatar(
     } else {
         val multiTransformation = MultiTransformation(
             buildList {
-                transforms?.let { this.addAll(it) }
                 add(centerCropTransformation)
                 add(RoundedCorners(radius))
+                transforms?.let { this.addAll(it) }
             },
         )
 


### PR DESCRIPTION
Previous code applied a background to avatars to ensure that partially transparent areas are fully opaque when drawing content under them. This happened before the avatar image was scaled for use.

Not sure why, but this has started to cause animated avatars to be displayed at the wrong size.

Fix the problem by only performing the compositing after the avatars have been scaled.

While I'm here, clean up an unnecessary pass of "null" as the value.