### PR TITLE
fix: Always load cached thread status data with the correct account

### DIFF
--- a/app/src/main/java/app/pachli/components/viewthread/ViewThreadViewModel.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/ViewThreadViewModel.kt
@@ -142,7 +142,7 @@ class ViewThreadViewModel @Inject constructor(
 
             Timber.d("Finding status with: %s", id)
             val contextCall = async { api.statusContext(id) }
-            val timelineStatusWithAccount = timelineDao.getStatus(id)
+            val timelineStatusWithAccount = timelineDao.getStatus(account.id, id)
 
             var detailedStatus = if (timelineStatusWithAccount != null) {
                 Timber.d("Loaded status from local timeline")

--- a/core/database/src/main/kotlin/app/pachli/core/database/dao/TimelineDao.kt
+++ b/core/database/src/main/kotlin/app/pachli/core/database/dao/TimelineDao.kt
@@ -268,13 +268,13 @@ LEFT JOIN
     TranslatedStatusEntity AS t
     ON (s.timelineUserId = t.timelineUserId AND (s.serverId = t.serverId OR s.reblogServerId = t.serverId))
 WHERE
-    (s.serverId = :statusId OR s.reblogServerId = :statusId)
+    s.timelineUserId == :pachliAccountId
+    AND (s.serverId = :statusId OR s.reblogServerId = :statusId)
     AND s.authorServerId IS NOT NULL
 """,
     )
-    // TODO: Probably doesn't need to use TimelineStatus. Does need a
-    // pachliAccountId
-    abstract suspend fun getStatus(statusId: String): TimelineStatusWithAccount?
+    // TODO: Probably doesn't need to use TimelineStatus.
+    abstract suspend fun getStatus(pachliAccountId: Long, statusId: String): TimelineStatusWithAccount?
 
     @Query(
         """


### PR DESCRIPTION
When viewing a thread the previous code loaded the status, including the view data, from the local database, but without using the Pachli account ID.

This could result in the view showing status view data from another account.

For example, consider two accounts on the device that both have the same status in their timeline. The status is in a different language, and the first account translates the status. This is now part of the cached view data.

The second account sees the same status, does not translate it, and clicks through to view the thread. The cached data is loaded, and that's the translated status -- so the second user sees the translation even though they did not explicitly request it.

Fix this by passing the Pachli account ID through to the cache query and using it in the query.