### PR TITLE
feat: Allow delete over autocomplete-inserted space

### DIFF
--- a/app/src/main/java/app/pachli/components/compose/ComposeTokenizer.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeTokenizer.kt
@@ -98,11 +98,11 @@ class ComposeTokenizer : MultiAutoCompleteTextView.Tokenizer {
         return if (i > 0 && text[i - 1] == ' ') {
             text
         } else if (text is Spanned) {
-            val s = SpannableString("$text ")
+            val s = SpannableString(text)
             TextUtils.copySpansFrom(text, 0, text.length, Object::class.java, s, 0)
             s
         } else {
-            "$text "
+            text
         }
     }
 }

--- a/app/src/main/java/app/pachli/components/compose/view/EditTextTyped.kt
+++ b/app/src/main/java/app/pachli/components/compose/view/EditTextTyped.kt
@@ -56,6 +56,11 @@ class EditTextTyped @JvmOverloads constructor(
         ViewCompat.setOnReceiveContentListener(this, arrayOf("image/*"), listener)
     }
 
+    override fun replaceText(text: CharSequence?) {
+        super.replaceText(text)
+        append(" ")
+    }
+
     override fun onCreateInputConnection(editorInfo: EditorInfo): InputConnection {
         val connection = super.onCreateInputConnection(editorInfo)
         EditorInfoCompat.setContentMimeTypes(editorInfo, arrayOf("image/*"))


### PR DESCRIPTION
Previous code inserted included a space at the end of the text when as part of the autocomplete result when inserting a suggestion (account, hashtag, or emoji).

This meant the space was considered part of the autocomplete result. So if the user autocompleted e.g., a hashtag, and wanted to delete the inserted space to replace it with a comma, the autocomplete portion of the result would also be deleted.

Change this behaviour, and insert the space after the autocomplete result is inserted, separate from the result itself. This allows the user to delete the space without affecting the autocomplete result. Pressing delete a second time will delete the autocomplete portion of the result.