### PR TITLE
feat: Support push notifications on GoToSocial

### DIFF
--- a/core/network/src/main/kotlin/app/pachli/core/network/model/NotificationSubscribeResult.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/NotificationSubscribeResult.kt
@@ -21,7 +21,15 @@ import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
 data class NotificationSubscribeResult(
-    val id: Int,
+    // Documentation about the type of `id` is inconsistent, showing it as both
+    // a string and a number (https://github.com/mastodon/mastodon/issues/36609).
+    //
+    // Mastodon returns a number, some other servers, like GoToSocial, return
+    // a string.
+    //
+    // Since we don't actually use it for anything ignore it for the moment.
+    //
+    // val id: Int,
     val endpoint: String,
     @Json(name = "server_key") val serverKey: String,
 )


### PR DESCRIPTION
The `WebPushSubscription.id` property is inconsistently documented and returned by different servers. In particular, documented as both a string and a number https://github.com/mastodon/mastodon/issues/36609.

This breaks trying to register for push notifications on GoToSocial servers. Since we don't use the property for anything just ignore it.

Fixes #1849