### PR TITLE
fix: Exclude boosted posts when reporting an account

### DIFF
--- a/app/src/main/java/app/pachli/components/report/ReportViewModel.kt
+++ b/app/src/main/java/app/pachli/components/report/ReportViewModel.kt
@@ -89,7 +89,7 @@ class ReportViewModel @AssistedInject constructor(
     accountManager: AccountManager,
     sharedPreferencesRepository: SharedPreferencesRepository,
 ) : NetworkTimelineViewModel(
-    timeline = Timeline.User.Replies(reportedAccountId),
+    timeline = Timeline.User.Replies(reportedAccountId, excludeReblogs = true),
     repository = repository,
     timelineCases = timelineCases,
     eventHub = eventHub,

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelineRemoteMediator.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelineRemoteMediator.kt
@@ -279,6 +279,7 @@ class NetworkTimelineRemoteMediator(
                 maxId = maxId,
                 minId = minId,
                 limit = loadSize,
+                excludeReblogs = timeline.excludeReblogs,
             )
             is Timeline.UserList -> api.listTimeline(
                 timeline.listId,

--- a/core/model/src/main/kotlin/app/pachli/core/model/Timeline.kt
+++ b/core/model/src/main/kotlin/app/pachli/core/model/Timeline.kt
@@ -79,7 +79,11 @@ sealed class Timeline : Parcelable {
     @TypeLabel("direct")
     data object Conversations : Timeline()
 
-    /** Any timeline showing statuses from a single user */
+    /**
+     * Any timeline showing statuses from a single user.
+     *
+     * @property id ID of the account that posted the statuses.
+     */
     @NestedSealed
     @Parcelize
     sealed class User : Timeline() {
@@ -95,10 +99,18 @@ sealed class Timeline : Parcelable {
         @JsonClass(generateAdapter = true)
         data class Pinned(override val id: String) : User()
 
-        /** Timeline showing a user's top-level statuses and replies they have made */
+        /**
+         * Timeline showing a user's top-level statuses and replies they have made.
+         *
+         * @property excludeReblogs If true, statuses the account has reblogged
+         * are excluded from the timeline.
+         */
         @TypeLabel("userReplies")
         @JsonClass(generateAdapter = true)
-        data class Replies(override val id: String) : User()
+        data class Replies(
+            override val id: String,
+            val excludeReblogs: Boolean = false,
+        ) : User()
     }
 
     @TypeLabel("favourites")


### PR DESCRIPTION
When reporting an account the user is prompted to select one or more statuses sent by the account being reported.

This was including statuses reblogged by the account, without any indication they were reblogs.

Fix this by explicitly excluding reblogs from the timeline when fetching statuses to include in a report.