### PR TITLE
fix: Click on notification top text to open the referenced account

### DIFF
--- a/app/src/main/java/app/pachli/components/notifications/StatusNotificationViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/notifications/StatusNotificationViewHolder.kt
@@ -59,6 +59,10 @@ internal class StatusNotificationViewHolder(
         statusDisplayOptions: StatusDisplayOptions,
     ) {
         if (payloads.isNullOrEmpty()) {
+            binding.notificationTopText.setOnClickListener {
+                notificationActionListener.onViewAccount(viewData.account.id)
+            }
+
             binding.statusView.setupWithStatus(
                 setStatusContent,
                 glide,


### PR DESCRIPTION
Behaviour was omitted in the refactoring in
49ccf30ca32965c3e0202f762125037ac9ac8f9d