### PR TITLE
fix: Improve accessibility of hidden attachments

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -319,7 +319,7 @@
         errorLine2="                 ~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/adapter/StatusBaseViewHolder.kt"
-            line="294"
+            line="295"
             column="18"/>
     </issue>
 
@@ -330,7 +330,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/adapter/StatusBaseViewHolder.kt"
-            line="296"
+            line="297"
             column="13"/>
     </issue>
 
@@ -631,7 +631,7 @@
         errorLine2="                                           ~~~~~">
         <location
             file="src/main/res/values-nb-rNO/strings.xml"
-            line="33"
+            line="32"
             column="44"/>
     </issue>
 
@@ -642,7 +642,7 @@
         errorLine2="                                                 ~~~~~~">
         <location
             file="src/main/res/values-tr/strings.xml"
-            line="39"
+            line="38"
             column="50"/>
     </issue>
 
@@ -653,7 +653,7 @@
         errorLine2="                                             ~~~~~~~~~~">
         <location
             file="src/main/res/values-tr/strings.xml"
-            line="39"
+            line="38"
             column="46"/>
     </issue>
 
@@ -664,7 +664,7 @@
         errorLine2="                                     ~~~~~">
         <location
             file="src/main/res/values-nb-rNO/strings.xml"
-            line="68"
+            line="67"
             column="38"/>
     </issue>
 
@@ -675,7 +675,7 @@
         errorLine2="                                             ~~~~~">
         <location
             file="src/main/res/values-nb-rNO/strings.xml"
-            line="70"
+            line="69"
             column="46"/>
     </issue>
 
@@ -686,7 +686,7 @@
         errorLine2="                                           ~~~~~">
         <location
             file="src/main/res/values-nb-rNO/strings.xml"
-            line="76"
+            line="75"
             column="44"/>
     </issue>
 
@@ -697,7 +697,7 @@
         errorLine2="                                            ~~~~~">
         <location
             file="src/main/res/values-nb-rNO/strings.xml"
-            line="93"
+            line="92"
             column="45"/>
     </issue>
 
@@ -708,7 +708,7 @@
         errorLine2="                                           ~~~~~">
         <location
             file="src/main/res/values-nb-rNO/strings.xml"
-            line="96"
+            line="95"
             column="44"/>
     </issue>
 
@@ -719,7 +719,7 @@
         errorLine2="                                                ~~~~~">
         <location
             file="src/main/res/values-nb-rNO/strings.xml"
-            line="97"
+            line="96"
             column="49"/>
     </issue>
 
@@ -730,7 +730,7 @@
         errorLine2="                                     ~~~~~">
         <location
             file="src/main/res/values-nb-rNO/strings.xml"
-            line="100"
+            line="99"
             column="38"/>
     </issue>
 
@@ -741,7 +741,7 @@
         errorLine2="                                                                     ~~~~~">
         <location
             file="src/main/res/values-nb-rNO/strings.xml"
-            line="115"
+            line="114"
             column="70"/>
     </issue>
 
@@ -752,7 +752,7 @@
         errorLine2="                                                                             ~~~~~">
         <location
             file="src/main/res/values-nb-rNO/strings.xml"
-            line="148"
+            line="147"
             column="78"/>
     </issue>
 
@@ -763,7 +763,7 @@
         errorLine2="                                                                ~~~~~">
         <location
             file="src/main/res/values-nb-rNO/strings.xml"
-            line="154"
+            line="153"
             column="65"/>
     </issue>
 
@@ -774,7 +774,7 @@
         errorLine2="                               ~~~~~">
         <location
             file="src/main/res/values-nb-rNO/strings.xml"
-            line="180"
+            line="177"
             column="32"/>
     </issue>
 
@@ -785,7 +785,7 @@
         errorLine2="                                          ~~~~~">
         <location
             file="src/main/res/values-nb-rNO/strings.xml"
-            line="238"
+            line="235"
             column="43"/>
     </issue>
 
@@ -796,7 +796,7 @@
         errorLine2="                                                                                     ~~~~~">
         <location
             file="src/main/res/values-nb-rNO/strings.xml"
-            line="326"
+            line="323"
             column="86"/>
     </issue>
 
@@ -807,7 +807,7 @@
         errorLine2="                                                  ~~~~~">
         <location
             file="src/main/res/values-nb-rNO/strings.xml"
-            line="443"
+            line="438"
             column="51"/>
     </issue>
 
@@ -818,7 +818,7 @@
         errorLine2="                                          ~~~~~~~">
         <location
             file="src/main/res/values-nb-rNO/strings.xml"
-            line="555"
+            line="550"
             column="43"/>
     </issue>
 
@@ -829,7 +829,7 @@
         errorLine2="                                                  ~~~~~">
         <location
             file="src/main/res/values-nb-rNO/strings.xml"
-            line="640"
+            line="635"
             column="51"/>
     </issue>
 
@@ -840,7 +840,7 @@
         errorLine2="                                                                   ~~~~~">
         <location
             file="src/main/res/values-nb-rNO/strings.xml"
-            line="664"
+            line="659"
             column="68"/>
     </issue>
 
@@ -851,7 +851,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="328"
+            line="323"
             column="5"/>
     </issue>
 
@@ -862,7 +862,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="607"
+            line="598"
             column="5"/>
     </issue>
 
@@ -3557,7 +3557,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="94"
+            line="89"
             column="13"/>
     </issue>
 
@@ -3568,7 +3568,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="100"
+            line="95"
             column="13"/>
     </issue>
 
@@ -3579,7 +3579,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="142"
+            line="137"
             column="13"/>
     </issue>
 
@@ -3590,7 +3590,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="150"
+            line="145"
             column="13"/>
     </issue>
 
@@ -3601,7 +3601,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="186"
+            line="181"
             column="13"/>
     </issue>
 
@@ -3612,7 +3612,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="244"
+            line="239"
             column="13"/>
     </issue>
 
@@ -3623,7 +3623,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="265"
+            line="260"
             column="13"/>
     </issue>
 
@@ -3634,7 +3634,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="266"
+            line="261"
             column="13"/>
     </issue>
 
@@ -3645,7 +3645,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="318"
+            line="313"
             column="13"/>
     </issue>
 
@@ -3656,7 +3656,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="414"
+            line="405"
             column="13"/>
     </issue>
 
@@ -3667,7 +3667,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="440"
+            line="431"
             column="13"/>
     </issue>
 
@@ -3678,7 +3678,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="443"
+            line="434"
             column="13"/>
     </issue>
 
@@ -3689,7 +3689,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="446"
+            line="437"
             column="13"/>
     </issue>
 
@@ -3700,7 +3700,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="447"
+            line="438"
             column="13"/>
     </issue>
 
@@ -3711,7 +3711,7 @@
         errorLine2="            ~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="448"
+            line="439"
             column="13"/>
     </issue>
 
@@ -3722,7 +3722,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="450"
+            line="441"
             column="13"/>
     </issue>
 
@@ -3733,7 +3733,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="462"
+            line="453"
             column="13"/>
     </issue>
 
@@ -3744,7 +3744,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="463"
+            line="454"
             column="13"/>
     </issue>
 
@@ -3755,7 +3755,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="501"
+            line="492"
             column="13"/>
     </issue>
 
@@ -3766,7 +3766,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="502"
+            line="493"
             column="13"/>
     </issue>
 
@@ -3777,7 +3777,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="512"
+            line="503"
             column="13"/>
     </issue>
 
@@ -3788,7 +3788,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="513"
+            line="504"
             column="13"/>
     </issue>
 
@@ -3799,7 +3799,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="514"
+            line="505"
             column="13"/>
     </issue>
 
@@ -3810,7 +3810,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="517"
+            line="508"
             column="13"/>
     </issue>
 
@@ -3821,7 +3821,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="525"
+            line="516"
             column="13"/>
     </issue>
 
@@ -3832,7 +3832,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="567"
+            line="558"
             column="13"/>
     </issue>
 
@@ -3843,7 +3843,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="573"
+            line="564"
             column="13"/>
     </issue>
 
@@ -3854,7 +3854,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="599"
+            line="590"
             column="13"/>
     </issue>
 
@@ -3865,7 +3865,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="625"
+            line="616"
             column="13"/>
     </issue>
 

