### PR TITLE
feat: Allow the user to see an emoji's detail

### DIFF
--- a/app/src/main/java/app/pachli/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeActivity.kt
@@ -1619,12 +1619,12 @@ class ComposeActivity :
         return viewModel.searchAutocompleteSuggestions(token)
     }
 
-    private fun bindEmojiList(emojiList: List<Emoji>) {
+    private fun bindEmojiList(emojis: List<Emoji>) {
         binding.emojiPickerBottomSheet.animate = sharedPreferencesRepository.animateEmojis
-        binding.emojiPickerBottomSheet.clickListener = { replaceTextAtCaret("${it.shortcode} ") }
-        binding.emojiPickerBottomSheet.emojis = emojiList
+        binding.emojiPickerBottomSheet.onSelectEmoji = { replaceTextAtCaret("${it.shortcode} ") }
+        binding.emojiPickerBottomSheet.emojis = emojis
 
-        enableButton(binding.composeEmojiButton, emojiList.isNotEmpty(), emojiList.isNotEmpty())
+        enableButton(binding.composeEmojiButton, emojis.isNotEmpty(), emojis.isNotEmpty())
     }
 
     /**

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/emoji/ChooseEmojiDialogFragment.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/emoji/ChooseEmojiDialogFragment.kt
@@ -46,7 +46,7 @@ class ChooseEmojiDialogFragment : AppCompatDialogFragment(), SuspendDialogResult
 
         val args = requireArguments()
         emojiPickerView.animate = args.getBoolean(ARG_ANIMATE_EMOJIS)
-        emojiPickerView.clickListener = {
+        emojiPickerView.onSelectEmoji = {
             result = it
             dismiss()
         }

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/emoji/EmojiGridView.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/emoji/EmojiGridView.kt
@@ -43,7 +43,7 @@ internal class EmojiGridView @JvmOverloads constructor(
     private val gridLayoutManager = GridLayoutManager(context, 1, GridLayoutManager.VERTICAL, false)
 
     /** Width of an [app.pachli.databinding.ItemEmojiButtonBinding] in pixels. */
-    private val pxSpanWidth = dpToPx(48f, context.resources.displayMetrics)
+    private val pxSpanWidth = dpToPx(40f, context.resources.displayMetrics)
 
     /**
      * Determines the size of each span based on the item's view type.

--- a/core/ui/src/main/res/layout/emoji_picker.xml
+++ b/core/ui/src/main/res/layout/emoji_picker.xml
@@ -23,12 +23,16 @@
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/emojiFilter"
         style="@style/AppTextInput"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:hint="@string/hint_search_emojis"
         app:endIconContentDescription="@string/clear_text_end_icon_content_description"
         app:endIconMinSize="32dp"
-        app:endIconMode="clear_text">
+        app:endIconMode="clear_text"
+        app:layout_constrainedWidth="true"
+        app:layout_constraintEnd_toStartOf="@id/showDetail"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/emojiFilterText"
@@ -41,11 +45,60 @@
             tools:text="Some query" />
     </com.google.android.material.textfield.TextInputLayout>
 
+    <CheckBox
+        android:id="@+id/showDetail"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:text="@string/emoji_picker_show_detail"
+        app:layout_constraintBaseline_toBaselineOf="@id/emojiFilter"
+        app:layout_constraintTop_toTopOf="@id/emojiFilter"
+        app:layout_constraintBottom_toBottomOf="@+id/emojiFilter"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/emojiFilter" />
+
     <app.pachli.core.ui.emoji.EmojiGridView
         android:id="@+id/emojiGrid"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="200dp"
         android:scrollbars="vertical"
-        android:layout_marginTop="8dp" />
+        android:layout_marginTop="8dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/emojiFilter"
+        app:layout_constraintEnd_toStartOf="@id/emojiDetail"
+        app:layout_constraintBottom_toBottomOf="parent" />
 
+    <LinearLayout
+        android:id="@+id/emojiDetail"
+        android:layout_width="150dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:layout_marginStart="8dp"
+        app:layout_constraintStart_toEndOf="@id/emojiGrid"
+        app:layout_constraintTop_toBottomOf="@id/emojiFilter"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:orientation="vertical"
+        tools:ignore="UseCompoundDrawables">
+
+        <ImageView
+            android:id="@+id/emojiDetailImage"
+            android:layout_width="150dp"
+            android:layout_height="150dp"
+            android:padding="8dp"
+            tools:ignore="ContentDescription" />
+
+        <!-- Keep android:singleLine="true", otherwise the marquee effect won't trigger. -->
+        <TextView
+            android:id="@+id/emojiDetailShortcode"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textSize="?attr/status_text_small"
+            android:paddingTop="8dp"
+            android:maxLines="1"
+            android:singleLine="true"
+            android:ellipsize="marquee"
+            android:marqueeRepeatLimit="marquee_forever"
+            android:gravity="center"
+            tools:ignore="SelectableText" />
+
+    </LinearLayout>
 </merge>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -32,4 +32,5 @@
     <string name="action_logout">Log out</string>
     <string name="hint_search_emojis">Search emojis…</string>
     <string name="label_emoji_no_category">No category</string>
+    <string name="emoji_picker_show_detail">Show detail</string>
 </resources>


### PR DESCRIPTION
Previous code shows the emoji grid and allowed the user to long-press an emoji to see the shortcode. But the emoji were still quite small.

To improve this, add a "Show detail" checkbox next to the emoji filter. When checked a "detail" panel appears on the right and the emoji tap mode changes.

With the panel closed tapping an emoji inserts it in the text. With the panel open tapping an emoji shows it at roughly 4x size in the detail panel, and the emoji shortcode is shown below the image. The user can tap the detail image to insert the emoji.