### PR TITLE
fix: Work around Android bug where editable text disappears

### DIFF
--- a/app/src/main/res/layout/activity_compose.xml
+++ b/app/src/main/res/layout/activity_compose.xml
@@ -294,8 +294,7 @@
                 android:paddingTop="8dp"
                 android:paddingBottom="8dp"
                 android:textColorHint="?android:attr/textColorTertiary"
-                android:textSize="?attr/status_text_large"
-                android:layerType="software" />
+                android:textSize="?attr/status_text_large" />
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/composeMediaPreviewBar"


### PR DESCRIPTION
When displaying emojis when editing the previous code worked around an `EditText` bug -- unless the `layerType` is `software` the span's `draw()` method is not called on `EditText.invalidate()`. So the previous code set the `layerType` to `software`.

That triggered a different problem. Adding too many characters to the `EditText` caused all the content to disappear. Too many is about 740 in my testing.

When this happens it logs `not displayed because it is too large to fit into a software layer (or drawing cache), needs 10210380 bytes, only 10108800 available"` and then all the text disappears.`

Fix this with special handling for `EditText`. Instead of invalidating the view, remove the span and add it back to trigger a redraw.

Fixes #1770