### PR TITLE
fix: Scale attachment preview images correctly with `.centerInside()`

### DIFF
--- a/core/ui/src/main/kotlin/app/pachli/core/ui/AttachmentPreviewView.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/AttachmentPreviewView.kt
@@ -208,12 +208,14 @@ class AttachmentPreviewView @JvmOverloads constructor(
             mediaPreviewImageView.setFocalPoint(focus)
             glide.load(url)
                 .placeholder(placeholder)
+                .centerInside()
                 .addListener(mediaPreviewImageView)
                 .into(mediaPreviewImageView)
         } else {
             mediaPreviewImageView.removeFocalPoint()
             glide.load(url)
                 .placeholder(placeholder)
+                .centerInside()
                 .into(mediaPreviewImageView)
         }
     }


### PR DESCRIPTION
Inadvertently dropped as part of
https://github.com/pachli/pachli-android/pull/1819.

Fixes #1826