### PR TITLE
fix: Show if a post is a boost on network timelines

### DIFF
--- a/app/src/main/java/app/pachli/components/timeline/NetworkTimelineRepository.kt
+++ b/app/src/main/java/app/pachli/components/timeline/NetworkTimelineRepository.kt
@@ -176,7 +176,7 @@ class NetworkTimelineRepository @Inject constructor(
                     val statusViewData = statusRepository.getStatusViewData(pachliAccountId, status.actionableId)
                     val translations = statusRepository.getTranslation(pachliAccountId, status.actionableId)
                     TimelineStatusWithAccount(
-                        status = status.reblog?.asEntity(pachliAccountId) ?: status.asEntity(pachliAccountId),
+                        status = status.asEntity(pachliAccountId),
                         account = status.reblog?.account?.asEntity(pachliAccountId) ?: status.account.asEntity(pachliAccountId),
                         reblogAccount = status.reblog?.let { status.account.asEntity(pachliAccountId) },
                         viewData = statusViewData,


### PR DESCRIPTION
Previous code inadvertently broke this by calling `Status.asEntity()` with on either the `status.reblog` property or the `status`. This isn't necessary, `.asEntity()` does the right thing.

Fixes #1797