### PR TITLE
refactor: Include the colons in an emoji's short code

### DIFF
--- a/app/src/main/java/app/pachli/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeActivity.kt
@@ -1587,7 +1587,7 @@ class ComposeActivity :
 
     private fun bindEmojiList(emojiList: List<Emoji>) {
         binding.emojiPickerBottomSheet.animate = sharedPreferencesRepository.animateEmojis
-        binding.emojiPickerBottomSheet.clickListener = { replaceTextAtCaret(":${it.shortcode}: ") }
+        binding.emojiPickerBottomSheet.clickListener = { replaceTextAtCaret("${it.shortcode} ") }
         binding.emojiPickerBottomSheet.emojis = emojiList
 
         enableButton(binding.composeEmojiButton, emojiList.isNotEmpty(), emojiList.isNotEmpty())

--- a/app/src/main/java/app/pachli/components/compose/ComposeAutoCompleteAdapter.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeAutoCompleteAdapter.kt
@@ -23,7 +23,6 @@ import android.widget.BaseAdapter
 import android.widget.Filter
 import android.widget.Filterable
 import androidx.annotation.WorkerThread
-import app.pachli.R
 import app.pachli.core.common.extensions.visible
 import app.pachli.core.common.util.formatNumber
 import app.pachli.core.designsystem.R as DR
@@ -140,7 +139,7 @@ class ComposeAutoCompleteAdapter(
             }
             is ItemAutocompleteEmojiBinding -> {
                 val emoji = (getItem(position) as AutocompleteResult.EmojiResult).emoji
-                binding.shortcode.text = context.getString(R.string.emoji_shortcode_format, emoji.shortcode)
+                binding.shortcode.text = emoji.shortcode
                 glide.load(emoji.url).into(binding.preview)
             }
         }
@@ -183,7 +182,7 @@ class ComposeAutoCompleteAdapter(
         }
 
         private fun formatEmoji(result: AutocompleteResult.EmojiResult): String {
-            return ":${result.emoji.shortcode}:"
+            return result.emoji.shortcode
         }
     }
 }

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -239,7 +239,6 @@
     <string name="restart_emoji">你需要重启 Pachli 才能生效</string>
     <string name="later">稍后</string>
     <string name="restart">立即重启</string>
-    <!-- string name="emoji_shortcode_format" translatable="false">:%s:</string -->
     <string name="download_failed">下载失败</string>
     <string name="account_moved_description">%1$s 已迁移到：</string>
     <string name="reblog_private">转嘟（可见者不变）</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -239,7 +239,6 @@
     <string name="restart_emoji">你需要重啟 Pachli 才能生效</string>
     <string name="later">稍後</string>
     <string name="restart">立即重啟</string>
-    <!-- string name="emoji_shortcode_format" translatable="false">:%s:</string -->
     <string name="download_failed">下載失敗</string>
     <string name="account_moved_description">%1$s 已遷移到：</string>
     <string name="reblog_private">轉嘟（可見者不變）</string>

--- a/app/src/main/res/values-zh-rMO/strings.xml
+++ b/app/src/main/res/values-zh-rMO/strings.xml
@@ -239,7 +239,6 @@
     <string name="restart_emoji">你需要重啟 Pachli 才能生效</string>
     <string name="later">稍後</string>
     <string name="restart">立即重啟</string>
-    <!-- string name="emoji_shortcode_format" translatable="false">:%s:</string -->
     <string name="download_failed">下載失敗</string>
     <string name="account_moved_description">%1$s 已遷移到：</string>
     <string name="reblog_private">轉嘟（可見者不變）</string>

--- a/app/src/main/res/values-zh-rSG/strings.xml
+++ b/app/src/main/res/values-zh-rSG/strings.xml
@@ -239,7 +239,6 @@
     <string name="restart_emoji">你需要重启 Pachli 才能生效</string>
     <string name="later">稍后</string>
     <string name="restart">立即重启</string>
