### PR TITLE
feat: Improve accessibility of account name, handle, and roles

### DIFF
--- a/app/src/main/java/app/pachli/adapter/AccountViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/AccountViewHolder.kt
@@ -23,7 +23,7 @@ import app.pachli.core.designsystem.R as DR
 import app.pachli.core.model.TimelineAccount
 import app.pachli.core.ui.LinkListener
 import app.pachli.core.ui.emojify
-import app.pachli.core.ui.extensions.setRoles
+import app.pachli.core.ui.extensions.contentDescription
 import app.pachli.core.ui.loadAvatar
 import app.pachli.databinding.ItemAccountBinding
 import app.pachli.interfaces.AccountActionListener
@@ -63,6 +63,8 @@ class AccountViewHolder(
         binding.accountBotBadge.visible(showBotOverlay && account.bot)
 
         binding.roleChipGroup.setRoles(account.roles)
+
+        binding.root.contentDescription = account.contentDescription(binding.root.context)
     }
 
     fun setupActionListener(listener: AccountActionListener) {

--- a/app/src/main/java/app/pachli/adapter/FollowRequestViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/FollowRequestViewHolder.kt
@@ -34,7 +34,6 @@ import app.pachli.core.model.TimelineAccount
 import app.pachli.core.network.parseAsMastodonHtml
 import app.pachli.core.ui.LinkListener
 import app.pachli.core.ui.emojify
-import app.pachli.core.ui.extensions.setRoles
 import app.pachli.core.ui.loadAvatar
 import app.pachli.core.ui.setClickableText
 import app.pachli.databinding.ItemFollowRequestBinding

--- a/app/src/main/java/app/pachli/adapter/StatusBaseViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/StatusBaseViewHolder.kt
@@ -40,15 +40,16 @@ import app.pachli.core.ui.MediaPreviewLayout
 import app.pachli.core.ui.PollView
 import app.pachli.core.ui.PollViewData.Companion.from
 import app.pachli.core.ui.PreviewCardView
+import app.pachli.core.ui.RoleChipGroup
 import app.pachli.core.ui.SetStatusContent
 import app.pachli.core.ui.StatusActionListener
 import app.pachli.core.ui.emojify
 import app.pachli.core.ui.extensions.aspectRatios
+import app.pachli.core.ui.extensions.contentDescription
 import app.pachli.core.ui.extensions.description
 import app.pachli.core.ui.extensions.getContentDescription
 import app.pachli.core.ui.extensions.getFormattedDescription
 import app.pachli.core.ui.extensions.iconResource
-import app.pachli.core.ui.extensions.setRoles
 import app.pachli.core.ui.getRelativeTimeSpanString
 import app.pachli.core.ui.loadAvatar
 import app.pachli.core.ui.makeIcon
@@ -58,7 +59,6 @@ import at.connyduck.sparkbutton.SparkButton
 import at.connyduck.sparkbutton.helpers.Utils
 import com.bumptech.glide.RequestManager
 import com.google.android.material.button.MaterialButton
-import com.google.android.material.chip.ChipGroup
 import com.google.android.material.color.MaterialColors
 import com.mikepenz.iconics.typeface.library.googlematerial.GoogleMaterial
 import java.text.NumberFormat
@@ -72,7 +72,7 @@ abstract class StatusBaseViewHolder<T : IStatusViewData> protected constructor(
     protected val context: Context = itemView.context
     private val displayName: TextView = itemView.findViewById(R.id.status_display_name)
     private val username: TextView = itemView.findViewById(R.id.status_username)
-    private val roleChipGroup: ChipGroup = itemView.findViewById(R.id.roleChipGroup)
+    private val roleChipGroup: RoleChipGroup = itemView.findViewById(R.id.roleChipGroup)
     private val replyButton: ImageButton = itemView.findViewById(R.id.status_reply)
     private val replyCountLabel: TextView? = itemView.findViewById(R.id.status_replies)
     private val reblogButton: SparkButton? = itemView.findViewById(R.id.status_inset)
@@ -371,7 +371,7 @@ abstract class StatusBaseViewHolder<T : IStatusViewData> protected constructor(
      * @param viewData
      */
     private fun setRoleChips(viewData: T) {
-        roleChipGroup.setRoles(viewData.actionable.account.roles)
+        roleChipGroup.setRoles(viewData.actionable.account.roles, viewData.actionable.account.domain)
     }
 
     private fun getCreatedAtDescription(
@@ -813,18 +813,7 @@ abstract class StatusBaseViewHolder<T : IStatusViewData> protected constructor(
         // (, "n Favorite")
         // (, "n Boost")
         val description = StringBuilder().apply {
-            append(account.name)
-
-            if (account.roles.isNotEmpty()) {
-                append("; ")
-                append(
-                    context.resources.getQuantityString(
-                        R.plurals.description_post_roles,
-                        account.roles.size,
-                    ),
-                )
-                append(account.roles.joinToString(", ") { it.name })
-            }
+            append(account.contentDescription(context))
 
             append(".")
 
@@ -855,8 +844,6 @@ abstract class StatusBaseViewHolder<T : IStatusViewData> protected constructor(
             editedAt?.let { append(", ", context.getString(R.string.description_post_edited)) }
 
             getReblogDescription(context, viewData)?.let { append(", ", it) }
-
-            append(", ", viewData.actionable.account.username)
 
             if (reblogged) {
                 append(", ", context.getString(R.string.description_post_reblogged))

--- a/app/src/main/java/app/pachli/components/account/AccountActivity.kt
+++ b/app/src/main/java/app/pachli/components/account/AccountActivity.kt
@@ -77,6 +77,8 @@ import app.pachli.core.ui.emojify
 import app.pachli.core.ui.extensions.InsetType
 import app.pachli.core.ui.extensions.applyDefaultWindowInsets
 import app.pachli.core.ui.extensions.applyWindowInsets
+import app.pachli.core.ui.extensions.handleContentDescription
+import app.pachli.core.ui.extensions.nameContentDescription
 import app.pachli.core.ui.extensions.reduceSwipeSensitivity
 import app.pachli.core.ui.getDomain
 import app.pachli.core.ui.loadAvatar
@@ -513,9 +515,12 @@ class AccountActivity :
     private fun onAccountChanged(account: Account?) {
         loadedAccount = account ?: return
 
+        binding.accountDisplayNameTextView.text = account.name.emojify(glide, account.emojis, binding.accountDisplayNameTextView, animateEmojis)
+        binding.accountDisplayNameTextView.contentDescription = account.nameContentDescription(this)
+
         val usernameFormatted = getString(DR.string.post_username_format, account.username)
         binding.accountUsernameTextView.text = usernameFormatted
-        binding.accountDisplayNameTextView.text = account.name.emojify(glide, account.emojis, binding.accountDisplayNameTextView, animateEmojis)
+        binding.accountUsernameTextView.contentDescription = account.handleContentDescription(this)
 
         // Long press on username to copy it to clipboard
         for (view in listOf(binding.accountUsernameTextView, binding.accountDisplayNameTextView)) {
@@ -821,8 +826,7 @@ class AccountActivity :
         // so follow suit for the moment, https://github.com/mastodon/mastodon/issues/28327
         loadedAccount?.roles?.forEach { role ->
             val badgeView = getBadge(app.pachli.core.ui.R.drawable.profile_role_badge).apply {
-                this.role = role.name
-                this.domain = viewModel.domain
+                bind(role, viewModel.domain)
             }
 
             binding.accountBadgeContainer.addView(badgeView)

--- a/app/src/main/java/app/pachli/components/compose/ComposeAutoCompleteAdapter.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeAutoCompleteAdapter.kt
@@ -30,7 +30,7 @@ import app.pachli.core.model.Emoji
 import app.pachli.core.model.TimelineAccount
 import app.pachli.core.ui.databinding.ItemAutocompleteAccountBinding
 import app.pachli.core.ui.emojify
-import app.pachli.core.ui.extensions.setRoles
+import app.pachli.core.ui.extensions.contentDescription
 import app.pachli.core.ui.loadAvatar
 import app.pachli.databinding.ItemAutocompleteEmojiBinding
 import app.pachli.databinding.ItemAutocompleteHashtagBinding
@@ -131,6 +131,7 @@ class ComposeAutoCompleteAdapter(
                 binding.avatarBadge.visible(showBotBadge && account.bot)
 
                 binding.roleChipGroup.setRoles(account.roles)
+                binding.root.contentDescription = account.contentDescription(context)
             }
             is ItemAutocompleteHashtagBinding -> {
                 val result = getItem(position) as AutocompleteResult.HashtagResult

--- a/app/src/main/java/app/pachli/components/notifications/FollowViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/notifications/FollowViewHolder.kt
@@ -31,7 +31,7 @@ import app.pachli.core.model.TimelineAccount
 import app.pachli.core.network.parseAsMastodonHtml
 import app.pachli.core.ui.LinkListener
 import app.pachli.core.ui.emojify
-import app.pachli.core.ui.extensions.setRoles
+import app.pachli.core.ui.extensions.handleContentDescription
 import app.pachli.core.ui.loadAvatar
 import app.pachli.core.ui.setClickableText
 import app.pachli.databinding.ItemFollowBinding
@@ -100,6 +100,7 @@ class FollowViewHolder(
         binding.notificationText.text = emojifiedMessage
         val username = context.getString(DR.string.post_username_format, account.username)
         binding.notificationUsername.text = username
+        binding.notificationUsername.contentDescription = account.handleContentDescription(context)
         loadAvatar(
             glide,
             account.avatar,

--- a/app/src/main/res/layout/item_account.xml
+++ b/app/src/main/res/layout/item_account.xml
@@ -36,7 +36,7 @@
         tools:src="#000"
         tools:visibility="visible" />
 
-    <com.google.android.material.chip.ChipGroup
+    <app.pachli.core.ui.RoleChipGroup
         android:id="@+id/roleChipGroup"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -44,7 +44,8 @@
         app:chipSpacingVertical="4dp"
         app:layout_constraintStart_toStartOf="@id/account_display_name"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@id/account_avatar" />
+        app:layout_constraintTop_toTopOf="@id/account_avatar"
+        android:importantForAccessibility="no" />
 
     <TextView
         android:id="@+id/account_display_name"

--- a/app/src/main/res/layout/item_follow.xml
+++ b/app/src/main/res/layout/item_follow.xml
@@ -39,7 +39,7 @@
         app:layout_constraintTop_toBottomOf="@+id/notification_text"
         tools:src="@drawable/avatar_default" />
 
-    <com.google.android.material.chip.ChipGroup
+    <app.pachli.core.ui.RoleChipGroup
         android:id="@+id/roleChipGroup"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -47,7 +47,8 @@
         app:chipSpacingVertical="4dp"
         app:layout_constraintStart_toStartOf="@id/notification_username"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@id/notification_avatar" />
+        app:layout_constraintTop_toTopOf="@id/notification_avatar"
+        android:importantForAccessibility="no" />
 
     <TextView
         android:id="@+id/notification_username"

--- a/app/src/main/res/layout/item_follow_request.xml
+++ b/app/src/main/res/layout/item_follow_request.xml
@@ -46,7 +46,7 @@
         app:layout_constraintBottom_toBottomOf="@id/avatar"
         app:layout_constraintEnd_toEndOf="@id/avatar" />
 
-    <com.google.android.material.chip.ChipGroup
+    <app.pachli.core.ui.RoleChipGroup
         android:id="@+id/roleChipGroup"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -54,7 +54,8 @@
         app:chipSpacingVertical="4dp"
         app:layout_constraintStart_toStartOf="@id/displayNameTextView"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@id/avatar" />
+        app:layout_constraintTop_toTopOf="@id/avatar"
+        android:importantForAccessibility="no" />
 
     <TextView
         android:id="@+id/displayNameTextView"

--- a/app/src/main/res/layout/item_status.xml
+++ b/app/src/main/res/layout/item_status.xml
@@ -55,7 +55,7 @@
         tools:src="#000"
         tools:visibility="visible" />
 
-    <com.google.android.material.chip.ChipGroup
+    <app.pachli.core.ui.RoleChipGroup
         android:id="@+id/roleChipGroup"
         android:layout_width="0dp"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/item_status_detailed.xml
+++ b/app/src/main/res/layout/item_status_detailed.xml
@@ -35,7 +35,7 @@
         tools:src="#000"
         tools:visibility="visible" />
 
-    <com.google.android.material.chip.ChipGroup
+    <app.pachli.core.ui.RoleChipGroup
         android:id="@+id/roleChipGroup"
         android:layout_width="0dp"
         android:layout_height="wrap_content"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -778,10 +778,6 @@
     <string name="translator_error_unsupported_source_language_fmt">kann von %1$s nicht übersetzen</string>
     <string name="translator_error_unsupported_target_language_fmt">kann nicht nach %1$s übersetzen</string>
     <string name="translator_error_download_required_fmt">Übersetzung in %1$s erfordert das Herunterladen des Sprachpakets und es besteht keine WLAN-Verbindung</string>
-    <plurals name="description_post_roles">
-        <item quantity="one">mit Rolle:</item>
-        <item quantity="other">mit Rollen:</item>
-    </plurals>
     <string name="filter_description_blur">Inhalt anzeigen, Medien mit Inhaltswarnung ausblenden</string>
     <string name="filter_action_blur">Anhänge ausblenden</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -784,11 +784,6 @@
     <string name="translator_error_unsupported_source_language_fmt">no se puede traducir desde %1$s</string>
     <string name="translator_error_unsupported_target_language_fmt">no se puede traducir al %1$s</string>
     <string name="translator_error_download_required_fmt">para traducir al %1$s se necesita descargar el paquete de idioma, pero el Wi‑Fi no está conectado</string>
-    <plurals name="description_post_roles">
-        <item quantity="one">con rol:</item>
-        <item quantity="many">con roles:</item>
-        <item quantity="other">con roles:</item>
-    </plurals>
     <string name="filter_action_blur">Ocultar adjuntos</string>
     <string name="filter_description_blur">Mostrar contenido, ocultar adjuntos con una advertencia</string>
 </resources>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -597,10 +597,6 @@
     <string name="wellbeing_hide_stats_posts">Peida postituste statistika</string>
     <string name="wellbeing_hide_stats_profile">Peida profiilide statistika</string>
     <string name="pref_title_labs">Arendamisel lahendused ja katsetused</string>
-    <plurals name="description_post_roles">
-        <item quantity="one">rollis:</item>
-        <item quantity="other">rollides:</item>
-    </plurals>
     <string name="notification_moderation_warning_title">Sõnum sinu koduserveri moderaatoritelt</string>
     <string name="notification_moderation_warning_body_none_fmt">Moderaatorid on saatnud sulle hoiatuse: %1$s</string>
     <string name="notification_moderation_warning_body_disable_fmt">Sinu konto on kasutuselt eemaldatud: %1$s</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -767,10 +767,6 @@
     <string name="pref_default_audio_playback">Äänen oletusarvoinen toisto</string>
     <string name="notification_moderation_warnings_name">Moderointivaroitukset</string>
     <string name="notification_moderation_warnings_description">Ilmoitukset moderointivaroituksista</string>
-    <plurals name="description_post_roles">
-        <item quantity="one">roolissa:</item>
-        <item quantity="other">rooleissa:</item>
-    </plurals>
     <string name="error_share_media">hakemisto väliaikaisen median tallentamiseen puuttuu</string>
     <string name="translator_error_server_does_not_translate">palvelin ei tue kääntämistä</string>
     <string name="translator_error_no_language_detected">alkukieltä ei voitu tunnistaa</string>

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -790,13 +790,6 @@
     <string name="pref_title_notification_filter_moderation_warning">Seolann modhnóir teachtaireacht</string>
     <string name="notification_moderation_warnings_name">Rabhaidh mhodhnóireachta</string>
     <string name="notification_moderation_warnings_description">Fógraí faoi rabhaidh modhnóireachta</string>
-    <plurals name="description_post_roles">
-        <item quantity="one">le ról:</item>
-        <item quantity="two">le róil:</item>
-        <item quantity="few">le róil:</item>
-        <item quantity="many">le róil:</item>
-        <item quantity="other">le róil:</item>
-    </plurals>
     <string name="translator_error_server_does_not_translate">ní thacaíonn an freastalaí le haistriúchán</string>
     <string name="translator_error_no_language_detected">níorbh fhéidir an teanga bhunaidh a chinneadh</string>
     <string name="translator_error_unsupported_source_language_fmt">ní féidir aistriú ó %1$s</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -764,11 +764,6 @@
     <string name="pref_title_notification_filter_moderation_warning">Satura pārraudzītājs nosūta ziņojumu</string>
     <string name="notification_moderation_warnings_name">Satura pārraudzības brīdinājumi</string>
     <string name="notification_moderation_warnings_description">Paziņojumi par satura pārraudzības brīdinājumiem</string>
-    <plurals name="description_post_roles" tools:ignore="ImpliedQuantity">
-        <item quantity="zero">ar lomām:</item>
-        <item quantity="one">ar lomu:</item>
-        <item quantity="other">ar lomām:</item>
-    </plurals>
     <string name="translator_error_server_does_not_translate">serveris neatbalsta tulkošanu</string>
     <string name="translator_error_no_language_detected">nevarēja noteikt sākotnējo valodu</string>
     <string name="translator_error_unsupported_source_language_fmt">nevar tulkot no %1$s</string>

--- a/app/src/main/res/values-nn/strings.xml
+++ b/app/src/main/res/values-nn/strings.xml
@@ -758,9 +758,5 @@
     <string name="pref_default_audio_playback">Standard audioavspeling</string>
     <string name="notification_moderation_warnings_name">Moderasjonsåtvaringar</string>
     <string name="notification_moderation_warnings_description">Varsel om moderasjonsåtvaringar</string>
-    <plurals name="description_post_roles">
-        <item quantity="one">med rolle:</item>
-        <item quantity="other">med roller:</item>
-    </plurals>
     <string name="error_share_media">ingen mappe for å lagre mellombels medium finst</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -779,12 +779,6 @@
     <string name="pref_title_notification_filter_moderation_warning">Moderacja przysłała wiadomość</string>
     <string name="notification_moderation_warnings_name">Ostrzeżenie moderacji</string>
     <string name="notification_moderation_warnings_description">Powiadomienia o ostrzeżeniach moderacji</string>
-    <plurals name="description_post_roles">
-        <item quantity="one">z rolą:</item>
-        <item quantity="few">z rolami:</item>
-        <item quantity="many">z rolami:</item>
-        <item quantity="other">z rolami:</item>
-    </plurals>
     <string name="error_share_media">brak katalogu do zapisu mediów tymczasowych</string>
     <string name="translator_error_server_does_not_translate">serwer nie obsługuje tłumaczenia</string>
     <string name="translator_error_no_language_detected">nie udało się ustalić oryginalnego języka</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -782,12 +782,6 @@
         <item quantity="other">%1$s · %2$d прикреплённых записей</item>
     </plurals>
     <string name="action_post_failed_detail">Ваша публикация не была закачана и сохранена в черновиках.\n\nЛибо сервер недоступен, либо он отклонил публикацию.</string>
-    <plurals name="description_post_roles">
-        <item quantity="one" tools:ignore="ImpliedQuantity">с ролью:</item>
-        <item quantity="few">с ролями:</item>
-        <item quantity="many">с ролями:</item>
-        <item quantity="other">с ролями:</item>
-    </plurals>
     <string name="error_missing_edits">Ваш сервер знает, что это сообщение было отредактировано, но не сохраняет копию правок, поэтому не может их вам показать.\n\nЭто <a href="https://github.com/mastodon/mastodon/issues/25398">проблема в Mastodon #25398</a>.</string>
     <string name="pref_change_unified_push_distributor_msg">Это приведет к сбросу выбора распределителя UnifiedPush и перезапуску Pachli.\n\nЕсли установлено несколько распределителей UnifiedPush, то вам будет предложено выбрать один.</string>
     <string name="upload_failed_msg_fmt">Не удалось закачать вложение. Закачка будет повторена после отправки публикации. Если снова возникнет ошибка, публикация будет сохранена в черновиках.\n\nОшибка: %1$s</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -764,11 +764,6 @@
     <string name="notification_moderation_warnings_name">Upozornenia moderácie</string>
     <string name="notification_moderation_warnings_description">Upozornenia o moderátorských varovaniach</string>
     <string name="error_share_media">neexistuje žiadny adresár na uloženie dočasných médií</string>
-    <plurals name="description_post_roles">
-        <item quantity="one">s rolou:</item>
-        <item quantity="few">s rolami:</item>
-        <item quantity="other">s rolami:</item>
-    </plurals>
     <string name="translator_error_server_does_not_translate">server nepodporuje preklad</string>
     <string name="translator_error_no_language_detected">nedokázal rozpoznať pôvodný jazyk</string>
     <string name="translator_error_unsupported_source_language_fmt">nemôže preložiť z %1$s</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -647,9 +647,6 @@
     <string name="notification_moderation_warnings_name">审查警告</string>
     <string name="notification_moderation_warnings_description">关于审查警告的通知</string>
     <string name="pref_title_public_filter_home_and_lists">首页和列表</string>
-    <plurals name="description_post_roles">
-        <item quantity="other">具有身份：</item>
-    </plurals>
     <string name="title_report_category_fmt">类别: %1$s</string>
     <string name="title_report_comment">报告者的评论</string>
     <string name="ui_error_filter_v1_load_fmt">加载过滤器失败：%1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -464,10 +464,6 @@
     <string name="description_post_media">
         Media: %s
     </string>
-    <plurals name="description_post_roles">
-        <item quantity="one">with role: </item>
-        <item quantity="other">with roles: </item>
-    </plurals>
     <string name="description_post_cw">
         Content warning: %s
     </string>

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/RoleChip.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/RoleChip.kt
@@ -23,6 +23,11 @@ import android.text.SpannableStringBuilder
 import android.text.Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
 import android.text.style.StyleSpan
 import android.util.AttributeSet
+import app.pachli.core.common.extensions.hide
+import app.pachli.core.common.extensions.show
+import app.pachli.core.model.Role
+import app.pachli.core.ui.extensions.contentDescription
+import com.google.android.material.chip.ChipGroup
 
 /**
  * A [ProfileChip] for showing an [app.pachli.core.model.Role].
@@ -47,29 +52,72 @@ class RoleChip @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     defStyleAttr: Int = com.google.android.material.R.attr.chipStyle,
 ) : ProfileChip(context, attrs, defStyleAttr) {
-    var role: String = ""
-        set(value) {
-            field = value
-            updateText()
-        }
-
-    var domain: String = ""
-        set(value) {
-            field = value
-            updateText()
-        }
-
     init {
         setChipIconResource(R.drawable.profile_role_badge)
     }
 
-    private fun updateText() {
-        val sb = SpannableStringBuilder(role).apply {
-            setSpan(StyleSpan(Typeface.BOLD), 0, role.length, SPAN_EXCLUSIVE_EXCLUSIVE)
-            if (domain.isNotBlank()) {
+    fun bind(role: Role, domain: String? = null) {
+        val sb = SpannableStringBuilder(role.name).apply {
+            setSpan(StyleSpan(Typeface.BOLD), 0, role.name.length, SPAN_EXCLUSIVE_EXCLUSIVE)
+            if (!domain.isNullOrBlank()) {
                 append(" $domain")
             }
         }
         text = sb
+        contentDescription = role.contentDescription(context, domain)
+    }
+}
+
+/**
+ * A [ChipGroup] for displaying zero or more [Role].
+ *
+ * Differs from [ChipGroup] by honouring the `android:importantForAccessibility`
+ * attribute (see https://github.com/material-components/material-components-android/issues/4946)
+ * and by providing [setRoles] to set the roles to show.
+ */
+class RoleChipGroup @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+) : ChipGroup(context, attrs) {
+
+    init {
+        attrs?.getAttributeIntValue(
+            "http://schemas.android.com/apk/res/android",
+            "importantForAccessibility",
+            IMPORTANT_FOR_ACCESSIBILITY_YES,
+        )?.let {
+            importantForAccessibility = it
+        }
+    }
+
+    /**
+     * Clears chips from this [RoleChipGroup], sets them to [roles], and shows
+     * the group.
+     *
+     * Hides the group if [roles] is empty.
+     *
+     * @param roles Roles to show.
+     * @param domain Domain each role is for.
+     */
+    fun setRoles(roles: List<Role>, domain: String? = null) {
+        removeAllViews()
+        if (roles.isEmpty()) {
+            hide()
+            return
+        }
+
+        roles.forEach { role ->
+            val roleChip = RoleChip(context).apply { bind(role, domain) }
+
+            // Each chip should have the same accessibility importance as
+            // the parent group. This allows them to be unimportant if
+            // displayed as part of a status, but important (or default
+            // behaviour) if displayed elsewhere (e.g., when viewing an
+            // account).
+            roleChip.importantForAccessibility = importantForAccessibility
+
+            addView(roleChip)
+        }
+        show()
     }
 }

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/extensions/AccountExtensions.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/extensions/AccountExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Pachli Association
+ * Copyright (c) 2025 Pachli Association
  *
  * This file is a part of Pachli.
  *
@@ -17,28 +17,11 @@
 
 package app.pachli.core.ui.extensions
 
-import app.pachli.core.common.extensions.hide
-import app.pachli.core.common.extensions.show
-import app.pachli.core.model.Role
-import app.pachli.core.ui.RoleChip
-import com.google.android.material.chip.ChipGroup
+import android.content.Context
+import app.pachli.core.model.Account
 
-/**
- * Clears chips from this [ChipGroup], sets them to [roles], and shows
- * the group.
- *
- * Hides the group if [roles] is empty.
- */
-fun ChipGroup.setRoles(roles: List<Role>) {
-    removeAllViews()
-    if (roles.isEmpty()) {
-        hide()
-        return
-    }
+/** @see [app.pachli.core.model.TimelineAccount.nameContentDescription] */
+fun Account.nameContentDescription(context: Context) = nameContentDescription(context, name)
 
-    roles.forEach { role ->
-        val roleChip = RoleChip(context).apply { this.role = role.name }
-        addView(roleChip)
-    }
-    show()
-}
+/** @see [app.pachli.core.model.TimelineAccount.handleContentDescription] */
+fun Account.handleContentDescription(context: Context) = handleContentDescription(context, username)

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/extensions/RoleExtensions.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/extensions/RoleExtensions.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.core.ui.extensions
+
+import android.content.Context
+import app.pachli.core.model.Role
+import app.pachli.core.ui.R
+
+/**
+ * @return String suitable for use as a [contentDescription][android.view.View.setContentDescription]
+ * for a view displaying a role (e.g., [RoleChip].
+ */
+fun Role.contentDescription(context: Context, domain: String? = null): String {
+    if (domain.isNullOrBlank()) {
+        return this.name
+    }
+
+    val dotInName = context.getString(R.string.dot_in_name)
+    val domainDescription = domain.replace(".", " $dotInName ")
+    return context.getString(R.string.role_content_description_fmt, name, domainDescription)
+}

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/extensions/TimelineAccountExtensions.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/extensions/TimelineAccountExtensions.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2025 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.core.ui.extensions
+
+import android.content.Context
+import app.pachli.core.model.TimelineAccount
+import app.pachli.core.ui.R
+import timber.log.Timber
+
+/**
+ * Returns a content description for this account.
+ *
+ * The description looks like (content in parentheses is optional)
+ *
+ * "${account.name}"
+ * ","
+ * "Handle, @${account.username}"
+ * ";"
+ * ("with role: 1-n roles")
+ *
+ * When reading account names any embedded "." in the name is converted to " dot "
+ * to make it explicit (otherwise TalkBack inserts a short pause, which is no use
+ * for domains). See [nameContentDescription].
+ */
+fun TimelineAccount.contentDescription(context: Context): String {
+    val roleString = if (roles.isNotEmpty()) {
+        StringBuilder().apply {
+            append(context.resources.getQuantityString(R.plurals.description_post_roles, roles.size))
+            append(roles.joinToString(", ") { it.contentDescription(context) })
+        }.toString()
+    } else {
+        ""
+    }
+
+    return context.getString(
+        R.string.account_contentdescription_fmt,
+        // Some names have dots in them
+        nameContentDescription(context),
+        handleContentDescription(context),
+        roleString,
+    )
+}
+
+/**
+ * @return A content description for the account's name. Dots in the name are
+ * replaced with R.string.dot_in_name so TalkBack reads them correctly.
+ *
+ * For example, for the account "@staff@mastodon.social" the display name is
+ * "Mastodon.social Staff", and this ensures this is read as "Mastodon dot social
+ * Staff", not "Mastodon <pause> Social staff".
+ */
+fun TimelineAccount.nameContentDescription(context: Context) = nameContentDescription(context, name)
+
+internal fun nameContentDescription(context: Context, name: String): String {
+    val dotReplacement = context.getString(R.string.dot_in_name)
+    return name.replace(".", " $dotReplacement ")
+}
+
+/**
+ * Map of domain suffixes that TalkBack doesn't read correctly to
+ * better ways to pronounce the content.
+ *
+ * Work around for https://issuetracker.google.com/issues/447792953.
+ */
+val talkbackTlds = mapOf(".xyz" to ".x y z")
+
+/** Regex that matches and groups each domain suffix in [talkbackTlds]. */
+val rxTalkbackTlds = "(${talkbackTlds.keys.joinToString("|")}$)".toRegex()
+
+/**
+ * @return A content description for the account's handle. If the handle
+ * contains a TLD with a key in [talkbackTlds] it is replaced with the
+ * value at that key for better TalkBack pronounciation.
+ */
+fun TimelineAccount.handleContentDescription(context: Context) = handleContentDescription(context, username)
+
+internal fun handleContentDescription(context: Context, handle: String): String {
+    // Create a pronounceable version of the handle by replacing problematic TLDs.
+    val correctedHandle = rxTalkbackTlds.replace(handle) { m ->
+        m.groupValues.getOrNull(1)?.let {
+            Timber.w("Matched: $it, ${m.groupValues}")
+            talkbackTlds[it] as CharSequence
+        } ?: ""
+    }
+
+    return context.getString(R.string.handle_contentdescription_fmt, correctedHandle)
+}

--- a/core/ui/src/main/res/layout/item_autocomplete_account.xml
+++ b/core/ui/src/main/res/layout/item_autocomplete_account.xml
@@ -31,7 +31,7 @@
         app:layout_constraintEnd_toEndOf="@id/avatar" />
 
 
-    <com.google.android.material.chip.ChipGroup
+    <app.pachli.core.ui.RoleChipGroup
         android:id="@+id/roleChipGroup"
         android:layout_width="0dp"
         android:layout_height="wrap_content"

--- a/core/ui/src/main/res/values-de/strings.xml
+++ b/core/ui/src/main/res/values-de/strings.xml
@@ -92,4 +92,8 @@
     <string name="post_media_audio">Audio</string>
     <string name="post_media_video">Video</string>
     <string name="post_media_attachments">Anhänge</string>
+    <plurals name="description_post_roles">
+        <item quantity="one">mit Rolle:</item>
+        <item quantity="other">mit Rollen:</item>
+    </plurals>
 </resources>

--- a/core/ui/src/main/res/values-es/strings.xml
+++ b/core/ui/src/main/res/values-es/strings.xml
@@ -98,4 +98,9 @@
     <string name="post_media_audio">Audio</string>
     <string name="post_media_video">Video</string>
     <string name="post_media_attachments">Adjuntos</string>
+    <plurals name="description_post_roles">
+        <item quantity="one">con rol:</item>
+        <item quantity="many">con roles:</item>
+        <item quantity="other">con roles:</item>
+    </plurals>
 </resources>

--- a/core/ui/src/main/res/values-et/strings.xml
+++ b/core/ui/src/main/res/values-et/strings.xml
@@ -92,4 +92,8 @@
     <string name="post_media_audio">Helifail</string>
     <string name="post_media_video">Video</string>
     <string name="post_media_attachments">Manused</string>
+    <plurals name="description_post_roles">
+        <item quantity="one">rollis:</item>
+        <item quantity="other">rollides:</item>
+    </plurals>
 </resources>

--- a/core/ui/src/main/res/values-fi/strings.xml
+++ b/core/ui/src/main/res/values-fi/strings.xml
@@ -86,4 +86,8 @@
     <string name="post_media_audio">Ääni</string>
     <string name="post_media_video">Video</string>
     <string name="post_media_attachments">Liitteet</string>
+    <plurals name="description_post_roles">
+        <item quantity="one">roolissa:</item>
+        <item quantity="other">rooleissa:</item>
+    </plurals>
 </resources>

--- a/core/ui/src/main/res/values-ga/strings.xml
+++ b/core/ui/src/main/res/values-ga/strings.xml
@@ -110,4 +110,11 @@
     <string name="post_media_audio">Fuaim</string>
     <string name="post_media_video">Físeán</string>
     <string name="post_media_attachments">Ceangaltáin</string>
+    <plurals name="description_post_roles">
+        <item quantity="one">le ról:</item>
+        <item quantity="two">le róil:</item>
+        <item quantity="few">le róil:</item>
+        <item quantity="many">le róil:</item>
+        <item quantity="other">le róil:</item>
+    </plurals>
 </resources>

--- a/core/ui/src/main/res/values-lv/strings.xml
+++ b/core/ui/src/main/res/values-lv/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="error_network">Atgadījās tīkla kļūda. Lūgums pārbaudīt savienojumu un mēģināt vēlreiz.</string>
     <string name="error_generic">Atgadījās kļūda.</string>
     <string name="message_empty">Šeit nekā nav.</string>
@@ -98,4 +98,9 @@
     <string name="post_media_audio">Audio</string>
     <string name="post_media_video">Video</string>
     <string name="post_media_attachments">Pielikumi</string>
+    <plurals name="description_post_roles" tools:ignore="ImpliedQuantity">
+        <item quantity="zero">ar lomām:</item>
+        <item quantity="one">ar lomu:</item>
+        <item quantity="other">ar lomām:</item>
+    </plurals>
 </resources>

--- a/core/ui/src/main/res/values-nn/strings.xml
+++ b/core/ui/src/main/res/values-nn/strings.xml
@@ -86,4 +86,8 @@
     <string name="post_media_audio">Ljod</string>
     <string name="post_media_video">Video</string>
     <string name="post_media_attachments">Vedlegg</string>
+    <plurals name="description_post_roles">
+        <item quantity="one">med rolle:</item>
+        <item quantity="other">med roller:</item>
+    </plurals>
 </resources>

--- a/core/ui/src/main/res/values-pl/strings.xml
+++ b/core/ui/src/main/res/values-pl/strings.xml
@@ -100,4 +100,10 @@
     <string name="post_media_audio">Dźwięk</string>
     <string name="post_media_video">Wideo</string>
     <string name="post_media_attachments">Załączniki</string>
+    <plurals name="description_post_roles">
+        <item quantity="one">z rolą:</item>
+        <item quantity="few">z rolami:</item>
+        <item quantity="many">z rolami:</item>
+        <item quantity="other">z rolami:</item>
+    </plurals>
 </resources>

--- a/core/ui/src/main/res/values-ru/strings.xml
+++ b/core/ui/src/main/res/values-ru/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="error_network">Произошла ошибка сети! Пожалуйста, проверьте интернет-соединение и попробуйте снова.</string>
     <string name="error_generic">Произошла ошибка.</string>
     <string name="message_empty">Ничего нет.</string>
@@ -104,4 +104,10 @@
     <string name="post_media_audio">Аудио</string>
     <string name="post_media_video">Видео</string>
     <string name="post_media_attachments">Вложения</string>
+    <plurals name="description_post_roles">
+        <item quantity="one" tools:ignore="ImpliedQuantity">с ролью:</item>
+        <item quantity="few">с ролями:</item>
+        <item quantity="many">с ролями:</item>
+        <item quantity="other">с ролями:</item>
+    </plurals>
 </resources>

--- a/core/ui/src/main/res/values-sk/strings.xml
+++ b/core/ui/src/main/res/values-sk/strings.xml
@@ -94,4 +94,9 @@
     <string name="post_media_audio">Audio</string>
     <string name="post_media_video">Video</string>
     <string name="post_media_attachments">Prílohy</string>
+    <plurals name="description_post_roles">
+        <item quantity="one">s rolou:</item>
+        <item quantity="few">s rolami:</item>
+        <item quantity="other">s rolami:</item>
+    </plurals>
 </resources>

--- a/core/ui/src/main/res/values-zh-rCN/strings.xml
+++ b/core/ui/src/main/res/values-zh-rCN/strings.xml
@@ -74,4 +74,7 @@
     <string name="post_media_audio">音频</string>
     <string name="post_media_video">视频</string>
     <string name="post_media_attachments">附件</string>
+    <plurals name="description_post_roles">
+        <item quantity="other">具有身份：</item>
+    </plurals>
 </resources>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -109,4 +109,12 @@
     <string name="post_media_attachments">Attachments</string>
     <string name="action_show_attachments">Show attachments</string>
     <string name="action_hide_attachments">Hide attachments</string>
+    <string name="dot_in_name">dot</string>
+    <string name="role_content_description_fmt">%1$s, at %2$s</string>
+    <plurals name="description_post_roles">
+        <item quantity="one">with role: </item>
+        <item quantity="other">with roles: </item>
+    </plurals>
+    <string name="handle_contentdescription_fmt">Handle, @%1$s</string>
+    <string name="account_contentdescription_fmt">%1$s, %2$s; %3$s</string>
 </resources>

--- a/feature/lists/src/main/kotlin/app/pachli/feature/lists/AccountsInListFragment.kt
+++ b/feature/lists/src/main/kotlin/app/pachli/feature/lists/AccountsInListFragment.kt
@@ -45,7 +45,7 @@ import app.pachli.core.network.retrofit.apiresult.ApiError
 import app.pachli.core.preferences.SharedPreferencesRepository
 import app.pachli.core.ui.BindingHolder
 import app.pachli.core.ui.emojify
-import app.pachli.core.ui.extensions.setRoles
+import app.pachli.core.ui.extensions.contentDescription
 import app.pachli.core.ui.loadAvatar
 import app.pachli.feature.lists.databinding.FragmentAccountsInListBinding
 import app.pachli.feature.lists.databinding.ItemAccountInListBinding
@@ -264,6 +264,7 @@ class AccountsInListFragment : AppCompatDialogFragment() {
             loadAvatar(glide, account.avatar, holder.binding.avatar, radius, animateAvatar)
 
             holder.binding.roleChipGroup.setRoles(account.roles)
+            holder.binding.root.contentDescription = account.contentDescription(holder.binding.root.context)
         }
     }
 
@@ -307,6 +308,8 @@ class AccountsInListFragment : AppCompatDialogFragment() {
             holder.binding.avatarBadge.visible(account.bot)
 
             holder.binding.roleChipGroup.setRoles(account.roles)
+
+            holder.binding.root.contentDescription = account.contentDescription(holder.binding.root.context)
 
             with(holder.binding.checkBox) {
                 contentDescription = getString(

--- a/feature/lists/src/main/res/layout/item_account_in_list.xml
+++ b/feature/lists/src/main/res/layout/item_account_in_list.xml
@@ -45,15 +45,16 @@
         app:layout_constraintBottom_toBottomOf="@id/avatar"
         app:layout_constraintEnd_toEndOf="@id/avatar" />
 
-    <com.google.android.material.chip.ChipGroup
+    <app.pachli.core.ui.RoleChipGroup
         android:id="@+id/roleChipGroup"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:paddingBottom="4dp"
         app:chipSpacingVertical="4dp"
         app:layout_constraintStart_toStartOf="@id/displayName"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@id/avatar" />
+        app:layout_constraintEnd_toStartOf="@id/checkBox"
+        app:layout_constraintTop_toTopOf="@id/avatar"
+        android:importantForAccessibility="no" />
 
     <TextView
         android:id="@+id/displayName"

--- a/feature/suggestions/src/main/kotlin/app/pachli/feature/suggestions/SuggestionsAdapter.kt
+++ b/feature/suggestions/src/main/kotlin/app/pachli/feature/suggestions/SuggestionsAdapter.kt
@@ -36,6 +36,7 @@ import app.pachli.core.model.Suggestion
 import app.pachli.core.network.parseAsMastodonHtml
 import app.pachli.core.ui.LinkListener
 import app.pachli.core.ui.emojify
+import app.pachli.core.ui.extensions.nameContentDescription
 import app.pachli.core.ui.loadAvatar
 import app.pachli.core.ui.setClickableText
 import app.pachli.feature.suggestions.SuggestionViewHolder.ChangePayload
@@ -194,7 +195,7 @@ internal class SuggestionViewHolder(
             // Build an accessible content description.
             root.contentDescription = root.context.getString(
                 R.string.account_content_description_fmt,
-                account.displayName,
+                account.nameContentDescription(root.context),
                 followerCount.text,
                 followsCount.text,
                 statusesCount.text,


### PR DESCRIPTION
Provide a consistent `contentDescription` for account name, handle, and roles, in `TimelineAccount.contentDescription`.

This ensures any dots in the name are read correctly (e.g., the name "Mastodon.social Staff" is now read as "Mastodon dot Social Staff", not "Mastodon <pause> Social Staff". Some TLDs TalkBack doesn't read correctly, like ".xyz", are special-cased.

Mark the chip group that contains any account roles as unimportant for accessibility, as the information is included in the account's `contentDescription`. `ChipGroup` overrides this, so provide a custom `RoleChipGroup` that does the right thing.