### PR TITLE
fix: Ensure "Open in browser" is safe when viewing a thread

### DIFF
--- a/app/src/main/java/app/pachli/components/conversation/ConversationsFragment.kt
+++ b/app/src/main/java/app/pachli/components/conversation/ConversationsFragment.kt
@@ -385,7 +385,7 @@ class ConversationsFragment :
     }
 
     override fun onViewThread(status: Status) {
-        viewThread(status.actionableId, status.url)
+        viewThread(status.actionableId, status.actionableStatus.url)
     }
 
     override fun onOpenReblog(status: Status) {

--- a/app/src/main/java/app/pachli/components/timeline/TimelineFragment.kt
+++ b/app/src/main/java/app/pachli/components/timeline/TimelineFragment.kt
@@ -674,7 +674,7 @@ class TimelineFragment :
     }
 
     override fun onViewThread(status: Status) {
-        super.viewThread(status.actionableId, status.url)
+        super.viewThread(status.actionableId, status.actionableStatus.url)
     }
 
     override fun onViewTag(tag: String) {

--- a/app/src/main/java/app/pachli/components/viewthread/ViewThreadFragment.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/ViewThreadFragment.kt
@@ -42,6 +42,7 @@ import app.pachli.core.common.PachliError
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
 import app.pachli.core.common.extensions.viewBinding
+import app.pachli.core.common.util.unsafeLazy
 import app.pachli.core.data.model.StatusViewData
 import app.pachli.core.database.model.TranslationState
 import app.pachli.core.designsystem.R as DR
@@ -90,6 +91,8 @@ class ViewThreadFragment :
 
     private lateinit var adapter: ThreadAdapter
     private val thisThreadsStatusId by lazy { requireArguments().getString(ARG_ID)!! }
+
+    private val thisThreadsUrl by unsafeLazy { requireArguments().getString(ARG_URL) }
 
     override var pachliAccountId by Delegates.notNull<Long>()
 
@@ -284,6 +287,8 @@ class ViewThreadFragment :
                 else -> R.drawable.ic_hide_media_24dp
             },
         )
+
+        menu.findItem(R.id.action_open_in_web).apply { isVisible = thisThreadsUrl != null }
     }
 
     override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
@@ -293,7 +298,8 @@ class ViewThreadFragment :
                 true
             }
             R.id.action_open_in_web -> {
-                openUrl(requireArguments().getString(ARG_URL)!!)
+                // Belt-and-braces, menu shouldn't be showing if thisThreadsUrl is null.
+                thisThreadsUrl?.let { openUrl(it) }
                 true
             }
             R.id.action_refresh -> {
@@ -454,6 +460,13 @@ class ViewThreadFragment :
         private const val ARG_ID = "app.pachli.ARG_ID"
         private const val ARG_URL = "app.pachli.ARG_URL"
 
+        /**
+         * @param pachliAccountId
+         * @param id Actionable ID of the status to root the thread at.
+         * @param url URL of the status in [id]. May be null if the status doesn't have
+         * an associated URL (in which case the "Open in browser" menu item is
+         * disabled).
+         */
         fun newInstance(pachliAccountId: Long, id: String, url: String?): ViewThreadFragment {
             val fragment = ViewThreadFragment()
             fragment.arguments = Bundle(3).apply {

--- a/core/activity/src/main/kotlin/app/pachli/core/activity/ViewUrlActivity.kt
+++ b/core/activity/src/main/kotlin/app/pachli/core/activity/ViewUrlActivity.kt
@@ -87,7 +87,7 @@ abstract class ViewUrlActivity : BaseActivity() {
                 onEndSearch(url)
 
                 statuses.firstOrNull()?.let {
-                    viewThread(pachliAccountId, it.id, it.url)
+                    viewThread(pachliAccountId, it.actionableStatus.id, it.actionableStatus.url)
                     return@onSuccess
                 }
 

--- a/core/navigation/src/main/kotlin/app/pachli/core/navigation/Navigation.kt
+++ b/core/navigation/src/main/kotlin/app/pachli/core/navigation/Navigation.kt
@@ -843,9 +843,9 @@ class ViewMediaActivityIntent private constructor(context: Context, accountId: L
 /**
  * @param context
  * @param accountId ID of the Pachli account viewing the thread
- * @param statusId ID of the status to start from (may be in the middle of the thread)
- * @param statusUrl Optional URL of the status in `statusId`
- * @see [app.pachli.components.viewthread.ViewThreadActivity]
+ * @param statusId ID of the actionable status to start from (may be in the middle of the thread)
+ * @param statusUrl Optional URL of the actionable status in `statusId`
+ * @see [app.pachli.components.viewthread.ViewThreadFragment.newInstance]
  */
 class ViewThreadActivityIntent(context: Context, accountId: Long, statusId: String, statusUrl: String? = null) : Intent() {
     init {


### PR DESCRIPTION
Previous code had two problems.

1. A mis-match between the ID of the status used to root the thread and the URL used if "Open in browser" was used. Worst case one of them could have been the status and the other could have been a reblog of the status, so there's no risk the user would see different content.

Fix this by always using the ID and URL of the actionable status.

2. It's technically possible for a Status from the API to not have an associated URL. `ViewThreadFragment` didn't consider this, and would crash if (a) a null URL was provided, and (b) the user clicked the menu item.

Fix this by gating display of the menu on whether or not the URL is null.