### PR TITLE
fix: Don't crash on notifications with null `status` property

### DIFF
--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/notifications/NotificationsRemoteMediator.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/notifications/NotificationsRemoteMediator.kt
@@ -167,10 +167,7 @@ class NotificationsRemoteMediator(
                 }
             }
 
-            // Filter out notifications that should have a non-null status but don't.
-            val notifications = response.body.filter { notification ->
-                !notificationTypesWithStatus.contains(notification.type) || notification.status != null
-            }
+            val notifications = response.body
 
             upsertNotifications(pachliAccountId, notifications)
 


### PR DESCRIPTION
Previous code tried to fix this by filtering out these notifications at the time they're fetched from the server.

This didn't consider the possibility that the user might already have a cached copy of these broken notifications. Reading them from the database and then converting them to notifications to show in the UI would crash.

Fix this be filtering the notifications returned from `NotificationsRepository`, so it doesn't matter whether they were read from the network or the local cache.