--- a/app/src/main/java/app/pachli/util/StatusViewHelper.kt
+++ b/app/src/main/java/app/pachli/util/StatusViewHelper.kt
@@ -178,7 +178,7 @@ class StatusViewHelper(
             sensitiveMediaShow.visibility = View.GONE
         } else {
             sensitiveMediaWarning.text = if (sensitive) {
-                context.getString(R.string.post_sensitive_media_title)
+                context.getString(app.pachli.core.ui.R.string.post_sensitive_media_title)
             } else {
                 context.getString(R.string.post_media_hidden_title)
             }
@@ -235,7 +235,7 @@ class StatusViewHelper(
         val context = mediaLabel.context
         var labelText = getLabelTypeText(context, attachments[0].type)
         if (sensitive) {
-            val sensitiveText = context.getString(R.string.post_sensitive_media_title)
+            val sensitiveText = context.getString(app.pachli.core.ui.R.string.post_sensitive_media_title)
             labelText += " ($sensitiveText)"
         }
         mediaLabel.text = labelText
@@ -249,10 +249,10 @@ class StatusViewHelper(
 
     private fun getLabelTypeText(context: Context, type: Attachment.Type): String {
         return when (type) {
-            Attachment.Type.IMAGE -> context.getString(R.string.post_media_images)
-            Attachment.Type.GIFV, Attachment.Type.VIDEO -> context.getString(R.string.post_media_video)
-            Attachment.Type.AUDIO -> context.getString(R.string.post_media_audio)
-            else -> context.getString(R.string.post_media_attachments)
+            Attachment.Type.IMAGE -> context.getString(app.pachli.core.ui.R.string.post_media_images)
+            Attachment.Type.GIFV, Attachment.Type.VIDEO -> context.getString(app.pachli.core.ui.R.string.post_media_video)
+            Attachment.Type.AUDIO -> context.getString(app.pachli.core.ui.R.string.post_media_audio)
+            else -> context.getString(app.pachli.core.ui.R.string.post_media_attachments)
         }
     }
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -29,7 +29,6 @@
     <string name="title_edit_profile">عدل ملفك التعريفي</string>
     <string name="title_drafts">المسودات</string>
     <string name="post_boosted_format">شاركه %s</string>
-    <string name="post_sensitive_media_title">محتوى حساس</string>
     <string name="post_media_hidden_title">وسائط مخفية</string>
     <string name="post_sensitive_media_directions">اضغط للعرض</string>
     <string name="post_content_warning_show_more">اعرض المزيد</string>
@@ -189,8 +188,6 @@
     -->
     <string name="post_share_content">شارك محتوى التبويق</string>
     <string name="post_share_link">شارك الرابط إلى التبويق</string>
-    <string name="post_media_images">صور</string>
-    <string name="post_media_video">فيديو</string>
     <string name="state_follow_requested">طلب متابعة</string>
     <!--These are for timestamps on statuses. For example: "16s" or "2d"-->
     <string name="follows_you">يتبعك الآن</string>
@@ -357,13 +354,11 @@
     <string name="action_delete_conversation">احذف المحادثة</string>
     <string name="dialog_delete_conversation_warning">هل تريد حذف هذه المحادثة؟</string>
     <string name="notification_subscription_name">منشورات جديدة</string>
-    <string name="post_media_attachments">مرفقات</string>
     <string name="label_duration">المدة</string>
     <string name="no_announcements">لا توجد إعلانات.</string>
     <string name="account_note_hint">ملاحظتك الخاصة عن هذا الحساب</string>
     <string name="account_note_saved">تم حفظها!</string>
     <string name="review_notifications">راجع الإشعارات</string>
-    <string name="post_media_audio">صوت</string>
     <string name="drafts_post_reply_removed">لقد حُذِف التبويق الذي حررت من أجله مسودة الرد</string>
     <string name="pref_title_notification_filter_subscriptions">شخص ما أنا مشترك في حسابه قد نشر منشورا جديدا</string>
     <string name="pref_title_animate_custom_emojis">حرّك الإيموجيات المخصصة</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -42,7 +42,6 @@
     <string name="title_announcements">Аб\'явы</string>
     <string name="title_followed_hashtags">Падпіскі на хэштэгі</string>
     <string name="post_boosted_format">%s пашырыў(-ла)</string>
-    <string name="post_sensitive_media_title">Далікатнае змесціва</string>
     <string name="post_media_hidden_title">Медыя схаванае</string>
     <string name="post_content_show_more">Разгарнуць</string>
     <string name="report_comment_hint">Дадатковыя каментарыі\?</string>
@@ -257,10 +256,6 @@
     <string name="notification_summary_small">%1$s ды %2$s</string>
     <string name="post_share_content">Падзяліцца зместам допісу</string>
     <string name="post_share_link">Падзяліцца спасылкай на допіс</string>
-    <string name="post_media_images">Выявы</string>
-    <string name="post_media_video">Відэа</string>
-    <string name="post_media_audio">Аўдыё</string>
-    <string name="post_media_attachments">Далучэнні</string>
     <string name="status_count_one_plus">1+</string>
     <string name="state_follow_requested">Запыт на падпіску</string>
     <string name="title_media">Медыя</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -99,10 +99,6 @@
     <string name="pref_title_alway_show_sensitive_media">Винаги показване на деликатно съдържание</string>
     <string name="follows_you">Следва ви</string>
     <string name="state_follow_requested">Заявено последване</string>
-    <string name="post_media_attachments">Прикачени файлове</string>
-    <string name="post_media_audio">Аудио</string>
-    <string name="post_media_video">Видео</string>
-    <string name="post_media_images">Изображения</string>
     <string name="post_share_link">Споделяне на връзка към публикация</string>
     <string name="post_share_content">Споделяне на съдържание на публикация</string>
     <string name="description_account_locked">Заключен акаунт</string>
@@ -263,7 +259,6 @@
     <string name="post_content_warning_show_more">Покажи повече</string>
     <string name="post_sensitive_media_directions">Щракнете за преглед</string>
     <string name="post_media_hidden_title">Мултимедията е скрита</string>
-    <string name="post_sensitive_media_title">Деликатно съдържание</string>
     <string name="post_boosted_format">%s сподели</string>
     <string name="title_announcements">Оповестявания</string>
     <string name="title_scheduled_posts">Планирани публикации</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -50,8 +50,6 @@
     <string name="pref_title_alway_show_sensitive_media">সর্বদা সংবেদনশীল কন্টেন্ট প্রদর্শন করুন</string>
     <string name="follows_you">আপনাকে অনুসরন করে</string>
     <string name="state_follow_requested">অনুরোধ অনুসরণ করুন</string>
-    <string name="post_media_video">ভিডিও</string>
-    <string name="post_media_images">চিত্রগুলি</string>
     <string name="post_share_link">টুট এর সাথে লিংক ভাগ করুন</string>
     <string name="post_share_content">টুট এর কন্টেন্ট ভাগ করুন</string>
     <string name="description_account_locked">লক অ্যাকাউন্ট</string>
@@ -201,7 +199,6 @@
     <string name="post_content_warning_show_more">আরও দেখাও</string>
     <string name="post_sensitive_media_directions">দেখার জন্য ক্লিক করুন</string>
     <string name="post_media_hidden_title">মিডিয়া লুকানো</string>
-    <string name="post_sensitive_media_title">সংবেদনশীল কন্টেন্ট</string>
     <string name="title_drafts">খসড়া</string>
     <string name="title_edit_profile">আপনার প্রোফাইল সম্পাদনা করুন</string>
     <string name="title_follow_requests">অনুরোধ অনুসরণ করুন</string>
@@ -355,8 +352,6 @@
         <item quantity="other">&lt;b&gt;%s&lt;/b&gt; বুস্ট</item>
     </plurals>
     <string name="account_moved_description">%1$s স্থানান্তরিত হয়েছে এখানে:</string>
-    <string name="post_media_attachments">সংযুক্তি</string>
-    <string name="post_media_audio">শব্দ</string>
     <plurals name="notification_title_summary">
         <item quantity="one">%dটি নতুন ক্রিয়া</item>
         <item quantity="other">%dটি নতুন ক্রিয়া</item>

--- a/app/src/main/res/values-bn-rIN/strings.xml
+++ b/app/src/main/res/values-bn-rIN/strings.xml
@@ -29,7 +29,6 @@
     <string name="title_edit_profile">আপনার প্রোফাইল সম্পাদনা করুন</string>
     <string name="title_drafts">খসড়াগুলো</string>
     <string name="post_boosted_format">%s সমর্থন দিয়েছে</string>
-    <string name="post_sensitive_media_title">সংবেদনশীল কন্টেন্ট</string>
     <string name="post_media_hidden_title">মিডিয়া লুকানো</string>
     <string name="post_sensitive_media_directions">দেখার জন্য ক্লিক করুন</string>
     <string name="post_content_warning_show_more">আরও দেখাও</string>
@@ -195,8 +194,6 @@
     -->
     <string name="post_share_content">টুট এর কন্টেন্ট ভাগ করুন</string>
     <string name="post_share_link">টুট এর সাথে লিংক ভাগ করুন</string>
-    <string name="post_media_images">চিত্রগুলি</string>
-    <string name="post_media_video">ভিডিও</string>
     <string name="state_follow_requested">অনুরোধ অনুসরণ করুন</string>
     <!--These are for timestamps on statuses. For example: "16s" or "2d"-->
     <string name="follows_you">আপনাকে অনুসরন করে</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -24,7 +24,6 @@
     <string name="title_edit_profile">Edita el perfil</string>
     <string name="title_drafts">Esborranys</string>
     <string name="post_boosted_format">%s ha impulsat</string>
-    <string name="post_sensitive_media_title">Contingut sensible</string>
     <string name="post_sensitive_media_directions">Fes clic per a visualitzar-lo</string>
     <string name="post_content_warning_show_more">Mostra\'n més</string>
     <string name="post_content_warning_show_less">Mostra\'n menys</string>
@@ -136,8 +135,6 @@
     <!-- note to translators: the url can be changed to link to the localized version of the license -->
     <string name="post_share_content">Comparteix el contingut de la publicació</string>
     <string name="post_share_link">Comparteix l\'enllaç a la publicació</string>
-    <string name="post_media_images">Imatges</string>
-    <string name="post_media_video">Vídeo</string>
     <!--These are for timestamps on statuses. For example: "16s" or "2d"-->
     <string name="follows_you">Et segueix</string>
     <string name="pref_title_alway_show_sensitive_media">Mostra el contingut no apte (NSFW)</string>
@@ -338,8 +335,6 @@
     <string name="no_announcements">No hi ha cap avís.</string>
     <string name="duration_indefinite">Indefinit</string>
     <string name="label_duration">Durada</string>
-    <string name="post_media_attachments">Adjuncions</string>
-    <string name="post_media_audio">Àudio</string>
     <string name="notification_subscription_description">Notificacions quan algú a qui estàs subscrit publica una publicació nova</string>
     <string name="notification_subscription_name">Publicacions noves</string>
     <string name="pref_title_animate_custom_emojis">emojis personalitzats animats</string>

--- a/app/src/main/res/values-ckb/strings.xml
+++ b/app/src/main/res/values-ckb/strings.xml
@@ -90,7 +90,6 @@
     <string name="post_content_warning_show_more">زیاتر پیشان بدە</string>
     <string name="post_sensitive_media_directions">کرتە بکە بۆ بینین</string>
     <string name="post_media_hidden_title">میدیا شاراوە</string>
-    <string name="post_sensitive_media_title">ناوەڕۆکی هەستیار</string>
     <string name="post_boosted_format">%s پۆستی کردەوە</string>
     <string name="title_announcements">ڕاگه یه نراوەکان</string>
     <string name="title_scheduled_posts">توتی خشتەکراو</string>
@@ -303,8 +302,6 @@
     <string name="pref_title_alway_show_sensitive_media">هەمیشە ناوەڕۆکی هەستیار نیشان بدە</string>
     <string name="follows_you">دوای تۆ دەکەوێت</string>
     <string name="state_follow_requested">بەدواداچوونەوەی داواکراو</string>
-    <string name="post_media_video">ڤیدیۆ</string>
-    <string name="post_media_images">وێنەکان</string>
     <string name="post_share_link">هاوبەشکردنی لینک بۆ توت</string>
     <string name="post_share_content">هاوبەشکردنی ناوەڕۆکی دووت</string>
     <string name="description_account_locked">هەژماری داخراو</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -29,7 +29,6 @@
     <string name="title_edit_profile">Upravit váš profil</string>
     <string name="title_drafts">Koncepty</string>
     <string name="post_boosted_format">%s boostnul/a</string>
-    <string name="post_sensitive_media_title">Citlivý obsah</string>
     <string name="post_media_hidden_title">Média skryta</string>
     <string name="post_sensitive_media_directions">Klikněte pro zobrazení</string>
     <string name="post_content_warning_show_more">Zobrazit více</string>
@@ -190,8 +189,6 @@
     -->
     <string name="post_share_content">Sdílet obsah příspěvku</string>
     <string name="post_share_link">Sdílet odkaz na příspěvek</string>
-    <string name="post_media_images">Obrázky</string>
-    <string name="post_media_video">Video</string>
     <string name="state_follow_requested">Vyžádáno sledování</string>
     <!--These are for timestamps on statuses. For example: "16s" or "2d"-->
     <string name="follows_you">Sleduje vás</string>
@@ -385,8 +382,6 @@
     <string name="notification_sign_up_description">Oznámení o nových uživatelích</string>
     <string name="notification_update_name">Úpravy příspěvků</string>
     <string name="notification_update_description">Oznámení, když je upraven příspěvek, se kterým jste interagovala, je upraven</string>
-    <string name="post_media_audio">Audio</string>
-    <string name="post_media_attachments">Přílohy</string>
     <string name="status_count_one_plus">1+</string>
     <string name="description_post_language">Jazyk příspěvku</string>
     <string name="label_duration">Doba trvání</string>

--- a/app/src/main/res/values-cy/strings.xml
+++ b/app/src/main/res/values-cy/strings.xml
@@ -26,7 +26,6 @@
     <string name="title_edit_profile">Golygu\'ch proffil</string>
     <string name="title_drafts">Drafftiau</string>
     <string name="post_boosted_format">Hybodd %s</string>
-    <string name="post_sensitive_media_title">Cynnwys sensitif</string>
     <string name="post_media_hidden_title">Cyfryngau cudd</string>
     <string name="post_sensitive_media_directions">Cliciwch i weld</string>
     <string name="post_content_warning_show_more">Dangos Mwy</string>
@@ -175,8 +174,6 @@
     -->
     <string name="post_share_content">Rhannu cynnwys y neges</string>
     <string name="post_share_link">Rhannu dolen i\'r neges</string>
-    <string name="post_media_images">Delweddau</string>
-    <string name="post_media_video">Fideo</string>
     <string name="state_follow_requested">Ceisiwyd</string>
     <!--These are for timestamps on statuses. For example: "16s" or "2d"-->
     <string name="follows_you">Yn eich dilyn chi</string>
@@ -308,7 +305,6 @@
     <string name="duration_6_hours">6 awr</string>
     <string name="duration_1_day">Diwrnod</string>
     <string name="unpin_action">Dadbinio</string>
-    <string name="post_media_attachments">Atodiadau</string>
     <string name="action_edit_image">Golygu llun</string>
     <string name="title_reblogged_by">Hybwyd gan</string>
     <string name="label_duration">Hyd</string>
@@ -353,7 +349,6 @@
     <string name="create_poll_title">Pôl</string>
     <string name="add_hashtag_title">Ychwanegu hashnod</string>
     <string name="status_count_one_plus">1+</string>
-    <string name="post_media_audio">Sain</string>
     <string name="compose_shortcut_long_label">Ysgrifennu neges</string>
     <string name="drafts_post_failed_to_send">Methodd anfon y neges hon!</string>
     <string name="pachli_compose_post_quicksetting_label">Ysgrifennu Neges</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -29,7 +29,6 @@
     <string name="title_edit_profile">Dein Profil bearbeiten</string>
     <string name="title_drafts">Entwürfe</string>
     <string name="post_boosted_format">%s teilte</string>
-    <string name="post_sensitive_media_title">Inhaltswarnung. Antippen zum Anzeigen.</string>
     <string name="post_media_hidden_title">Medien ausgeblendet</string>
     <string name="post_sensitive_media_directions">Zum Anzeigen tippen</string>
     <string name="post_content_warning_show_more">Mehr anzeigen</string>
@@ -188,8 +187,6 @@
     -->
     <string name="post_share_content">Inhalt des Beitrags teilen</string>
     <string name="post_share_link">Link zum Beitrag teilen</string>
-    <string name="post_media_images">Bilder</string>
-    <string name="post_media_video">Video</string>
     <string name="state_follow_requested">Folgeanfrage gesendet</string>
     <!--These are for timestamps on statuses. For example: "16s" or "2d"-->
     <string name="follows_you">Folgt dir</string>
@@ -354,8 +351,6 @@
     <string name="pref_title_wellbeing_mode">Wohlbefinden</string>
     <string name="label_duration">Dauer</string>
     <string name="duration_indefinite">Für immer</string>
-    <string name="post_media_attachments">Anhänge</string>
-    <string name="post_media_audio">Audio</string>
     <string name="notification_subscription_description">Benachrichtigungen, wenn jemand, den ich abonniert habe, eine neue Nachricht veröffentlicht</string>
     <string name="notification_subscription_name">Neue Beiträge</string>
     <string name="pref_title_animate_custom_emojis">GIF-Emojis animieren</string>
@@ -789,10 +784,6 @@
         <item quantity="one">mit Rolle:</item>
         <item quantity="other">mit Rollen:</item>
     </plurals>
-    <string name="attachment_matches_filter_one_fmt">Entspricht Filter: \"%1$s\". Antippen zum Anzeigen.</string>
-    <string name="attachment_matches_filter_two_fmt">Entspricht Filtern: \"%1$s\" und \"%2$s\". Antippen zum Anzeigen.</string>
-    <string name="attachment_matches_filter_other_fmt">Entspricht Filtern: \"%1$s\", \"%2$s\" und weiteren. Antippen zum Anzeigen.</string>
-    <string name="attachment_hidden_user_action">Du hast dies ausgeblendet. Antippen zum Anzeigen.</string>
     <string name="filter_description_blur">Inhalt anzeigen, Medien mit Inhaltswarnung ausblenden</string>
     <string name="filter_action_blur">Anhänge ausblenden</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -80,7 +80,6 @@
     <string name="title_scheduled_posts">Προγραμματισμένες δημοσιεύσεις</string>
     <string name="title_posts">Δημοσιεύσεις</string>
     <string name="title_posts_pinned">Καρφιτσωμένο</string>
-    <string name="post_sensitive_media_title">Ευαίσθητο περιεχόμενο</string>
     <string name="post_media_hidden_title">Κρυμμένα μέσα</string>
     <string name="post_boosted_format">ο/η %s το προώθησε</string>
     <string name="title_posts_with_replies">Με απαντήσεις</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -29,7 +29,6 @@
     <string name="title_edit_profile">Redakti vian profilon</string>
     <string name="title_drafts">Malnetoj</string>
     <string name="post_boosted_format">%s diskonigis</string>
-    <string name="post_sensitive_media_title">Tikla enhavo</string>
     <string name="post_media_hidden_title">Kaŝitaj aŭdovidaĵoj</string>
     <string name="post_sensitive_media_directions">Alklaki por vidi</string>
     <string name="post_content_warning_show_more">Montri pli</string>
@@ -189,8 +188,6 @@
     -->
     <string name="post_share_content">Konigi enhavon de la mesaĝo</string>
     <string name="post_share_link">Konigi ligilon al mesaĝo</string>
-    <string name="post_media_images">Bildoj</string>
-    <string name="post_media_video">Video</string>
     <string name="state_follow_requested">Sekvado petita</string>
     <!--These are for timestamps on statuses. For example: "16s" or "2d"-->
     <string name="follows_you">Sekvas vin</string>
@@ -344,9 +341,7 @@
     <string name="no_announcements">Estas neniu anonco.</string>
     <string name="pref_title_enable_swipe_for_tabs">Ebligi ŝovumadon por ŝanĝi inter la langetoj</string>
     <string name="warning_scheduling_interval">Mastodon havas minimuman intervalon de planado de 5 minutoj.</string>
-    <string name="post_media_attachments">Kunsendaĵoj</string>
     <string name="pref_title_notification_filter_subscriptions">iu, kiun mi sekvas, afiŝis novan mesaĝon</string>
-    <string name="post_media_audio">Aŭdaĵo</string>
     <string name="action_subscribe_account">Aboni</string>
     <string name="draft_deleted">Malneto forigita</string>
     <plurals name="error_upload_max_media_reached">

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -29,7 +29,6 @@
     <string name="title_edit_profile">Editar tu perfil</string>
     <string name="title_drafts">Borradores</string>
     <string name="post_boosted_format">%s impulsó</string>
-    <string name="post_sensitive_media_title">Contenido sensible. Toca para mostrar.</string>
     <string name="post_media_hidden_title">Material oculto</string>
     <string name="post_sensitive_media_directions">Pulsa para ver</string>
     <string name="post_content_warning_show_more">Mostrar más</string>
@@ -179,8 +178,6 @@
     -->
     <string name="post_share_content">Compartir contenido</string>
     <string name="post_share_link">Compartir enlace</string>
-    <string name="post_media_images">Imágenes</string>
-    <string name="post_media_video">Video</string>
     <string name="state_follow_requested">Solicitud enviada</string>
     <!--These are for timestamps on statuses. For example: "16s" or "2d"-->
     <string name="follows_you">Te sigue</string>
@@ -368,8 +365,6 @@
     <string name="drafts_post_failed_to_send">¡Esta publicación no se pudo enviar!</string>
     <string name="duration_indefinite">Indefinido</string>
     <string name="label_duration">Duración</string>
-    <string name="post_media_attachments">Adjuntos</string>
-    <string name="post_media_audio">Audio</string>
     <string name="action_unbookmark">Quitar marcador</string>
     <string name="follow_requests_info">Aunque tu cuenta no está protegida, el personal de %1$s pensó que podrías querer revisar las solicitudes de seguimiento de estas cuentas manualmente.</string>
     <string name="action_subscribe_account">Suscribir</string>
@@ -796,10 +791,6 @@
         <item quantity="many">con roles:</item>
         <item quantity="other">con roles:</item>
     </plurals>
-    <string name="attachment_matches_filter_one_fmt">Filtro aplicado: \"%1$s\". Toca para mostrar.</string>
-    <string name="attachment_matches_filter_two_fmt">Filtros aplicados: \"%1$s\" y \"%2$s\". Toca para mostrar.</string>
-    <string name="attachment_matches_filter_other_fmt">Filtros aplicados: \"%1$s\", \"%2$s\" y otros. Toca para mostrar.</string>
-    <string name="attachment_hidden_user_action">Ocultado por ti. Toca para mostrar.</string>
     <string name="filter_action_blur">Ocultar adjuntos</string>
     <string name="filter_description_blur">Mostrar contenido, ocultar adjuntos con una advertencia</string>
 </resources>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -107,7 +107,6 @@
     <string name="dialog_follow_hashtag_title">Jälgi teemaviidet</string>
     <string name="dialog_follow_hashtag_hint">#teemaviide</string>
     <string name="post_boosted_format">%s lisas hoogu</string>
-    <string name="post_sensitive_media_title">Delikaatne sisu. Nägemiseks klõpsa.</string>
     <string name="post_media_hidden_title">Meedium on peidetud</string>
     <string name="post_sensitive_media_directions">Vaatamiseks klõpsi</string>
     <string name="notification_unknown">Tundmatu teavituse tüüp</string>
@@ -455,10 +454,6 @@
     <string name="description_account_locked">Lukustatud kasutajakonto</string>
     <string name="post_share_content">Jaga postituse sisu</string>
     <string name="post_share_link">Jaga postituse linki</string>
-    <string name="post_media_images">Pildid</string>
-    <string name="post_media_video">Video</string>
-    <string name="post_media_audio">Helifail</string>
-    <string name="post_media_attachments">Manused</string>
     <string name="status_count_one_plus">1+</string>
     <string name="status_filtered_show_anyway">Näita ikkagi</string>
     <string name="status_filter_placeholder_label_format">Filtreeritud: <b>%1$s</b></string>
@@ -770,10 +765,6 @@
     <string name="error_prepare_media_content_resolver_missing_path_fmt">sisulahendaja URI asukoht on puudu: %1$s</string>
     <string name="error_prepare_media_content_resolver_unsupported_scheme_fmt">sisulahendaja URI skeem pole toetatud: %1$s</string>
     <string name="error_prepare_media_io_fmt">%1$s</string>
-    <string name="attachment_matches_filter_one_fmt">Vastab filtrile: „%1$s“. Nägemiseks klõpsa.</string>
-    <string name="attachment_matches_filter_two_fmt">Vastab filtritele: „%1$s“ ja „%2$s“. Nägemiseks klõpsa.</string>
-    <string name="attachment_matches_filter_other_fmt">Vastab filtritele: „%1$s“, „%2$s“ ja teistele. Nägemiseks klõpsa.</string>
-    <string name="attachment_hidden_user_action">Sa oled selle peitnud. Nägemiseks klõpsa.</string>
     <string name="filter_action_blur">Peida manused</string>
     <string name="filter_description_blur">Näita sisu, peida manused hoiatuse taha</string>
 </resources>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -26,7 +26,6 @@
     <string name="title_edit_profile">Profila editatu</string>
     <string name="title_drafts">Zirriborroak</string>
     <string name="post_boosted_format">%s-(e)k bultzatu du</string>
-    <string name="post_sensitive_media_title">Eduki hunkigarria</string>
     <string name="post_media_hidden_title">Ezkutuko media</string>
     <string name="post_sensitive_media_directions">Sakatu ikusteko</string>
     <string name="post_content_warning_show_more">Gehiago erakutsi</string>
@@ -175,8 +174,6 @@
     -->
     <string name="post_share_content">Tutaren edukia partekatu</string>
     <string name="post_share_link">Tutaren esteka partekatu</string>
-    <string name="post_media_images">Irudiak</string>
-    <string name="post_media_video">Bideoa</string>
     <string name="state_follow_requested">Eskaera bidalita</string>
     <!--These are for timestamps on statuses. For example: "16s" or "2d"-->
     <string name="follows_you">Jarraitzen zaitu</string>
@@ -340,8 +337,6 @@
     <string name="pref_title_confirm_favourites">Erakutsi baieztapen elkarrizketa-koadroa gogokoenetara gehitu aurretik</string>
     <string name="follow_requests_info">Zure kontua blokeatuta ez badago ere, %1$s-ko langileek kontu hauetako eskaerak eskuz berrikusi nahi dituzula pentsatu dute.</string>
     <string name="pref_title_notification_filter_subscriptions">harpidedun naizen norbaitek tut berria argitaratu du</string>
-    <string name="post_media_attachments">Eranskinak</string>
-    <string name="post_media_audio">Audioa</string>
     <string name="action_subscribe_account">Harpidetu</string>
     <string name="dialog_delete_conversation_warning">Elkarrizketa ezabatu nahi duzu\?</string>
     <string name="pref_title_animate_custom_emojis">Animatu emoji pertsonalizatuak</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -26,7 +26,6 @@
     <string name="title_edit_profile">ویرایش نمایه‌تان</string>
     <string name="title_drafts">پیش‌نویس‌ها</string>
     <string name="post_boosted_format">%s تقویت کرد</string>
-    <string name="post_sensitive_media_title">محتوای حسّاس</string>
     <string name="post_media_hidden_title">رسانهٔ نهفته</string>
     <string name="post_sensitive_media_directions">کلیک برای نمایش</string>
     <string name="post_content_warning_show_more">نمایش بیش‌تر</string>
@@ -175,8 +174,6 @@
     -->
     <string name="post_share_content">هم‌رسانی محتوای فرسته</string>
     <string name="post_share_link">هم‌رسانی پیوند فرسته</string>
-    <string name="post_media_images">تصویرها</string>
-    <string name="post_media_video">ویدیو</string>
     <string name="state_follow_requested">تقاضای پیگیری شد</string>
     <!--These are for timestamps on statuses. For example: "16s" or "2d"-->
     <string name="follows_you">پیگیرتان است</string>
@@ -349,8 +346,6 @@
     <string name="review_notifications">بازبینی آگاهی‌ها</string>
     <string name="pref_title_wellbeing_mode">سلامتی</string>
     <string name="label_duration">طول</string>
-    <string name="post_media_attachments">پیوست‌ها</string>
-    <string name="post_media_audio">صدا</string>
     <string name="notification_subscription_description">آگاهی‌ها هنگام انتشار فرسته‌ای جدید از کسی که پی‌می‌گیرید</string>
     <string name="notification_subscription_name">فرسته‌های جدید</string>
     <string name="pref_title_animate_custom_emojis">اموجی‌های شخصی متحرّک</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -74,9 +74,6 @@
     <string name="action_remove">Poista</string>
     <string name="filter_dialog_update_button">Päivitä</string>
     <string name="filter_dialog_remove_button">Poista</string>
-    <string name="post_media_audio">Ääni</string>
-    <string name="post_media_video">Video</string>
-    <string name="post_media_images">Kuvat</string>
     <string name="pref_title_proxy_settings">Välityspalvelin</string>
     <string name="post_privacy_followers_only">Vain seuraajat</string>
     <string name="post_privacy_public">Julkinen</string>
@@ -197,7 +194,6 @@
     <string name="action_toggle_visibility">Julkaisun näkyvyys</string>
     <string name="title_posts_with_replies">Vastauksetkin</string>
     <string name="post_boosted_format">%s jakoi</string>
-    <string name="post_sensitive_media_title">Herkkää sisältoä</string>
     <string name="post_sensitive_media_directions">Klikkaa näyttääksesi</string>
     <string name="post_content_show_more">Laajenna</string>
     <string name="post_content_show_less">Vähennä</string>
@@ -232,7 +228,6 @@
     <string name="post_text_size_large">Suuri</string>
     <string name="post_text_size_largest">Suurin</string>
     <string name="post_share_link">Jaa linkki postaukseen</string>
-    <string name="post_media_attachments">Liitteet</string>
     <string name="title_media">Media</string>
     <string name="pref_title_public_filter_keywords">Julkiset aikajanat</string>
     <string name="pref_title_thread_filter_keywords">Keskustelut</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -29,7 +29,6 @@
     <string name="title_edit_profile">Modifier votre profil</string>
     <string name="title_drafts">Brouillons</string>
     <string name="post_boosted_format">%s a partagé</string>
-    <string name="post_sensitive_media_title">Contenu sensible</string>
     <string name="post_media_hidden_title">Média caché</string>
     <string name="post_sensitive_media_directions">Appuyer pour voir</string>
     <string name="post_content_warning_show_more">Voir plus</string>
@@ -190,8 +189,6 @@
     -->
     <string name="post_share_content">Partager le contenu du message</string>
     <string name="post_share_link">Partager le lien du message</string>
-    <string name="post_media_images">Images</string>
-    <string name="post_media_video">Vidéo</string>
     <string name="state_follow_requested">Demande d’abonnement effectuée</string>
     <!--These are for timestamps on statuses. For example: "16s" or "2d"-->
     <string name="follows_you">Vous suit</string>
@@ -365,7 +362,6 @@
     <string name="wellbeing_hide_stats_profile">Cacher les statistiques quantitatives sur les profils</string>
     <string name="wellbeing_hide_stats_posts">Cacher les statistiques quantitatives sur les messages</string>
     <string name="action_unbookmark">Supprimer le signet</string>
-    <string name="post_media_attachments">Pièces jointes</string>
     <string name="action_subscribe_account">S’abonner</string>
     <string name="dialog_delete_conversation_warning">Supprimer cette conversation \?</string>
     <string name="pref_title_animate_custom_emojis">Animer les émojis personnalisés</string>
@@ -374,7 +370,6 @@
     <string name="duration_indefinite">Indéfinie</string>
     <string name="action_unsubscribe_account">Se désabonner</string>
     <string name="action_delete_conversation">Supprimer la conversation</string>
-    <string name="post_media_audio">Audio</string>
     <string name="pref_title_confirm_favourites">Demander confirmation avant de mettre en favoris</string>
     <string name="drafts_post_reply_removed">Le message auquel répondait ce brouillon a été supprimé</string>
     <string name="drafts_post_failed_to_send">Échec d’envoi du message !</string>

--- a/app/src/main/res/values-fy/strings.xml
+++ b/app/src/main/res/values-fy/strings.xml
@@ -19,10 +19,6 @@
     <string name="title_media">Media</string>
     <string name="pref_title_alway_show_sensitive_media">Altyd gefoeliche ynhâld sjen litte</string>
     <string name="follows_you">Folget jo</string>
-    <string name="post_media_attachments">Taheaksels</string>
-    <string name="post_media_audio">Lûd</string>
-    <string name="post_media_video">Fideo</string>
-    <string name="post_media_images">Ôfbyldingen</string>
     <string name="post_share_link">Keppeling nei toot diele</string>
     <string name="post_share_content">Ynhâld fan toot diele</string>
     <plurals name="notification_title_summary">
@@ -166,7 +162,6 @@
     <string name="post_content_warning_show_more">Mear sjen litte</string>
     <string name="post_sensitive_media_directions">Klik om te besjen</string>
     <string name="post_media_hidden_title">Media ferburgen</string>
-    <string name="post_sensitive_media_title">Gefoelige ynhâld</string>
     <string name="title_scheduled_posts">Ynplanne toots</string>
     <string name="title_drafts">Sketsen</string>
     <string name="title_edit_profile">Jo profyl oanpasse</string>

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -5,7 +5,6 @@
     <string name="post_content_warning_show_more">Taispeáin Níos Mó</string>
     <string name="post_sensitive_media_directions">Cliceáil chun amharc</string>
     <string name="post_media_hidden_title">Meáin i bhfolach</string>
-    <string name="post_sensitive_media_title">Ábhar íogair. Tapáil le taispeáint.</string>
     <string name="post_boosted_format">D\'athchraol %s</string>
     <string name="title_scheduled_posts">Postálacha sceidealta</string>
     <string name="title_edit_profile">Cuir do phróifíl in eagar</string>
@@ -146,7 +145,6 @@
     <string name="action_view_preferences">Sainroghanna</string>
     <string name="title_drafts">Dréachtaí</string>
     <string name="title_favourites">Toghanna</string>
-    <string name="post_media_images">Íomhánna</string>
     <string name="post_share_link">Comhroinn nasc chuig postáil</string>
     <string name="post_share_content">Comhroinn inneachar na postála</string>
     <string name="description_account_locked">Cuntas faoi Ghlas</string>
@@ -217,7 +215,6 @@
     <string name="notification_favourite_format">Thogh %s do phostáil</string>
     <string name="action_unmute_desc">Díbhalbhaigh %s</string>
     <string name="action_mute_conversation">Comhrá tost</string>
-    <string name="post_media_video">Físeán</string>
     <string name="state_follow_requested">Lean iarrtha</string>
     <string name="follows_you">Leanann tú</string>
     <string name="pref_title_alway_show_sensitive_media">Taispeáin ábhar íogair i gcónaí</string>
@@ -565,8 +562,6 @@
     <string name="pref_default_post_language">Teanga phostála réamhshocraithe</string>
     <string name="notification_listenable_worker_name">Gníomhaíocht chúlra</string>
     <string name="notification_listenable_worker_description">Fógraí nuair atá Pachli ag obair sa chúlra</string>
-    <string name="post_media_audio">Fuaim</string>
-    <string name="post_media_attachments">Ceangaltáin</string>
     <string name="status_filter_placeholder_label_format">Scagtha: &lt;b&gt;%1$s&lt;/b&gt;</string>
     <string name="compose_save_draft_loses_media">Uaslódálfar ceangaltáin arís nuair a chuirfidh tú an dréacht ar ais.</string>
     <string name="update_dialog_title">Tá nuashonrú ar fáil</string>
@@ -809,10 +804,6 @@
     <string name="translator_error_unsupported_source_language_fmt">ní féidir aistriú ó %1$s</string>
     <string name="translator_error_unsupported_target_language_fmt">ní féidir aistriú go %1$s</string>
     <string name="translator_error_download_required_fmt">Éilíonn aistriúchán go %1$s an pacáiste teanga a íoslódáil, agus níl Wi-Fi ceangailte</string>
-    <string name="attachment_matches_filter_one_fmt">Meaitseálann an scagaire: \"%1$s\". Tapáil le taispeáint.</string>
-    <string name="attachment_matches_filter_two_fmt">Meaitseálann na scagairí seo a leanas: \"%1$s\" agus \"%2$s\". Tapáil le taispeáint.</string>
-    <string name="attachment_matches_filter_other_fmt">Meaitseálann scagairí: \"%1$s\", \"%2$s\", agus tuilleadh. Tapáil le taispeáint.</string>
-    <string name="attachment_hidden_user_action">Chuir tú seo i bhfolach. Tapáil le taispeáint.</string>
     <string name="filter_action_blur">Folaigh ceangaltáin</string>
     <string name="filter_description_blur">Taispeáin ábhar, folaigh ceangaltáin le rabhadh</string>
 </resources>

--- a/app/src/main/res/values-gd/strings.xml
+++ b/app/src/main/res/values-gd/strings.xml
@@ -49,8 +49,6 @@
     <string name="draft_deleted">Chaidh an dreach a sguabadh às</string>
     <string name="drafts_failed_loading_reply">Cha deach leinn fiosrachadh na freagairte a luchdadh</string>
     <string name="drafts_post_failed_to_send">Cha b’ urrainn dhuinn am post a chur!</string>
-    <string name="post_media_attachments">Ceanglachain</string>
-    <string name="post_media_audio">Fuaim</string>
     <string name="duration_7_days">7 làithean</string>
     <string name="duration_3_days">3 làithean</string>
     <string name="duration_1_day">Latha</string>
@@ -205,8 +203,6 @@
     <string name="pref_title_alway_show_sensitive_media">Seall susbaint fhrionasach an-còmhnaidh</string>
     <string name="follows_you">’Gad leantainn</string>
     <string name="state_follow_requested">Iarrtas leantainn air</string>
-    <string name="post_media_video">Videothan</string>
-    <string name="post_media_images">Dealbhan</string>
     <string name="description_account_locked">Cunntas glaiste</string>
     <plurals name="notification_title_summary">
         <item quantity="one">%d chonaltradh ùr</item>
@@ -345,7 +341,6 @@
     <string name="post_content_warning_show_more">Seall barrachd dheth</string>
     <string name="post_sensitive_media_directions">Briog air gus a shealltainn</string>
     <string name="post_media_hidden_title">Meadhanan falaichte</string>
-    <string name="post_sensitive_media_title">Susbaint fhrionasach</string>
     <string name="post_boosted_format">’Ga bhrosnachadh le %s</string>
     <string name="title_follow_requests">Iarrtasan leantainn</string>
     <string name="title_domain_mutes">Àrainnean falaichte</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -69,7 +69,6 @@
     <string name="post_content_warning_show_more">Ver máis</string>
     <string name="post_sensitive_media_directions">Click para ver</string>
     <string name="post_media_hidden_title">Multimedia agochado</string>
-    <string name="post_sensitive_media_title">Contido sensible</string>
     <string name="post_boosted_format">%s promoveu</string>
     <string name="title_announcements">Anuncios</string>
     <string name="title_scheduled_posts">Toots programados</string>
@@ -200,10 +199,6 @@
     <string name="pref_title_alway_show_sensitive_media">Mostrar sempre contido sensible</string>
     <string name="follows_you">Séguete</string>
     <string name="state_follow_requested">Seguimento solicitado</string>
-    <string name="post_media_attachments">Anexos</string>
-    <string name="post_media_audio">Audio</string>
-    <string name="post_media_video">Vídeo</string>
-    <string name="post_media_images">Imaxes</string>
     <string name="post_share_link">Compartir ligazón ao toot</string>
     <string name="post_share_content">Compartir contido do toot</string>
     <string name="description_account_locked">Conta bloqueada</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -139,7 +139,6 @@
     <string name="post_content_warning_show_more">और दिखाओ</string>
     <string name="post_sensitive_media_directions">देखने के लिए क्लिक करें</string>
     <string name="post_media_hidden_title">मीडिया छिपा हुआ</string>
-    <string name="post_sensitive_media_title">संवेदनशील विषय वस्तु</string>
     <string name="title_view_thread">टूट</string>
     <string name="title_scheduled_posts">अनुसूचित टूट</string>
     <string name="title_domain_mutes">छिपे हुए डोमेन</string>
@@ -235,8 +234,6 @@
     <string name="follows_you">आपको फॉलो करते है</string>
     <string name="pref_title_notification_filter_follow_requests">फ़ॉलो करने का अनुरोध किया</string>
     <string name="state_follow_requested">फ़ॉलो करने का अनुरोध किया हुआ</string>
-    <string name="post_media_video">वीडियो</string>
-    <string name="post_media_images">तस्वीरें</string>
     <string name="post_share_link">टूट का लिंक साझा करें</string>
     <string name="post_share_content">टूट की विषय वस्तु साझा करें</string>
     <string name="notification_mention_format">%s ने आपका जिक्र किया</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -29,7 +29,6 @@
     <string name="title_edit_profile">Profilod szerkesztése</string>
     <string name="title_drafts">Piszkozatok</string>
     <string name="post_boosted_format">%s megtolta</string>
-    <string name="post_sensitive_media_title">Érzékeny tartalom</string>
     <string name="post_media_hidden_title">Rejtett média</string>
     <string name="post_sensitive_media_directions">Kattints a megtekintéshez</string>
     <string name="post_content_warning_show_more">Mutass többet</string>
@@ -177,8 +176,6 @@
     -->
     <string name="post_share_content">Bejegyzés tartalmának megosztása</string>
     <string name="post_share_link">Bejegyzés hivatkozásának megosztása</string>
-    <string name="post_media_images">Képek</string>
-    <string name="post_media_video">Videó</string>
     <string name="state_follow_requested">Követés kérelmezve</string>
     <!--These are for timestamps on statuses. For example: "16s" or "2d"-->
     <string name="follows_you">Követ téged</string>
@@ -360,8 +357,6 @@
 \nA Push-értesítéseket ez nem befolyásolja, de kézzel átállíthatod az értesítési beállításaidat.</string>
     <string name="duration_indefinite">Végtelen</string>
     <string name="label_duration">Időtartam</string>
-    <string name="post_media_attachments">Csatolmányok</string>
-    <string name="post_media_audio">Audio</string>
     <string name="notification_subscription_description">Értesítések általam követett személy új bejegyzéseiről</string>
     <string name="notification_subscription_name">Új bejegyzések</string>
     <string name="pref_title_notification_filter_subscriptions">valaki, akit követek új bejegyzést tett közzé</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -94,9 +94,6 @@
     <string name="notification_follow_name">Pengikut Baru</string>
     <string name="notification_follow_description">Notifikasi tentang pengikut baru</string>
     <string name="notification_sign_up_name">Daftar</string>
-    <string name="post_media_video">Video</string>
-    <string name="post_media_audio">Audio</string>
-    <string name="post_media_attachments">Lampiran</string>
     <string name="status_count_one_plus">1+</string>
     <string name="follows_you">Mengikuti Anda</string>
     <string name="add_account_description">Tambahkan Akun Mastodon baru</string>
@@ -108,7 +105,6 @@
     <string name="error_sender_account_gone">Gagal mengirim postingan.</string>
     <string name="title_mutes">Pengguna dibisukan</string>
     <string name="title_announcements">Pengumuman</string>
-    <string name="post_sensitive_media_title">Konten sensitif</string>
     <string name="notification_follow_request_format">%s meminta untuk mengikuti anda</string>
     <string name="action_edit">Ubah</string>
     <string name="action_delete_conversation">Hapus percakapan</string>
@@ -123,7 +119,6 @@
     <string name="pref_title_language">Bahasa</string>
     <string name="post_text_size_smallest">Terkecil</string>
     <string name="notification_favourite_name">Favorit</string>
-    <string name="post_media_images">Gambar</string>
     <string name="later">Nanti</string>
     <string name="pachli_compose_post_quicksetting_label">Tulis Postingan</string>
     <string name="error_media_upload_image_or_video">gambar dan video tidak dapat dilampirkan ke postingan yang sama.</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -36,7 +36,6 @@
     <string name="title_edit_profile">Breyta notandasniðinu þínu</string>
     <string name="title_scheduled_posts">Áætlaðar færslur</string>
     <string name="post_boosted_format">%s endurbirti</string>
-    <string name="post_sensitive_media_title">Viðkvæmt efni</string>
     <string name="post_media_hidden_title">Myndefni er falið</string>
     <string name="post_sensitive_media_directions">Ýttu til að skoða</string>
     <string name="post_content_warning_show_more">Sýna meira</string>
@@ -205,8 +204,6 @@
     <string name="description_account_locked">Læstur notandaaðgangur</string>
     <string name="post_share_content">Deila efni úr færslu</string>
     <string name="post_share_link">Deila tengli á færslu</string>
-    <string name="post_media_images">Myndir</string>
-    <string name="post_media_video">Myndskeið</string>
     <string name="state_follow_requested">Beðið um að fylgja</string>
     <string name="follows_you">Fylgir þér</string>
     <string name="pref_title_alway_show_sensitive_media">Alltaf birta myndefni sem merkt er viðkvæmt</string>
@@ -347,8 +344,6 @@
     <string name="draft_deleted">Eyddi drögum</string>
     <string name="drafts_failed_loading_reply">Mistókst að hlaða inn svarupplýsingum</string>
     <string name="drafts_post_failed_to_send">Mistókst að senda þessa færslu!</string>
-    <string name="post_media_attachments">Viðhengi</string>
-    <string name="post_media_audio">Hljóð</string>
     <string name="duration_indefinite">Ótiltekið</string>
     <string name="label_duration">Tímalengd</string>
     <plurals name="error_upload_max_media_reached">

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -33,7 +33,6 @@
     <string name="title_edit_profile">Modifica il tuo profilo</string>
     <string name="title_drafts">Bozze</string>
     <string name="post_boosted_format">%s ha condiviso</string>
-    <string name="post_sensitive_media_title">Contenuto sensibile</string>
     <string name="post_media_hidden_title">Media nascosto</string>
     <string name="post_sensitive_media_directions">Clicca per visualizzare</string>
     <string name="post_content_warning_show_more">Mostra di più</string>
@@ -203,8 +202,6 @@
     -->
     <string name="post_share_content">Condividi contenuto</string>
     <string name="post_share_link">Condividi collegamento</string>
-    <string name="post_media_images">Immagini</string>
-    <string name="post_media_video">Video</string>
     <string name="state_follow_requested">Richiesta inviata</string>
     <!--These are for timestamps on statuses. For example: "16s" or "2d"-->
     <string name="follows_you">Ti segue</string>
@@ -377,8 +374,6 @@
     <string name="drafts_post_failed_to_send">L\'invio di questo messaggio è fallito!</string>
     <string name="duration_indefinite">Indefinita</string>
     <string name="label_duration">Durata</string>
-    <string name="post_media_attachments">Allegati</string>
-    <string name="post_media_audio">Audio</string>
     <string name="pref_title_animate_custom_emojis">Riproduci emoji animate</string>
     <string name="action_subscribe_account">Iscriviti</string>
     <string name="dialog_delete_conversation_warning">Rimuovere questa conversazione?</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -29,7 +29,6 @@
     <string name="title_edit_profile">プロフィールを編集</string>
     <string name="title_drafts">下書き</string>
     <string name="post_boosted_format">%sさんがブーストしました</string>
-    <string name="post_sensitive_media_title">閲覧注意</string>
     <string name="post_media_hidden_title">非表示のメディア</string>
     <string name="post_sensitive_media_directions">タップして表示</string>
     <string name="post_content_warning_show_more">続きを表示</string>
@@ -181,8 +180,6 @@
     -->
     <string name="post_share_content">投稿の内容を共有</string>
     <string name="post_share_link">投稿へのリンクを共有</string>
-    <string name="post_media_images">画像</string>
-    <string name="post_media_video">動画</string>
     <string name="state_follow_requested">フォローリクエスト中</string>
     <!--These are for timestamps on statuses. For example: "16s" or "2d"-->
     <string name="follows_you">あなたをフォロー中</string>
@@ -327,7 +324,6 @@
     <string name="notification_subscription_format">%sさんが投稿しました</string>
     <string name="title_announcements">お知らせ</string>
     <string name="mute_domain_warning">本当に %s のすべてをブロックするのですか？ そのドメインからのコンテンツは、公開タイムラインや通知に表示されなくなります。また、そのドメインのフォロワーは削除されます。</string>
-    <string name="post_media_audio">音声</string>
     <string name="mute_domain_warning_dialog_ok">ドメイン全体を非表示</string>
     <string name="delete_scheduled_post_warning">この予約投稿を削除しますか？</string>
     <string name="action_unbookmark">ブックマークを削除</string>
@@ -380,7 +376,6 @@
     <string name="notification_sign_up_name">サインアップ</string>
     <string name="notification_report_name">報告</string>
     <string name="notification_report_description">モデレーション報告に関する通知</string>
-    <string name="post_media_attachments">添付ファイル</string>
     <string name="status_count_one_plus">1+</string>
     <string name="no_announcements">アナウンスはありません。</string>
     <string name="description_post_edited">編集しました</string>

--- a/app/src/main/res/values-kab/strings.xml
+++ b/app/src/main/res/values-kab/strings.xml
@@ -65,8 +65,6 @@
     <string name="notification_summary_large">%1$s, %2$s, %3$s d %4$d nniḍen</string>
     <string name="notification_summary_medium">%1$s, %2$s, akked %3$s</string>
     <string name="notification_summary_small">%1$s akked %2$s</string>
-    <string name="post_media_images">Tugniwin</string>
-    <string name="post_media_video">Tibidyutin</string>
     <string name="follows_you">Yeṭṭafar-ik·ikem-id</string>
     <string name="filter_dialog_remove_button">Kkes</string>
     <string name="filter_dialog_update_button">Lqem</string>
@@ -156,7 +154,6 @@
     <string name="compose_save_draft">Sekles amzun d arewway\?</string>
     <string name="later">Ticki</string>
     <string name="description_post_bookmarked">Yettwarna ɣer ticṛad</string>
-    <string name="post_sensitive_media_title">Agbur amḥulfu</string>
     <string name="pref_default_media_sensitivity">Creḍ allal n teywalt amzun d amḥulfu</string>
     <string name="action_reset_schedule">Wennez tikkelt-nniḍen</string>
     <string name="error_media_upload_sending">Asali ur yeddi ara.</string>
@@ -198,7 +195,6 @@
     <string name="translation_provider_fmt">%1$s</string>
     <string name="hint_description">Aglam</string>
     <string name="label_image">Tugna</string>
-    <string name="post_media_audio">Imesli</string>
     <string name="status_count_one_plus">1+</string>
     <string name="profile_metadata_content_label">Agbur</string>
     <string name="filter_action_hide">Ffer</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -30,7 +30,6 @@
     <string name="title_edit_profile">프로필 편집</string>
     <string name="title_drafts">임시 저장</string>
     <string name="post_boosted_format">%s님이 부스트 했습니다</string>
-    <string name="post_sensitive_media_title">민감한 미디어</string>
     <string name="post_media_hidden_title">미디어 숨겨짐</string>
     <string name="post_sensitive_media_directions">클릭하여 보기</string>
     <string name="post_content_warning_show_more">더 보기</string>
@@ -201,8 +200,6 @@
     -->
     <string name="post_share_content">이 툿의 내용 공유</string>
     <string name="post_share_link">이 툿의 링크 공유</string>
-    <string name="post_media_images">사진</string>
-    <string name="post_media_video">비디오</string>
     <string name="state_follow_requested">팔로우 요청함</string>
     <!--These are for timestamps on statuses. For example: "16s" or "2d"-->
     <string name="follows_you">당신을 팔로우합니다</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -21,7 +21,6 @@
     <string name="title_follow_requests">Sekošanas pieprasījumi</string>
     <string name="title_scheduled_posts">Ieplānotie ieraksti</string>
     <string name="title_announcements">Paziņojumi</string>
-    <string name="post_sensitive_media_title">Jūtīgs saturs. Jāpiesit, lai parādītu.</string>
     <string name="post_content_show_less">Sakļaut</string>
     <string name="post_content_warning_show_more">Rādīt vairāk</string>
     <string name="post_content_warning_show_less">Rādīt mazāk</string>
@@ -90,9 +89,6 @@
     <string name="post_text_size_largest">Lielākais</string>
     <string name="notification_poll_name">Aptaujas</string>
     <string name="notification_report_name">Ziņojumi</string>
-    <string name="post_media_video">Video</string>
-    <string name="post_media_audio">Audio</string>
-    <string name="post_media_attachments">Pielikumi</string>
     <string name="state_follow_requested">Sekošana pieprasīta</string>
     <string name="pref_title_public_filter_keywords">Publiskās laika līnijas</string>
     <string name="filter_addition_title">Pievienot filtru</string>
@@ -164,7 +160,6 @@
     <string name="pref_title_timeline_filters">Filtri</string>
     <string name="pref_title_browser_settings">Pārlūks</string>
     <string name="post_text_size_smallest">Mazākais</string>
-    <string name="post_media_images">Attēli</string>
     <string name="action_remove">Noņemt</string>
     <string name="list">Saraksts</string>
     <string name="account_note_saved">Saglabāts!</string>
@@ -781,10 +776,6 @@
     <string name="translator_error_unsupported_source_language_fmt">nevar tulkot no %1$s</string>
     <string name="translator_error_unsupported_target_language_fmt">nevar tulkot uz %1$s</string>
     <string name="translator_error_download_required_fmt">tulkošanai uz %1$s nepieciešama valodas pakas lejupielādēšana, un nav savienojuma ar Wi-Fi</string>
-    <string name="attachment_matches_filter_one_fmt">Atbilst atlasītājam: “%1$s”. Jāpiesit, lai parādītu.</string>
-    <string name="attachment_matches_filter_two_fmt">Atbilst atlasītājiem: “%1$s” un “%2$s”. Jāpiesit, lai parādītu.</string>
-    <string name="attachment_matches_filter_other_fmt">Atbilst atlasītājiem: “%1$s”, “%2$s” un vēl. Jāpiesit, lai parādītu.</string>
-    <string name="attachment_hidden_user_action">Tu paslēpi šo. Jāpiesit, lai parādītu.</string>
     <string name="filter_action_blur">Paslēpt pielikumus</string>
     <string name="filter_description_blur">Rādīt saturu, paslēpt pielikumus ar brīdinājumu</string>
 </resources>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -48,7 +48,6 @@
     <string name="post_content_warning_show_more">കൂടുതൽ കാണിക്കൂ</string>
     <string name="post_sensitive_media_directions">തുറന്ന് കാണുവാൻ</string>
     <string name="post_media_hidden_title">മറയ്ക്കപ്പെട്ട മീഡിയ</string>
-    <string name="post_sensitive_media_title">സെൻസിറ്റീവ് ഉള്ളടക്കം</string>
     <string name="title_scheduled_posts">മുന്‍നിശ്ചയിച്ച ടൂറ്റ്‌സ്</string>
     <string name="title_bookmarks">ബുക് മാർക്ക്</string>
     <string name="action_reset_schedule">പുനഃക്രമീകരിക്കുക</string>
@@ -104,7 +103,6 @@
     <string name="follows_you">നിങ്ങളെ പിന്തുടരുന്നു</string>
     <string name="action_photo_take">ഫോട്ടോ എടുക്കുക</string>
     <string name="hint_search">തിരയുക…</string>
-    <string name="post_media_images">ചിത്രങ്ങൾ</string>
     <string name="hint_note">ബയോ</string>
     <string name="conversation_1_recipients">%1$s</string>
     <string name="pref_title_thread_filter_keywords">സംഭാഷണങ്ങൾ</string>
@@ -125,7 +123,6 @@
     <string name="profile_metadata_content_label">ഉള്ളടക്കം</string>
     <string name="filter_dialog_update_button">പുതുക്കുക</string>
     <string name="label_avatar">അവതാർ</string>
-    <string name="post_media_video">വിഡിയോ</string>
     <string name="action_mention">സൂചിപ്പിക്കുക</string>
     <string name="filter_dialog_remove_button">നീക്കം ചെയ്യുക</string>
 </resources>

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -79,7 +79,6 @@
     <string name="title_bookmarks">သိမ်းဆည်းမှုများ</string>
     <string name="title_edits">ပြုပြင်မှုများ</string>
     <string name="post_boosted_format">%s တစ်ဆင့်မျှဝေပြီး</string>
-    <string name="post_sensitive_media_title">ထိလွယ်ရှလွယ်သော</string>
     <string name="post_media_hidden_title">မီဒီယာဖျောက်ထား</string>
     <string name="notification_reblog_format">%s မှသင့်ပိုစ့်ကိုတစ်ဆင့်မျှဝေသည်</string>
     <string name="post_content_show_more">ချဲ့မည်</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -29,7 +29,6 @@
     <string name="title_edit_profile">Redigere profilen din</string>
     <string name="title_drafts">Utkast</string>
     <string name="post_boosted_format">%s delte</string>
-    <string name="post_sensitive_media_title">Sensitivt innhold</string>
     <string name="post_media_hidden_title">Media skjult</string>
     <string name="post_sensitive_media_directions">Trykk for å vise</string>
     <string name="post_content_warning_show_more">Vis mer</string>
@@ -172,8 +171,6 @@
     <string name="description_account_locked">Låst konto</string>
     <string name="post_share_content">Del inneholdet i innlegget</string>
     <string name="post_share_link">Del lenke til tuten</string>
-    <string name="post_media_images">Bilder</string>
-    <string name="post_media_video">Video</string>
     <string name="state_follow_requested">Forespørsel sendt</string>
     <string name="follows_you">Følger deg</string>
     <string name="pref_title_alway_show_sensitive_media">Vis alltid sensitivt innhold</string>
@@ -354,8 +351,6 @@
     </plurals>
     <string name="duration_indefinite">Uendelig</string>
     <string name="label_duration">Varighet</string>
-    <string name="post_media_attachments">Vedlegg</string>
-    <string name="post_media_audio">Lyd</string>
     <string name="drafts_post_reply_removed">Innlegget du hadde opprettet et utkast som svar på har blitt fjernet</string>
     <string name="draft_deleted">Utkast slettet</string>
     <string name="drafts_failed_loading_reply">Lasting av svarinformasjon feilet</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -29,7 +29,6 @@
     <string name="title_edit_profile">Profiel bewerken</string>
     <string name="title_drafts">Concepten</string>
     <string name="post_boosted_format">%s boostte</string>
-    <string name="post_sensitive_media_title">Gevoelige inhoud</string>
     <string name="post_media_hidden_title">Verborgen media</string>
     <string name="post_sensitive_media_directions">Klik om te bekijken</string>
     <string name="post_content_warning_show_more">Meer tonen</string>
@@ -186,8 +185,6 @@
     -->
     <string name="post_share_content">Inhoud van bericht delen</string>
     <string name="post_share_link">Link van het bericht delen</string>
-    <string name="post_media_images">Afbeeldingen</string>
-    <string name="post_media_video">Video</string>
     <string name="state_follow_requested">Volgverzoek verzonden</string>
     <!--These are for timestamps on statuses. For example: "16s" or "2d"-->
     <string name="follows_you">Volgt jou</string>
@@ -319,7 +316,6 @@
     <string name="warning_scheduling_interval">Om in te plannen moet je in Mastodon een minimum interval van 5 minuten gebruiken.</string>
     <string name="notification_follow_request_name">Volgverzoeken</string>
     <string name="hashtags">Hashtags</string>
-    <string name="post_media_attachments">Bijlagen</string>
     <string name="pref_title_notification_filter_follow_requests">volgverzoek verstuurd</string>
     <string name="action_unsubscribe_account">Afmelden</string>
     <string name="action_subscribe_account">Abonneren</string>
@@ -340,7 +336,6 @@
     <string name="label_duration">Looptijd</string>
     <string name="pref_title_enable_swipe_for_tabs">Swipebewegingen om tussen tabs te schakelen inschakelen</string>
     <string name="add_hashtag_title">Hashtag toevoegen</string>
-    <string name="post_media_audio">Geluid</string>
     <string name="notification_subscription_description">Meldingen wanneer iemand waar je op bent geabonneerd een nieuw bericht plaatst</string>
     <string name="notification_subscription_name">Nieuwe berichten</string>
     <string name="notification_follow_request_description">Meldingen over volgverzoeken</string>

--- a/app/src/main/res/values-nn/strings.xml
+++ b/app/src/main/res/values-nn/strings.xml
@@ -46,7 +46,6 @@
     <string name="dialog_follow_hashtag_title">Fylg emneknagg</string>
     <string name="dialog_follow_hashtag_hint">#emneknagg</string>
     <string name="post_boosted_format">%s delte</string>
-    <string name="post_sensitive_media_title">Sensitivt innhald</string>
     <string name="post_media_hidden_title">Media skjult</string>
     <string name="post_sensitive_media_directions">Trykk for å syne</string>
     <string name="post_content_warning_show_more">Syn meir</string>
@@ -232,7 +231,6 @@
     <string name="notification_summary_medium">%1$s, %2$s, og %3$s</string>
     <string name="notification_summary_small">%1$s og %2$s</string>
     <string name="notification_prune_cache">Hurtiglagringsvedlikehald…</string>
-    <string name="post_media_attachments">Vedlegg</string>
     <string name="status_count_one_plus">1+</string>
     <string name="status_filtered_show_anyway">Syn likevel</string>
     <string name="status_filter_placeholder_label_format">Filtrert: &lt;b&gt;%1$s&lt;/b&gt;</string>
@@ -366,9 +364,6 @@
     <string name="notification_notification_worker">Hentar varsel…</string>
     <string name="description_account_locked">Låst konto</string>
     <string name="post_share_link">Del lenkja til innlegget</string>
-    <string name="post_media_images">Bilete</string>
-    <string name="post_media_video">Video</string>
-    <string name="post_media_audio">Ljod</string>
     <string name="pref_title_alway_open_spoiler">Utvid alltid innlegg med innhaldsåtvaringar</string>
     <string name="title_media">Media</string>
     <string name="pref_title_account_filter_keywords">Profilar</string>

--- a/app/src/main/res/values-oc/strings.xml
+++ b/app/src/main/res/values-oc/strings.xml
@@ -25,7 +25,6 @@
     <string name="title_edit_profile">Modificar lo perfil</string>
     <string name="title_drafts">Borrolhons</string>
     <string name="post_boosted_format">%s a partejat</string>
-    <string name="post_sensitive_media_title">Contengut sensible</string>
     <string name="post_media_hidden_title">Mèdia amagat</string>
     <string name="post_sensitive_media_directions">Clicar per mostrar</string>
     <string name="post_content_warning_show_more">Mostrar mai</string>
@@ -168,8 +167,6 @@
     -->
     <string name="post_share_content">Partejar lo contengut del tut</string>
     <string name="post_share_link">Partejar lo ligam del tut</string>
-    <string name="post_media_images">Imatges</string>
-    <string name="post_media_video">Vidèo</string>
     <string name="state_follow_requested">Demanda d’abonament</string>
     <!--These are for timestamps on statuses. For example: "16s" or "2d"-->
     <string name="follows_you">Vos sèc</string>
@@ -337,8 +334,6 @@
     <string name="duration_indefinite">Infinit</string>
     <string name="label_duration">Durada</string>
     <string name="add_hashtag_title">Apondre hashtag</string>
-    <string name="post_media_attachments">Pèças juntas</string>
-    <string name="post_media_audio">Àudio</string>
     <string name="notification_subscription_name">Publicacions novèlas</string>
     <string name="notification_follow_request_description">Notificacions de demandas de seguiment</string>
     <string name="pref_main_nav_position">Posicion de navigacion principala</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -26,7 +26,6 @@
     <string name="title_edit_profile">Edytuj profil</string>
     <string name="title_drafts">Szkice</string>
     <string name="post_boosted_format">Podbicie od %s</string>
-    <string name="post_sensitive_media_title">Treści drażliwe</string>
     <string name="post_media_hidden_title">Ukryto multimedia</string>
     <string name="post_sensitive_media_directions">Naciśnij, aby wyświetlić</string>
     <string name="post_content_warning_show_more">Pokaż więcej</string>
@@ -168,8 +167,6 @@
     -->
     <string name="post_share_content">Udostępnij zawartość wpisu</string>
     <string name="post_share_link">Udostępnij odnośnik do wpisu</string>
-    <string name="post_media_images">Obrazy</string>
-    <string name="post_media_video">Wideo</string>
     <string name="state_follow_requested">Wysłano prośbę o obserwację</string>
     <!--These are for timestamps on statuses. For example: "16s" or "2d"-->
     <string name="follows_you">Obserwuje cię</string>
@@ -349,7 +346,6 @@
     <string name="notification_subscription_name">Nowe wpisy</string>
     <string name="wellbeing_mode_notice">Niektóre informacje, które mogą wpływać na twój dobrostan psychiczny, zostaną ukryte. W ich skład wchodzą:\n\n - powiadomienia o ulubionych/podbiciach/obserwowaniu\n - liczba polubień/podbić wpisu \n - statystyki obserwujących/postów na profilach \n\nNie będzie to miało wpływu na powiadomienia, ale możesz zmienić ustawienia powiadomień ręcznie.</string>
     <string name="pref_title_enable_swipe_for_tabs">Włącz gest przesuwania, by przełączać między kartami</string>
-    <string name="post_media_attachments">Załączniki</string>
     <string name="notification_follow_request_description">Powiadomienia o prośbach o obserwowanie</string>
     <string name="pref_title_notification_filter_subscriptions">Ktoś, kogo obserwuję opublikował nowy wpis</string>
     <string name="pref_title_notification_filter_follow_requests">Wysłano prośbę o obserwowanie</string>
@@ -366,7 +362,6 @@
     <string name="account_note_saved">Zapisano!</string>
     <string name="account_note_hint">Twoja prywatna notatka o tym koncie</string>
     <string name="duration_indefinite">Nieograniczony</string>
-    <string name="post_media_audio">Dźwięk</string>
     <string name="notification_subscription_description">Powiadomienia o opublikowaniu nowego wpisu przez kogoś, kogo obserwujesz</string>
     <string name="pref_main_nav_position">Pozycja głównego paska nawigacji</string>
     <string name="pref_title_animate_custom_emojis">Animuj niestandardowe emoji</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -28,7 +28,6 @@
     <string name="title_edit_profile">Editar perfil</string>
     <string name="title_drafts">Rascunhos</string>
     <string name="post_boosted_format">%s deu Boost</string>
-    <string name="post_sensitive_media_title">Mídia sensível</string>
     <string name="post_media_hidden_title">Mídia sensível</string>
     <string name="post_sensitive_media_directions">Toque para ver</string>
     <string name="post_content_warning_show_more">Expandir</string>
@@ -179,8 +178,6 @@
     -->
     <string name="post_share_content">Compartilhar conteúdo do Toot</string>
     <string name="post_share_link">Compartilhar URL do Toot</string>
-    <string name="post_media_images">Imagens</string>
-    <string name="post_media_video">Vídeo</string>
     <string name="state_follow_requested">Solicitação enviada</string>
     <!--These are for timestamps on statuses. For example: "16s" or "2d"-->
     <string name="follows_you">te segue</string>
@@ -366,8 +363,6 @@
     <string name="no_announcements">Sem comunicados.</string>
     <string name="duration_indefinite">Indefinido</string>
     <string name="label_duration">Duração</string>
-    <string name="post_media_attachments">Anexos</string>
-    <string name="post_media_audio">Áudio</string>
     <string name="notification_subscription_name">Novos Toots</string>
     <string name="notification_subscription_format">%s recém postou</string>
     <string name="title_announcements">Comunicados</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -45,7 +45,6 @@
     <string name="title_blocks">Utilizadores bloqueados</string>
     <string name="title_domain_mutes">Instâncias bloqueadas</string>
     <string name="title_follow_requests">Seguidores Pendentes</string>
-    <string name="post_sensitive_media_title">Conteúdo sensível</string>
     <string name="title_edit_profile">Editar perfil</string>
     <string name="post_media_hidden_title">Conteúdo multimédia ocultado</string>
     <string name="title_drafts">Rascunhos</string>
@@ -239,10 +238,6 @@
     <string name="filter_dialog_update_button">Atualizar</string>
     <string name="post_share_content">Partilhar conteúdo do toot</string>
     <string name="post_share_link">Partilhar hiperligação do toot</string>
-    <string name="post_media_images">Imagens</string>
-    <string name="post_media_video">Vídeo</string>
-    <string name="post_media_audio">Áudio</string>
-    <string name="post_media_attachments">Anexos</string>
     <string name="state_follow_requested">Pedido para seguir enviado</string>
     <string name="follows_you">Segue-te</string>
     <string name="pref_title_alway_show_sensitive_media">Mostrar sempre conteúdo multimédia sensível</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -29,7 +29,6 @@
     <string name="title_edit_profile">Редактировать профиль</string>
     <string name="title_drafts">Черновики</string>
     <string name="post_boosted_format">%s продвинул(а)</string>
-    <string name="post_sensitive_media_title">Чувствительный контент</string>
     <string name="post_media_hidden_title">Медиа скрыто</string>
     <string name="post_sensitive_media_directions">Нажмите для просмотра</string>
     <string name="post_content_warning_show_more">Показать больше</string>
@@ -190,8 +189,6 @@
     <!-- note to translators: the url can be changed to link to the localized version of the license -->
     <string name="post_share_content">Поделиться содержанием гудка</string>
     <string name="post_share_link">Поделиться ссылкой на гудок</string>
-    <string name="post_media_images">Изображения</string>
-    <string name="post_media_video">Видео</string>
     <string name="state_follow_requested">Запрошенные подписки</string>
     <!--Отметки времени у постов: "16s" or "2d"-->
     <!--Оставшееся время в опросах -->
@@ -354,8 +351,6 @@
     <string name="pref_title_wellbeing_mode">Самочувствие</string>
     <string name="duration_indefinite">Неопределённая</string>
     <string name="label_duration">Продолжительность</string>
-    <string name="post_media_attachments">Вложения</string>
-    <string name="post_media_audio">Аудио</string>
     <string name="notification_subscription_format">%s только что опубликовал(а)</string>
     <string name="follow_requests_info">Несмотря на то, что ваша профиль не закрыт, наши сотрудники %1$s решили, что вы, возможно, захотите просмотреть запросы на отслеживание от этих профилей вручную.</string>
     <plurals name="error_upload_max_media_reached">

--- a/app/src/main/res/values-sa/strings.xml
+++ b/app/src/main/res/values-sa/strings.xml
@@ -20,7 +20,6 @@
     <string name="post_content_warning_show_more">अधिकं दृश्यताम्</string>
     <string name="post_sensitive_media_directions">द्रष्टुमत्र नुद्यताम्</string>
     <string name="post_media_hidden_title">प्रच्छन्नसामग्र्यः</string>
-    <string name="post_sensitive_media_title">संवेदनशीलो विषयः</string>
     <string name="post_boosted_format">%s अप्रकाशयत्</string>
     <string name="title_scheduled_posts">कालबद्धदौत्यानि</string>
     <string name="title_drafts">लेखविकर्षाः</string>
@@ -169,8 +168,6 @@
     <string name="pref_title_alway_show_sensitive_media">सर्वदा संवेदनशीलविषयो दृश्यताम्</string>
     <string name="follows_you">त्वामनुसरति</string>
     <string name="state_follow_requested">अनुसरणं निवेदितम्</string>
-    <string name="post_media_video">चलचित्राणि</string>
-    <string name="post_media_images">चित्राणि</string>
     <string name="post_share_link">दौत्याय जालस्थानं विभाज्यताम्</string>
     <string name="post_share_content">दौत्यविषयो विभाज्यताम्</string>
     <string name="description_account_locked">कपाटितव्यक्तिविवरणलेखः</string>
@@ -351,7 +348,6 @@
     <string name="pref_title_show_self_username">साधनशलाकासु उपभोक्तृनाम दृश्यताम्</string>
     <string name="title_edits">सम्पादनानि</string>
     <string name="notification_sign_up_description">नूतनोपभोक्तॄन् प्रति सूचनाः</string>
-    <string name="post_media_audio">ध्वनिः</string>
     <string name="filter_expiration_format">%s (%s)</string>
     <string name="duration_30_days">३० दिनानि</string>
     <string name="report_category_other">अन्यम्</string>
@@ -395,7 +391,6 @@
     <string name="description_post_language">दौत्यस्य भाषा</string>
     <string name="error_following_hashtag_format">#%s-अनुसरणे दोषो जातः</string>
     <string name="error_unfollowing_hashtag_format">#%s-अनुसरण-अपाकरणे दोषो जातः</string>
-    <string name="post_media_attachments">सम्योजितानि</string>
     <string name="status_count_one_plus">१+</string>
     <string name="account_note_saved">रक्षितम् !</string>
     <string name="title_announcements">उद्घोषणाः</string>

--- a/app/src/main/res/values-si/strings.xml
+++ b/app/src/main/res/values-si/strings.xml
@@ -27,7 +27,6 @@
     <string name="search_no_results">ප්‍රතිඵල නැත</string>
     <string name="pref_title_notifications_enabled">දැනුම්දීම්</string>
     <string name="post_privacy_public">ප්‍රසිද්ධ</string>
-    <string name="post_media_attachments">ඇමුණුම්</string>
     <string name="notification_mention_name">නව සැඳහුම්</string>
     <string name="action_compose_shortcut">රචනා කරන්න</string>
     <string name="post_content_warning_show_more">තව පෙන්වන්න</string>
@@ -44,7 +43,6 @@
     <string name="action_edit_profile">පැතිකඩ සංස්කරණය</string>
     <string name="hint_display_name">දර්ශන නාමය</string>
     <string name="post_text_size_medium">මධ්‍යම</string>
-    <string name="post_media_audio">ශ්‍රව්‍ය</string>
     <string name="filter_edit_title">පෙරහන සංස්කරණය</string>
     <string name="notification_summary_medium">%1$s, %2$s, සහ %3$s</string>
     <string name="lock_account_label">ගිණුම අගුළුලන්න</string>
@@ -60,7 +58,6 @@
     <string name="pref_title_notification_filter_mentions">සඳහන් කළ</string>
     <string name="send_post_link_to">වෙත ටූට් ඒ.ස.නි. බෙදාගන්න…</string>
     <string name="compose_save_draft">කටුපිටපත සුරකින්නද\?</string>
-    <string name="post_sensitive_media_title">සංවේදී අන්තර්ගතයකි</string>
     <string name="action_bookmark">පොත්යොමුව</string>
     <string name="failed_report">වාර්තා කිරීමට අසමත් විය</string>
     <string name="action_open_faved_by">ප්‍රියතමයන් පෙන්වන්න</string>
@@ -177,7 +174,6 @@
     <string name="post_sent">යැවිණි!</string>
     <string name="filter_dialog_whole_word">මුළු වචනය</string>
     <string name="drafts_post_failed_to_send">මෙම ටූට් යැවීමට අසමත් විය!</string>
-    <string name="post_media_video">දෘශ්‍යකය</string>
     <string name="later">පසුව</string>
     <string name="action_edit_own_profile">සංස්කරණය</string>
     <string name="send_post_notification_title">ටූට් යැවෙමින්…</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -11,7 +11,6 @@
     <string name="title_posts_pinned">Pripnuté</string>
     <string name="title_followers">Sledujúci</string>
     <string name="title_bookmarks">Záložky</string>
-    <string name="post_sensitive_media_title">Citlivý obsah</string>
     <string name="post_sensitive_media_directions">Klikni pre zobrazenie</string>
     <string name="post_content_warning_show_more">Zobraziť viac</string>
     <string name="post_content_warning_show_less">Zobraziť menej</string>
@@ -338,8 +337,6 @@
     <string name="mute_notifications_switch">Stíšiť upozornenia</string>
     <string name="ui_error_accept_follow_request">Potvrdenie žiadosti o sledovanie zlyhalo: %s</string>
     <string name="no_announcements">Žiadne oznámenia.</string>
-    <string name="post_media_images">Obrázky</string>
-    <string name="post_media_video">Video</string>
     <string name="follows_you">Sleduje ťa</string>
     <string name="add_poll_choice">Pridať voľbu</string>
     <string name="poll_allow_multiple_choices">Viacero možností</string>
@@ -394,7 +391,6 @@
     <string name="wellbeing_mode_notice">Niektoré informácie, ktoré by mohli mať vplyv na tvoju duševnú pohodu, budú skryté. Týka sa to:\n\n - Upozornení na zdieľanie, sledovaníe a pridanie medzi obľúbené\n - Počtu obľúbení a zdieľaní pri príspevkoch\n - Štatistík sledujúcich a príspevkov na profiloch\n\nPush upozornenia nebudú ovplyvnené, ale môžeš si skontrolovať ich nastavenia manuálne.</string>
     <string name="notifications_apply_filter">Filtrovať upozornenia</string>
     <string name="filter_apply">Použiť</string>
-    <string name="post_media_audio">Audio</string>
     <string name="pref_title_thread_filter_keywords">Konverzácie</string>
     <string name="filter_add_description">Fráza pre filtrovanie</string>
     <string name="notification_clear_text">Naozaj si si istý/á, že chceš natrvalo vymazať všetky svoje oznámenia?</string>
@@ -424,7 +420,6 @@
     <string name="notification_unknown_name">Neznáme</string>
     <string name="notification_mention_format">%s ťa zmienil/a</string>
     <string name="notification_summary_medium">%1$s, %2$s a %3$s</string>
-    <string name="post_media_attachments">Prílohy</string>
     <string name="filter_dialog_whole_word">Celé slovo</string>
     <string name="add_account_description">Pridať nový účet Mastodon</string>
     <string name="compose_save_draft_loses_media">Prílohy budú opätovne nahrané po obnovení konceptu.</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -28,7 +28,6 @@
     <string name="title_follow_requests">Zahteve za Sledenje</string>
     <string name="title_edit_profile">Uredi svoj profil</string>
     <string name="title_drafts">Osnutki</string>
-    <string name="post_sensitive_media_title">Občutljiva vsebina</string>
     <string name="post_media_hidden_title">Medij je skrit</string>
     <string name="post_sensitive_media_directions">Kliknite za ogled</string>
     <string name="post_content_warning_show_more">Pokaži več</string>
@@ -173,8 +172,6 @@
     <string name="description_account_locked">Zaklenjen račun</string>
     <string name="post_share_content">Deli vsebino tuta</string>
     <string name="post_share_link">Deli povezavo do tuta</string>
-    <string name="post_media_images">Slike</string>
-    <string name="post_media_video">Video</string>
     <string name="state_follow_requested">Prošnja za sledenje</string>
     <string name="follows_you">Vam sledi</string>
     <string name="pref_title_alway_show_sensitive_media">Vedno prikaži občutljivo vsebino</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -29,7 +29,6 @@
     <string name="title_edit_profile">Redigera din profil</string>
     <string name="title_drafts">Utkast</string>
     <string name="post_boosted_format">%s knuffade</string>
-    <string name="post_sensitive_media_title">Känsligt innehåll</string>
     <string name="post_media_hidden_title">Dold media</string>
     <string name="post_sensitive_media_directions">Tryck för att visa</string>
     <string name="post_content_warning_show_more">Visa mer</string>
@@ -187,8 +186,6 @@
     -->
     <string name="post_share_content">Dela innehåll av toot</string>
     <string name="post_share_link">Dela länk till toot</string>
-    <string name="post_media_images">Bilder</string>
-    <string name="post_media_video">Video</string>
     <string name="state_follow_requested">Följarförfrågan</string>
     <!--These are for timestamps on statuses. For example: "16s" or "2d"-->
     <string name="follows_you">Följer dig</string>
@@ -402,8 +399,6 @@
     <string name="pref_title_notification_filter_sign_ups">någon registrerade sig</string>
     <string name="pref_title_notification_filter_updates">ett inlägg jag interagerat med har redigerats</string>
     <string name="pref_title_animate_custom_emojis">Animera skräddarsydda emojis</string>
-    <string name="post_media_audio">Ljud</string>
-    <string name="post_media_attachments">Bilagor</string>
     <string name="status_count_one_plus">1+</string>
     <string name="title_migration_relogin">Logga in igen för pushnotiser</string>
     <string name="compose_save_draft_loses_media">Bilagor kommer att laddas upp igen när du återställer utkastet.</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -24,7 +24,6 @@
     <string name="title_edit_profile">சுயவிவரத்தை திருத்த</string>
     <string name="title_drafts">வரைவுகள்</string>
     <string name="post_boosted_format">%s மேலேற்றப்பட்டது</string>
-    <string name="post_sensitive_media_title">உணர்ச்சிகரமான உள்ளடக்கம்</string>
     <string name="post_media_hidden_title">ஊடகம் மறைக்கப்பட்டது</string>
     <string name="post_sensitive_media_directions">பார்வையிட சொடுக்கவும்</string>
     <string name="post_content_warning_show_more">அதிகமாக்கு</string>
@@ -158,8 +157,6 @@
     -->
     <string name="post_share_content">Toot உள்ளடக்கத்தைப் பகிர்</string>
     <string name="post_share_link">Toot இணைப்பைப் பகிர்</string>
-    <string name="post_media_images">படங்கள்</string>
-    <string name="post_media_video">காணொளி</string>
     <string name="state_follow_requested">கோரிக்கையைப் பின்பற்றவும்</string>
     <!--These are for timestamps on statuses. For example: "16s" or "2d"-->
     <string name="follows_you">நீங்கள் பின் தொடரபடுகிறீர்கள்</string>
@@ -267,7 +264,6 @@
     <string name="notification_listenable_worker_description">பச்ச்லி பின்னணியில் வேலை செய்யும் போது அறிவிப்புகள்</string>
     <string name="notification_unknown_name">தெரியவில்லை</string>
     <string name="notification_notification_worker">அறிவிப்புகளைப் பெறுதல்…</string>
-    <string name="post_media_attachments">இணைப்புகள்</string>
     <string name="status_count_one_plus">1+</string>
     <string name="pref_title_public_filter_keywords">பொது காலவரிசைகள்</string>
     <string name="action_set_focus">கவனம் செலுத்தும் புள்ளியை அமைக்கவும்</string>
@@ -526,7 +522,6 @@
     <string name="filter_addition_title">வடிகட்டியைச் சேர்க்கவும்</string>
     <string name="filter_edit_title">வடிகட்டியைத் திருத்து</string>
     <string name="filter_dialog_whole_word">முழு சொல்</string>
-    <string name="post_media_audio">ஆடியோ</string>
     <string name="status_filtered_show_anyway">எப்படியும் காட்டு</string>
     <string name="filter_dialog_whole_word_description">முக்கிய சொல் அல்லது சொற்றொடர் எண்ணெழுத்து மட்டுமே இருக்கும்போது, அது முழு வார்த்தையுடனும் பொருந்தினால் மட்டுமே அது பயன்படுத்தப்படும்</string>
     <string name="set_focus_description">சிறுபடங்களில் எப்போதும் காணப்படும் மைய புள்ளியைத் தேர்வுசெய்ய வட்டத்தைத் தட்டவும் அல்லது இழுக்கவும்.</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -98,8 +98,6 @@
     <string name="pref_title_alway_show_sensitive_media">แสดงเนื้อหาอ่อนไหวเสมอ</string>
     <string name="follows_you">กำลังติดตามคุณ</string>
     <string name="state_follow_requested">กำลังขอติดตาม</string>
-    <string name="post_media_video">วิดีทัศน์</string>
-    <string name="post_media_images">ภาพ</string>
     <string name="post_share_link">แบ่งปันลิงก์ Toot</string>
     <string name="post_share_content">แบ่งปันเนื้อหา Toot</string>
     <string name="description_account_locked">บัญชีไม่สาธารณะ</string>
@@ -274,7 +272,6 @@
     <string name="post_content_warning_show_more">แสดงเพิ่มเติม</string>
     <string name="post_sensitive_media_directions">แตะเพื่อดู</string>
     <string name="post_media_hidden_title">ซ่อนสื่ออยู่</string>
-    <string name="post_sensitive_media_title">เนื้อหาอ่อนไหว</string>
     <string name="post_boosted_format">%s ได้ดัน</string>
     <string name="title_scheduled_posts">โพสต์แบบกำหนดเวลา</string>
     <string name="title_edit_profile">แก้ไขโปรไฟล์</string>
@@ -351,8 +348,6 @@
     <string name="no_announcements">ไม่มีประกาศ</string>
     <string name="duration_indefinite">ไม่มีกำหนด</string>
     <string name="label_duration">ระยะเวลา</string>
-    <string name="post_media_attachments">ไฟล์แนบ</string>
-    <string name="post_media_audio">เสียง</string>
     <string name="notification_subscription_name">โพสต์ใหม่</string>
     <string name="notification_subscription_format">%s เพิ่งโพสต์</string>
     <string name="title_announcements">ประกาศ</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -29,7 +29,6 @@
     <string name="title_edit_profile">Profili düzenle</string>
     <string name="title_drafts">Taslaklar</string>
     <string name="post_boosted_format">%s yeniden paylaştı</string>
-    <string name="post_sensitive_media_title">Hassas medya</string>
     <string name="post_media_hidden_title">Gizlenmiş medya</string>
     <string name="post_sensitive_media_directions">Görüntülemek için dokunun</string>
     <string name="post_content_warning_show_more">Daha fazlası</string>
@@ -179,8 +178,6 @@
     -->
     <string name="post_share_content">Gönderinin içeriğini paylaş</string>
     <string name="post_share_link">Gönderinin adresini paylaş</string>
-    <string name="post_media_images">Görseller</string>
-    <string name="post_media_video">Video</string>
     <string name="state_follow_requested">Takip istenen</string>
     <!--These are for timestamps on statuses. For example: "16s" or "2d"-->
     <string name="follows_you">Seni takip ediyor</string>
@@ -399,8 +396,6 @@
     <string name="dialog_delete_conversation_warning">Bu görüşmeyi sil\?</string>
     <string name="pref_title_notification_filter_subscriptions">abone olduğum birisi yeni bir gönderi yayınladı</string>
     <string name="pref_title_notification_filter_sign_ups">birisi kaydolmuş</string>
-    <string name="post_media_audio">Ses</string>
-    <string name="post_media_attachments">Ekler</string>
     <string name="filter_expiration_format">%s (%s)</string>
     <string name="failed_to_pin">Sabitleme Başarısız</string>
     <string name="failed_to_unpin">Açılamadı</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -108,7 +108,6 @@
     <string name="notification_reblog_format">%s поширює ваш допис</string>
     <string name="post_content_show_less">Згорнути</string>
     <string name="post_content_show_more">Розгорнути</string>
-    <string name="post_sensitive_media_title">Делікатний вміст</string>
     <string name="post_boosted_format">%s поширює</string>
     <string name="title_domain_mutes">Приховані домени</string>
     <string name="title_mutes">Приховувані користувачі</string>
@@ -203,10 +202,6 @@
     <string name="follows_you">Підписники</string>
     <string name="pref_title_alway_show_sensitive_media">Завжди показувати делікатний вміст</string>
     <string name="state_follow_requested">Запит на підписку надіслано</string>
-    <string name="post_media_attachments">Вкладення</string>
-    <string name="post_media_audio">Звуки</string>
-    <string name="post_media_video">Відео</string>
-    <string name="post_media_images">Зображення</string>
     <string name="post_share_link">Поділитися посиланням на допис</string>
     <string name="post_share_content">Поділитися вмістом допису</string>
     <string name="description_account_locked">Заблокований обліковий запис</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -131,7 +131,6 @@
     <string name="post_content_warning_show_more">Mở rộng</string>
     <string name="post_sensitive_media_directions">Hiển thị</string>
     <string name="post_media_hidden_title">Media bị ẩn</string>
-    <string name="post_sensitive_media_title">Nhạy cảm</string>
     <string name="post_boosted_format">%s đăng lại</string>
     <string name="title_scheduled_posts">Những tút đã lên lịch</string>
     <string name="title_edit_profile">Chỉnh sửa hồ sơ</string>
@@ -232,8 +231,6 @@
     <string name="pref_title_alway_show_sensitive_media">Hiện nội dung nhạy cảm</string>
     <string name="follows_you">Đang theo dõi bạn</string>
     <string name="state_follow_requested">Yêu cầu theo dõi</string>
-    <string name="post_media_video">Video</string>
-    <string name="post_media_images">Hình ảnh</string>
     <string name="post_share_link">URL tút</string>
     <string name="post_share_content">Nội dung tút</string>
     <string name="pref_title_confirm_reblogs">Hỏi trước khi đăng lại tút</string>
@@ -350,8 +347,6 @@
     </plurals>
     <string name="duration_indefinite">Vĩnh viễn</string>
     <string name="label_duration">Thời hạn</string>
-    <string name="post_media_attachments">Đính kèm</string>
-    <string name="post_media_audio">Âm thanh</string>
     <string name="drafts_post_reply_removed">Đã xóa tút trả lời nháp</string>
     <string name="draft_deleted">Đã xóa tút lên lịch</string>
     <string name="drafts_failed_loading_reply">Chưa tải được bình luận</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -29,7 +29,6 @@
     <string name="title_edit_profile">编辑个人资料</string>
     <string name="title_drafts">草稿</string>
     <string name="post_boosted_format">%s 转嘟了</string>
-    <string name="post_sensitive_media_title">敏感内容</string>
     <string name="post_media_hidden_title">已隐藏的照片或视频</string>
     <string name="post_sensitive_media_directions">点击查看</string>
     <string name="post_content_warning_show_more">显示更多</string>
@@ -193,8 +192,6 @@
     -->
     <string name="post_share_content">分享嘟文内容</string>
     <string name="post_share_link">分享嘟文链接</string>
-    <string name="post_media_images">图片</string>
-    <string name="post_media_video">视频</string>
     <string name="state_follow_requested">已发送关注请求</string>
     <!--These are for timestamps on statuses. For example: "16s" or "2d"-->
     <string name="follows_you">关注了你</string>
@@ -360,8 +357,6 @@
     <string name="pref_title_wellbeing_mode">健康模式</string>
     <string name="duration_indefinite">永久</string>
     <string name="label_duration">持续时间</string>
-    <string name="post_media_attachments">附件</string>
-    <string name="post_media_audio">音频</string>
     <string name="notification_subscription_description">当我关注的用户发布了新嘟文时通知</string>
     <string name="notification_subscription_name">新嘟文</string>
     <string name="pref_title_animate_custom_emojis">显示动态自定义Emoji</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -29,7 +29,6 @@
     <string name="title_edit_profile">編輯個人資料</string>
     <string name="title_drafts">草稿</string>
     <string name="post_boosted_format">%s 轉嘟了</string>
-    <string name="post_sensitive_media_title">敏感內容</string>
     <string name="post_media_hidden_title">已隱藏的照片或影片</string>
     <string name="post_sensitive_media_directions">點一下顯示</string>
     <string name="post_content_warning_show_more">顯示更多</string>
@@ -193,8 +192,6 @@
     -->
     <string name="post_share_content">分享嘟文內容</string>
     <string name="post_share_link">分享嘟文連結</string>
-    <string name="post_media_images">照片</string>
-    <string name="post_media_video">影片</string>
     <string name="state_follow_requested">已請求關注</string>
     <!--These are for timestamps on statuses. For example: "16s" or "2d"-->
     <string name="follows_you">關注了你</string>
@@ -352,8 +349,6 @@
     <string name="select_list_title">選擇列表</string>
     <string name="add_hashtag_title">加上話題標籤</string>
     <string name="pref_title_alway_open_spoiler">總是顯示被標注為內容警告的嘟文</string>
-    <string name="post_media_attachments">附件</string>
-    <string name="post_media_audio">錄音</string>
     <string name="notification_subscription_description">當你關注的人發布新嘟文時通知</string>
     <string name="notification_subscription_name">新嘟文</string>
     <string name="notification_follow_request_description">關注請求的通知</string>

--- a/app/src/main/res/values-zh-rMO/strings.xml
+++ b/app/src/main/res/values-zh-rMO/strings.xml
@@ -29,7 +29,6 @@
     <string name="title_edit_profile">編輯個人資料</string>
     <string name="title_drafts">草稿</string>
     <string name="post_boosted_format">%s 轉嘟了</string>
-    <string name="post_sensitive_media_title">敏感內容</string>
     <string name="post_media_hidden_title">已隱藏的照片或影片</string>
     <string name="post_sensitive_media_directions">點一下顯示</string>
     <string name="post_content_warning_show_more">顯示更多</string>
@@ -193,8 +192,6 @@
     -->
     <string name="post_share_content">分享嘟文內容</string>
     <string name="post_share_link">分享嘟文連結</string>
-    <string name="post_media_images">照片</string>
-    <string name="post_media_video">影片</string>
     <string name="state_follow_requested">已請求關注</string>
     <!--These are for timestamps on statuses. For example: "16s" or "2d"-->
     <string name="follows_you">關注了你</string>

--- a/app/src/main/res/values-zh-rSG/strings.xml
+++ b/app/src/main/res/values-zh-rSG/strings.xml
@@ -29,7 +29,6 @@
     <string name="title_edit_profile">编辑个人资料</string>
     <string name="title_drafts">草稿</string>
     <string name="post_boosted_format">%s 转嘟了</string>
-    <string name="post_sensitive_media_title">敏感内容</string>
     <string name="post_media_hidden_title">已隐藏的照片或视频</string>
     <string name="post_sensitive_media_directions">点击显示</string>
     <string name="post_content_warning_show_more">显示更多</string>
@@ -193,8 +192,6 @@
     -->
     <string name="post_share_content">分享嘟文内容</string>
     <string name="post_share_link">分享嘟文链接</string>
-    <string name="post_media_images">照片</string>
-    <string name="post_media_video">视频</string>
     <string name="state_follow_requested">已发送关注请求</string>
     <!--These are for timestamps on statuses. For example: "16s" or "2d"-->
     <string name="follows_you">关注了你</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -29,7 +29,6 @@
     <string name="title_edit_profile">編輯個人資料</string>
     <string name="title_drafts">草稿</string>
     <string name="post_boosted_format">%s 轉嘟了</string>
-    <string name="post_sensitive_media_title">敏感內容</string>
     <string name="post_media_hidden_title">已隱藏的照片或影片</string>
     <string name="post_sensitive_media_directions">點一下顯示</string>
     <string name="post_content_warning_show_more">顯示更多</string>
@@ -193,8 +192,6 @@
     -->
     <string name="post_share_content">分享嘟文內容</string>
     <string name="post_share_link">分享嘟文連結</string>
-    <string name="post_media_images">照片</string>
-    <string name="post_media_video">影片</string>
     <string name="state_follow_requested">已請求關注</string>
     <!--These are for timestamps on statuses. For example: "16s" or "2d"-->
     <string name="follows_you">關注了你</string>
@@ -314,8 +311,6 @@
     <string name="draft_deleted">草稿已刪除</string>
     <string name="drafts_failed_loading_reply">載入回覆資訊失敗</string>
     <string name="drafts_post_failed_to_send">這條嘟文發送失敗！</string>
-    <string name="post_media_attachments">附件</string>
-    <string name="post_media_audio">錄音</string>
     <string name="duration_7_days">7 天</string>
     <string name="duration_3_days">3 天</string>
     <string name="duration_1_day">1 天</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,14 +82,9 @@
     <string name="dialog_follow_hashtag_title">Follow hashtag</string>
     <string name="dialog_follow_hashtag_hint">#hashtag</string>
     <string name="post_boosted_format">%s boosted</string>
-    <string name="post_sensitive_media_title">Sensitive content. Tap to show.</string>
     <!-- Can't use 'plurals' here because e.g. English doesn't distinguish between
          "two" and "other", resulting in "other" being used even if the quantity is
          only two. -->
-    <string name="attachment_matches_filter_one_fmt">Matches filter: \"%1$s\". Tap to show.</string>
-    <string name="attachment_matches_filter_two_fmt">Matches filters: \"%1$s\" and \"%2$s\". Tap to show.</string>
-    <string name="attachment_matches_filter_other_fmt">Matches filters: \"%1$s\", \"%2$s\", and more. Tap to show.</string>
-    <string name="attachment_hidden_user_action">You hid this. Tap to show.</string>
     <string name="post_media_hidden_title">Media hidden</string>
     <string name="post_sensitive_media_directions">Click to view</string>
     <string name="post_content_warning_show_more">Show More</string>
@@ -229,7 +224,7 @@
     <string name="translator_error_unsupported_target_language_fmt">cannot translate to "%1$s"</string>
     <string name="translator_error_download_required_fmt">translating to "%1$s" requires downloading the language pack, and Wi-Fi is not connected</string>
     <string name="action_translate_undo">Undo translate</string>
-    <string name="action_open_media_n">Open media #%d</string>
+    <string name="action_open_media_n">Open attachment #%d</string>
     <string name="download_image">Downloading %1$s</string>
     <string name="action_copy_link">Copy the link</string>
     <string name="action_refresh_account">Refresh account</string>
@@ -392,10 +387,6 @@
     -->
     <string name="post_share_content">Share content of post</string>
     <string name="post_share_link">Share link to post</string>
-    <string name="post_media_images">Images</string>
-    <string name="post_media_video">Video</string>
-    <string name="post_media_audio">Audio</string>
-    <string name="post_media_attachments">Attachments</string>
     <string name="status_count_one_plus">1+</string>
     <string name="status_filtered_show_anyway">Show anyway</string>
     <string name="status_filter_placeholder_label_format">Filtered: &lt;b>%1$s&lt;/b></string>

--- a/core/model/src/main/kotlin/app/pachli/core/model/AttachmentDisplayAction.kt
+++ b/core/model/src/main/kotlin/app/pachli/core/model/AttachmentDisplayAction.kt
@@ -68,7 +68,7 @@ sealed interface AttachmentDisplayAction {
     data class Show(val originalAction: Hide? = null) : AttachmentDisplayAction
 
     /**
-     * The attachment should be hidden.
+     * The attachment should be hidden and replaced with a placeholder image.
      *
      * @property reason The reason why this attachment should be hidden.
      */

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/extensions/AttachmentDisplayReasonExtensions.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/extensions/AttachmentDisplayReasonExtensions.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.core.ui.extensions
+
+import android.content.Context
+import app.pachli.core.model.AttachmentDisplayReason
+import app.pachli.core.ui.R
+
+/** @return UX string explaining why an attachment has been hidden. */
+fun AttachmentDisplayReason.getFormattedDescription(context: Context) = when (this) {
+    is AttachmentDisplayReason.BlurFilter -> {
+        val resource = when (filters.size) {
+            1 -> R.string.attachment_matches_filter_one_fmt
+            2 -> R.string.attachment_matches_filter_two_fmt
+            else -> R.string.attachment_matches_filter_other_fmt
+        }
+        context.getString(resource, *filters.map { it.title }.toTypedArray())
+    }
+    is AttachmentDisplayReason.Sensitive -> context.getText(R.string.post_sensitive_media_title)
+    is AttachmentDisplayReason.UserAction -> context.getText(R.string.attachment_hidden_user_action)
+}

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/extensions/AttachmentExtensions.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/extensions/AttachmentExtensions.kt
@@ -33,7 +33,8 @@ fun Attachment.iconResource() = when (this.type) {
 }
 
 /**
- * Returns a formatted version of [Attachment.description].
+ * Returns a formatted version of [Attachment.description] for use in a
+ * UX label.
  *
  * If the media has no description then the content of
  * R.string.description_post_media_no_description_placeholder is returned.
@@ -41,6 +42,9 @@ fun Attachment.iconResource() = when (this.type) {
  * If the media has a duration (i.e., it's audio or video) the duration is
  * prepended to the description, and returned (again, the string resource
  * is used if the media has no description).
+ *
+ * Use [Attachment.getContentDescription] for text to use as the attachment's
+ * content description.
  */
 fun Attachment.getFormattedDescription(context: Context): CharSequence {
     var duration = ""
@@ -52,6 +56,24 @@ fun Attachment.getFormattedDescription(context: Context): CharSequence {
     } else {
         duration + description
     }
+}
+
+/**
+ * Returns text suitable for use in an attachment's content description.
+ *
+ * Like [Attachment.getFormattedDescription], but prepends the text with
+ * information about the media's type (image, video, etc).
+ */
+fun Attachment.getContentDescription(context: Context): CharSequence {
+    val description = getFormattedDescription(context)
+    val label = when (type) {
+        Attachment.Type.IMAGE -> context.getString(R.string.post_media_images)
+        Attachment.Type.GIFV, Attachment.Type.VIDEO -> context.getString(R.string.post_media_video)
+        Attachment.Type.AUDIO -> context.getString(R.string.post_media_audio)
+        else -> context.getString(R.string.post_media_attachments)
+    }
+
+    return "$label, $description"
 }
 
 private fun formatDuration(durationInSeconds: Double): String {

--- a/core/ui/src/main/res/values-ar/strings.xml
+++ b/core/ui/src/main/res/values-ar/strings.xml
@@ -89,4 +89,9 @@
     <string name="description_visibility_unlisted">غير مُدرَج    </string>
     <string name="description_visibility_private">المتابِعون    </string>
     <string name="description_visibility_direct">مباشر    </string>
+    <string name="post_sensitive_media_title">محتوى حساس</string>
+    <string name="post_media_images">صور</string>
+    <string name="post_media_audio">صوت</string>
+    <string name="post_media_video">فيديو</string>
+    <string name="post_media_attachments">مرفقات</string>
 </resources>

--- a/core/ui/src/main/res/values-be/strings.xml
+++ b/core/ui/src/main/res/values-be/strings.xml
@@ -77,4 +77,9 @@
     <string name="description_visibility_unlisted">Не ў стужках</string>
     <string name="description_visibility_private">Падпісчыкі</string>
     <string name="description_visibility_direct">Асабіста</string>
+    <string name="post_sensitive_media_title">Далікатнае змесціва</string>
+    <string name="post_media_images">Выявы</string>
+    <string name="post_media_audio">Аўдыё</string>
+    <string name="post_media_video">Відэа</string>
+    <string name="post_media_attachments">Далучэнні</string>
 </resources>

--- a/core/ui/src/main/res/values-bg/strings.xml
+++ b/core/ui/src/main/res/values-bg/strings.xml
@@ -61,4 +61,9 @@
     <string name="description_visibility_unlisted">Скрито</string>
     <string name="description_visibility_private">Последователи</string>
     <string name="description_visibility_direct">Директно</string>
+    <string name="post_sensitive_media_title">Деликатно съдържание</string>
+    <string name="post_media_images">Изображения</string>
+    <string name="post_media_audio">Аудио</string>
+    <string name="post_media_video">Видео</string>
+    <string name="post_media_attachments">Прикачени файлове</string>
 </resources>

--- a/core/ui/src/main/res/values-bn-rBD/strings.xml
+++ b/core/ui/src/main/res/values-bn-rBD/strings.xml
@@ -61,4 +61,9 @@
     <string name="description_visibility_unlisted">অতালিকাভুক্ত</string>
     <string name="description_visibility_private">অনুগামিবৃন্দ</string>
     <string name="description_visibility_direct">সরাসরি</string>
+    <string name="post_sensitive_media_title">সংবেদনশীল কন্টেন্ট</string>
+    <string name="post_media_images">চিত্রগুলি</string>
+    <string name="post_media_audio">শব্দ</string>
+    <string name="post_media_video">ভিডিও</string>
+    <string name="post_media_attachments">সংযুক্তি</string>
 </resources>

--- a/core/ui/src/main/res/values-bn-rIN/strings.xml
+++ b/core/ui/src/main/res/values-bn-rIN/strings.xml
@@ -61,4 +61,7 @@
     <string name="description_visibility_unlisted">অতালিকাভুক্ত</string>
     <string name="description_visibility_private">অনুগামিবৃন্দ</string>
     <string name="description_visibility_direct">সরাসরি</string>
+    <string name="post_sensitive_media_title">সংবেদনশীল কন্টেন্ট</string>
+    <string name="post_media_images">চিত্রগুলি</string>
+    <string name="post_media_video">ভিডিও</string>
 </resources>

--- a/core/ui/src/main/res/values-ca/strings.xml
+++ b/core/ui/src/main/res/values-ca/strings.xml
@@ -65,4 +65,9 @@
     <string name="description_visibility_unlisted">Sense llistar</string>
     <string name="description_visibility_private">Seguidors</string>
     <string name="description_visibility_direct">Directe</string>
+    <string name="post_sensitive_media_title">Contingut sensible</string>
+    <string name="post_media_images">Imatges</string>
+    <string name="post_media_audio">Àudio</string>
+    <string name="post_media_video">Vídeo</string>
+    <string name="post_media_attachments">Adjuncions</string>
 </resources>

--- a/core/ui/src/main/res/values-ckb/strings.xml
+++ b/core/ui/src/main/res/values-ckb/strings.xml
@@ -61,4 +61,7 @@
     <string name="description_visibility_unlisted">لە لیست نەکراو</string>
     <string name="description_visibility_private">شوێنکەوتوانی</string>
     <string name="description_visibility_direct">ڕاستەوخۆ</string>
+    <string name="post_sensitive_media_title">ناوەڕۆکی هەستیار</string>
+    <string name="post_media_images">وێنەکان</string>
+    <string name="post_media_video">ڤیدیۆ</string>
 </resources>

--- a/core/ui/src/main/res/values-cs/strings.xml
+++ b/core/ui/src/main/res/values-cs/strings.xml
@@ -68,4 +68,9 @@
     <string name="description_visibility_unlisted">Neuvedený</string>
     <string name="description_visibility_private">Pro sledující</string>
     <string name="description_visibility_direct">Přímý</string>
+    <string name="post_sensitive_media_title">Citlivý obsah</string>
+    <string name="post_media_images">Obrázky</string>
+    <string name="post_media_audio">Audio</string>
+    <string name="post_media_video">Video</string>
+    <string name="post_media_attachments">Přílohy</string>
 </resources>

--- a/core/ui/src/main/res/values-cy/strings.xml
+++ b/core/ui/src/main/res/values-cy/strings.xml
@@ -89,4 +89,9 @@
     <string name="description_visibility_unlisted">Heb ei restru</string>
     <string name="description_visibility_private">Dilynwyr</string>
     <string name="description_visibility_direct">Uniongyrchol</string>
+    <string name="post_sensitive_media_title">Cynnwys sensitif</string>
+    <string name="post_media_images">Delweddau</string>
+    <string name="post_media_audio">Sain</string>
+    <string name="post_media_video">Fideo</string>
+    <string name="post_media_attachments">Atodiadau</string>
 </resources>

--- a/core/ui/src/main/res/values-de/strings.xml
+++ b/core/ui/src/main/res/values-de/strings.xml
@@ -83,4 +83,13 @@
     <string name="description_visibility_unlisted">Nicht gelistet</string>
     <string name="description_visibility_private">Follower</string>
     <string name="description_visibility_direct">Direkt    </string>
+    <string name="attachment_matches_filter_one_fmt">Entspricht Filter: \"%1$s\". Antippen zum Anzeigen.</string>
+    <string name="attachment_matches_filter_two_fmt">Entspricht Filtern: \"%1$s\" und \"%2$s\". Antippen zum Anzeigen.</string>
+    <string name="attachment_matches_filter_other_fmt">Entspricht Filtern: \"%1$s\", \"%2$s\" und weiteren. Antippen zum Anzeigen.</string>
+    <string name="post_sensitive_media_title">Inhaltswarnung. Antippen zum Anzeigen.</string>
+    <string name="attachment_hidden_user_action">Du hast dies ausgeblendet. Antippen zum Anzeigen.</string>
+    <string name="post_media_images">Bilder</string>
+    <string name="post_media_audio">Audio</string>
+    <string name="post_media_video">Video</string>
+    <string name="post_media_attachments">Anhänge</string>
 </resources>

--- a/core/ui/src/main/res/values-el/strings.xml
+++ b/core/ui/src/main/res/values-el/strings.xml
@@ -9,4 +9,5 @@
     <string name="title_links_dialog">Σύνδεσμοι</string>
     <string name="action_logout_confirm">Είστε σίγουροι ότι θέλετε να αποσυνδεθείτε από τον λογαριασμό %1$s;</string>
     <string name="action_logout">Αποσύνδεση</string>
+    <string name="post_sensitive_media_title">Ευαίσθητο περιεχόμενο</string>
 </resources>

--- a/core/ui/src/main/res/values-eo/strings.xml
+++ b/core/ui/src/main/res/values-eo/strings.xml
@@ -65,4 +65,9 @@
     <string name="description_visibility_private">        Sekvantoj
     </string>
     <string name="description_visibility_direct">        Rekta    </string>
+    <string name="post_sensitive_media_title">Tikla enhavo</string>
+    <string name="post_media_images">Bildoj</string>
+    <string name="post_media_audio">Aŭdaĵo</string>
+    <string name="post_media_video">Video</string>
+    <string name="post_media_attachments">Kunsendaĵoj</string>
 </resources>

--- a/core/ui/src/main/res/values-es/strings.xml
+++ b/core/ui/src/main/res/values-es/strings.xml
@@ -89,4 +89,13 @@
     <string name="description_visibility_unlisted">Sin listar</string>
     <string name="description_visibility_private">Seguidores</string>
     <string name="description_visibility_direct">Directo</string>
+    <string name="attachment_matches_filter_one_fmt">Filtro aplicado: \"%1$s\". Toca para mostrar.</string>
+    <string name="attachment_matches_filter_two_fmt">Filtros aplicados: \"%1$s\" y \"%2$s\". Toca para mostrar.</string>
+    <string name="attachment_matches_filter_other_fmt">Filtros aplicados: \"%1$s\", \"%2$s\" y otros. Toca para mostrar.</string>
+    <string name="post_sensitive_media_title">Contenido sensible. Toca para mostrar.</string>
+    <string name="attachment_hidden_user_action">Ocultado por ti. Toca para mostrar.</string>
+    <string name="post_media_images">Imágenes</string>
+    <string name="post_media_audio">Audio</string>
+    <string name="post_media_video">Video</string>
+    <string name="post_media_attachments">Adjuntos</string>
 </resources>

--- a/core/ui/src/main/res/values-et/strings.xml
+++ b/core/ui/src/main/res/values-et/strings.xml
@@ -83,4 +83,13 @@
     <string name="description_visibility_unlisted">Ajajooneväline</string>
     <string name="description_visibility_private">Vaid jälgijatele</string>
     <string name="description_visibility_direct">Otsesõnum</string>
+    <string name="attachment_matches_filter_one_fmt">Vastab filtrile: „%1$s“. Nägemiseks klõpsa.</string>
+    <string name="attachment_matches_filter_two_fmt">Vastab filtritele: „%1$s“ ja „%2$s“. Nägemiseks klõpsa.</string>
+    <string name="attachment_matches_filter_other_fmt">Vastab filtritele: „%1$s“, „%2$s“ ja teistele. Nägemiseks klõpsa.</string>
+    <string name="post_sensitive_media_title">Delikaatne sisu. Nägemiseks klõpsa.</string>
+    <string name="attachment_hidden_user_action">Sa oled selle peitnud. Nägemiseks klõpsa.</string>
+    <string name="post_media_images">Pildid</string>
+    <string name="post_media_audio">Helifail</string>
+    <string name="post_media_video">Video</string>
+    <string name="post_media_attachments">Manused</string>
 </resources>

--- a/core/ui/src/main/res/values-eu/strings.xml
+++ b/core/ui/src/main/res/values-eu/strings.xml
@@ -62,4 +62,9 @@
     <string name="description_visibility_unlisted">Zerrendatu gabea</string>
     <string name="description_visibility_private">Jarraitzaileak</string>
     <string name="description_visibility_direct">Zuzena</string>
+    <string name="post_sensitive_media_title">Eduki hunkigarria</string>
+    <string name="post_media_images">Irudiak</string>
+    <string name="post_media_audio">Audioa</string>
+    <string name="post_media_video">Bideoa</string>
+    <string name="post_media_attachments">Eranskinak</string>
 </resources>

--- a/core/ui/src/main/res/values-fa/strings.xml
+++ b/core/ui/src/main/res/values-fa/strings.xml
@@ -65,4 +65,9 @@
     <string name="description_visibility_unlisted">فهرست نشده</string>
     <string name="description_visibility_private">پی‌گیران</string>
     <string name="description_visibility_direct">مستقیم</string>
+    <string name="post_sensitive_media_title">محتوای حسّاس</string>
+    <string name="post_media_images">تصویرها</string>
+    <string name="post_media_audio">صدا</string>
+    <string name="post_media_video">ویدیو</string>
+    <string name="post_media_attachments">پیوست‌ها</string>
 </resources>

--- a/core/ui/src/main/res/values-fi/strings.xml
+++ b/core/ui/src/main/res/values-fi/strings.xml
@@ -81,4 +81,9 @@
     <string name="description_visibility_unlisted">Listaamaton</string>
     <string name="description_visibility_private">Seuraajat</string>
     <string name="description_visibility_direct">Vain mainitut</string>
+    <string name="post_sensitive_media_title">Herkkää sisältoä</string>
+    <string name="post_media_images">Kuvat</string>
+    <string name="post_media_audio">Ääni</string>
+    <string name="post_media_video">Video</string>
+    <string name="post_media_attachments">Liitteet</string>
 </resources>

--- a/core/ui/src/main/res/values-fr/strings.xml
+++ b/core/ui/src/main/res/values-fr/strings.xml
@@ -72,4 +72,9 @@
     <string name="description_visibility_private">        Abonné·e·s
     </string>
     <string name="description_visibility_direct">Direct</string>
+    <string name="post_sensitive_media_title">Contenu sensible</string>
+    <string name="post_media_images">Images</string>
+    <string name="post_media_audio">Audio</string>
+    <string name="post_media_video">Vidéo</string>
+    <string name="post_media_attachments">Pièces jointes</string>
 </resources>

--- a/core/ui/src/main/res/values-fy/strings.xml
+++ b/core/ui/src/main/res/values-fy/strings.xml
@@ -17,4 +17,9 @@
     <string name="abbreviated_in_hours">oer %dh</string>
     <string name="abbreviated_in_days">oer %dd</string>
     <string name="abbreviated_years_ago">%dy</string>
+    <string name="post_sensitive_media_title">Gefoelige ynhâld</string>
+    <string name="post_media_images">Ôfbyldingen</string>
+    <string name="post_media_audio">Lûd</string>
+    <string name="post_media_video">Fideo</string>
+    <string name="post_media_attachments">Taheaksels</string>
 </resources>

--- a/core/ui/src/main/res/values-ga/strings.xml
+++ b/core/ui/src/main/res/values-ga/strings.xml
@@ -101,4 +101,13 @@
     <string name="description_visibility_unlisted">Neamhliostaithe</string>
     <string name="description_visibility_private">Leantóirí</string>
     <string name="description_visibility_direct">Díreach</string>
+    <string name="attachment_matches_filter_one_fmt">Meaitseálann an scagaire: \"%1$s\". Tapáil le taispeáint.</string>
+    <string name="attachment_matches_filter_two_fmt">Meaitseálann na scagairí seo a leanas: \"%1$s\" agus \"%2$s\". Tapáil le taispeáint.</string>
+    <string name="attachment_matches_filter_other_fmt">Meaitseálann scagairí: \"%1$s\", \"%2$s\", agus tuilleadh. Tapáil le taispeáint.</string>
+    <string name="post_sensitive_media_title">Ábhar íogair. Tapáil le taispeáint.</string>
+    <string name="attachment_hidden_user_action">Chuir tú seo i bhfolach. Tapáil le taispeáint.</string>
+    <string name="post_media_images">Íomhánna</string>
+    <string name="post_media_audio">Fuaim</string>
+    <string name="post_media_video">Físeán</string>
+    <string name="post_media_attachments">Ceangaltáin</string>
 </resources>

--- a/core/ui/src/main/res/values-gd/strings.xml
+++ b/core/ui/src/main/res/values-gd/strings.xml
@@ -77,4 +77,9 @@
     <string name="description_visibility_unlisted">Falaichte o liostaichean</string>
     <string name="description_visibility_private">Luchd-leantainn</string>
     <string name="description_visibility_direct">Dìreach</string>
+    <string name="post_sensitive_media_title">Susbaint fhrionasach</string>
+    <string name="post_media_images">Dealbhan</string>
+    <string name="post_media_audio">Fuaim</string>
+    <string name="post_media_video">Videothan</string>
+    <string name="post_media_attachments">Ceanglachain</string>
 </resources>

--- a/core/ui/src/main/res/values-gl/strings.xml
+++ b/core/ui/src/main/res/values-gl/strings.xml
@@ -75,4 +75,9 @@
     <string name="description_visibility_unlisted">Non listado</string>
     <string name="description_visibility_private">Seguidoras</string>
     <string name="description_visibility_direct">Directo</string>
+    <string name="post_sensitive_media_title">Contido sensible</string>
+    <string name="post_media_images">Imaxes</string>
+    <string name="post_media_audio">Audio</string>
+    <string name="post_media_video">Vídeo</string>
+    <string name="post_media_attachments">Anexos</string>
 </resources>

--- a/core/ui/src/main/res/values-hi/strings.xml
+++ b/core/ui/src/main/res/values-hi/strings.xml
@@ -46,4 +46,7 @@
     <string name="description_visibility_unlisted">असूचीबद्ध</string>
     <string name="description_visibility_private">अनुगामी</string>
     <string name="description_visibility_direct">प्रत्यक्ष</string>
+    <string name="post_sensitive_media_title">संवेदनशील विषय वस्तु</string>
+    <string name="post_media_images">तस्वीरें</string>
+    <string name="post_media_video">वीडियो</string>
 </resources>

--- a/core/ui/src/main/res/values-hu/strings.xml
+++ b/core/ui/src/main/res/values-hu/strings.xml
@@ -65,4 +65,9 @@
     <string name="description_visibility_unlisted">Listázatlan</string>
     <string name="description_visibility_private">Követők</string>
     <string name="description_visibility_direct">Közvetlen</string>
+    <string name="post_sensitive_media_title">Érzékeny tartalom</string>
+    <string name="post_media_images">Képek</string>
+    <string name="post_media_audio">Audio</string>
+    <string name="post_media_video">Videó</string>
+    <string name="post_media_attachments">Csatolmányok</string>
 </resources>

--- a/core/ui/src/main/res/values-in/strings.xml
+++ b/core/ui/src/main/res/values-in/strings.xml
@@ -27,4 +27,9 @@
     <string name="abbreviated_days_ago">%dd</string>
     <string name="abbreviated_in_years">Dalam %d</string>
     <string name="abbreviated_years_ago">%dy</string>
+    <string name="post_sensitive_media_title">Konten sensitif</string>
+    <string name="post_media_images">Gambar</string>
+    <string name="post_media_audio">Audio</string>
+    <string name="post_media_video">Video</string>
+    <string name="post_media_attachments">Lampiran</string>
 </resources>

--- a/core/ui/src/main/res/values-is/strings.xml
+++ b/core/ui/src/main/res/values-is/strings.xml
@@ -65,4 +65,9 @@
     <string name="description_visibility_unlisted">Óskráð</string>
     <string name="description_visibility_private">Fylgjendur</string>
     <string name="description_visibility_direct">Beint</string>
+    <string name="post_sensitive_media_title">Viðkvæmt efni</string>
+    <string name="post_media_images">Myndir</string>
+    <string name="post_media_audio">Hljóð</string>
+    <string name="post_media_video">Myndskeið</string>
+    <string name="post_media_attachments">Viðhengi</string>
 </resources>

--- a/core/ui/src/main/res/values-it/strings.xml
+++ b/core/ui/src/main/res/values-it/strings.xml
@@ -85,4 +85,9 @@
     <string name="description_visibility_unlisted">Non in elenco</string>
     <string name="description_visibility_private">Solo seguaci</string>
     <string name="description_visibility_direct">Diretti</string>
+    <string name="post_sensitive_media_title">Contenuto sensibile</string>
+    <string name="post_media_images">Immagini</string>
+    <string name="post_media_audio">Audio</string>
+    <string name="post_media_video">Video</string>
+    <string name="post_media_attachments">Allegati</string>
 </resources>

--- a/core/ui/src/main/res/values-ja/strings.xml
+++ b/core/ui/src/main/res/values-ja/strings.xml
@@ -62,4 +62,9 @@
     <string name="description_visibility_private">フォロワー</string>
     <string name="description_visibility_direct">        ダイレクト
     </string>
+    <string name="post_sensitive_media_title">閲覧注意</string>
+    <string name="post_media_images">画像</string>
+    <string name="post_media_audio">音声</string>
+    <string name="post_media_video">動画</string>
+    <string name="post_media_attachments">添付ファイル</string>
 </resources>

--- a/core/ui/src/main/res/values-kab/strings.xml
+++ b/core/ui/src/main/res/values-kab/strings.xml
@@ -56,4 +56,8 @@
     <string name="abbreviated_years_ago">%dis aya</string>
     <string name="description_visibility_private">Imeḍfaṛen</string>
     <string name="description_visibility_direct">Srid</string>
+    <string name="post_sensitive_media_title">Agbur amḥulfu</string>
+    <string name="post_media_images">Tugniwin</string>
+    <string name="post_media_audio">Imesli</string>
+    <string name="post_media_video">Tibidyutin</string>
 </resources>

--- a/core/ui/src/main/res/values-ko/strings.xml
+++ b/core/ui/src/main/res/values-ko/strings.xml
@@ -52,4 +52,7 @@
     <string name="description_visibility_unlisted">타임라인에 비표시</string>
     <string name="description_visibility_private">비공개</string>
     <string name="description_visibility_direct">다이렉트</string>
+    <string name="post_sensitive_media_title">민감한 미디어</string>
+    <string name="post_media_images">사진</string>
+    <string name="post_media_video">비디오</string>
 </resources>

--- a/core/ui/src/main/res/values-lv/strings.xml
+++ b/core/ui/src/main/res/values-lv/strings.xml
@@ -89,4 +89,13 @@
     <string name="description_visibility_unlisted">Neiekļauts</string>
     <string name="description_visibility_private">Sekotāji</string>
     <string name="description_visibility_direct">Tiešs</string>
+    <string name="attachment_matches_filter_one_fmt">Atbilst atlasītājam: “%1$s”. Jāpiesit, lai parādītu.</string>
+    <string name="attachment_matches_filter_two_fmt">Atbilst atlasītājiem: “%1$s” un “%2$s”. Jāpiesit, lai parādītu.</string>
+    <string name="attachment_matches_filter_other_fmt">Atbilst atlasītājiem: “%1$s”, “%2$s” un vēl. Jāpiesit, lai parādītu.</string>
+    <string name="post_sensitive_media_title">Jūtīgs saturs. Jāpiesit, lai parādītu.</string>
+    <string name="attachment_hidden_user_action">Tu paslēpi šo. Jāpiesit, lai parādītu.</string>
+    <string name="post_media_images">Attēli</string>
+    <string name="post_media_audio">Audio</string>
+    <string name="post_media_video">Video</string>
+    <string name="post_media_attachments">Pielikumi</string>
 </resources>

--- a/core/ui/src/main/res/values-ml/strings.xml
+++ b/core/ui/src/main/res/values-ml/strings.xml
@@ -15,4 +15,7 @@
     <string name="add_account_name">അക്കൗണ്ട് ചേർക്കുക</string>
     <string name="action_logout">പുറത്തിറങ്ങുക</string>
     <string name="description_visibility_private">പിന്തുടരുന്നവർ</string>
+    <string name="post_sensitive_media_title">സെൻസിറ്റീവ് ഉള്ളടക്കം</string>
+    <string name="post_media_images">ചിത്രങ്ങൾ</string>
+    <string name="post_media_video">വിഡിയോ</string>
 </resources>

--- a/core/ui/src/main/res/values-my/strings.xml
+++ b/core/ui/src/main/res/values-my/strings.xml
@@ -3,4 +3,5 @@
     <string name="action_logout_confirm">သင် %1$s? မှထွက်ရန် သေချာသလား။ပုံကြမ်းများနှင့်ချိန်ညှိမှုများကိုဖျက်မည်ဖြစ်သည်။</string>
     <string name="action_logout">ထွက်မည်</string>
     <string name="post_media_alt">ပုံစာ</string>
+    <string name="post_sensitive_media_title">ထိလွယ်ရှလွယ်သော</string>
 </resources>

--- a/core/ui/src/main/res/values-nb-rNO/strings.xml
+++ b/core/ui/src/main/res/values-nb-rNO/strings.xml
@@ -77,4 +77,9 @@
     <string name="description_visibility_unlisted">Ikke listet</string>
     <string name="description_visibility_private">Følgere</string>
     <string name="description_visibility_direct">Direkte</string>
+    <string name="post_sensitive_media_title">Sensitivt innhold</string>
+    <string name="post_media_images">Bilder</string>
+    <string name="post_media_audio">Lyd</string>
+    <string name="post_media_video">Video</string>
+    <string name="post_media_attachments">Vedlegg</string>
 </resources>

--- a/core/ui/src/main/res/values-nl/strings.xml
+++ b/core/ui/src/main/res/values-nl/strings.xml
@@ -66,4 +66,9 @@
     <string name="description_visibility_unlisted">Minder openbaar</string>
     <string name="description_visibility_private">Volgers</string>
     <string name="description_visibility_direct">Direct</string>
+    <string name="post_sensitive_media_title">Gevoelige inhoud</string>
+    <string name="post_media_images">Afbeeldingen</string>
+    <string name="post_media_audio">Geluid</string>
+    <string name="post_media_video">Video</string>
+    <string name="post_media_attachments">Bijlagen</string>
 </resources>

--- a/core/ui/src/main/res/values-nn/strings.xml
+++ b/core/ui/src/main/res/values-nn/strings.xml
@@ -81,4 +81,9 @@
     <string name="description_visibility_unlisted">Ulista</string>
     <string name="description_visibility_private">Fylgjarar</string>
     <string name="description_visibility_direct">Direkte</string>
+    <string name="post_sensitive_media_title">Sensitivt innhald</string>
+    <string name="post_media_images">Bilete</string>
+    <string name="post_media_audio">Ljod</string>
+    <string name="post_media_video">Video</string>
+    <string name="post_media_attachments">Vedlegg</string>
 </resources>

--- a/core/ui/src/main/res/values-oc/strings.xml
+++ b/core/ui/src/main/res/values-oc/strings.xml
@@ -65,4 +65,9 @@
     <string name="description_visibility_unlisted">Pas listada</string>
     <string name="description_visibility_private">Seguidors</string>
     <string name="description_visibility_direct">Dirècte</string>
+    <string name="post_sensitive_media_title">Contengut sensible</string>
+    <string name="post_media_images">Imatges</string>
+    <string name="post_media_audio">Àudio</string>
+    <string name="post_media_video">Vidèo</string>
+    <string name="post_media_attachments">Pèças juntas</string>
 </resources>

--- a/core/ui/src/main/res/values-pl/strings.xml
+++ b/core/ui/src/main/res/values-pl/strings.xml
@@ -95,4 +95,9 @@
     <string name="description_visibility_unlisted">Niewidoczny</string>
     <string name="description_visibility_private">Obserwujący</string>
     <string name="description_visibility_direct">Bezpośrednio</string>
+    <string name="post_sensitive_media_title">Treści drażliwe</string>
+    <string name="post_media_images">Obrazy</string>
+    <string name="post_media_audio">Dźwięk</string>
+    <string name="post_media_video">Wideo</string>
+    <string name="post_media_attachments">Załączniki</string>
 </resources>

--- a/core/ui/src/main/res/values-pt-rBR/strings.xml
+++ b/core/ui/src/main/res/values-pt-rBR/strings.xml
@@ -71,4 +71,9 @@
     <string name="description_visibility_unlisted">Não-listado</string>
     <string name="description_visibility_private">Seguidores</string>
     <string name="description_visibility_direct">Direto</string>
+    <string name="post_sensitive_media_title">Mídia sensível</string>
+    <string name="post_media_images">Imagens</string>
+    <string name="post_media_audio">Áudio</string>
+    <string name="post_media_video">Vídeo</string>
+    <string name="post_media_attachments">Anexos</string>
 </resources>

--- a/core/ui/src/main/res/values-pt-rPT/strings.xml
+++ b/core/ui/src/main/res/values-pt-rPT/strings.xml
@@ -69,4 +69,9 @@
     <string name="description_visibility_unlisted">Não-listado</string>
     <string name="description_visibility_private">Privado</string>
     <string name="description_visibility_direct">Direto</string>
+    <string name="post_sensitive_media_title">Conteúdo sensível</string>
+    <string name="post_media_images">Imagens</string>
+    <string name="post_media_audio">Áudio</string>
+    <string name="post_media_video">Vídeo</string>
+    <string name="post_media_attachments">Anexos</string>
 </resources>

--- a/core/ui/src/main/res/values-ru/strings.xml
+++ b/core/ui/src/main/res/values-ru/strings.xml
@@ -99,4 +99,9 @@
     <string name="description_visibility_unlisted">Не в списке</string>
     <string name="description_visibility_private">Подписчики</string>
     <string name="description_visibility_direct">Непосредственно</string>
+    <string name="post_sensitive_media_title">Чувствительный контент</string>
+    <string name="post_media_images">Изображения</string>
+    <string name="post_media_audio">Аудио</string>
+    <string name="post_media_video">Видео</string>
+    <string name="post_media_attachments">Вложения</string>
 </resources>

--- a/core/ui/src/main/res/values-sa/strings.xml
+++ b/core/ui/src/main/res/values-sa/strings.xml
@@ -64,4 +64,9 @@
     <string name="description_visibility_unlisted">अनिर्दिष्टम्</string>
     <string name="description_visibility_private">अनुसर्तारः</string>
     <string name="description_visibility_direct">प्रत्यक्षम्</string>
+    <string name="post_sensitive_media_title">संवेदनशीलो विषयः</string>
+    <string name="post_media_images">चित्राणि</string>
+    <string name="post_media_audio">ध्वनिः</string>
+    <string name="post_media_video">चलचित्राणि</string>
+    <string name="post_media_attachments">सम्योजितानि</string>
 </resources>

--- a/core/ui/src/main/res/values-si/strings.xml
+++ b/core/ui/src/main/res/values-si/strings.xml
@@ -52,4 +52,8 @@
     <string name="abbreviated_years_ago">අවු. %d</string>
     <string name="description_visibility_public">ප්‍රසිද්ධ</string>
     <string name="description_visibility_direct">සෘජු</string>
+    <string name="post_sensitive_media_title">සංවේදී අන්තර්ගතයකි</string>
+    <string name="post_media_audio">ශ්‍රව්‍ය</string>
+    <string name="post_media_video">දෘශ්‍යකය</string>
+    <string name="post_media_attachments">ඇමුණුම්</string>
 </resources>

--- a/core/ui/src/main/res/values-sk/strings.xml
+++ b/core/ui/src/main/res/values-sk/strings.xml
@@ -89,4 +89,9 @@
     <string name="description_visibility_unlisted">Tiché verejné</string>
     <string name="description_visibility_private">Sledujúci</string>
     <string name="description_visibility_direct">Priame</string>
+    <string name="post_sensitive_media_title">Citlivý obsah</string>
+    <string name="post_media_images">Obrázky</string>
+    <string name="post_media_audio">Audio</string>
+    <string name="post_media_video">Video</string>
+    <string name="post_media_attachments">Prílohy</string>
 </resources>

--- a/core/ui/src/main/res/values-sl/strings.xml
+++ b/core/ui/src/main/res/values-sl/strings.xml
@@ -67,4 +67,7 @@
     <string name="description_visibility_unlisted">Ni prikazano</string>
     <string name="description_visibility_private">Sledilci</string>
     <string name="description_visibility_direct">Neposredno</string>
+    <string name="post_sensitive_media_title">Občutljiva vsebina</string>
+    <string name="post_media_images">Slike</string>
+    <string name="post_media_video">Video</string>
 </resources>

--- a/core/ui/src/main/res/values-sv/strings.xml
+++ b/core/ui/src/main/res/values-sv/strings.xml
@@ -71,4 +71,9 @@
     </string>
     <string name="description_visibility_direct">        Direkt
     </string>
+    <string name="post_sensitive_media_title">Känsligt innehåll</string>
+    <string name="post_media_images">Bilder</string>
+    <string name="post_media_audio">Ljud</string>
+    <string name="post_media_video">Video</string>
+    <string name="post_media_attachments">Bilagor</string>
 </resources>

--- a/core/ui/src/main/res/values-ta/strings.xml
+++ b/core/ui/src/main/res/values-ta/strings.xml
@@ -82,4 +82,9 @@
     <string name="description_visibility_unlisted">பட்டியலிடப்படாதவர்களுக்கு</string>
     <string name="description_visibility_private">பின்பற்றுபவர்கள்</string>
     <string name="description_visibility_direct">நேரடி</string>
+    <string name="post_sensitive_media_title">உணர்ச்சிகரமான உள்ளடக்கம்</string>
+    <string name="post_media_images">படங்கள்</string>
+    <string name="post_media_audio">ஆடியோ</string>
+    <string name="post_media_video">காணொளி</string>
+    <string name="post_media_attachments">இணைப்புகள்</string>
 </resources>

--- a/core/ui/src/main/res/values-th/strings.xml
+++ b/core/ui/src/main/res/values-th/strings.xml
@@ -55,4 +55,9 @@
     <string name="description_visibility_unlisted">ไม่อยู่ในรายการ</string>
     <string name="description_visibility_private">ผู้ติดตาม</string>
     <string name="description_visibility_direct">ไดเร็กต์</string>
+    <string name="post_sensitive_media_title">เนื้อหาอ่อนไหว</string>
+    <string name="post_media_images">ภาพ</string>
+    <string name="post_media_audio">เสียง</string>
+    <string name="post_media_video">วิดีทัศน์</string>
+    <string name="post_media_attachments">ไฟล์แนบ</string>
 </resources>

--- a/core/ui/src/main/res/values-tr/strings.xml
+++ b/core/ui/src/main/res/values-tr/strings.xml
@@ -65,4 +65,9 @@
     <string name="description_visibility_unlisted">Liste dışı</string>
     <string name="description_visibility_private">Takipçiler</string>
     <string name="description_visibility_direct">Doğrudan</string>
+    <string name="post_sensitive_media_title">Hassas medya</string>
+    <string name="post_media_images">Görseller</string>
+    <string name="post_media_audio">Ses</string>
+    <string name="post_media_video">Video</string>
+    <string name="post_media_attachments">Ekler</string>
 </resources>

--- a/core/ui/src/main/res/values-uk/strings.xml
+++ b/core/ui/src/main/res/values-uk/strings.xml
@@ -77,4 +77,9 @@
     <string name="description_visibility_unlisted">Приховано</string>
     <string name="description_visibility_private">Підписники</string>
     <string name="description_visibility_direct">Безпосередньо</string>
+    <string name="post_sensitive_media_title">Делікатний вміст</string>
+    <string name="post_media_images">Зображення</string>
+    <string name="post_media_audio">Звуки</string>
+    <string name="post_media_video">Відео</string>
+    <string name="post_media_attachments">Вкладення</string>
 </resources>

--- a/core/ui/src/main/res/values-vi/strings.xml
+++ b/core/ui/src/main/res/values-vi/strings.xml
@@ -59,4 +59,9 @@
     <string name="description_visibility_unlisted">Hạn chế</string>
     <string name="description_visibility_private">Người theo dõi</string>
     <string name="description_visibility_direct">Nhắn riêng</string>
+    <string name="post_sensitive_media_title">Nhạy cảm</string>
+    <string name="post_media_images">Hình ảnh</string>
+    <string name="post_media_audio">Âm thanh</string>
+    <string name="post_media_video">Video</string>
+    <string name="post_media_attachments">Đính kèm</string>
 </resources>

--- a/core/ui/src/main/res/values-zh-rCN/strings.xml
+++ b/core/ui/src/main/res/values-zh-rCN/strings.xml
@@ -69,4 +69,9 @@
     <string name="description_visibility_direct">
         私信
     </string>
+    <string name="post_sensitive_media_title">敏感内容</string>
+    <string name="post_media_images">图片</string>
+    <string name="post_media_audio">音频</string>
+    <string name="post_media_video">视频</string>
+    <string name="post_media_attachments">附件</string>
 </resources>

--- a/core/ui/src/main/res/values-zh-rHK/strings.xml
+++ b/core/ui/src/main/res/values-zh-rHK/strings.xml
@@ -66,4 +66,9 @@
     <string name="description_visibility_direct">
         私信
     </string>
+    <string name="post_sensitive_media_title">敏感內容</string>
+    <string name="post_media_images">照片</string>
+    <string name="post_media_audio">錄音</string>
+    <string name="post_media_video">影片</string>
+    <string name="post_media_attachments">附件</string>
 </resources>

--- a/core/ui/src/main/res/values-zh-rMO/strings.xml
+++ b/core/ui/src/main/res/values-zh-rMO/strings.xml
@@ -57,4 +57,7 @@
     <string name="description_visibility_direct">
         私信
     </string>
+    <string name="post_sensitive_media_title">敏感內容</string>
+    <string name="post_media_images">照片</string>
+    <string name="post_media_video">影片</string>
 </resources>

--- a/core/ui/src/main/res/values-zh-rSG/strings.xml
+++ b/core/ui/src/main/res/values-zh-rSG/strings.xml
@@ -57,4 +57,7 @@
     <string name="description_visibility_direct">
         私信
     </string>
+    <string name="post_sensitive_media_title">敏感内容</string>
+    <string name="post_media_images">照片</string>
+    <string name="post_media_video">视频</string>
 </resources>

--- a/core/ui/src/main/res/values-zh-rTW/strings.xml
+++ b/core/ui/src/main/res/values-zh-rTW/strings.xml
@@ -67,4 +67,9 @@
     <string name="description_visibility_direct">
         私信
     </string>
+    <string name="post_sensitive_media_title">敏感內容</string>
+    <string name="post_media_images">照片</string>
+    <string name="post_media_audio">錄音</string>
+    <string name="post_media_video">影片</string>
+    <string name="post_media_attachments">附件</string>
 </resources>

--- a/core/ui/src/main/res/values/actions.xml
+++ b/core/ui/src/main/res/values/actions.xml
@@ -59,4 +59,9 @@
 
     <item name="action_show_anyway" type="id" />
     <item name="action_edit_filter" type="id" />
+
+    <!-- Show hidden attachments. -->
+    <item name="action_show_attachments" type="id" />
+    <!-- Hide shown attachments. -->
+    <item name="action_hide_attachments" type="id" />
 </resources>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -95,4 +95,15 @@
     <string name="description_visibility_direct">
         Direct
     </string>
+    <string name="action_show_attachments">Show attachments</string>
+    <string name="action_hide_attachments">Hide attachments</string>
+    <string name="attachment_matches_filter_one_fmt">Matches filter: \"%1$s\". Tap to show.</string>
+    <string name="attachment_matches_filter_two_fmt">Matches filters: \"%1$s\" and \"%2$s\". Tap to show.</string>
+    <string name="attachment_matches_filter_other_fmt">Matches filters: \"%1$s\", \"%2$s\", and more. Tap to show.</string>
+    <string name="post_sensitive_media_title">Sensitive content. Tap to show.</string>
+    <string name="attachment_hidden_user_action">You hid this. Tap to show.</string>
+    <string name="post_media_images">Images</string>
+    <string name="post_media_audio">Audio</string>
+    <string name="post_media_video">Video</string>
+    <string name="post_media_attachments">Attachments</string>
 </resources>


### PR DESCRIPTION
Previous code had two problems:

1. If Talkback was enabled and the user read out a status where the attachments had been hidden (sensitive, matched a "blur" filter, or user action), the media descriptions were also read out.

2. There was no accessibility action to allow the user to hide/show attachments.

To fix the first problem, the description for hidden media is now the reason why the media is hidden (e.g., marked sensitive, matched a filter, etc).

To fix the second, two new accessibility actions have been introduced to show or hide attachments on a status.