### PR TITLE
feat: Allow user to drag attachments to reorder when composing

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -152,6 +152,7 @@ dependencies {
     implementation(libs.kotlinx.coroutines.android)
 
     implementation(libs.bundles.androidx)
+    implementation(libs.androidx.core.animation)
 
     implementation(libs.android.material)
 

--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -154,7 +154,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/components/compose/ComposeActivity.kt"
-            line="489"
+            line="566"
             column="13"/>
     </issue>
 
@@ -165,7 +165,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/components/compose/ComposeActivity.kt"
-            line="502"
+            line="579"
             column="17"/>
     </issue>
 
@@ -176,7 +176,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/components/compose/ComposeActivity.kt"
-            line="507"
+            line="584"
             column="9"/>
     </issue>
 
@@ -363,7 +363,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/TabPreferenceActivity.kt"
-            line="322"
+            line="329"
             column="9"/>
     </issue>
 
@@ -840,7 +840,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="589"
+            line="591"
             column="5"/>
     </issue>
 
@@ -3645,7 +3645,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="426"
+            line="428"
             column="13"/>
     </issue>
 
@@ -3656,7 +3656,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="429"
+            line="431"
             column="13"/>
     </issue>
 
@@ -3667,7 +3667,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="432"
+            line="434"
             column="13"/>
     </issue>
 
@@ -3678,7 +3678,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="433"
+            line="435"
             column="13"/>
     </issue>
 
@@ -3689,7 +3689,7 @@
         errorLine2="            ~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="434"
+            line="436"
             column="13"/>
     </issue>
 
@@ -3700,7 +3700,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="436"
+            line="438"
             column="13"/>
     </issue>
 
@@ -3711,7 +3711,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="448"
+            line="450"
             column="13"/>
     </issue>
 
@@ -3722,7 +3722,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="449"
+            line="451"
             column="13"/>
     </issue>
 
@@ -3733,7 +3733,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="483"
+            line="485"
             column="13"/>
     </issue>
 
@@ -3744,7 +3744,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="484"
+            line="486"
             column="13"/>
     </issue>
 
@@ -3755,7 +3755,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="494"
+            line="496"
             column="13"/>
     </issue>
 
@@ -3766,7 +3766,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="495"
+            line="497"
             column="13"/>
     </issue>
 
@@ -3777,7 +3777,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="496"
+            line="498"
             column="13"/>
     </issue>
 
@@ -3788,7 +3788,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="499"
+            line="501"
             column="13"/>
     </issue>
 
@@ -3799,7 +3799,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="507"
+            line="509"
             column="13"/>
     </issue>
 
@@ -3810,7 +3810,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="549"
+            line="551"
             column="13"/>
     </issue>
 
@@ -3821,7 +3821,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="555"
+            line="557"
             column="13"/>
     </issue>
 
@@ -3832,7 +3832,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="581"
+            line="583"
             column="13"/>
     </issue>
 
@@ -3843,7 +3843,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="607"
+            line="609"
             column="13"/>
     </issue>
 

--- a/app/src/main/java/app/pachli/components/compose/ComposeViewModel.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeViewModel.kt
@@ -70,6 +70,7 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.github.z4kn4fein.semver.constraints.toConstraint
+import java.util.Collections
 import java.util.Date
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -346,6 +347,24 @@ class ComposeViewModel @AssistedInject constructor(
         mediaUploader.cancelUploadScope(item.localId)
         _media.update { mediaList -> mediaList.filter { it.localId != item.localId } }
         updateCloseConfirmation()
+    }
+
+    /**
+     * Swaps the position of [first] and [second] in [_media].
+     *
+     * @param first Index of the first item to swap.
+     * @param second Index of the second item to swap.
+     */
+    fun swapAttachmentOrder(first: Int, second: Int) {
+        _media.update { mediaList ->
+            val newList = mediaList.toMutableList()
+            try {
+                Collections.swap(newList, first, second)
+            } catch (_: IndexOutOfBoundsException) {
+                /* do nothing, original list will be returned */
+            }
+            newList
+        }
     }
 
     fun toggleMarkSensitive() {

--- a/app/src/main/res/layout/item_compose_media_attachment.xml
+++ b/app/src/main/res/layout/item_compose_media_attachment.xml
@@ -46,6 +46,18 @@
         android:background="@drawable/background_circle"
         android:src="@drawable/ic_more_horiz_24dp" />
 
+    <ImageView
+        android:id="@+id/drag_handle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:rotation="90"
+        android:src="@drawable/ic_drag_indicator_24dp"
+        app:tint="?attr/colorControlNormal"
+        android:importantForAccessibility="no"
+        app:layout_constraintStart_toStartOf="@id/media"
+        app:layout_constraintTop_toBottomOf="@id/media"
+        app:layout_constraintEnd_toEndOf="@id/media" />
+
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/descriptionLayout"
         style="?attr/textInputFilledStyle"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -411,6 +411,8 @@
     <string name="action_set_focus">Set focus point</string>
     <string name="action_edit_image">Edit image</string>
     <string name="action_remove">Remove</string>
+    <string name="action_move_up">Move up</string>
+    <string name="action_move_down">Move down</string>
     <string name="lock_account_label">Lock account</string>
     <string name="lock_account_label_description">Requires you to manually approve followers</string>
     <string name="compose_delete_draft">Delete draft?</string>

--- a/core/designsystem/src/main/res/values/dimens.xml
+++ b/core/designsystem/src/main/res/values/dimens.xml
@@ -31,7 +31,7 @@
 
     <dimen name="preference_icon_size">20dp</dimen>
 
-    <dimen name="selected_drag_item_elevation">12dp</dimen>
+    <dimen name="selected_drag_item_elevation">4dp</dimen>
 
     <dimen name="avatar_radius_94dp">11.75dp</dimen> <!-- 1/8 of 100dp - 2 * 3dp padding -->
     <dimen name="avatar_radius_80dp">10dp</dimen> <!-- 1/8 of 80dp -->

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/AnimatorUtils.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/AnimatorUtils.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2025 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.core.ui
+
+import android.animation.Animator
+import android.animation.AnimatorSet
+import android.animation.ObjectAnimator
+import android.view.View
+import android.view.animation.AccelerateDecelerateInterpolator
+import androidx.core.animation.doOnEnd
+import androidx.core.animation.doOnStart
+import javax.annotation.CheckReturnValue
+
+/**
+ * Recommended animator for a view when dragging starts.
+ *
+ * - Zooms the view by a factor of 1.02
+ * - Sets the elevation to [dragElevation]
+ *
+ * @param view View to operate on.
+ * @param dragElevation Elevation to set.
+ * @param onStart Optional function to run when animation starts.
+ * E.g., to set the [clipChildren][android.view.ViewGroup.clipChildren]
+ * property on further up the view hierarchy.
+ * @param onEnd Optional function to run when animation ends.
+ *
+ * @see androidx.recyclerview.widget.ItemTouchHelper.Callback.onSelectedChanged
+ */
+@CheckReturnValue
+fun startDragAnimator(
+    view: View,
+    dragElevation: Float,
+    onStart: ((animator: Animator) -> Unit)? = null,
+    onEnd: ((animator: Animator) -> Unit)? = null,
+) = AnimatorSet().apply {
+    duration = 100
+    interpolator = AccelerateDecelerateInterpolator()
+    playTogether(
+        scaleX(view, 1.02f),
+        scaleY(view, 1.02f),
+        translateZ(view, dragElevation),
+    )
+
+    onStart?.let { doOnStart { it(this) } }
+
+    onEnd?.let { doOnEnd { it(this) } }
+}
+
+/**
+ * Recommended animator for a view when dragging is cleared.
+ *
+ * Animates reversing the scale and elevation changes made by
+ * [startDragAnimator].
+ *
+ * @param view View to operate on.
+ * @param onStart Optional function to run when animation starts.
+ * @param onEnd Optional function to run when animation ends.
+ *
+ * @see androidx.recyclerview.widget.ItemTouchHelper.Callback.clearView
+ */
+@CheckReturnValue
+fun clearDragAnimator(
+    view: View,
+    onStart: ((animator: Animator) -> Unit)? = null,
+    onEnd: ((animator: Animator) -> Unit)? = null,
+) = AnimatorSet().apply {
+    // 2x speed of startDragAnimator, for snappier behaviour.
+    duration = 50
+    interpolator = AccelerateDecelerateInterpolator()
+    playTogether(
+        scaleX(view, 1f),
+        scaleY(view, 1f),
+        translateZ(view, 0f),
+    )
+
+    onStart?.let { doOnStart { it(this) } }
+
+    onEnd?.let { doOnEnd { it(this) } }
+}
+
+/**
+ * @return [Animator] that changes the [scaleX][View.getScaleX] property
+ * of [view] to [scaleTo].
+ */
+private fun scaleX(view: View, scaleTo: Float): Animator {
+    return ObjectAnimator.ofFloat(view, View.SCALE_X, view.scaleX, scaleTo)
+}
+
+/**
+ * @return [Animator] that changes the [scaleY][View.getScaleY] property
+ * of [view] to [scaleTo].
+ */
+private fun scaleY(view: View, scaleTo: Float): Animator {
+    return ObjectAnimator.ofFloat(view, View.SCALE_Y, view.scaleY, scaleTo)
+}
+
+/**
+ * @return [Animator] that changes the [translationZ][View.getTranslationZ]
+ * property of [view] to [translateTo].
+ */
+private fun translateZ(view: View, translateTo: Float): Animator {
+    return ObjectAnimator.ofFloat(view, View.TRANSLATION_Z, view.translationZ, translateTo)
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ androidx-browser = "1.8.0"
 androidx-cardview = "1.0.0"
 androidx-constraintlayout = "2.2.1"
 androidx-core = "1.17.0"
+androidx-core-animation = "1.0.0"
 androidx-exifinterface = "1.4.1"
 androidx-fragment = "1.8.6"
 androidx-hilt = "1.2.0"
@@ -122,6 +123,7 @@ androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "a
 androidx-browser = { module = "androidx.browser:browser", version.ref = "androidx-browser" }
 androidx-cardview = { module = "androidx.cardview:cardview", version.ref = "androidx-cardview" }
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidx-constraintlayout" }
+androidx-core-animation = { group = "androidx.core", name = "core-animation", version.ref = "androidx-core-animation" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
 androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "androidx-splashscreen" }
 androidx-core-testing = { module = "androidx.arch.core:core-testing", version.ref = "androidx-testing" }


### PR DESCRIPTION
Show a drag-handle below each attachment preview if there is more than one attachment loaded.

Dragging the handle, or long-pressing on the attachment item starts a drag. Dropping the attachment in a different spot in the list reorders the list.

Add "Move up" and "Move down" entries to the per-attachment menu so there is an accessible way to access this functionality

Fixes #1187