### PR TITLE
refactor: Replace SparkButton.Utils.dpToPx with TypedValueCompat.dpToPx

### DIFF
--- a/app/src/main/java/app/pachli/TabPreferenceActivity.kt
+++ b/app/src/main/java/app/pachli/TabPreferenceActivity.kt
@@ -28,6 +28,7 @@ import androidx.activity.OnBackPressedCallback
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.AppCompatEditText
+import androidx.core.util.TypedValueCompat.dpToPx
 import androidx.core.view.ViewGroupCompat
 import androidx.core.view.updatePadding
 import androidx.core.widget.doOnTextChanged
@@ -58,7 +59,6 @@ import app.pachli.core.ui.extensions.applyDefaultWindowInsets
 import app.pachli.core.ui.extensions.applyWindowInsets
 import app.pachli.databinding.ActivityTabPreferenceBinding
 import app.pachli.databinding.DialogSelectListBinding
-import at.connyduck.sparkbutton.helpers.Utils
 import com.google.android.material.divider.MaterialDividerItemDecoration
 import com.google.android.material.transition.MaterialArcMotion
 import com.google.android.material.transition.MaterialContainerTransform
@@ -247,7 +247,7 @@ class TabPreferenceActivity : BaseActivity(), ItemInteractionListener {
 
     private fun showAddHashtagDialog(timeline: Timeline.Hashtags? = null, tabPosition: Int = 0) {
         val frameLayout = FrameLayout(this)
-        val padding = Utils.dpToPx(this, 8)
+        val padding = dpToPx(8f, resources.displayMetrics).toInt()
         frameLayout.updatePadding(left = padding, right = padding)
 
         val editText = AppCompatEditText(this)

--- a/app/src/main/java/app/pachli/adapter/ReportNotificationViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/ReportNotificationViewHolder.kt
@@ -20,6 +20,7 @@ package app.pachli.adapter
 import android.content.Context
 import android.text.TextUtils
 import androidx.appcompat.content.res.AppCompatResources
+import androidx.core.util.TypedValueCompat.dpToPx
 import androidx.recyclerview.widget.RecyclerView
 import app.pachli.R
 import app.pachli.components.notifications.NotificationActionListener
@@ -36,7 +37,6 @@ import app.pachli.core.ui.loadAvatar
 import app.pachli.core.ui.updateEmojiTargets
 import app.pachli.databinding.ItemReportNotificationBinding
 import app.pachli.viewdata.NotificationViewData
-import at.connyduck.sparkbutton.helpers.Utils
 import com.bumptech.glide.RequestManager
 
 class ReportNotificationViewHolder(
@@ -109,7 +109,7 @@ class ReportNotificationViewHolder(
         }
 
         // Fancy avatar inset
-        val padding = Utils.dpToPx(binding.notificationReporteeAvatar.context, 12)
+        val padding = dpToPx(12f, binding.notificationReporteeAvatar.context.resources.displayMetrics).toInt()
         binding.notificationReporteeAvatar.setPaddingRelative(0, 0, padding, padding)
 
         loadAvatar(

--- a/app/src/main/java/app/pachli/adapter/StatusBaseViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/StatusBaseViewHolder.kt
@@ -10,6 +10,7 @@ import android.widget.ImageView
 import android.widget.TextView
 import androidx.appcompat.widget.PopupMenu
 import androidx.core.text.HtmlCompat
+import androidx.core.util.TypedValueCompat.dpToPx
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import app.pachli.R
@@ -48,7 +49,6 @@ import app.pachli.core.ui.makeIcon
 import app.pachli.core.ui.setClickableMentions
 import app.pachli.util.expandTouchSizeToFillRow
 import at.connyduck.sparkbutton.SparkButton
-import at.connyduck.sparkbutton.helpers.Utils
 import com.bumptech.glide.RequestManager
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.color.MaterialColors
@@ -288,7 +288,7 @@ abstract class StatusBaseViewHolder<T : IStatusViewData> protected constructor(
             }
             avatarRadius = avatarRadius48dp
         } else {
-            val padding = Utils.dpToPx(context, 12)
+            val padding = dpToPx(12f, context.resources.displayMetrics).toInt()
             avatar.setPaddingRelative(0, 0, padding, padding)
             avatarInset.visibility = View.VISIBLE
             avatarInset.background = null

--- a/app/src/main/java/app/pachli/adapter/StatusViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/StatusViewHolder.kt
@@ -19,6 +19,7 @@ package app.pachli.adapter
 import android.text.InputFilter
 import android.text.TextUtils
 import android.view.View
+import androidx.core.util.TypedValueCompat.dpToPx
 import app.pachli.R
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
@@ -34,7 +35,6 @@ import app.pachli.core.ui.SetStatusContent
 import app.pachli.core.ui.StatusActionListener
 import app.pachli.core.ui.emojify
 import app.pachli.databinding.ItemStatusBinding
-import at.connyduck.sparkbutton.helpers.Utils
 import com.bumptech.glide.RequestManager
 
 open class StatusViewHolder<T : IStatusViewData>(
@@ -93,8 +93,8 @@ open class StatusViewHolder<T : IStatusViewData>(
     protected fun setPollInfo(ownPoll: Boolean) = with(binding) {
         statusInfo.setText(if (ownPoll) R.string.poll_ended_created else R.string.poll_ended_voted)
         statusInfo.setCompoundDrawablesRelativeWithIntrinsicBounds(R.drawable.ic_poll_24dp, 0, 0, 0)
-        statusInfo.compoundDrawablePadding = Utils.dpToPx(context, 10)
-        statusInfo.setPaddingRelative(Utils.dpToPx(context, 28), 0, 0, 0)
+        statusInfo.compoundDrawablePadding = dpToPx(10f, context.resources.displayMetrics).toInt()
+        statusInfo.setPaddingRelative(dpToPx(28f, context.resources.displayMetrics).toInt(), 0, 0, 0)
         statusInfo.show()
     }
 

--- a/app/src/main/java/app/pachli/components/compose/view/ProgressImageView.kt
+++ b/app/src/main/java/app/pachli/components/compose/view/ProgressImageView.kt
@@ -25,11 +25,11 @@ import android.graphics.PorterDuffXfermode
 import android.graphics.RectF
 import android.util.AttributeSet
 import androidx.annotation.OptIn
+import androidx.core.util.TypedValueCompat.dpToPx
 import app.pachli.components.compose.MediaUploaderError
 import app.pachli.components.compose.UploadState
 import app.pachli.core.ui.MediaPreviewImageView
 import app.pachli.core.ui.makeIcon
-import at.connyduck.sparkbutton.helpers.Utils
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.onFailure
@@ -49,14 +49,14 @@ class ProgressImageView
     private val biggerRect = RectF()
     private val circlePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
         color = MaterialColors.getColor(this@ProgressImageView, androidx.appcompat.R.attr.colorPrimary)
-        strokeWidth = Utils.dpToPx(context, 4).toFloat()
+        strokeWidth = dpToPx(4f, context.resources.displayMetrics)
         style = Paint.Style.STROKE
     }
     private val clearPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
         xfermode = PorterDuffXfermode(PorterDuff.Mode.DST_OUT)
     }
 
-    private val uploadErrorRadius = Utils.dpToPx(context, 24)
+    private val uploadErrorRadius = dpToPx(24f, context.resources.displayMetrics).toInt()
 
     private val uploadErrorDrawable = makeIcon(context, GoogleMaterial.Icon.gmd_error, 48).apply {
         setTint(Color.WHITE)

--- a/app/src/main/java/app/pachli/components/conversation/ConversationsFragment.kt
+++ b/app/src/main/java/app/pachli/components/conversation/ConversationsFragment.kt
@@ -24,6 +24,7 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AlertDialog
+import androidx.core.util.TypedValueCompat.dpToPx
 import androidx.core.view.MenuProvider
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
@@ -68,7 +69,6 @@ import app.pachli.databinding.FragmentTimelineBinding
 import app.pachli.fragment.SFragment
 import app.pachli.interfaces.ActionButtonActivity
 import app.pachli.util.ListStatusAccessibilityDelegate
-import at.connyduck.sparkbutton.helpers.Utils
 import com.bumptech.glide.Glide
 import com.google.android.material.color.MaterialColors
 import com.google.android.material.divider.MaterialDividerItemDecoration
@@ -227,7 +227,7 @@ class ConversationsFragment :
                                 if (getView() != null) {
                                     binding.recyclerView.scrollBy(
                                         0,
-                                        Utils.dpToPx(requireContext(), -30),
+                                        dpToPx(-30f, requireContext().resources.displayMetrics).toInt(),
                                     )
                                 }
                             }

--- a/app/src/main/java/app/pachli/components/notifications/NotificationsFragment.kt
+++ b/app/src/main/java/app/pachli/components/notifications/NotificationsFragment.kt
@@ -30,6 +30,7 @@ import android.view.accessibility.AccessibilityManager
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
+import androidx.core.util.TypedValueCompat.dpToPx
 import androidx.core.view.MenuProvider
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
@@ -74,7 +75,6 @@ import app.pachli.interfaces.AccountActionListener
 import app.pachli.interfaces.ActionButtonActivity
 import app.pachli.util.ListStatusAccessibilityDelegate
 import app.pachli.viewdata.NotificationViewData
-import at.connyduck.sparkbutton.helpers.Utils
 import com.bumptech.glide.Glide
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.onFailure
@@ -444,7 +444,7 @@ class NotificationsFragment :
                     view ?: return@post
                     binding.recyclerView.smoothScrollBy(
                         0,
-                        Utils.dpToPx(requireContext(), -30),
+                        dpToPx(-30f, requireContext().resources.displayMetrics).toInt(),
                     )
                 }
             }

--- a/app/src/main/java/app/pachli/components/notifications/StatusNotificationViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/notifications/StatusNotificationViewHolder.kt
@@ -25,6 +25,7 @@ import android.text.TextUtils
 import android.text.format.DateUtils
 import android.text.style.StyleSpan
 import android.view.View
+import androidx.core.util.TypedValueCompat.dpToPx
 import androidx.recyclerview.widget.RecyclerView
 import app.pachli.R
 import app.pachli.adapter.StatusViewDataDiffCallback
@@ -44,7 +45,6 @@ import app.pachli.core.ui.getRelativeTimeSpanString
 import app.pachli.core.ui.loadAvatar
 import app.pachli.databinding.ItemStatusNotificationBinding
 import app.pachli.viewdata.NotificationViewData
-import at.connyduck.sparkbutton.helpers.Utils
 import com.bumptech.glide.RequestManager
 import java.util.Date
 
@@ -207,7 +207,7 @@ internal class StatusNotificationViewHolder(
     }
 
     private fun setAvatars(statusAvatarUrl: String?, notificationAvatarUrl: String?, animateAvatars: Boolean) {
-        val padding = Utils.dpToPx(binding.notificationStatusAvatar.context, 12)
+        val padding = dpToPx(12f, binding.notificationStatusAvatar.context.resources.displayMetrics).toInt()
         binding.notificationStatusAvatar.setPaddingRelative(0, 0, padding, padding)
         loadAvatar(
             glide,

--- a/app/src/main/java/app/pachli/components/timeline/TimelineFragment.kt
+++ b/app/src/main/java/app/pachli/components/timeline/TimelineFragment.kt
@@ -28,6 +28,7 @@ import android.view.accessibility.AccessibilityManager
 import android.widget.Toast
 import android.widget.Toast.LENGTH_LONG
 import androidx.core.content.ContextCompat
+import androidx.core.util.TypedValueCompat.dpToPx
 import androidx.core.view.MenuProvider
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
@@ -83,7 +84,6 @@ import app.pachli.fragment.SFragment
 import app.pachli.interfaces.ActionButtonActivity
 import app.pachli.interfaces.AppBarLayoutHost
 import app.pachli.util.ListStatusAccessibilityDelegate
-import at.connyduck.sparkbutton.helpers.Utils
 import com.bumptech.glide.Glide
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.onFailure
@@ -576,10 +576,10 @@ class TimelineFragment :
             adapter.postPrepend {
                 binding.recyclerView.post {
                     view ?: return@post
-                    Timber.d("scrolling up by -30px because peeking after refresh")
+                    Timber.d("scrolling up by -30dp because peeking after refresh")
                     binding.recyclerView.smoothScrollBy(
                         0,
-                        Utils.dpToPx(requireContext(), -30),
+                        dpToPx(-30f, requireContext().resources.displayMetrics).toInt(),
                     )
                 }
             }

--- a/app/src/main/java/app/pachli/components/trending/TrendingTagsFragment.kt
+++ b/app/src/main/java/app/pachli/components/trending/TrendingTagsFragment.kt
@@ -25,6 +25,7 @@ import android.view.MenuItem
 import android.view.View
 import android.view.accessibility.AccessibilityManager
 import androidx.core.content.ContextCompat
+import androidx.core.util.TypedValueCompat.dpToPx
 import androidx.core.view.MenuProvider
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -51,7 +52,6 @@ import app.pachli.databinding.FragmentTrendingTagsBinding
 import app.pachli.interfaces.ActionButtonActivity
 import app.pachli.interfaces.AppBarLayoutHost
 import app.pachli.viewdata.TrendingViewData
-import at.connyduck.sparkbutton.helpers.Utils
 import com.google.android.material.color.MaterialColors
 import com.mikepenz.iconics.IconicsDrawable
 import com.mikepenz.iconics.typeface.library.googlematerial.GoogleMaterial
@@ -105,7 +105,7 @@ class TrendingTagsFragment :
                             if (getView() != null) {
                                 binding.recyclerView.scrollBy(
                                     0,
-                                    Utils.dpToPx(requireContext(), -30),
+                                    dpToPx(-30f, requireContext().resources.displayMetrics).toInt(),
                                 )
                             }
                         }


### PR DESCRIPTION
They do the same thing, but an upcoming change is going to move the use of SparkButton to `core.ui`. Refactoring now makes that future change smaller.