### PR TITLE
fix: Show translation state when viewing a thread

### DIFF
--- a/app/src/main/java/app/pachli/components/viewthread/ViewThreadViewModel.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/ViewThreadViewModel.kt
@@ -492,6 +492,10 @@ class ViewThreadViewModel @Inject constructor(
 
     fun translate(statusViewData: StatusViewData) {
         viewModelScope.launch {
+            updateStatusViewData(statusViewData.id) { viewData ->
+                viewData.copy(translationState = TranslationState.TRANSLATING)
+            }
+
             timelineCases.translate(statusViewData)
                 .onSuccess {
                     val translatedEntity = it.toEntity(statusViewData.pachliAccountId, statusViewData.actionableId)
@@ -499,7 +503,12 @@ class ViewThreadViewModel @Inject constructor(
                         viewData.copy(translation = translatedEntity, translationState = TranslationState.SHOW_TRANSLATION)
                     }
                 }
-                .onFailure { _errors.send(it) }
+                .onFailure {
+                    updateStatusViewData(statusViewData.id) { viewData ->
+                        viewData.copy(translationState = TranslationState.SHOW_ORIGINAL)
+                    }
+                    _errors.send(it)
+                }
         }
     }
 


### PR DESCRIPTION
Previous code could translate posts in a thread, but didn't update the `translationState` when translation started or when it failed. This meant the user had no feedback that a translation was in-progress.