### PR TITLE
fix: Show source language name if translation is not supported

### DIFF
--- a/app/src/google/kotlin/app/pachli/translation/MlKitTranslationService.kt
+++ b/app/src/google/kotlin/app/pachli/translation/MlKitTranslationService.kt
@@ -166,7 +166,8 @@ class MlKitTranslationService(
         }
         val sourceLanguage = TranslateLanguage.fromLanguageTag(identifiedLanguageTag)
         if (sourceLanguage == null) {
-            return Err(TranslatorError.UnsupportedSourceLanguage(identifiedLanguageTag))
+            val locale = Locale.forLanguageTag(identifiedLanguageTag)
+            return Err(TranslatorError.UnsupportedSourceLanguage(locale.displayLanguage.ifEmpty { identifiedLanguageTag }))
         }
 
         Timber.d("Source language: $sourceLanguage")

--- a/app/src/main/java/app/pachli/translation/Translation.kt
+++ b/app/src/main/java/app/pachli/translation/Translation.kt
@@ -60,10 +60,10 @@ sealed interface TranslatorError : PachliError {
         override val cause = null
     }
 
-    /** Language detected succeeded, but the source language is not supported. */
-    data class UnsupportedSourceLanguage(val languageTag: String) : TranslatorError {
+    /** Language detection succeeded, but the source language is not supported. */
+    data class UnsupportedSourceLanguage(val language: String) : TranslatorError {
         override val resourceId = R.string.translator_error_unsupported_source_language_fmt
-        override val formatArgs = arrayOf(languageTag)
+        override val formatArgs = arrayOf(language)
         override val cause = null
     }
 


### PR DESCRIPTION
Previous code showed the language code, resulting in UI messages like:

> cannot translate from eu

Fix that to use the language code's `displayLanguage`, if available. Now the error message looks like:

> cannot translate from Basque