### PR TITLE
fix: Fix black theme rendering

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -242,7 +242,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="1109"
+            line="1106"
             column="13"/>
     </issue>
 
@@ -253,7 +253,7 @@
         errorLine2="             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="1110"
+            line="1107"
             column="14"/>
     </issue>
 
@@ -264,7 +264,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/MainActivity.kt"
-            line="1168"
+            line="1165"
             column="17"/>
     </issue>
 
@@ -995,17 +995,6 @@
         <location
             file="src/main/res/layout/activity_view_media.xml"
             line="6"
-            column="5"/>
-    </issue>
-
-    <issue
-        id="Overdraw"
-        message="Possible overdraw: Root element paints background `?android:attr/colorBackground` with a theme that also paints a background (inferred theme is `@style/AppTheme`)"
-        errorLine1="    android:background=&quot;?android:attr/colorBackground&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/layout/fragment_timeline_notifications.xml"
-            line="24"
             column="5"/>
     </issue>
 
@@ -3865,7 +3854,7 @@
         errorLine2="           ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="../core/designsystem/src/main/res/values/styles.xml"
-            line="196"
+            line="201"
             column="12"/>
     </issue>
 

--- a/app/src/main/java/app/pachli/MainActivity.kt
+++ b/app/src/main/java/app/pachli/MainActivity.kt
@@ -23,7 +23,6 @@ import android.app.NotificationManager
 import android.content.Context
 import android.content.pm.PackageManager.PERMISSION_GRANTED
 import android.graphics.Bitmap
-import android.graphics.Color
 import android.graphics.drawable.Animatable
 import android.graphics.drawable.Drawable
 import android.net.Uri
@@ -315,8 +314,6 @@ class MainActivity : ViewUrlActivity(), ActionButtonActivity, MenuProvider {
                 }
             }
         }
-
-        window.statusBarColor = Color.TRANSPARENT // don't draw a status bar, the DrawerLayout and the MaterialDrawerLayout have their own
 
         // Determine which of the three toolbars should be the supportActionBar (which hosts
         // the options menu).

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -16,8 +16,7 @@
             android:id="@+id/appBar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:liftOnScroll="true"
-            app:liftOnScrollTargetViewId="@id/viewPager">
+            app:liftOnScroll="true">
 
             <com.google.android.material.appbar.MaterialToolbar
                 style="@style/Pachli.Widget.Toolbar"

--- a/app/src/main/res/layout/fragment_timeline.xml
+++ b/app/src/main/res/layout/fragment_timeline.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    tools:context=".MainActivity">
 
     <com.google.android.material.progressindicator.LinearProgressIndicator
         android:id="@+id/progressIndicator"

--- a/app/src/main/res/layout/fragment_timeline_notifications.xml
+++ b/app/src/main/res/layout/fragment_timeline_notifications.xml
@@ -21,7 +21,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="?android:attr/colorBackground"
     tools:context=".MainActivity">
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/core/activity/src/main/kotlin/app/pachli/core/activity/BaseActivity.kt
+++ b/core/activity/src/main/kotlin/app/pachli/core/activity/BaseActivity.kt
@@ -140,6 +140,18 @@ abstract class BaseActivity : AppCompatActivity(), MenuProvider {
         }
     }
 
+    override fun onPostCreate(savedInstanceState: Bundle?) {
+        super.onPostCreate(savedInstanceState)
+
+        if (window.isFloating) return
+
+        // Enabling edge-to-edge appears to cause the decor and main content view
+        // to have the wrong background colour, so set it it here.
+        window.decorView.setBackgroundColor(Color.BLACK)
+        val contentView: View = findViewById(android.R.id.content)
+        contentView.setBackgroundColor(MaterialColors.getColor(contentView, android.R.attr.colorBackground))
+    }
+
     override fun attachBaseContext(newBase: Context) {
         val sharedPreferencesRepository = fromApplication(
             newBase.applicationContext,

--- a/core/designsystem/src/main/res/values/styles.xml
+++ b/core/designsystem/src/main/res/values/styles.xml
@@ -155,20 +155,27 @@
         <item name="android:colorBackground">@color/black</item>
         <item name="windowBackgroundColor">@color/black</item>
 
+        <item name="colorOnPrimary">@color/black</item>
         <item name="colorSurface">@color/tusky_grey_10</item>
+        <item name="colorSurfaceContainerLowest">@color/tusky_grey_10</item>
+        <item name="colorSurfaceContainerLow">@color/tusky_grey_10</item>
+        <item name="colorSurfaceContainer">@color/tusky_grey_10</item>
+        <item name="colorSurfaceContainerHigh">@color/tusky_grey_10</item>
+        <item name="colorSurfaceContainerHighest">@color/tusky_grey_10</item>
 
         <!-- TODO: Remove this, use colorControlNormal everywhere instead of iconColor -->
         <item name="iconColor">?attr/colorControlNormal</item>
 
-        <item name="toolbarStyle">@style/Pachli.Widget.Toolbar.Black</item>
+        <item name="appBarLayoutStyle">@style/Pachli.Widget.Material3.AppBarLayout.Black</item>
         <item name="tabStyle">@style/Pachli.Widget.Material3.TabLayout.Black</item>
-        <item name="android:horizontalScrollViewStyle">
-            @style/Pachli.Widget.HorizontalScrollView.Black
-        </item>
+        <item name="android:horizontalScrollViewStyle">@style/Pachli.Widget.HorizontalScrollView.Black</item>
     </style>
 
-    <style name="Pachli.Widget.Toolbar.Black" parent="Widget.Material3.Toolbar">
+    <style name="Pachli.Widget.Material3.AppBarLayout.Black" parent="Widget.Material3.AppBarLayout">
         <item name="android:background">@color/black</item>
+
+        <!-- Prevents flashing/colour changes when scrolling. -->
+        <item name="liftOnScrollColor">@color/black</item>
     </style>
 
     <style name="Pachli.Widget.Material3.TabLayout.Black" parent="Widget.Material3.TabLayout">
@@ -178,6 +185,8 @@
     <style name="Pachli.Widget.HorizontalScrollView.Black" parent="">
         <item name="android:background">@color/black</item>
     </style>
+
+    <style name="Theme.Pachli.Black" parent="Base.Theme.Black" />
 
     <style name="Pachli.Widget.GraphView" parent="">
         <item name="primaryLineColor">@color/pachli_blue</item>
@@ -189,8 +198,6 @@
         <item name="minHideDelay">500</item>
         <item name="showDelay">500</item>
     </style>
-
-    <style name="Theme.Pachli.Black" parent="Base.Theme.Black" />
 
     <!-- customize the shape of the avatars in account selection list -->
     <style name="BezelImageView">


### PR DESCRIPTION
The switch to edge-to-edge seems to trigger different behaviour in Google libraries that broke the black theme, with some elements appearing dark grey.

Fix this by setting explicit colours for the content and decor view, and adjusting styles.