### PR TITLE
fix: Don't crash on older devices, use CASE instead of IIF

### DIFF
--- a/core/database/src/main/kotlin/app/pachli/core/database/dao/StatusDao.kt
+++ b/core/database/src/main/kotlin/app/pachli/core/database/dao/StatusDao.kt
@@ -63,7 +63,7 @@ WHERE timelineUserId = :pachliAccountId AND (serverId = :statusId)
 UPDATE StatusEntity
 SET
     favourited = :favourited,
-    favouritesCount = favouritesCount + IIF(:favourited, 1, -1)
+    favouritesCount = favouritesCount + CASE WHEN :favourited THEN 1 ELSE -1 END
 WHERE timelineUserId = :pachliAccountId AND (serverId = :statusId OR reblogServerId = :statusId)
 """,
     )
@@ -84,7 +84,7 @@ WHERE timelineUserId = :pachliAccountId AND (serverId = :statusId OR reblogServe
 UPDATE StatusEntity
 SET
     reblogged = :reblogged,
-    reblogsCount = reblogsCount + IIF(:reblogged, 1, -1)
+    reblogsCount = reblogsCount + CASE WHEN :reblogged THEN 1 ELSE -1 END
 WHERE timelineUserId = :pachliAccountId AND (serverId = :statusId OR reblogServerId = :statusId)
 """,
     )


### PR DESCRIPTION
`IIF()` isn't available in the SQLite version on some devices, causing a crash. Replace with a more verbose `CASE`, which is available.