### PR TITLE
fix: Show reported post when reporting an account

### DIFF
--- a/app/src/main/java/app/pachli/components/report/ReportActivity.kt
+++ b/app/src/main/java/app/pachli/components/report/ReportActivity.kt
@@ -27,14 +27,17 @@ import app.pachli.R
 import app.pachli.components.report.adapter.ReportPagerAdapter
 import app.pachli.core.activity.ViewUrlActivity
 import app.pachli.core.common.extensions.viewBinding
+import app.pachli.core.model.Timeline
 import app.pachli.core.navigation.ReportActivityIntent
 import app.pachli.core.navigation.pachliAccountId
 import app.pachli.core.ui.extensions.InsetType
 import app.pachli.core.ui.extensions.applyDefaultWindowInsets
 import app.pachli.core.ui.extensions.applyWindowInsets
 import app.pachli.databinding.ActivityReportBinding
+import app.pachli.usecase.TimelineCases
 import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.lifecycle.withCreationCallback
+import javax.inject.Inject
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
@@ -54,6 +57,9 @@ class ReportActivity : ViewUrlActivity() {
             }
         },
     )
+
+    @Inject
+    lateinit var timelineCases: TimelineCases
 
     private val binding by viewBinding(ActivityReportBinding::inflate)
 
@@ -84,6 +90,14 @@ class ReportActivity : ViewUrlActivity() {
             setDisplayShowHomeEnabled(true)
             setHomeAsUpIndicator(app.pachli.core.ui.R.drawable.ic_close_24dp)
         }
+
+        // Save the ID of the reported status as the "refresh status ID", so it is
+        // focused in the initial list of statuses shown to the user.
+        timelineCases.saveRefreshStatusId(
+            intent.pachliAccountId,
+            Timeline.User.Replies(ReportActivityIntent.getAccountId(intent)).remoteKeyTimelineId,
+            ReportActivityIntent.getStatusId(intent),
+        )
 
         initViewPager()
         bind()

--- a/app/src/main/java/app/pachli/components/timeline/NetworkTimelineRepository.kt
+++ b/app/src/main/java/app/pachli/components/timeline/NetworkTimelineRepository.kt
@@ -139,7 +139,7 @@ class NetworkTimelineRepository @Inject constructor(
 
         Timber.d("timeline: $timeline, initialKey: $initialKey")
         factory = InvalidatingPagingSourceFactory {
-            NetworkTimelinePagingSource(pageCache)
+            NetworkTimelinePagingSource(pageCache, initialKey)
         }
 
         // Track changes to tables that might be changed by user actions. Changes to

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelineRemoteMediator.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelineRemoteMediator.kt
@@ -186,6 +186,16 @@ class NetworkTimelineRemoteMediator(
                 api.publicTimeline(local = false, minId = minId, maxId = maxId, limit = limit)
             }
 
+            is Timeline.User.Replies -> getPageAround(statusId, pageSize) { maxId, minId, limit ->
+                api.accountStatuses(
+                    timeline.id,
+                    maxId = maxId,
+                    minId = minId,
+                    limit = limit,
+                    excludeReblogs = timeline.excludeReblogs,
+                )
+            }
+
             is Timeline.UserList -> getPageAround(statusId, pageSize) { maxId, minId, limit ->
                 api.listTimeline(minId = minId, maxId = maxId, limit = limit, listId = timeline.listId)
             }

--- a/core/model/src/main/kotlin/app/pachli/core/model/Timeline.kt
+++ b/core/model/src/main/kotlin/app/pachli/core/model/Timeline.kt
@@ -110,7 +110,10 @@ sealed class Timeline : Parcelable {
         data class Replies(
             override val id: String,
             val excludeReblogs: Boolean = false,
-        ) : User()
+        ) : User() {
+            @IgnoredOnParcel
+            override val remoteKeyTimelineId: String = "USER.REPLIES:$id"
+        }
     }
 
     @TypeLabel("favourites")


### PR DESCRIPTION
This used to be the behaviour, and was dropped in the refactoring in 49ccf30ca32965c3e0202f762125037ac9ac8f9d.

To fix this:

- Make `Timeline.User.Replies` restoreable.
- Set the desired reading position in `ReportActivity`

This surfaced a bug in the position restoration code for network timelines. Previously, if the `state` passed to `getRefreshKey` was null the ID in middle of the first loaded page was used.

This might not work -- testing showed the desired key might be in the *second* page loaded. The `state` passed to `getRefreshKey` doesn't have the initial key that would be passed to `load`, so pass a copy of the initial key in the constructor (it may still be null), and fall back to that if the `state` is null.