### PR TITLE
fix(i18n): Consistently link across translations

### DIFF
--- a/feature/login/src/main/res/values-bg/strings.xml
+++ b/feature/login/src/main/res/values-bg/strings.xml
@@ -1,16 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="dialog_whats_an_instance">Тук може да се въведе адресът или домейнът на която и да е инстанция, като mastodon.social, icosahedron.website, social.tchncs.de и &lt;a href=\"https://instances.social\"&gt;други!&lt;/a&gt;
+    <string name="dialog_whats_an_instance">Тук може да се въведе адресът или домейнът на която и да е инстанция, като mastodon.social, icosahedron.website, social.tchncs.de и <a href="https://instances.social">други!</a>
 \n
 \nАко все още нямате акаунт, можете да въведете името на инстанцията, към който искате да се присъедините, и да създадете акаунт там.
 \n
 \nИнстанцията е единично място, където се хоства акаунтът ви, но можете лесно да комуникирате и да следвате хора в други инстанции, сякаш сте на същия сайт.
 \n
-\nПовече информация можете да намерите на &lt;a href=\"https://joinmastodon.org\"&gt;joinmastodon.org&lt;/a&gt;. <a href="https://instances.social">more!</a>
-\n
-\nAn instance is a single place where your account is hosted, but you can easily communicate with and follow folks on other instances as though you were on the same site.
-\n
-\nMore info can be found at <a href="https://joinmastodon.org">joinmastodon.org</a>. </string>
+\nПовече информация можете да намерите на <a href="https://joinmastodon.org">joinmastodon.org</a>.</string>
     <string name="action_close">Затваряне</string>
     <string name="error_invalid_domain">Въведен е невалиден домейн</string>
     <string name="error_failed_app_registration_fmt">Неуспешно удостоверяване с тази инстанция: %1$s</string>

--- a/feature/login/src/main/res/values-bn-rBD/strings.xml
+++ b/feature/login/src/main/res/values-bn-rBD/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="dialog_whats_an_instance">কোনও উদাহরণের ঠিকানা বা ডোমেন এখানে প্রবেশ করা যেতে পারে যেমন mastodon.social, icosahedron.website, social.tchncs.de, এবং &lt;a href=\"https://instances.social\"&gt; আরও! &lt;/a&gt;
+    <string name="dialog_whats_an_instance">কোনও উদাহরণের ঠিকানা বা ডোমেন এখানে প্রবেশ করা যেতে পারে যেমন mastodon.social, icosahedron.website, social.tchncs.de, এবং <a href="https://instances.social">আরও!</a>
 \n
 \nআপনার যদি এখনো অ্যাকাউন্ট না থাকে তবে আপনি যে ইনস্ট্যান্সটিতে যোগ দিতে চান সেটির নামটি প্রবেশ করতে এবং সেখানে একটি অ্যাকাউন্ট তৈরি করতে পারেন।
 \n
@@ -10,11 +10,11 @@
 \n
 \n
 \n
-\nআরো তথ্য &lt;a href=\"https://joinmastodon.org\"&gt; joinmastodon.org &lt;/a&gt; এ পাওয়া যেতে পারে। <a href="https://instances.social">more!</a>
+\nআরো তথ্য <a href="https://joinmastodon.org">joinmastodon.org</a> এ পাওয়া যেতে পারে। <a href="https://instances.social">more!</a>
 \n
 \nAn instance is a single place where your account is hosted, but you can easily communicate with and follow folks on other instances as though you were on the same site.
 \n
-\nMore info can be found at <a href="https://joinmastodon.org">joinmastodon.org</a>. </string>
+\nMore info can be found at <a href="https://joinmastodon.org">joinmastodon.org</a>.</string>
     <string name="action_close">বদ্ধ</string>
     <string name="error_invalid_domain">অবৈধ ডোমেইন প্রবেশ করানো হয়েছে</string>
     <string name="error_failed_app_registration_fmt">এই ইনস্ট্যান্স এর সঙ্গে প্রমাণীকরণ ব্যর্থ।: %1$s</string>

--- a/feature/login/src/main/res/values-pt-rBR/strings.xml
+++ b/feature/login/src/main/res/values-pt-rBR/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="dialog_whats_an_instance">"O domínio de qualquer instância pode ser inserido aqui, tal como mastodon.social, masto.donte.com.br, colorid.es ou &lt;a href=\"https://instances.social\"&gt;qualquer outro&lt;/a&gt;!\n\n\n\n\n\n\n\nSe não tem uma conta ainda, insira o nome da instância que gostaria de participar e crie uma conta lá.\n\n\n\n\n\n\n\nUma instância é um lugar único onde tua conta é hospedada, mas pode te comunicar facilmente e seguir pessoas de outras instâncias como se todos estivessem no mesmo lugar.\n\n\n\n\n\n\n\nMais informações podem ser encontradas em &lt;a href=https://joinmastodon.org/pt-BR\"&gt;joinmastodon.org/pt-BR&lt;/a&gt;. "</string>
+    <string name="dialog_whats_an_instance">"O domínio de qualquer instância pode ser inserido aqui, tal como mastodon.social, masto.donte.com.br, colorid.es ou <a href="https://instances.social">qualquer outro</a>!\n\nSe não tem uma conta ainda, insira o nome da instância que gostaria de participar e crie uma conta lá.\n\nUma instância é um lugar único onde tua conta é hospedada, mas pode te comunicar facilmente e seguir pessoas de outras instâncias como se todos estivessem no mesmo lugar.\n\nMais informações podem ser encontradas em <a href="https://joinmastodon.org/pt-BR">joinmastodon.org/pt-BR</a>.</string>
     <string name="action_close">Fechar</string>
     <string name="action_browser_login">Entrar com navegador</string>
     <string name="error_invalid_domain">Domínio inválido</string>


### PR DESCRIPTION
Some previous translations were using `&lt;a href...>...&lt;/a>` in some translated text.

Android's rules for this are conflicting. This is correct if the string resource is used with `getString`, but wrong if the resource will be passed to `getText`.

Fix these.