### PR TITLE
fix: Allow for filters to be cleared on non-cached timelines

### DIFF
--- a/app/src/main/java/app/pachli/components/timeline/NetworkTimelineRepository.kt
+++ b/app/src/main/java/app/pachli/components/timeline/NetworkTimelineRepository.kt
@@ -226,6 +226,17 @@ class NetworkTimelineRepository @Inject constructor(
         invalidate()
     }
 
+    /**
+     * Updates whatever the actionable status is in the status identified by
+     * [statusId].
+     *
+     * Note: [statusId] is **not** the ID of the actionable status, it's the ID
+     * of the status that (possibly) contains it.
+     *
+     * @param statusId
+     * @param updater Function to call, receives a copy of the actionable status
+     * and returns the modified version.
+     */
     suspend fun updateActionableStatusById(statusId: String, updater: (Status) -> Status) {
         pageCache.withLock { pageCache.updateActionableStatusById(statusId, updater) }
         invalidate()

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelineViewModel.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelineViewModel.kt
@@ -149,7 +149,7 @@ open class NetworkTimelineViewModel @AssistedInject constructor(
 
     override fun clearWarning(statusViewData: StatusViewData) {
         viewModelScope.launch {
-            repository.updateActionableStatusById(statusViewData.actionableId) {
+            repository.updateActionableStatusById(statusViewData.id) {
                 it.copy(filtered = null)
             }
         }


### PR DESCRIPTION
When updating statuses based on user actions on non-cached timelines the previous code was both (a) acting on the wrong status ID (should have used the real ID, not the actionable ID), and (b) not calling the provided `updater` function if the status was a reblog.

The net effect was that if a non-cached timeline, like a list, contained a status that was both 1. a reblog, and 2. filtered, the "Clear filters" button was displayed, but didn't do anything.

Fixes #1875