-    <!-- string name="emoji_shortcode_format" translatable="false">:%s:</string -->
     <string name="download_failed">下载失败</string>
     <string name="account_moved_description">%1$s 已迁移到：</string>
     <string name="reblog_private">转嘟（可见者不变）</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -239,7 +239,6 @@
     <string name="restart_emoji">你需要重啟 Pachli 才能生效</string>
     <string name="later">稍後</string>
     <string name="restart">立即重啟</string>
-    <!-- string name="emoji_shortcode_format" translatable="false">:%s:</string -->
     <string name="download_failed">下載失敗</string>
     <string name="account_moved_description">%1$s 已遷移到：</string>
     <string name="reblog_private">轉嘟（可見者不變）</string>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -5,7 +5,6 @@
     <string name="title_tag" translatable="false">#%s</string>
     <string name="title_tag_with_initial_position" translatable="false">" #%s"</string>
 
-    <string name="emoji_shortcode_format" translatable="false">:%s:</string>
     <string name="post_timestamp_with_edited_indicator" translatable="false">%s *</string>
     <string name="metadata_joiner" translatable="false">" • "</string>
     <string name="date_range" translatable="false">%1$s — %2$s</string>

--- a/core/model/src/main/kotlin/app/pachli/core/model/Emoji.kt
+++ b/core/model/src/main/kotlin/app/pachli/core/model/Emoji.kt
@@ -21,6 +21,18 @@ import android.os.Parcelable
 import com.squareup.moshi.JsonClass
 import kotlinx.parcelize.Parcelize
 
+/**
+ * A custom emoji. Either available on the user's server, or associated with
+ * data returned from the server.
+ *
+ * @property shortcode The emoji's shortcode -- this is the name of the
+ * emoji enclosed in `:`.
+ * @property url URL of the image to show as the emoji.
+ * @property staticUrl As [url], but does not animate.
+ * @param visibleInPicker True if the emoji should be visible to user when
+ * picking emojis.
+ * @param category Arbitrary category the emoji is a member of. Not localised.
+ */
 @Parcelize
 @JsonClass(generateAdapter = true)
 data class Emoji(

--- a/core/network/src/main/kotlin/app/pachli/core/network/model/Emoji.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/Emoji.kt
@@ -28,7 +28,7 @@ data class Emoji(
     val category: String? = null,
 ) {
     fun asModel() = app.pachli.core.model.Emoji(
-        shortcode = shortcode,
+        shortcode = if (shortcode.startsWith(':')) shortcode else ":$shortcode:",
         url = url,
         staticUrl = staticUrl,
         visibleInPicker = visibleInPicker,

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/CustomEmojiHelper.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/CustomEmojiHelper.kt
@@ -57,11 +57,10 @@ class EmojiTargetScope<T : View>(val view: T) {
         val spannable = toSpannable()
 
         emojis.forEach { (shortcode, url, staticUrl) ->
-            val pattern = ":$shortcode:"
-            var start = indexOf(pattern)
+            var start = indexOf(shortcode)
 
             while (start != -1) {
-                val end = start + pattern.length
+                val end = start + shortcode.length
                 val span = EmojiSpan(view)
 
                 spannable.setSpan(span, start, end, 0)
@@ -69,7 +68,7 @@ class EmojiTargetScope<T : View>(val view: T) {
                 glide.asDrawable().load(if (animate) url else staticUrl).into(target)
                 _targets.add(target)
 
-                start = indexOf(pattern, end)
+                start = indexOf(shortcode, end)
             }
         }
 


### PR DESCRIPTION
Previous code used the emoji data exactly as received from the server.
This replicates a Mastodon API bug, where the network model for an emoji
does not include the `:` in the emoji's shortcode.

Fix this. Include the colons when converting from the network model to
the app model, and update code that inserts emojis so it doesn't need to
include the colons.