### PR TITLE
fix: Periodically update timestamps in threads, search results

### DIFF
--- a/app/src/main/java/app/pachli/adapter/FilterableStatusViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/FilterableStatusViewHolder.kt
@@ -41,7 +41,7 @@ open class FilterableStatusViewHolder<T : IStatusViewData>(
         viewData: T,
         listener: StatusActionListener<T>,
         statusDisplayOptions: StatusDisplayOptions,
-        payloads: Any?,
+        payloads: List<List<Any?>>?,
     ) {
         super.setupWithStatus(viewData, listener, statusDisplayOptions, payloads)
         setupFilterPlaceholder(viewData, listener)

--- a/app/src/main/java/app/pachli/adapter/FollowRequestViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/FollowRequestViewHolder.kt
@@ -52,7 +52,7 @@ class FollowRequestViewHolder(
 
     override fun bind(
         viewData: NotificationViewData,
-        payloads: List<*>?,
+        payloads: List<List<Any?>>?,
         statusDisplayOptions: StatusDisplayOptions,
     ) {
         // Skip updates with payloads. That indicates a timestamp update, and

--- a/app/src/main/java/app/pachli/adapter/ReportNotificationViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/ReportNotificationViewHolder.kt
@@ -47,7 +47,7 @@ class ReportNotificationViewHolder(
 
     override fun bind(
         viewData: NotificationViewData,
-        payloads: List<*>?,
+        payloads: List<List<Any?>>?,
         statusDisplayOptions: StatusDisplayOptions,
     ) {
         // Skip updates with payloads. That indicates a timestamp update, and

--- a/app/src/main/java/app/pachli/adapter/StatusBaseViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/StatusBaseViewHolder.kt
@@ -714,9 +714,9 @@ abstract class StatusBaseViewHolder<T : IStatusViewData> protected constructor(
         viewData: T,
         listener: StatusActionListener<T>,
         statusDisplayOptions: StatusDisplayOptions,
-        payloads: Any? = null,
+        payloads: List<List<Any?>>?,
     ) {
-        if (payloads == null) {
+        if (payloads.isNullOrEmpty()) {
             val actionable = viewData.actionable
             setDisplayName(actionable.account.name, actionable.account.emojis, statusDisplayOptions)
             setUsername(actionable.account.username)
@@ -786,11 +786,9 @@ abstract class StatusBaseViewHolder<T : IStatusViewData> protected constructor(
             // and let RecyclerView ask for a new delegate.
             itemView.accessibilityDelegate = null
         } else {
-            if (payloads is List<*>) {
-                for (item in payloads) {
-                    if (Key.KEY_CREATED == item) {
-                        setMetaData(viewData, statusDisplayOptions, listener)
-                    }
+            payloads.flatten().forEach { item ->
+                if (item == Key.KEY_CREATED) {
+                    setMetaData(viewData, statusDisplayOptions, listener)
                 }
             }
         }

--- a/app/src/main/java/app/pachli/adapter/StatusDetailedViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/StatusDetailedViewHolder.kt
@@ -115,7 +115,7 @@ class StatusDetailedViewHolder(
         viewData: StatusViewData,
         listener: StatusActionListener<StatusViewData>,
         statusDisplayOptions: StatusDisplayOptions,
-        payloads: Any?,
+        payloads: List<List<Any?>>?,
     ) {
         // We never collapse statuses in the detail view
         val uncollapsedViewdata =
@@ -128,7 +128,7 @@ class StatusDetailedViewHolder(
             statusDisplayOptions,
             listener,
         ) // Always show card for detailed status
-        if (payloads == null) {
+        if (payloads.isNullOrEmpty()) {
             val reblogsCount = uncollapsedViewdata.actionable.reblogsCount
             val favouritesCount = uncollapsedViewdata.actionable.favouritesCount
             if (!statusDisplayOptions.hideStatsInDetailedView) {

--- a/app/src/main/java/app/pachli/adapter/StatusViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/StatusViewHolder.kt
@@ -48,9 +48,9 @@ open class StatusViewHolder<T : IStatusViewData>(
         viewData: T,
         listener: StatusActionListener<T>,
         statusDisplayOptions: StatusDisplayOptions,
-        payloads: Any?,
+        payloads: List<List<Any?>>?,
     ) = with(binding) {
-        if (payloads == null) {
+        if (payloads.isNullOrEmpty()) {
             val sensitive = !TextUtils.isEmpty(viewData.actionable.spoilerText)
             val expanded = viewData.isExpanded
             setupCollapsedState(viewData, sensitive, expanded, listener)

--- a/app/src/main/java/app/pachli/components/compose/MediaPreviewAdapter.kt
+++ b/app/src/main/java/app/pachli/components/compose/MediaPreviewAdapter.kt
@@ -259,7 +259,7 @@ class AttachmentViewHolder(
     fun bind(item: QueuedMedia, payloads: List<Any?>? = null) {
         this.item = item
 
-        if (payloads == null || payloads.isEmpty()) {
+        if (payloads.isNullOrEmpty()) {
             bindAll(item)
             return
         }

--- a/app/src/main/java/app/pachli/components/conversation/ConversationAdapter.kt
+++ b/app/src/main/java/app/pachli/components/conversation/ConversationAdapter.kt
@@ -48,7 +48,7 @@ internal class ConversationAdapter(
         /** Bind the data from the notification and payloads to the view. */
         fun bind(
             viewData: ConversationViewData,
-            payloads: List<*>?,
+            payloads: List<List<Any?>>?,
             statusDisplayOptions: StatusDisplayOptions,
         )
     }
@@ -108,10 +108,10 @@ internal class ConversationAdapter(
     override fun onBindViewHolder(
         holder: RecyclerView.ViewHolder,
         position: Int,
-        payloads: List<Any>,
+        payloads: List<Any?>,
     ) {
         getItem(position)?.let { conversationViewData ->
-            (holder as ViewHolder).bind(conversationViewData, payloads, statusDisplayOptions)
+            (holder as ViewHolder).bind(conversationViewData, payloads as? List<List<Any?>>, statusDisplayOptions)
         }
     }
 
@@ -165,7 +165,7 @@ class FilterableConversationStatusViewHolder internal constructor(
     setStatusContent: SetStatusContent,
     private val listener: StatusActionListener<ConversationViewData>,
 ) : ConversationAdapter.ViewHolder, FilterableStatusViewHolder<ConversationViewData>(binding, glide, setStatusContent) {
-    override fun bind(viewData: ConversationViewData, payloads: List<*>?, statusDisplayOptions: StatusDisplayOptions) {
+    override fun bind(viewData: ConversationViewData, payloads: List<List<Any?>>?, statusDisplayOptions: StatusDisplayOptions) {
         if (payloads.isNullOrEmpty()) {
             showStatusContent(true)
         }
@@ -173,7 +173,7 @@ class FilterableConversationStatusViewHolder internal constructor(
             viewData,
             listener,
             statusDisplayOptions,
-            payloads?.firstOrNull(),
+            payloads,
         )
     }
 }
@@ -221,7 +221,7 @@ class FilterableConversationViewHolder internal constructor(
         }
     }
 
-    override fun bind(viewData: ConversationViewData, payloads: List<*>?, statusDisplayOptions: StatusDisplayOptions) {
+    override fun bind(viewData: ConversationViewData, payloads: List<List<Any?>>?, statusDisplayOptions: StatusDisplayOptions) {
         this.viewData = viewData
         binding.accountFilterDomain.text = HtmlCompat.fromHtml(
             context.getString(

--- a/app/src/main/java/app/pachli/components/conversation/ConversationViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/conversation/ConversationViewHolder.kt
@@ -46,7 +46,7 @@ class ConversationViewHolder internal constructor(
         binding.statusAvatar2,
     )
 
-    override fun bind(viewData: ConversationViewData, payloads: List<*>?, statusDisplayOptions: StatusDisplayOptions) {
+    override fun bind(viewData: ConversationViewData, payloads: List<List<Any?>>?, statusDisplayOptions: StatusDisplayOptions) {
         val account = viewData.actionable.account
         val inReplyToId = viewData.actionable.inReplyToId
         val favourited = viewData.actionable.favourited
@@ -93,11 +93,9 @@ class ConversationViewHolder internal constructor(
             setConversationName(viewData.accounts)
             setAvatars(viewData.accounts, statusDisplayOptions.animateAvatars)
         } else {
-            if (payloads is List<*>) {
-                for (item in payloads) {
-                    if (Key.KEY_CREATED == item) {
-                        setMetaData(viewData, statusDisplayOptions, listener)
-                    }
+            payloads.flatten().forEach { item ->
+                if (item == Key.KEY_CREATED) {
+                    setMetaData(viewData, statusDisplayOptions, listener)
                 }
             }
         }

--- a/app/src/main/java/app/pachli/components/conversation/ConversationsFragment.kt
+++ b/app/src/main/java/app/pachli/components/conversation/ConversationsFragment.kt
@@ -265,12 +265,12 @@ class ConversationsFragment :
                 launch {
                     val useAbsoluteTime = sharedPreferencesRepository.useAbsoluteTime
                     while (!useAbsoluteTime) {
+                        delay(1.minutes)
                         adapter.notifyItemRangeChanged(
                             0,
                             adapter.itemCount,
                             listOf(StatusBaseViewHolder.Key.KEY_CREATED),
                         )
-                        delay(1.minutes)
                     }
                 }
 

--- a/app/src/main/java/app/pachli/components/notifications/FilterableNotificationViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/notifications/FilterableNotificationViewHolder.kt
@@ -70,7 +70,7 @@ class FilterableNotificationViewHolder(
         }
     }
 
-    override fun bind(viewData: NotificationViewData, payloads: List<*>?, statusDisplayOptions: StatusDisplayOptions) {
+    override fun bind(viewData: NotificationViewData, payloads: List<List<Any?>>?, statusDisplayOptions: StatusDisplayOptions) {
         this.viewData = viewData
 
         val icon = viewData.type.icon(context)

--- a/app/src/main/java/app/pachli/components/notifications/FollowViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/notifications/FollowViewHolder.kt
@@ -50,7 +50,7 @@ class FollowViewHolder(
 
     override fun bind(
         viewData: NotificationViewData,
-        payloads: List<*>?,
+        payloads: List<List<Any?>>?,
         statusDisplayOptions: StatusDisplayOptions,
     ) {
         // Skip updates with payloads. That indicates a timestamp update, and

--- a/app/src/main/java/app/pachli/components/notifications/ModerationWarningViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/notifications/ModerationWarningViewHolder.kt
@@ -40,7 +40,7 @@ class ModerationWarningViewHolder(
         }
     }
 
-    override fun bind(viewData: NotificationViewData, payloads: List<*>?, statusDisplayOptions: StatusDisplayOptions) {
+    override fun bind(viewData: NotificationViewData, payloads: List<List<Any?>>?, statusDisplayOptions: StatusDisplayOptions) {
         this.viewData = viewData
         val context = itemView.context
         val warning = viewData.accountWarning!!

--- a/app/src/main/java/app/pachli/components/notifications/NotificationsPagingAdapter.kt
+++ b/app/src/main/java/app/pachli/components/notifications/NotificationsPagingAdapter.kt
@@ -168,7 +168,7 @@ class NotificationsPagingAdapter(
         /** Bind the data from the notification and payloads to the view. */
         fun bind(
             viewData: NotificationViewData,
-            payloads: List<*>?,
+            payloads: List<List<Any?>>?,
             statusDisplayOptions: StatusDisplayOptions,
         )
     }
@@ -272,12 +272,12 @@ class NotificationsPagingAdapter(
     override fun onBindViewHolder(
         holder: RecyclerView.ViewHolder,
         position: Int,
-        payloads: MutableList<Any>,
+        payloads: List<Any?>,
     ) {
-        bindViewHolder(holder, position, payloads)
+        bindViewHolder(holder, position, payloads as? List<List<Any?>>?)
     }
 
-    private fun bindViewHolder(holder: RecyclerView.ViewHolder, position: Int, payloads: List<*>?) {
+    private fun bindViewHolder(holder: RecyclerView.ViewHolder, position: Int, payloads: List<List<Any?>>?) {
         getItem(position)?.let {
             (holder as ViewHolder).bind(it, payloads, statusDisplayOptions)
         }
@@ -292,7 +292,7 @@ class NotificationsPagingAdapter(
     ) : ViewHolder, RecyclerView.ViewHolder(binding.root) {
         override fun bind(
             viewData: NotificationViewData,
-            payloads: List<*>?,
+            payloads: List<List<Any?>>?,
             statusDisplayOptions: StatusDisplayOptions,
         ) {
             binding.text1.text = binding.root.context.getString(R.string.notification_unknown)

--- a/app/src/main/java/app/pachli/components/notifications/SeveredRelationshipsViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/notifications/SeveredRelationshipsViewHolder.kt
@@ -35,7 +35,7 @@ class SeveredRelationshipsViewHolder(
 ) : NotificationsPagingAdapter.ViewHolder, RecyclerView.ViewHolder(binding.root) {
     override fun bind(
         viewData: NotificationViewData,
-        payloads: List<*>?,
+        payloads: List<List<Any?>>?,
         statusDisplayOptions: StatusDisplayOptions,
     ) {
         val context = itemView.context
@@ -82,7 +82,7 @@ class SeveredRelationshipsViewHolder(
                 event.followingCount,
             )
         } else {
-            if (payloads.any { it == StatusBaseViewHolder.Key.KEY_CREATED }) {
+            if (payloads.flatten().any { it == StatusBaseViewHolder.Key.KEY_CREATED }) {
                 binding.datetime.text = getRelativeTimeSpanString(itemView.context, event.createdAt.toEpochMilli(), System.currentTimeMillis())
             }
         }

--- a/app/src/main/java/app/pachli/components/notifications/StatusNotificationViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/notifications/StatusNotificationViewHolder.kt
@@ -78,7 +78,7 @@ internal class StatusNotificationViewHolder(
 
     override fun bind(
         viewData: NotificationViewData,
-        payloads: List<*>?,
+        payloads: List<List<Any?>>?,
         statusDisplayOptions: StatusDisplayOptions,
     ) {
         val statusViewData = viewData.statusViewData
@@ -123,8 +123,8 @@ internal class StatusNotificationViewHolder(
             }
             setMessage(viewData, statusActionListener, statusDisplayOptions)
         } else {
-            for (item in payloads) {
-                if (StatusBaseViewHolder.Key.KEY_CREATED == item && statusViewData != null) {
+            payloads.flatten().forEach { item ->
+                if (item == StatusBaseViewHolder.Key.KEY_CREATED && statusViewData != null) {
                     setCreatedAt(
                         viewData.actionable.createdAt,
                         statusDisplayOptions.useAbsoluteTime,

--- a/app/src/main/java/app/pachli/components/notifications/StatusViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/notifications/StatusViewHolder.kt
@@ -37,7 +37,7 @@ internal class StatusViewHolder(
 
     override fun bind(
         viewData: NotificationViewData,
-        payloads: List<*>?,
+        payloads: List<List<Any?>>?,
         statusDisplayOptions: StatusDisplayOptions,
     ) {
         val statusViewData = viewData.statusViewData
@@ -53,7 +53,7 @@ internal class StatusViewHolder(
                 viewData,
                 statusActionListener,
                 statusDisplayOptions,
-                payloads?.firstOrNull(),
+                payloads,
             )
         }
         if (viewData.type == NotificationEntity.Type.POLL) {
@@ -73,7 +73,7 @@ class FilterableStatusViewHolder(
     // Note: Identical to bind() in StatusViewHolder above
     override fun bind(
         viewData: NotificationViewData,
-        payloads: List<*>?,
+        payloads: List<List<Any?>>?,
         statusDisplayOptions: StatusDisplayOptions,
     ) {
         val statusViewData = viewData.statusViewData
@@ -89,7 +89,7 @@ class FilterableStatusViewHolder(
                 viewData,
                 statusActionListener,
                 statusDisplayOptions,
-                payloads?.firstOrNull(),
+                payloads,
             )
         }
         if (viewData.type == NotificationEntity.Type.POLL) {

--- a/app/src/main/java/app/pachli/components/search/adapter/SearchStatusesAdapter.kt
+++ b/app/src/main/java/app/pachli/components/search/adapter/SearchStatusesAdapter.kt
@@ -20,6 +20,7 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.DiffUtil
+import app.pachli.adapter.StatusBaseViewHolder
 import app.pachli.adapter.StatusViewHolder
 import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.data.model.StatusViewData
@@ -45,15 +46,32 @@ class SearchStatusesAdapter(
 
     override fun onBindViewHolder(holder: StatusViewHolder<StatusViewData>, position: Int) {
         getItem(position)?.let { item ->
-            holder.setupWithStatus(item, statusListener, statusDisplayOptions)
+            holder.setupWithStatus(item, statusListener, statusDisplayOptions, null)
+        }
+    }
+
+    override fun onBindViewHolder(holder: StatusViewHolder<StatusViewData>, position: Int, payloads: List<Any?>) {
+        getItem(position)?.let { item ->
+            holder.setupWithStatus(item, statusListener, statusDisplayOptions, payloads as? List<List<Any?>>?)
         }
     }
 
     companion object {
         val STATUS_COMPARATOR = object : DiffUtil.ItemCallback<StatusViewData>() {
-            override fun areContentsTheSame(oldItem: StatusViewData, newItem: StatusViewData): Boolean = oldItem == newItem
+            override fun areItemsTheSame(oldItem: StatusViewData, newItem: StatusViewData) = oldItem.id == newItem.id
 
-            override fun areItemsTheSame(oldItem: StatusViewData, newItem: StatusViewData): Boolean = oldItem.id == newItem.id
+            // Items are different always. It allows to refresh timestamp on every view holder update
+            override fun areContentsTheSame(oldItem: StatusViewData, newItem: StatusViewData) = false
+
+            override fun getChangePayload(oldItem: StatusViewData, newItem: StatusViewData): Any? {
+                return if (oldItem == newItem) {
+                    // If items are equal - update timestamp only
+                    listOf(StatusBaseViewHolder.Key.KEY_CREATED)
+                } else {
+                    // If items are different - update the whole view holder
+                    null
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/app/pachli/components/timeline/TimelinePagingAdapter.kt
+++ b/app/src/main/java/app/pachli/components/timeline/TimelinePagingAdapter.kt
@@ -70,13 +70,13 @@ class TimelinePagingAdapter(
         position: Int,
         payloads: List<*>,
     ) {
-        bindViewHolder(viewHolder, position, payloads)
+        bindViewHolder(viewHolder, position, payloads as? List<List<Any?>>?)
     }
 
     private fun bindViewHolder(
         viewHolder: RecyclerView.ViewHolder,
         position: Int,
-        payloads: List<*>?,
+        payloads: List<List<Any?>>?,
     ) {
         try {
             getItem(position)
@@ -87,7 +87,7 @@ class TimelinePagingAdapter(
                 it,
                 statusListener,
                 statusDisplayOptions,
-                payloads?.getOrNull(0),
+                payloads,
             )
         }
     }
@@ -116,24 +116,12 @@ class TimelinePagingAdapter(
         private const val VIEW_TYPE_PLACEHOLDER = -1
 
         val TimelineDifferCallback = object : DiffUtil.ItemCallback<StatusViewData>() {
-            override fun areItemsTheSame(
-                oldItem: StatusViewData,
-                newItem: StatusViewData,
-            ): Boolean {
-                return oldItem.id == newItem.id
-            }
+            override fun areItemsTheSame(oldItem: StatusViewData, newItem: StatusViewData) = oldItem.id == newItem.id
 
-            override fun areContentsTheSame(
-                oldItem: StatusViewData,
-                newItem: StatusViewData,
-            ): Boolean {
-                return oldItem == newItem
-            }
+            // Items are different always. It allows to refresh timestamp on every view holder update
+            override fun areContentsTheSame(oldItem: StatusViewData, newItem: StatusViewData) = false
 
-            override fun getChangePayload(
-                oldItem: StatusViewData,
-                newItem: StatusViewData,
-            ): Any? {
+            override fun getChangePayload(oldItem: StatusViewData, newItem: StatusViewData): Any? {
                 return if (oldItem == newItem) {
                     // If items are equal - update timestamp only
                     listOf(StatusBaseViewHolder.Key.KEY_CREATED)

--- a/app/src/main/java/app/pachli/components/viewthread/ThreadAdapter.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/ThreadAdapter.kt
@@ -74,7 +74,12 @@ class ThreadAdapter(
 
     override fun onBindViewHolder(viewHolder: StatusBaseViewHolder<StatusViewData>, position: Int) {
         val status = getItem(position)
-        viewHolder.setupWithStatus(status, statusActionListener, statusDisplayOptions)
+        viewHolder.setupWithStatus(status, statusActionListener, statusDisplayOptions, null)
+    }
+
+    override fun onBindViewHolder(holder: StatusBaseViewHolder<StatusViewData>, position: Int, payloads: List<Any?>) {
+        val status = getItem(position)
+        holder.setupWithStatus(status, statusActionListener, statusDisplayOptions, payloads as? List<List<Any?>>?)
     }
 
     override fun getItemViewType(position: Int): Int {
@@ -97,24 +102,12 @@ class ThreadAdapter(
         private const val VIEW_TYPE_STATUS_FILTERED = 2
 
         val ThreadDifferCallback = object : DiffUtil.ItemCallback<StatusViewData>() {
-            override fun areItemsTheSame(
-                oldItem: StatusViewData,
-                newItem: StatusViewData,
-            ): Boolean {
-                return oldItem.id == newItem.id
-            }
+            override fun areItemsTheSame(oldItem: StatusViewData, newItem: StatusViewData) = oldItem.id == newItem.id
 
-            override fun areContentsTheSame(
-                oldItem: StatusViewData,
-                newItem: StatusViewData,
-            ): Boolean {
-                return false // Items are different always. It allows to refresh timestamp on every view holder update
-            }
+            // Items are different always. It allows to refresh timestamp on every view holder update
+            override fun areContentsTheSame(oldItem: StatusViewData, newItem: StatusViewData) = false
 
-            override fun getChangePayload(
-                oldItem: StatusViewData,
-                newItem: StatusViewData,
-            ): Any? {
+            override fun getChangePayload(oldItem: StatusViewData, newItem: StatusViewData): Any? {
                 return if (oldItem == newItem) {
                     // If items are equal - update timestamp only
                     listOf(StatusBaseViewHolder.Key.KEY_CREATED)

--- a/feature/manageaccounts/src/main/kotlin/app/pachli/feature/manageaccounts/PachliAccountAdapter.kt
+++ b/feature/manageaccounts/src/main/kotlin/app/pachli/feature/manageaccounts/PachliAccountAdapter.kt
@@ -175,7 +175,7 @@ internal class PachliAccountViewHolder(
     ) = with(binding) {
         this@PachliAccountViewHolder.account = account
 
-        if (payloads == null || payloads.isEmpty()) {
+        if (payloads.isNullOrEmpty()) {
             bindAll(account, animateEmojis, animateAvatars, showBotOverlay)
             return@with
         }


### PR DESCRIPTION
If "Use absolute time" is off then the status date/time is shown relative to the current time, and updated every minute. The update is performed by notifying the adapter the item range has changed with a dedicated payload to indicate the update time should be re-bound.

This wasn't enabled for threads or search results. Implement the code to do that.

While I'm here clean up the payload handling. The payload can be be any arbitrary object. Make sure it's consistently treated as a `List<List<Any?>>?`.

This is difficult to make properly safe, as `RecyclerView` just assumes it's `Object` and doesn't parameterise this.

Pachli uses `List<List<Any?>>?` because the call to `DiffUtil.ItemCallback.getChangePayload()` may return a list of items, if multiple parts of the status or other item have changed (e.g., if the text of the status changed but the attachment did not there is no need to re-fetch and decode any image attachments on the status). So `getChangePayload()` has to return a `List<Any?>?`, and this return value is then put in another `List` when passed as the parameter to `onBindViewHolder`.