### PR TITLE
refactor: Don't start activities from StatusBaseViewHolder

### DIFF
--- a/app/src/main/java/app/pachli/adapter/StatusBaseViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/StatusBaseViewHolder.kt
@@ -35,8 +35,6 @@ import app.pachli.core.model.AttachmentDisplayReason
 import app.pachli.core.model.Emoji
 import app.pachli.core.model.PreviewCardKind
 import app.pachli.core.model.Status
-import app.pachli.core.navigation.AccountActivityIntent
-import app.pachli.core.navigation.ViewMediaActivityIntent
 import app.pachli.core.network.parseAsMastodonHtml
 import app.pachli.core.preferences.CardViewMode
 import app.pachli.core.ui.CompositeWithOpaqueBackground
@@ -1006,14 +1004,12 @@ abstract class StatusBaseViewHolder<T : IStatusViewData> protected constructor(
             cardView.visibility = View.VISIBLE
             cardView.bind(glide, card, viewData.actionable.sensitive, statusDisplayOptions, false) { card, target ->
                 if (target == PreviewCardView.Target.BYLINE) {
-                    card.authors?.firstOrNull()?.account?.id?.let {
-                        context.startActivity(AccountActivityIntent(context, viewData.pachliAccountId, it))
-                    }
+                    card.authors?.firstOrNull()?.account?.id?.let { listener.onViewAccount(it) }
                     return@bind
                 }
 
                 if (card.kind == PreviewCardKind.PHOTO && card.embedUrl.isNotEmpty() && target == PreviewCardView.Target.IMAGE) {
-                    context.startActivity(ViewMediaActivityIntent(context, viewData.pachliAccountId, viewData.actionable.account.username, card.embedUrl))
+                    listener.onViewMedia(viewData.pachliAccountId, viewData.actionable.account.username, card.embedUrl)
                     return@bind
                 }
 

--- a/app/src/main/java/app/pachli/components/search/fragments/SearchStatusesFragment.kt
+++ b/app/src/main/java/app/pachli/components/search/fragments/SearchStatusesFragment.kt
@@ -212,6 +212,13 @@ class SearchStatusesFragment : SearchFragment<StatusViewData>(), StatusActionLis
         )
     }
 
+    override fun onViewMedia(pachliAccountId: Long, username: String, url: String) {
+        startActivityWithTransition(
+            ViewMediaActivityIntent(requireContext(), pachliAccountId, username, url),
+            TransitionKind.SLIDE_FROM_END,
+        )
+    }
+
     private fun reply(status: StatusViewData) {
         val actionableStatus = status.actionable
         val mentionedUsernames = actionableStatus.mentions.map { it.username }

--- a/app/src/main/java/app/pachli/fragment/SFragment.kt
+++ b/app/src/main/java/app/pachli/fragment/SFragment.kt
@@ -544,6 +544,13 @@ abstract class SFragment<T : IStatusViewData> : Fragment(), StatusActionListener
         }
     }
 
+    override fun onViewMedia(pachliAccountId: Long, username: String, url: String) {
+        startActivityWithTransition(
+            ViewMediaActivityIntent(requireContext(), pachliAccountId, username, url),
+            TransitionKind.SLIDE_FROM_END,
+        )
+    }
+
     companion object {
         private fun accountIsInMentions(account: AccountEntity?, mentions: List<Status.Mention>): Boolean {
             return mentions.any { mention ->

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/StatusActionListener.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/StatusActionListener.kt
@@ -73,4 +73,13 @@ interface StatusActionListener<T : IStatusViewData> : LinkListener {
 
     /** Edit the filter that matched this status. */
     fun onEditFilterById(pachliAccountId: Long, filterId: String)
+
+    /**
+     * View non-attached media referenced by URL.
+     *
+     * @param pachliAccountId
+     * @param username The username that owns the media.
+     * @param url The URL of the media.
+     */
+    fun onViewMedia(pachliAccountId: Long, username: String, url: String)
 }


### PR DESCRIPTION
Previous code started activities from `StatusBaseViewHolder` if to show preview card authors and view media in preview cards.

This is a layering violation. Amend `StatusActionListener` to account for these, and call the listener (which will eventually be the fragment or activity hosting the `StatusBaseViewHolder`). Let that fragment or activity start the next activity.