### PR TITLE
refactor: Create statuses and accounts in AppDatabase when testing

### DIFF
--- a/app/src/test/java/app/pachli/ContentFilterV1Test.kt
+++ b/app/src/test/java/app/pachli/ContentFilterV1Test.kt
@@ -21,14 +21,10 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.pachli.components.filters.EditContentFilterViewModel.Companion.getSecondsForDurationIndex
 import app.pachli.core.data.model.ContentFilterModel
 import app.pachli.core.model.FilterAction
-import app.pachli.core.network.model.Attachment as NetworkAttachment
 import app.pachli.core.network.model.FilterContext
 import app.pachli.core.network.model.FilterV1
-import app.pachli.core.network.model.Poll as NetworkPoll
-import app.pachli.core.network.model.PollOption as NetworkPollOption
-import app.pachli.core.network.model.Status as NetworkStatus
 import app.pachli.core.network.model.asModel
-import app.pachli.core.testing.fakes.fakeAccount
+import app.pachli.core.testing.fakes.fakeStatus
 import java.time.Instant
 import java.util.Date
 import org.junit.Assert.assertEquals
@@ -110,7 +106,7 @@ class ContentFilterV1Test {
         assertEquals(
             FilterAction.NONE,
             contentFilterModel.filterActionFor(
-                mockStatus(content = "should not be filtered").asModel(),
+                fakeStatus(content = "should not be filtered").asModel(),
             ),
         )
     }
@@ -120,7 +116,7 @@ class ContentFilterV1Test {
         assertEquals(
             FilterAction.HIDE,
             contentFilterModel.filterActionFor(
-                mockStatus(content = "one two badWord three").asModel(),
+                fakeStatus(content = "one two badWord three").asModel(),
             ),
         )
     }
@@ -130,7 +126,7 @@ class ContentFilterV1Test {
         assertEquals(
             FilterAction.HIDE,
             contentFilterModel.filterActionFor(
-                mockStatus(content = "one two badWordPart three").asModel(),
+                fakeStatus(content = "one two badWordPart three").asModel(),
             ),
         )
     }
@@ -140,7 +136,7 @@ class ContentFilterV1Test {
         assertEquals(
             FilterAction.HIDE,
             contentFilterModel.filterActionFor(
-                mockStatus(content = "one two badWholeWord three").asModel(),
+                fakeStatus(content = "one two badWholeWord three").asModel(),
             ),
         )
     }
@@ -150,7 +146,7 @@ class ContentFilterV1Test {
         assertEquals(
             FilterAction.NONE,
             contentFilterModel.filterActionFor(
-                mockStatus(content = "one two badWholeWordTest three").asModel(),
+                fakeStatus(content = "one two badWholeWordTest three").asModel(),
             ),
         )
     }
