### PR TITLE
feat: Show emojis as images when writing/editing posts

### DIFF
--- a/app/src/main/java/app/pachli/components/compose/view/EditTextTyped.kt
+++ b/app/src/main/java/app/pachli/components/compose/view/EditTextTyped.kt
@@ -22,6 +22,7 @@ import android.text.method.KeyListener
 import android.util.AttributeSet
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputConnection
+import android.widget.EditText
 import androidx.appcompat.widget.AppCompatMultiAutoCompleteTextView
 import androidx.core.view.OnReceiveContentListener
 import androidx.core.view.ViewCompat
@@ -36,6 +37,14 @@ class EditTextTyped @JvmOverloads constructor(
     AppCompatMultiAutoCompleteTextView(context, attributeSet) {
 
     private val emojiEditTextHelper: EmojiEditTextHelper = EmojiEditTextHelper(this)
+
+    /**
+     * Optional listener called after text in the view has been replaced by the user
+     * auto-completing the text.
+     *
+     * Use this to, e.g., add spans to the newly inserted text.
+     */
+    var onReplaceTextListener: ((EditText, CharSequence?) -> Unit)? = null
 
     init {
         // fix a bug with autocomplete and some keyboards
@@ -59,6 +68,7 @@ class EditTextTyped @JvmOverloads constructor(
     override fun replaceText(text: CharSequence?) {
         super.replaceText(text)
         append(" ")
+        onReplaceTextListener?.invoke(this, text)
     }
 
     override fun onCreateInputConnection(editorInfo: EditorInfo): InputConnection {

--- a/app/src/main/res/layout/activity_compose.xml
+++ b/app/src/main/res/layout/activity_compose.xml
@@ -294,7 +294,8 @@
                 android:paddingTop="8dp"
                 android:paddingBottom="8dp"
                 android:textColorHint="?android:attr/textColorTertiary"
-                android:textSize="?attr/status_text_large" />
+                android:textSize="?attr/status_text_large"
+                android:layerType="software" />
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/composeMediaPreviewBar"


### PR DESCRIPTION
Previous code showed the user the emoji shortcode when inserting an emoji, whether through autocomplete or the emoji picker.

Change that -- insert the shortcode, but then wrap the shortcode in an `EmojiSpan` to display the actual emoji image.

When editing posts run the text-to-edit through `emojify` first so it also has the emoji span's inserted.

There's a bug in `EditText` that causes the emoji images to not always appear when added. To work around that set `android:layerType="software"` (see https://github.com/koral--/android-gif-drawable/issues/368).