### PR TITLE
refactor: Prevent nullability issues in NotificationViewData types

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -275,7 +275,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/components/notifications/NotificationsFragment.kt"
-            line="198"
+            line="196"
             column="13"/>
     </issue>
 
@@ -286,7 +286,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/components/notifications/NotificationsFragment.kt"
-            line="366"
+            line="364"
             column="17"/>
     </issue>
 
@@ -297,7 +297,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/components/notifications/NotificationsFragment.kt"
-            line="377"
+            line="375"
             column="17"/>
     </issue>
 
@@ -308,7 +308,7 @@
         errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/components/notifications/NotificationsFragment.kt"
-            line="384"
+            line="382"
             column="21"/>
     </issue>
 

--- a/app/src/main/java/app/pachli/adapter/FollowRequestViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/FollowRequestViewHolder.kt
@@ -28,7 +28,7 @@ import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
 import app.pachli.core.common.extensions.visible
 import app.pachli.core.common.string.unicodeWrap
-import app.pachli.core.data.model.NotificationViewData
+import app.pachli.core.data.model.NotificationViewData.FollowRequestNotificationViewData
 import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.designsystem.R as DR
 import app.pachli.core.model.TimelineAccount
@@ -47,10 +47,10 @@ class FollowRequestViewHolder(
     private val accountActionListener: AccountActionListener,
     private val linkListener: LinkListener,
     private val showHeader: Boolean,
-) : NotificationsPagingAdapter.ViewHolder, RecyclerView.ViewHolder(binding.root) {
+) : NotificationsPagingAdapter.ViewHolder<FollowRequestNotificationViewData>, RecyclerView.ViewHolder(binding.root) {
 
     override fun bind(
-        viewData: NotificationViewData,
+        viewData: FollowRequestNotificationViewData,
         payloads: List<List<Any?>>?,
         statusDisplayOptions: StatusDisplayOptions,
     ) {

--- a/app/src/main/java/app/pachli/adapter/ReportNotificationViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/ReportNotificationViewHolder.kt
@@ -28,7 +28,7 @@ import app.pachli.components.notifications.NotificationsPagingAdapter
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
 import app.pachli.core.common.string.unicodeWrap
-import app.pachli.core.data.model.NotificationViewData
+import app.pachli.core.data.model.NotificationViewData.ReportNotificationViewData
 import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.database.model.NotificationReportEntity
 import app.pachli.core.designsystem.R as DR
@@ -43,10 +43,10 @@ class ReportNotificationViewHolder(
     private val binding: ItemReportNotificationBinding,
     private val glide: RequestManager,
     private val notificationActionListener: NotificationActionListener,
-) : NotificationsPagingAdapter.ViewHolder, RecyclerView.ViewHolder(binding.root) {
+) : NotificationsPagingAdapter.ViewHolder<ReportNotificationViewData>, RecyclerView.ViewHolder(binding.root) {
 
     override fun bind(
-        viewData: NotificationViewData,
+        viewData: ReportNotificationViewData,
         payloads: List<List<Any?>>?,
         statusDisplayOptions: StatusDisplayOptions,
     ) {
@@ -54,19 +54,17 @@ class ReportNotificationViewHolder(
         // this view does not have timestamps.
         if (!payloads.isNullOrEmpty()) return
 
-        val report = viewData.report ?: return
-
         setupWithReport(
             viewData.account,
-            report,
+            viewData.report,
             statusDisplayOptions.animateAvatars,
             statusDisplayOptions.animateEmojis,
         )
         setupActionListener(
             notificationActionListener,
-            report.targetAccount.serverId,
+            viewData.report.targetAccount.serverId,
             viewData.account.id,
-            report.reportId,
+            viewData.report.reportId,
         )
     }
 

--- a/app/src/main/java/app/pachli/components/notifications/FilterableNotificationViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/notifications/FilterableNotificationViewHolder.kt
@@ -21,8 +21,12 @@ import androidx.core.text.HtmlCompat
 import androidx.recyclerview.widget.RecyclerView
 import app.pachli.R
 import app.pachli.core.data.model.NotificationViewData
+import app.pachli.core.data.model.NotificationViewData.FollowNotificationViewData
+import app.pachli.core.data.model.NotificationViewData.FollowRequestNotificationViewData
+import app.pachli.core.data.model.NotificationViewData.WithStatus.FavouriteNotificationViewData
+import app.pachli.core.data.model.NotificationViewData.WithStatus.MentionNotificationViewData
+import app.pachli.core.data.model.NotificationViewData.WithStatus.ReblogNotificationViewData
 import app.pachli.core.data.model.StatusDisplayOptions
-import app.pachli.core.database.model.NotificationEntity
 import app.pachli.core.model.AccountFilterDecision
 import app.pachli.core.model.AccountFilterReason
 import app.pachli.databinding.ItemNotificationFilteredBinding
@@ -40,7 +44,7 @@ import app.pachli.databinding.ItemNotificationFilteredBinding
 class FilterableNotificationViewHolder(
     private val binding: ItemNotificationFilteredBinding,
     private val notificationActionListener: NotificationActionListener,
-) : NotificationsPagingAdapter.ViewHolder, RecyclerView.ViewHolder(binding.root) {
+) : NotificationsPagingAdapter.ViewHolder<NotificationViewData>, RecyclerView.ViewHolder(binding.root) {
     private val context = binding.root.context
 
     lateinit var viewData: NotificationViewData
@@ -73,16 +77,16 @@ class FilterableNotificationViewHolder(
     override fun bind(viewData: NotificationViewData, payloads: List<List<Any?>>?, statusDisplayOptions: StatusDisplayOptions) {
         this.viewData = viewData
 
-        val icon = viewData.type.icon(context)
+        val icon = viewData.icon(context)
 
         // Labels for different notification types filtered by account. The account's
         // domain is interpolated in to the string.
-        val label = when (viewData.type) {
-            NotificationEntity.Type.MENTION -> R.string.account_filter_placeholder_type_mention_fmt
-            NotificationEntity.Type.REBLOG -> R.string.account_filter_placeholder_type_reblog_fmt
-            NotificationEntity.Type.FAVOURITE -> R.string.account_filter_placeholder_type_favourite_fmt
-            NotificationEntity.Type.FOLLOW -> R.string.account_filter_placeholder_type_follow_fmt
-            NotificationEntity.Type.FOLLOW_REQUEST -> R.string.account_filter_placeholder_type_follow_request_fmt
+        val label = when (viewData) {
+            is MentionNotificationViewData -> R.string.account_filter_placeholder_type_mention_fmt
+            is ReblogNotificationViewData -> R.string.account_filter_placeholder_type_reblog_fmt
+            is FavouriteNotificationViewData -> R.string.account_filter_placeholder_type_favourite_fmt
+            is FollowNotificationViewData -> R.string.account_filter_placeholder_type_follow_fmt
+            is FollowRequestNotificationViewData -> R.string.account_filter_placeholder_type_follow_request_fmt
             else -> R.string.account_filter_placeholder_label_domain
         }
 

--- a/app/src/main/java/app/pachli/components/notifications/FollowViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/notifications/FollowViewHolder.kt
@@ -26,7 +26,6 @@ import app.pachli.R
 import app.pachli.core.common.string.unicodeWrap
 import app.pachli.core.data.model.NotificationViewData
 import app.pachli.core.data.model.StatusDisplayOptions
-import app.pachli.core.database.model.NotificationEntity
 import app.pachli.core.designsystem.R as DR
 import app.pachli.core.model.TimelineAccount
 import app.pachli.core.network.parseAsMastodonHtml
@@ -41,9 +40,8 @@ import com.bumptech.glide.RequestManager
 class FollowViewHolder(
     private val binding: ItemFollowBinding,
     private val glide: RequestManager,
-    private val notificationActionListener: NotificationActionListener,
     private val linkListener: LinkListener,
-) : NotificationsPagingAdapter.ViewHolder, RecyclerView.ViewHolder(binding.root) {
+) : NotificationsPagingAdapter.ViewHolder<NotificationViewData>, RecyclerView.ViewHolder(binding.root) {
     private val avatarRadius42dp = itemView.context.resources.getDimensionPixelSize(
         DR.dimen.avatar_radius_42dp,
     )
@@ -59,7 +57,7 @@ class FollowViewHolder(
 
         setMessage(
             viewData.account,
-            viewData.type === NotificationEntity.Type.SIGN_UP,
+            viewData is NotificationViewData.SignupNotificationViewData,
             statusDisplayOptions.animateAvatars,
             statusDisplayOptions.animateEmojis,
         )

--- a/app/src/main/java/app/pachli/components/notifications/ModerationWarningViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/notifications/ModerationWarningViewHolder.kt
@@ -21,29 +21,29 @@ import android.content.Intent
 import androidx.core.net.toUri
 import androidx.recyclerview.widget.RecyclerView
 import app.pachli.R
-import app.pachli.core.data.model.NotificationViewData
+import app.pachli.core.data.model.NotificationViewData.ModerationWarningNotificationViewData
 import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.model.AccountWarning
 import app.pachli.databinding.ItemModerationWarningBinding
 
 class ModerationWarningViewHolder(
     private val binding: ItemModerationWarningBinding,
-) : NotificationsPagingAdapter.ViewHolder, RecyclerView.ViewHolder(binding.root) {
-    var viewData: NotificationViewData? = null
+) : NotificationsPagingAdapter.ViewHolder<ModerationWarningNotificationViewData>, RecyclerView.ViewHolder(binding.root) {
+    var viewData: ModerationWarningNotificationViewData? = null
 
     init {
         binding.root.setOnClickListener {
             viewData?.let {
-                val intent = Intent(Intent.ACTION_VIEW, "https://${it.localDomain}/disputes/strikes/${it.accountWarning!!.id}".toUri())
+                val intent = Intent(Intent.ACTION_VIEW, "https://${it.localDomain}/disputes/strikes/${it.accountWarning.id}".toUri())
                 binding.root.context.startActivity(intent)
             }
         }
     }
 
-    override fun bind(viewData: NotificationViewData, payloads: List<List<Any?>>?, statusDisplayOptions: StatusDisplayOptions) {
+    override fun bind(viewData: ModerationWarningNotificationViewData, payloads: List<List<Any?>>?, statusDisplayOptions: StatusDisplayOptions) {
         this.viewData = viewData
         val context = itemView.context
-        val warning = viewData.accountWarning!!
+        val warning = viewData.accountWarning
 
         val stringRes = when (warning.action) {
             AccountWarning.Action.NONE -> R.string.notification_moderation_warning_body_none_fmt

--- a/app/src/main/java/app/pachli/components/notifications/NotificationViewDataIcon.kt
+++ b/app/src/main/java/app/pachli/components/notifications/NotificationViewDataIcon.kt
@@ -23,63 +23,71 @@ import androidx.annotation.AttrRes
 import androidx.annotation.DrawableRes
 import androidx.appcompat.content.res.AppCompatResources
 import app.pachli.R
-import app.pachli.core.database.model.NotificationEntity
-import app.pachli.core.network.model.Notification
+import app.pachli.core.data.model.NotificationViewData
+import app.pachli.core.data.model.NotificationViewData.FollowNotificationViewData
+import app.pachli.core.data.model.NotificationViewData.FollowRequestNotificationViewData
+import app.pachli.core.data.model.NotificationViewData.UnknownNotificationViewData
+import app.pachli.core.data.model.NotificationViewData.WithStatus.FavouriteNotificationViewData
+import app.pachli.core.data.model.NotificationViewData.WithStatus.MentionNotificationViewData
+import app.pachli.core.data.model.NotificationViewData.WithStatus.PollNotificationViewData
+import app.pachli.core.data.model.NotificationViewData.WithStatus.ReblogNotificationViewData
+import app.pachli.core.data.model.NotificationViewData.WithStatus.StatusNotificationViewData
+import app.pachli.core.data.model.NotificationViewData.WithStatus.UpdateNotificationViewData
 import app.pachli.util.setDrawableTint
 
 /**
- * @return An icon for the given [Notification.Type], appropriately coloured.
+ * @return An icon for the given [NotificationViewData], appropriately coloured.
  */
-fun NotificationEntity.Type.icon(context: Context) = when (this) {
-    NotificationEntity.Type.UNKNOWN -> getIconWithColor(
+fun NotificationViewData.icon(context: Context) = when (this) {
+    is UnknownNotificationViewData -> getIconWithColor(
         context,
         R.drawable.ic_home_24dp,
         androidx.appcompat.R.attr.colorPrimary,
     )
 
-    NotificationEntity.Type.MENTION -> getIconWithColor(
+    is MentionNotificationViewData -> getIconWithColor(
         context,
         app.pachli.core.ui.R.drawable.ic_mention_24dp,
         androidx.appcompat.R.attr.colorPrimary,
     )
 
-    NotificationEntity.Type.REBLOG -> getIconWithColor(
+    is ReblogNotificationViewData -> getIconWithColor(
         context,
         R.drawable.ic_repeat_24dp,
         androidx.appcompat.R.attr.colorPrimary,
     )
 
-    NotificationEntity.Type.FAVOURITE -> getIconWithColor(
+    is FavouriteNotificationViewData -> getIconWithColor(
         context,
         R.drawable.ic_star_24dp,
         app.pachli.core.designsystem.R.attr.favoriteIconColor,
     )
 
-    NotificationEntity.Type.FOLLOW -> getIconWithColor(
+    is FollowNotificationViewData -> getIconWithColor(
         context,
         app.pachli.core.ui.R.drawable.ic_person_add_24dp,
         androidx.appcompat.R.attr.colorPrimary,
     )
 
-    NotificationEntity.Type.FOLLOW_REQUEST -> getIconWithColor(
+    is FollowRequestNotificationViewData -> getIconWithColor(
         context,
         app.pachli.core.ui.R.drawable.ic_person_add_24dp,
         androidx.appcompat.R.attr.colorPrimary,
     )
 
-    NotificationEntity.Type.POLL -> getIconWithColor(
+    is PollNotificationViewData -> getIconWithColor(
         context,
         R.drawable.ic_poll_24dp,
         androidx.appcompat.R.attr.colorPrimary,
     )
 
-    NotificationEntity.Type.STATUS -> getIconWithColor(
+    is StatusNotificationViewData -> getIconWithColor(
         context,
         R.drawable.ic_home_24dp,
         androidx.appcompat.R.attr.colorPrimary,
     )
 
-    NotificationEntity.Type.UPDATE -> getIconWithColor(
+    is UpdateNotificationViewData -> getIconWithColor(
         context,
         R.drawable.ic_edit_24dp,
         androidx.appcompat.R.attr.colorPrimary,

--- a/app/src/main/java/app/pachli/components/notifications/NotificationsPagingAdapter.kt
+++ b/app/src/main/java/app/pachli/components/notifications/NotificationsPagingAdapter.kt
@@ -26,8 +26,20 @@ import app.pachli.R
 import app.pachli.adapter.FollowRequestViewHolder
 import app.pachli.adapter.ReportNotificationViewHolder
 import app.pachli.core.data.model.NotificationViewData
+import app.pachli.core.data.model.NotificationViewData.FollowNotificationViewData
+import app.pachli.core.data.model.NotificationViewData.FollowRequestNotificationViewData
+import app.pachli.core.data.model.NotificationViewData.ModerationWarningNotificationViewData
+import app.pachli.core.data.model.NotificationViewData.ReportNotificationViewData
+import app.pachli.core.data.model.NotificationViewData.SeveredRelationshipsNotificationViewData
+import app.pachli.core.data.model.NotificationViewData.SignupNotificationViewData
+import app.pachli.core.data.model.NotificationViewData.UnknownNotificationViewData
+import app.pachli.core.data.model.NotificationViewData.WithStatus.FavouriteNotificationViewData
+import app.pachli.core.data.model.NotificationViewData.WithStatus.MentionNotificationViewData
+import app.pachli.core.data.model.NotificationViewData.WithStatus.PollNotificationViewData
+import app.pachli.core.data.model.NotificationViewData.WithStatus.ReblogNotificationViewData
+import app.pachli.core.data.model.NotificationViewData.WithStatus.StatusNotificationViewData
+import app.pachli.core.data.model.NotificationViewData.WithStatus.UpdateNotificationViewData
 import app.pachli.core.data.model.StatusDisplayOptions
-import app.pachli.core.database.model.NotificationEntity
 import app.pachli.core.model.AccountFilterDecision
 import app.pachli.core.model.FilterAction
 import app.pachli.core.ui.SetStatusContent
@@ -78,33 +90,34 @@ enum class NotificationViewKind {
     ;
 
     companion object {
-        fun from(kind: NotificationEntity.Type?): NotificationViewKind {
-            return when (kind) {
-                NotificationEntity.Type.MENTION,
-                NotificationEntity.Type.POLL,
+        fun from(viewData: NotificationViewData?): NotificationViewKind {
+            return when (viewData) {
+                is MentionNotificationViewData,
+                is PollNotificationViewData,
                 -> STATUS
 
-                NotificationEntity.Type.FAVOURITE,
-                NotificationEntity.Type.REBLOG,
-                NotificationEntity.Type.STATUS,
-                NotificationEntity.Type.UPDATE,
+                is FavouriteNotificationViewData,
+                is ReblogNotificationViewData,
+                is StatusNotificationViewData,
+                is UpdateNotificationViewData,
                 -> NOTIFICATION
 
-                NotificationEntity.Type.FOLLOW,
-                NotificationEntity.Type.SIGN_UP,
+                is FollowNotificationViewData,
+                is SignupNotificationViewData,
                 -> FOLLOW
-                NotificationEntity.Type.FOLLOW_REQUEST -> FOLLOW_REQUEST
-                NotificationEntity.Type.REPORT -> REPORT
-                NotificationEntity.Type.SEVERED_RELATIONSHIPS -> SEVERED_RELATIONSHIPS
-                NotificationEntity.Type.MODERATION_WARNING -> MODERATION_WARNING
-                NotificationEntity.Type.UNKNOWN -> UNKNOWN
+
+                is FollowRequestNotificationViewData -> FOLLOW_REQUEST
+                is ReportNotificationViewData -> REPORT
+                is SeveredRelationshipsNotificationViewData -> SEVERED_RELATIONSHIPS
+                is ModerationWarningNotificationViewData -> MODERATION_WARNING
+                is UnknownNotificationViewData -> UNKNOWN
                 null -> UNKNOWN
             }
         }
     }
 }
 
-interface NotificationActionListener : StatusActionListener<NotificationViewData> {
+interface NotificationActionListener : StatusActionListener<NotificationViewData.WithStatus> {
     fun onViewReport(reportId: String)
 
     /**
@@ -115,7 +128,7 @@ interface NotificationActionListener : StatusActionListener<NotificationViewData
      */
     fun onNotificationContentCollapsedChange(
         isCollapsed: Boolean,
-        viewData: NotificationViewData,
+        viewData: NotificationViewData.WithStatus,
     )
 
     /**
@@ -147,10 +160,10 @@ class NotificationsPagingAdapter(
 ) : PagingDataAdapter<NotificationViewData, RecyclerView.ViewHolder>(diffCallback) {
 
     /** View holders in this adapter must implement this interface. */
-    interface ViewHolder {
+    interface ViewHolder<T : NotificationViewData> {
         /** Bind the data from the notification and payloads to the view. */
         fun bind(
-            viewData: NotificationViewData,
+            viewData: T,
             payloads: List<List<Any?>>?,
             statusDisplayOptions: StatusDisplayOptions,
         )
@@ -158,7 +171,7 @@ class NotificationsPagingAdapter(
 
     override fun getItemViewType(position: Int): Int {
         val item = getItem(position)
-        if (item?.statusViewData?.contentFilterAction == FilterAction.WARN) {
+        if (item is NotificationViewData.WithStatus && item.statusViewData.contentFilterAction == FilterAction.WARN) {
             return NotificationViewKind.STATUS_FILTERED.ordinal
         }
 
@@ -166,7 +179,7 @@ class NotificationsPagingAdapter(
             return NotificationViewKind.ACCOUNT_FILTERED.ordinal
         }
 
-        return NotificationViewKind.from(item?.type).ordinal
+        return NotificationViewKind.from(item).ordinal
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
@@ -208,7 +221,6 @@ class NotificationsPagingAdapter(
                 FollowViewHolder(
                     ItemFollowBinding.inflate(inflater, parent, false),
                     glide,
-                    notificationActionListener,
                     notificationActionListener,
                 )
             }
@@ -260,7 +272,7 @@ class NotificationsPagingAdapter(
 
     private fun bindViewHolder(holder: RecyclerView.ViewHolder, position: Int, payloads: List<List<Any?>>?) {
         getItem(position)?.let {
-            (holder as ViewHolder).bind(it, payloads, statusDisplayOptions)
+            (holder as ViewHolder<NotificationViewData>).bind(it, payloads, statusDisplayOptions)
         }
     }
 
@@ -270,9 +282,9 @@ class NotificationsPagingAdapter(
      */
     private class FallbackNotificationViewHolder(
         val binding: ItemUnknownNotificationBinding,
-    ) : ViewHolder, RecyclerView.ViewHolder(binding.root) {
+    ) : ViewHolder<UnknownNotificationViewData>, RecyclerView.ViewHolder(binding.root) {
         override fun bind(
-            viewData: NotificationViewData,
+            viewData: UnknownNotificationViewData,
             payloads: List<List<Any?>>?,
             statusDisplayOptions: StatusDisplayOptions,
         ) {

--- a/app/src/main/java/app/pachli/components/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/app/pachli/components/notifications/NotificationsViewModel.kt
@@ -659,7 +659,7 @@ class NotificationsViewModel @AssistedInject constructor(
                             isAboutSelf = isAboutSelf,
                         )
                     }
-                    .filter { it.statusViewData?.contentFilterAction != FilterAction.HIDE }
+                    .filter { it !is NotificationViewData.WithStatus || it.statusViewData.contentFilterAction != FilterAction.HIDE }
                     .filter { it.accountFilterDecision !is AccountFilterDecision.Hide }
             }
     }

--- a/app/src/main/java/app/pachli/components/notifications/SeveredRelationshipsViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/notifications/SeveredRelationshipsViewHolder.kt
@@ -21,7 +21,7 @@ import androidx.core.text.HtmlCompat
 import androidx.recyclerview.widget.RecyclerView
 import app.pachli.R
 import app.pachli.adapter.StatusViewDataDiffCallback
-import app.pachli.core.data.model.NotificationViewData
+import app.pachli.core.data.model.NotificationViewData.SeveredRelationshipsNotificationViewData
 import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.model.RelationshipSeveranceEvent.Type.ACCOUNT_SUSPENSION
 import app.pachli.core.model.RelationshipSeveranceEvent.Type.DOMAIN_BLOCK
@@ -32,14 +32,14 @@ import app.pachli.databinding.ItemSeveredRelationshipsBinding
 
 class SeveredRelationshipsViewHolder(
     private val binding: ItemSeveredRelationshipsBinding,
-) : NotificationsPagingAdapter.ViewHolder, RecyclerView.ViewHolder(binding.root) {
+) : NotificationsPagingAdapter.ViewHolder<SeveredRelationshipsNotificationViewData>, RecyclerView.ViewHolder(binding.root) {
     override fun bind(
-        viewData: NotificationViewData,
+        viewData: SeveredRelationshipsNotificationViewData,
         payloads: List<List<Any?>>?,
         statusDisplayOptions: StatusDisplayOptions,
     ) {
         val context = itemView.context
-        val event = viewData.relationshipSeveranceEvent!!
+        val event = viewData.relationshipSeveranceEvent
 
         if (payloads.isNullOrEmpty()) {
             val topTextHtml = when (event.type) {

--- a/app/src/main/java/app/pachli/components/notifications/StatusViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/notifications/StatusViewHolder.kt
@@ -19,44 +19,40 @@ package app.pachli.components.notifications
 
 import app.pachli.adapter.FilterableStatusViewHolder
 import app.pachli.adapter.StatusViewHolder
-import app.pachli.core.data.model.NotificationViewData
+import app.pachli.core.data.model.NotificationViewData.WithStatus
 import app.pachli.core.data.model.StatusDisplayOptions
-import app.pachli.core.database.model.NotificationEntity
 import app.pachli.core.ui.SetStatusContent
 import app.pachli.core.ui.StatusActionListener
 import app.pachli.databinding.ItemStatusBinding
 import app.pachli.databinding.ItemStatusWrapperBinding
 import com.bumptech.glide.RequestManager
 
+/**
+ * Displays any notification of type
+ * [NotificationViewData.WithStatus][app.pachli.core.data.model.NotificationViewData.WithStatus].
+ */
 internal class StatusViewHolder(
     binding: ItemStatusBinding,
     glide: RequestManager,
     setStatusContent: SetStatusContent,
     private val statusActionListener: NotificationActionListener,
-) : NotificationsPagingAdapter.ViewHolder, StatusViewHolder<NotificationViewData>(binding, glide, setStatusContent) {
+) : NotificationsPagingAdapter.ViewHolder<WithStatus>, StatusViewHolder<WithStatus>(binding, glide, setStatusContent) {
 
     override fun bind(
-        viewData: NotificationViewData,
+        viewData: WithStatus,
         payloads: List<List<Any?>>?,
         statusDisplayOptions: StatusDisplayOptions,
     ) {
-        val statusViewData = viewData.statusViewData
-        if (statusViewData == null) {
-            // Hide null statuses. Shouldn't happen according to the spec, but some servers
-            // have been seen to do this (https://github.com/tuskyapp/Tusky/issues/2252)
-            showStatusContent(false)
-        } else {
-            if (payloads.isNullOrEmpty()) {
-                showStatusContent(true)
-            }
-            setupWithStatus(
-                viewData,
-                statusActionListener,
-                statusDisplayOptions,
-                payloads,
-            )
+        if (payloads.isNullOrEmpty()) {
+            showStatusContent(true)
         }
-        if (viewData.type == NotificationEntity.Type.POLL) {
+        setupWithStatus(
+            viewData,
+            statusActionListener,
+            statusDisplayOptions,
+            payloads,
+        )
+        if (viewData is WithStatus.PollNotificationViewData) {
             setPollInfo(viewData.isAboutSelf)
         } else {
             hideStatusInfo()
@@ -68,31 +64,24 @@ class FilterableStatusViewHolder(
     binding: ItemStatusWrapperBinding,
     glide: RequestManager,
     setStatusContent: SetStatusContent,
-    private val statusActionListener: StatusActionListener<NotificationViewData>,
-) : NotificationsPagingAdapter.ViewHolder, FilterableStatusViewHolder<NotificationViewData>(binding, glide, setStatusContent) {
+    private val statusActionListener: StatusActionListener<WithStatus>,
+) : NotificationsPagingAdapter.ViewHolder<WithStatus>, FilterableStatusViewHolder<WithStatus>(binding, glide, setStatusContent) {
     // Note: Identical to bind() in StatusViewHolder above
     override fun bind(
-        viewData: NotificationViewData,
+        viewData: WithStatus,
         payloads: List<List<Any?>>?,
         statusDisplayOptions: StatusDisplayOptions,
     ) {
-        val statusViewData = viewData.statusViewData
-        if (statusViewData == null) {
-            // Hide null statuses. Shouldn't happen according to the spec, but some servers
-            // have been seen to do this (https://github.com/tuskyapp/Tusky/issues/2252)
-            showStatusContent(false)
-        } else {
-            if (payloads.isNullOrEmpty()) {
-                showStatusContent(true)
-            }
-            setupWithStatus(
-                viewData,
-                statusActionListener,
-                statusDisplayOptions,
-                payloads,
-            )
+        if (payloads.isNullOrEmpty()) {
+            showStatusContent(true)
         }
-        if (viewData.type == NotificationEntity.Type.POLL) {
+        setupWithStatus(
+            viewData,
+            statusActionListener,
+            statusDisplayOptions,
+            payloads,
+        )
+        if (viewData is WithStatus.PollNotificationViewData) {
             setPollInfo(viewData.isAboutSelf)
         } else {
             hideStatusInfo()

--- a/app/src/main/java/app/pachli/util/ListStatusAccessibilityDelegate.kt
+++ b/app/src/main/java/app/pachli/util/ListStatusAccessibilityDelegate.kt
@@ -14,7 +14,6 @@ import app.pachli.adapter.FilterableStatusViewHolder
 import app.pachli.adapter.StatusBaseViewHolder
 import app.pachli.core.activity.OpenUrlUseCase
 import app.pachli.core.data.model.IStatusViewData
-import app.pachli.core.data.model.NotificationViewData
 import app.pachli.core.model.AttachmentDisplayAction
 import app.pachli.core.model.AttachmentDisplayReason
 import app.pachli.core.model.Status.Companion.MAX_MEDIA_ATTACHMENTS
@@ -54,13 +53,6 @@ class ListStatusAccessibilityDelegate<T : IStatusViewData>(
 
             val pos = recyclerView.getChildAdapterPosition(host)
             val status = statusProvider.getStatus(pos) ?: return
-
-            // Ignore notifications that don't have an associated statusViewData,
-            // otherwise the accessors throw IllegalStateException.
-            // See https://github.com/pachli/pachli-android/issues/669
-            if (status as? NotificationViewData != null) {
-                if (status.statusViewData == null) return
-            }
 
             val actionable = status.actionable
             if (actionable.spoilerText.isNotEmpty()) {

--- a/core/data/src/main/kotlin/app/pachli/core/data/model/StatusViewData.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/model/StatusViewData.kt
@@ -36,6 +36,11 @@ interface IStatusViewData {
     /** ID of the Pachli account that loaded this status. */
     val pachliAccountId: Long
     val username: String
+
+    // TODO: rebloggedAvatar is the wrong name for this property. This is the avatar to show
+    // inset in the main avatar view. When viewing a boosted status in a timeline this is
+    // avatar that boosted it, but when viewing a notification about a boost or favourite
+    // this the avatar that boosted/favourited it
     val rebloggedAvatar: String?
 
     var translation: TranslatedStatusEntity?

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/NotificationStatusView.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/NotificationStatusView.kt
@@ -35,7 +35,7 @@ class NotificationStatusView @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0,
     defStyleRes: Int = 0,
-) : StatusView<NotificationViewData>(context, attrs, defStyleAttr, defStyleRes) {
+) : StatusView<NotificationViewData.WithStatus>(context, attrs, defStyleAttr, defStyleRes) {
     val binding = StatusContentConversationBinding.inflate(LayoutInflater.from(context), this)
 
     override val avatar = binding.statusAvatar

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/extensions/NotificationViewDataExtensions.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/extensions/NotificationViewDataExtensions.kt
@@ -18,9 +18,23 @@
 package app.pachli.core.ui.extensions
 
 import app.pachli.core.data.model.NotificationViewData
+import app.pachli.core.data.model.NotificationViewData.FollowNotificationViewData
+import app.pachli.core.data.model.NotificationViewData.FollowRequestNotificationViewData
+import app.pachli.core.data.model.NotificationViewData.ModerationWarningNotificationViewData
+import app.pachli.core.data.model.NotificationViewData.ReportNotificationViewData
+import app.pachli.core.data.model.NotificationViewData.SeveredRelationshipsNotificationViewData
+import app.pachli.core.data.model.NotificationViewData.SignupNotificationViewData
+import app.pachli.core.data.model.NotificationViewData.UnknownNotificationViewData
+import app.pachli.core.data.model.NotificationViewData.WithStatus.FavouriteNotificationViewData
+import app.pachli.core.data.model.NotificationViewData.WithStatus.MentionNotificationViewData
+import app.pachli.core.data.model.NotificationViewData.WithStatus.PollNotificationViewData
+import app.pachli.core.data.model.NotificationViewData.WithStatus.ReblogNotificationViewData
+import app.pachli.core.data.model.NotificationViewData.WithStatus.StatusNotificationViewData
+import app.pachli.core.data.model.NotificationViewData.WithStatus.UpdateNotificationViewData
 import app.pachli.core.data.model.StatusViewData
 import app.pachli.core.database.model.AccountEntity
 import app.pachli.core.database.model.NotificationData
+import app.pachli.core.database.model.NotificationEntity
 import app.pachli.core.database.model.asModel
 import app.pachli.core.model.AccountFilterDecision
 import app.pachli.core.model.FilterAction
@@ -44,29 +58,208 @@ fun NotificationViewData.Companion.make(
     contentFilterAction: FilterAction,
     accountFilterDecision: AccountFilterDecision?,
     isAboutSelf: Boolean,
-) = NotificationViewData(
-    pachliAccountId = pachliAccountEntity.id,
-    localDomain = pachliAccountEntity.domain,
-    type = data.notification.type,
-    id = data.notification.serverId,
-    account = data.account.asModel(),
-    statusViewData = data.status?.let {
-        StatusViewData.from(
-            pachliAccountId = pachliAccountEntity.id,
-            it,
-            isExpanded = isExpanded,
-            isDetailed = false,
-            contentFilterAction = contentFilterAction,
-            attachmentDisplayAction = it.getAttachmentDisplayAction(
-                FilterContext.NOTIFICATIONS,
-                showSensitiveMedia,
-                it.viewData?.attachmentDisplayAction,
-            ),
-        )
-    },
-    report = data.report,
-    relationshipSeveranceEvent = data.relationshipSeveranceEvent?.asModel(),
-    isAboutSelf = isAboutSelf,
-    accountFilterDecision = accountFilterDecision ?: AccountFilterDecision.None,
-    accountWarning = data.accountWarning?.asModel(),
-)
+) = when (data.notification.type) {
+    NotificationEntity.Type.UNKNOWN -> UnknownNotificationViewData(
+        pachliAccountId = pachliAccountEntity.id,
+        localDomain = pachliAccountEntity.domain,
+        id = data.notification.serverId,
+        account = data.account.asModel(),
+        isAboutSelf = isAboutSelf,
+        accountFilterDecision = accountFilterDecision ?: AccountFilterDecision.None,
+    )
+
+    NotificationEntity.Type.MENTION -> MentionNotificationViewData(
+        pachliAccountId = pachliAccountEntity.id,
+        localDomain = pachliAccountEntity.domain,
+        id = data.notification.serverId,
+        account = data.account.asModel(),
+        isAboutSelf = isAboutSelf,
+        accountFilterDecision = accountFilterDecision ?: AccountFilterDecision.None,
+        statusViewData = data.status!!.let {
+            StatusViewData.from(
+                pachliAccountId = pachliAccountEntity.id,
+                it,
+                isExpanded = isExpanded,
+                isDetailed = false,
+                contentFilterAction = contentFilterAction,
+                attachmentDisplayAction = it.getAttachmentDisplayAction(
+                    FilterContext.NOTIFICATIONS,
+                    showSensitiveMedia,
+                    it.viewData?.attachmentDisplayAction,
+                ),
+            )
+        },
+    )
+
+    NotificationEntity.Type.REBLOG -> ReblogNotificationViewData(
+        pachliAccountId = pachliAccountEntity.id,
+        localDomain = pachliAccountEntity.domain,
+        id = data.notification.serverId,
+        account = data.account.asModel(),
+        isAboutSelf = isAboutSelf,
+        accountFilterDecision = accountFilterDecision ?: AccountFilterDecision.None,
+        statusViewData = data.status!!.let {
+            StatusViewData.from(
+                pachliAccountId = pachliAccountEntity.id,
+                it,
+                isExpanded = isExpanded,
+                isDetailed = false,
+                contentFilterAction = contentFilterAction,
+                attachmentDisplayAction = it.getAttachmentDisplayAction(
+                    FilterContext.NOTIFICATIONS,
+                    showSensitiveMedia,
+                    it.viewData?.attachmentDisplayAction,
+                ),
+            )
+        },
+    )
+
+    NotificationEntity.Type.FAVOURITE -> FavouriteNotificationViewData(
+        pachliAccountId = pachliAccountEntity.id,
+        localDomain = pachliAccountEntity.domain,
+        id = data.notification.serverId,
+        account = data.account.asModel(),
+        isAboutSelf = isAboutSelf,
+        accountFilterDecision = accountFilterDecision ?: AccountFilterDecision.None,
+        statusViewData = data.status!!.let {
+            StatusViewData.from(
+                pachliAccountId = pachliAccountEntity.id,
+                it,
+                isExpanded = isExpanded,
+                isDetailed = false,
+                contentFilterAction = contentFilterAction,
+                attachmentDisplayAction = it.getAttachmentDisplayAction(
+                    FilterContext.NOTIFICATIONS,
+                    showSensitiveMedia,
+                    it.viewData?.attachmentDisplayAction,
+                ),
+            )
+        },
+    )
+
+    NotificationEntity.Type.FOLLOW -> FollowNotificationViewData(
+        pachliAccountId = pachliAccountEntity.id,
+        localDomain = pachliAccountEntity.domain,
+        id = data.notification.serverId,
+        isAboutSelf = isAboutSelf,
+        accountFilterDecision = accountFilterDecision ?: AccountFilterDecision.None,
+        account = data.account.asModel(),
+    )
+
+    NotificationEntity.Type.FOLLOW_REQUEST -> FollowRequestNotificationViewData(
+        pachliAccountId = pachliAccountEntity.id,
+        localDomain = pachliAccountEntity.domain,
+        id = data.notification.serverId,
+        isAboutSelf = isAboutSelf,
+        accountFilterDecision = accountFilterDecision ?: AccountFilterDecision.None,
+        account = data.account.asModel(),
+    )
+
+    NotificationEntity.Type.POLL -> PollNotificationViewData(
+        pachliAccountId = pachliAccountEntity.id,
+        localDomain = pachliAccountEntity.domain,
+        id = data.notification.serverId,
+        account = data.account.asModel(),
+        isAboutSelf = isAboutSelf,
+        accountFilterDecision = accountFilterDecision ?: AccountFilterDecision.None,
+        statusViewData = data.status!!.let {
+            StatusViewData.from(
+                pachliAccountId = pachliAccountEntity.id,
+                it,
+                isExpanded = isExpanded,
+                isDetailed = false,
+                contentFilterAction = contentFilterAction,
+                attachmentDisplayAction = it.getAttachmentDisplayAction(
+                    FilterContext.NOTIFICATIONS,
+                    showSensitiveMedia,
+                    it.viewData?.attachmentDisplayAction,
+                ),
+            )
+        },
+    )
+
+    NotificationEntity.Type.STATUS -> StatusNotificationViewData(
+        pachliAccountId = pachliAccountEntity.id,
+        localDomain = pachliAccountEntity.domain,
+        id = data.notification.serverId,
+        account = data.account.asModel(),
+        isAboutSelf = isAboutSelf,
+        accountFilterDecision = accountFilterDecision ?: AccountFilterDecision.None,
+        statusViewData = data.status!!.let {
+            StatusViewData.from(
+                pachliAccountId = pachliAccountEntity.id,
+                it,
+                isExpanded = isExpanded,
+                isDetailed = false,
+                contentFilterAction = contentFilterAction,
+                attachmentDisplayAction = it.getAttachmentDisplayAction(
+                    FilterContext.NOTIFICATIONS,
+                    showSensitiveMedia,
+                    it.viewData?.attachmentDisplayAction,
+                ),
+            )
+        },
+    )
+
+    NotificationEntity.Type.SIGN_UP -> SignupNotificationViewData(
+        pachliAccountId = pachliAccountEntity.id,
+        localDomain = pachliAccountEntity.domain,
+        id = data.notification.serverId,
+        isAboutSelf = isAboutSelf,
+        accountFilterDecision = accountFilterDecision ?: AccountFilterDecision.None,
+        account = data.account.asModel(),
+    )
+
+    NotificationEntity.Type.UPDATE -> UpdateNotificationViewData(
+        pachliAccountId = pachliAccountEntity.id,
+        localDomain = pachliAccountEntity.domain,
+        id = data.notification.serverId,
+        account = data.account.asModel(),
+        isAboutSelf = isAboutSelf,
+        accountFilterDecision = accountFilterDecision ?: AccountFilterDecision.None,
+        statusViewData = data.status!!.let {
+            StatusViewData.from(
+                pachliAccountId = pachliAccountEntity.id,
+                it,
+                isExpanded = isExpanded,
+                isDetailed = false,
+                contentFilterAction = contentFilterAction,
+                attachmentDisplayAction = it.getAttachmentDisplayAction(
+                    FilterContext.NOTIFICATIONS,
+                    showSensitiveMedia,
+                    it.viewData?.attachmentDisplayAction,
+                ),
+            )
+        },
+    )
+
+    NotificationEntity.Type.REPORT -> ReportNotificationViewData(
+        pachliAccountId = pachliAccountEntity.id,
+        localDomain = pachliAccountEntity.domain,
+        id = data.notification.serverId,
+        account = data.account.asModel(),
+        isAboutSelf = isAboutSelf,
+        accountFilterDecision = accountFilterDecision ?: AccountFilterDecision.None,
+        report = data.report!!,
+    )
+
+    NotificationEntity.Type.SEVERED_RELATIONSHIPS -> SeveredRelationshipsNotificationViewData(
+        pachliAccountId = pachliAccountEntity.id,
+        localDomain = pachliAccountEntity.domain,
+        id = data.notification.serverId,
+        account = data.account.asModel(),
+        isAboutSelf = isAboutSelf,
+        accountFilterDecision = accountFilterDecision ?: AccountFilterDecision.None,
+        relationshipSeveranceEvent = data.relationshipSeveranceEvent!!.asModel(),
+    )
+
+    NotificationEntity.Type.MODERATION_WARNING -> ModerationWarningNotificationViewData(
+        pachliAccountId = pachliAccountEntity.id,
+        localDomain = pachliAccountEntity.domain,
+        id = data.notification.serverId,
+        account = data.account.asModel(),
+        isAboutSelf = isAboutSelf,
+        accountFilterDecision = accountFilterDecision ?: AccountFilterDecision.None,
+        accountWarning = data.accountWarning!!.asModel(),
+    )
+}


### PR DESCRIPTION
Previous code had a single `NotificationViewData` type to cover all possible types of notifications.

This meant it had to have a number of nullable properties, and a `type` property. Every time code interacted with `NotificationViewData` it had to inspect the `type` property and assume/hope the nullable properties were correctly non-null for that particular type of notification.

Improve this by converting `NotificationViewData` to a sealed interface. Each distinct notification type is a class that implements this interface and just the (non-nullable) properties it needs.

Add a `NotificationViewData.WithStatus` interface to cover the multiple notification types that have an embedded `StatusViewData`. This implements `IStatusViewData` by delegating to the embedded `statusViewData`, and allows e.g,. the accessibility to exclusively operate on types that implement `IStatusViewData`, removing additional code complexity in that class.