@@ -160,7 +156,7 @@ class ContentFilterV1Test {
         assertEquals(
             FilterAction.HIDE,
             contentFilterModel.filterActionFor(
-                mockStatus(
+                fakeStatus(
                     content = "should not be filtered",
                     spoilerText = "badWord should be filtered",
                 ).asModel(),
@@ -173,7 +169,7 @@ class ContentFilterV1Test {
         assertEquals(
             FilterAction.HIDE,
             contentFilterModel.filterActionFor(
-                mockStatus(
+                fakeStatus(
                     content = "should not be filtered",
                     spoilerText = "should not be filtered",
                     pollOptions = listOf("should not be filtered", "badWord"),
@@ -187,7 +183,7 @@ class ContentFilterV1Test {
         assertEquals(
             FilterAction.HIDE,
             contentFilterModel.filterActionFor(
-                mockStatus(
+                fakeStatus(
                     content = "should not be filtered",
                     spoilerText = "should not be filtered",
                     attachmentsDescriptions = listOf("should not be filtered", "badWord"),
@@ -201,7 +197,7 @@ class ContentFilterV1Test {
         assertEquals(
             FilterAction.HIDE,
             contentFilterModel.filterActionFor(
-                mockStatus(content = "one two someone@twitter.com three").asModel(),
+                fakeStatus(content = "one two someone@twitter.com three").asModel(),
             ),
         )
     }
@@ -211,7 +207,7 @@ class ContentFilterV1Test {
         assertEquals(
             FilterAction.HIDE,
             contentFilterModel.filterActionFor(
-                mockStatus(content = "#hashtag one two three").asModel(),
+                fakeStatus(content = "#hashtag one two three").asModel(),
             ),
         )
     }
@@ -221,7 +217,7 @@ class ContentFilterV1Test {
         assertEquals(
             FilterAction.HIDE,
             contentFilterModel.filterActionFor(
-                mockStatus(content = "<p><a href=\"https://foo.bar/tags/hashtag\" class=\"mention hashtag\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">#<span>hashtag</span></a>one two three</p>").asModel(),
+                fakeStatus(content = "<p><a href=\"https://foo.bar/tags/hashtag\" class=\"mention hashtag\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">#<span>hashtag</span></a>one two three</p>").asModel(),
             ),
         )
     }
@@ -231,7 +227,7 @@ class ContentFilterV1Test {
         assertEquals(
             FilterAction.NONE,
             contentFilterModel.filterActionFor(
-                mockStatus(content = "<p><a href=\"https://foo.bar/\">https://foo.bar/</a> one two three</p>").asModel(),
+                fakeStatus(content = "<p><a href=\"https://foo.bar/\">https://foo.bar/</a> one two three</p>").asModel(),
             ),
         )
     }
@@ -241,7 +237,7 @@ class ContentFilterV1Test {
         assertEquals(
             FilterAction.NONE,
             contentFilterModel.filterActionFor(
-                mockStatus(content = "content matching expired filter should not be filtered").asModel(),
+                fakeStatus(content = "content matching expired filter should not be filtered").asModel(),
             ),
         )
     }
@@ -251,7 +247,7 @@ class ContentFilterV1Test {
         assertEquals(
             FilterAction.HIDE,
             contentFilterModel.filterActionFor(
-                mockStatus(content = "content matching unexpired filter should be filtered").asModel(),
+                fakeStatus(content = "content matching unexpired filter should be filtered").asModel(),
             ),
         )
     }
@@ -270,78 +266,5 @@ class ContentFilterV1Test {
         val expiredDate = Date.from(Instant.now().plusSeconds(expiresInSeconds.toLong()))
         val updatedDuration = getSecondsForDurationIndex(-1, null, expiredDate)
         assert(updatedDuration != null && updatedDuration.toInt() > (expiresInSeconds - 60))
-    }
-
-    companion object {
-        fun mockStatus(
-            content: String = "",
-            spoilerText: String = "",
-            pollOptions: List<String>? = null,
-            attachmentsDescriptions: List<String>? = null,
-        ): NetworkStatus {
-            return NetworkStatus(
-                id = "123",
-                url = "https://mastodon.social/@Tusky/100571663297225812",
-                account = fakeAccount(),
-                inReplyToId = null,
-                inReplyToAccountId = null,
-                reblog = null,
-                content = content,
-                createdAt = Date(),
-                editedAt = null,
-                emojis = emptyList(),
-                reblogsCount = 0,
-                favouritesCount = 0,
-                repliesCount = 0,
-                reblogged = false,
-                favourited = false,
-                bookmarked = false,
-                sensitive = false,
-                spoilerText = spoilerText,
-                visibility = NetworkStatus.Visibility.PUBLIC,
-                attachments = if (attachmentsDescriptions != null) {
-                    ArrayList(
-                        attachmentsDescriptions.map {
-                            NetworkAttachment(
-                                id = "1234",
-                                url = "",
-                                previewUrl = null,
-                                meta = null,
-                                type = NetworkAttachment.Type.IMAGE,
-                                description = it,
-                                blurhash = null,
-                            )
-                        },
-                    )
-                } else {
-                    arrayListOf()
-                },
-                mentions = listOf(),
-                tags = listOf(),
-                application = null,
-                pinned = false,
-                muted = false,
-                poll = if (pollOptions != null) {
-                    NetworkPoll(
-                        id = "1234",
-                        expiresAt = null,
-                        expired = false,
-                        multiple = false,
-                        votesCount = 0,
-                        votersCount = 0,
-                        options = pollOptions.map {
-                            NetworkPollOption(it, 0)
-                        },
-                        voted = false,
-                        ownVotes = null,
-                    )
-                } else {
-                    null
-                },
-                card = null,
-                language = null,
-                filtered = null,
-            )
-        }
     }
 }

--- a/app/src/test/java/app/pachli/components/notifications/NotificationsViewModelTestBase.kt
+++ b/app/src/test/java/app/pachli/components/notifications/NotificationsViewModelTestBase.kt
@@ -25,6 +25,7 @@ import app.pachli.core.data.repository.ContentFiltersRepository
 import app.pachli.core.data.repository.OfflineFirstStatusRepository
 import app.pachli.core.data.repository.StatusDisplayOptionsRepository
 import app.pachli.core.data.repository.notifications.NotificationsRepository
+import app.pachli.core.database.AppDatabase
 import app.pachli.core.database.dao.AccountDao
 import app.pachli.core.eventhub.EventHub
 import app.pachli.core.network.di.test.DEFAULT_INSTANCE_V2
@@ -107,6 +108,9 @@ abstract class NotificationsViewModelTestBase {
 
     private val eventHub = EventHub()
 
+    @Inject
+    lateinit var appDatabase: AppDatabase
+
     private lateinit var accountPreferenceDataStore: AccountPreferenceDataStore
 
     private val account = CredentialAccount(
@@ -125,7 +129,7 @@ abstract class NotificationsViewModelTestBase {
     protected var pachliAccountId by Delegates.notNull<Long>()
 
     @Before
-    fun setup() = runTest {
+    open fun setup() = runTest {
         hilt.inject()
 
         reset(notificationsRepository)

--- a/app/src/test/java/app/pachli/components/timeline/CachedTimelineViewModelTestBase.kt
+++ b/app/src/test/java/app/pachli/components/timeline/CachedTimelineViewModelTestBase.kt
@@ -22,6 +22,7 @@ import app.pachli.PachliApplication
 import app.pachli.components.timeline.viewmodel.CachedTimelineViewModel
 import app.pachli.core.data.repository.AccountManager
 import app.pachli.core.data.repository.StatusDisplayOptionsRepository
+import app.pachli.core.database.AppDatabase
 import app.pachli.core.eventhub.EventHub
 import app.pachli.core.model.Timeline
 import app.pachli.core.network.di.test.DEFAULT_INSTANCE_V2
@@ -88,6 +89,9 @@ abstract class CachedTimelineViewModelTestBase {
     @Inject
     lateinit var statusDisplayOptionsRepository: StatusDisplayOptionsRepository
 
+    @Inject
+    lateinit var appDatabase: AppDatabase
+
     private lateinit var timelineCases: TimelineCases
     protected lateinit var viewModel: CachedTimelineViewModel
 
@@ -107,7 +111,7 @@ abstract class CachedTimelineViewModelTestBase {
     )
 
     @Before
-    fun setup() = runTest {
+    open fun setup() = runTest {
         hilt.inject()
 
         reset(mastodonApi)

--- a/app/src/test/java/app/pachli/components/timeline/NetworkTimelineViewModelTestBase.kt
+++ b/app/src/test/java/app/pachli/components/timeline/NetworkTimelineViewModelTestBase.kt
@@ -21,6 +21,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.pachli.components.timeline.viewmodel.NetworkTimelineViewModel
 import app.pachli.core.data.repository.AccountManager
 import app.pachli.core.data.repository.StatusDisplayOptionsRepository
+import app.pachli.core.database.AppDatabase
 import app.pachli.core.eventhub.EventHub
 import app.pachli.core.model.Timeline
 import app.pachli.core.network.di.test.DEFAULT_INSTANCE_V2
@@ -82,6 +83,9 @@ abstract class NetworkTimelineViewModelTestBase {
     @Inject
     lateinit var statusDisplayOptionsRepository: StatusDisplayOptionsRepository
 
+    @Inject
+    lateinit var appDatabase: AppDatabase
+
     protected lateinit var timelineCases: TimelineCases
     protected lateinit var viewModel: NetworkTimelineViewModel
 
@@ -101,7 +105,7 @@ abstract class NetworkTimelineViewModelTestBase {
     )
 
     @Before
-    fun setup() = runTest {
+    open fun setup() = runTest {
         hilt.inject()
 
         reset(mastodonApi)

--- a/core/data/src/test/kotlin/app/pachli/core/data/repository/StatusRepositoryTest.kt
+++ b/core/data/src/test/kotlin/app/pachli/core/data/repository/StatusRepositoryTest.kt
@@ -20,23 +20,36 @@ package app.pachli.core.data.repository
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
 import app.pachli.core.common.di.ApplicationScope
+import app.pachli.core.database.AppDatabase
 import app.pachli.core.database.dao.StatusDao
 import app.pachli.core.database.dao.TranslatedStatusDao
 import app.pachli.core.database.di.TransactionProvider
 import app.pachli.core.eventhub.EventHub
 import app.pachli.core.eventhub.PinEvent
 import app.pachli.core.network.extensions.getServerErrorMessage
+import app.pachli.core.network.model.AccountSource
+import app.pachli.core.network.model.CredentialAccount
+import app.pachli.core.network.model.InstanceConfiguration
+import app.pachli.core.network.model.InstanceV1
 import app.pachli.core.network.model.Status
+import app.pachli.core.network.model.nodeinfo.UnvalidatedJrd
+import app.pachli.core.network.model.nodeinfo.UnvalidatedNodeInfo
 import app.pachli.core.network.retrofit.MastodonApi
+import app.pachli.core.network.retrofit.NodeInfoApi
+import app.pachli.core.testing.extensions.insertStatuses
 import app.pachli.core.testing.failure
-import app.pachli.core.testing.fakes.fakeAccount
+import app.pachli.core.testing.fakes.fakeStatus
+import app.pachli.core.testing.fakes.fakeStatusEntityWithAccount
+import app.pachli.core.testing.rules.MainCoroutineRule
 import app.pachli.core.testing.success
 import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.andThen
 import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.onSuccess
 import com.google.common.truth.Truth.assertThat
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
-import java.util.Date
+import java.time.Instant
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -46,6 +59,8 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.reset
 import org.mockito.kotlin.stub
@@ -59,11 +74,17 @@ class StatusRepositoryTest {
     @get:Rule(order = 0)
     var hilt = HiltAndroidRule(this)
 
+    @get:Rule(order = 1)
+    val mainCoroutineRule = MainCoroutineRule()
+
     @Inject
     @ApplicationScope lateinit var externalScope: CoroutineScope
 
     @Inject
     lateinit var mastodonApi: MastodonApi
+
+    @Inject
+    lateinit var nodeInfoApi: NodeInfoApi
 
     @Inject
     lateinit var transactionProvider: TransactionProvider
@@ -77,14 +98,81 @@ class StatusRepositoryTest {
     @Inject
     lateinit var eventHub: EventHub
 
+    @Inject
+    lateinit var appDatabase: AppDatabase
+
+    @Inject
+    lateinit var accountManager: AccountManager
+
+    private val account = CredentialAccount(
+        id = "1",
+        localUsername = "username",
+        username = "username@domain.example",
+        displayName = "Display Name",
+        createdAt = Instant.now(),
+        note = "",
+        url = "",
+        avatar = "",
+        header = "",
+        source = AccountSource(),
+    )
+
     private lateinit var statusRepository: OfflineFirstStatusRepository
 
-    private val statusId = "1234"
-
     @Before
-    fun setup() {
+    fun setup() = runTest {
         hilt.inject()
+
         reset(mastodonApi)
+        mastodonApi.stub {
+            onBlocking { accountVerifyCredentials(anyOrNull(), anyOrNull()) } doReturn success(account)
+            onBlocking { getCustomEmojis() } doReturn success(emptyList())
+            onBlocking { getInstanceV2() } doReturn failure()
+            onBlocking { getInstanceV1(anyOrNull()) } doReturn success(
+                InstanceV1(
+                    uri = "https://example.token",
+                    version = "2.6.3",
+                    maxTootChars = 500,
+                    pollConfiguration = null,
+                    configuration = InstanceConfiguration(),
+                    pleroma = null,
+                    uploadLimit = null,
+                    rules = emptyList(),
+                ),
+            )
+            onBlocking { getLists() } doReturn success(emptyList())
+            onBlocking { listAnnouncements(any()) } doReturn success(emptyList())
+            onBlocking { getContentFilters() } doReturn success(emptyList())
+            onBlocking { getContentFiltersV1() } doReturn success(emptyList())
+            onBlocking { accountFollowing(any(), anyOrNull(), any()) } doReturn success(emptyList())
+        }
+
+        reset(nodeInfoApi)
+        nodeInfoApi.stub {
+            onBlocking { nodeInfoJrd() } doReturn success(
+                UnvalidatedJrd(
+                    listOf(
+                        UnvalidatedJrd.Link(
+                            "http://nodeinfo.diaspora.software/ns/schema/2.1",
+                            "https://example.com",
+                        ),
+                    ),
+                ),
+            )
+            onBlocking { nodeInfo(any()) } doReturn success(
+                UnvalidatedNodeInfo(UnvalidatedNodeInfo.Software("mastodon", "4.2.0")),
+            )
+        }
+
+        accountManager.verifyAndAddAccount(
+            accessToken = "token",
+            domain = "example.com",
+            clientId = "id",
+            clientSecret = "secret",
+            oauthScopes = "scopes",
+        )
+            .andThen { accountManager.setActiveAccount(it) }
+            .onSuccess { accountManager.refresh(it) }
 
         statusRepository = OfflineFirstStatusRepository(
             externalScope,
@@ -98,8 +186,14 @@ class StatusRepositoryTest {
 
     @Test
     fun `pin success emits PinEvent`() = runTest {
+        val fakeStatus = fakeStatus()
+        val fakeStatusEntityWithAccount = fakeStatusEntityWithAccount(makeFakeStatus = { fakeStatus })
+        val statusId = fakeStatus.id
+
+        appDatabase.insertStatuses(listOf(fakeStatusEntityWithAccount))
+
         mastodonApi.stub {
-            onBlocking { pinStatus(statusId) } doReturn success(mockStatus(pinned = true))
+            onBlocking { pinStatus(statusId) } doReturn success(fakeStatus)
         }
 
         eventHub.events.test {
@@ -110,6 +204,8 @@ class StatusRepositoryTest {
 
     @Test
     fun `pin failure with server error returns failure with server message`() {
+        val statusId = "1234"
+
         val apiResult = failure<Status>(
             code = 422,
             responseBody = "{\"error\":\"Validation Failed: You have already pinned the maximum number of toots\"}",
@@ -126,39 +222,5 @@ class StatusRepositoryTest {
                 "Validation Failed: You have already pinned the maximum number of toots",
             )
         }
-    }
-
-    private fun mockStatus(pinned: Boolean = false): Status {
-        return Status(
-            id = "123",
-            url = "https://mastodon.social/@Tusky/100571663297225812",
-            account = fakeAccount(),
-            inReplyToId = null,
-            inReplyToAccountId = null,
-            reblog = null,
-            content = "",
-            createdAt = Date(),
-            editedAt = null,
-            emojis = emptyList(),
-            reblogsCount = 0,
-            favouritesCount = 0,
-            repliesCount = 0,
-            reblogged = false,
-            favourited = false,
-            bookmarked = false,
-            sensitive = false,
-            spoilerText = "",
-            visibility = Status.Visibility.PUBLIC,
-            attachments = arrayListOf(),
-            mentions = listOf(),
-            tags = listOf(),
-            application = null,
-            pinned = pinned,
-            muted = false,
-            poll = null,
-            card = null,
-            language = null,
-            filtered = null,
-        )
     }
 }

--- a/core/testing/src/main/kotlin/app/pachli/core/testing/extensions/AppDatabaseExtensions.kt
+++ b/core/testing/src/main/kotlin/app/pachli/core/testing/extensions/AppDatabaseExtensions.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2025 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.core.testing.extensions
+
+import app.pachli.core.database.AppDatabase
+import app.pachli.core.database.model.TimelineStatusEntity
+import app.pachli.core.database.model.TimelineStatusWithAccount
+
+/**
+ * Inserts [statuses] in to the database, populating the correct
+ * [TimelineAccountEntity][app.pachli.core.database.model.TimelineAccountEntity],
+ * [StatusEntity][app.pachli.core.database.model.StatusEntity],
+ * [TimelineStatusEntity][app.pachli.core.database.model.TimelineStatusEntity]
+ * tables to ensure tests don't fail because of foreign key constraint
+ * violations.
+ */
+suspend fun AppDatabase.insertStatuses(statuses: Iterable<TimelineStatusWithAccount>) {
+    statuses.forEach { statusWithAccount ->
+        statusWithAccount.account.let { account ->
+            timelineDao().insertAccount(account)
+        }
+        statusWithAccount.reblogAccount?.let { account ->
+            timelineDao().insertAccount(account)
+        }
+        statusDao().insertStatus(statusWithAccount.status)
+    }
+    timelineDao().upsertStatuses(
+        statuses.map {
+            TimelineStatusEntity(
+                pachliAccountId = it.status.timelineUserId,
+                kind = TimelineStatusEntity.Kind.Home,
+                statusId = it.status.serverId,
+            )
+        },
+    )
+}


### PR DESCRIPTION
Tests were playing a bit fast and loose with whether or not data needed to exist in the in-memory database when testing. Fix this by finishing the work of consolidating the functions that create fake statuses for testing, and inserting these into the database before tests run.