### PR TITLE
feat: Tap on new-follower notifications to open the follower's account

### DIFF
--- a/app/src/main/java/app/pachli/components/notifications/FollowViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/notifications/FollowViewHolder.kt
@@ -63,7 +63,6 @@ class FollowViewHolder(
             statusDisplayOptions.animateAvatars,
             statusDisplayOptions.animateEmojis,
         )
-        setupButtons(notificationActionListener, viewData.account.id)
     }
 
     private fun setMessage(
@@ -118,9 +117,7 @@ class FollowViewHolder(
             animateEmojis,
         )
         setClickableText(binding.notificationAccountNote, emojifiedNote, emptyList(), null, linkListener)
-    }
-
-    private fun setupButtons(listener: NotificationActionListener, accountId: String) {
-        binding.root.setOnClickListener { listener.onViewAccount(accountId) }
+        binding.notificationAccountNote.setOnClickListener { linkListener.onViewAccount(account.id) }
+        itemView.setOnClickListener { linkListener.onViewAccount(account.id) }
     }
 }


### PR DESCRIPTION
Add a click handler for the bio text so tapping on it opens the account details.