### PR TITLE
change: Move strings used when a status is filtered to core.ui

### DIFF
--- a/app/src/main/java/app/pachli/adapter/FilterableStatusViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/FilterableStatusViewHolder.kt
@@ -19,7 +19,6 @@ package app.pachli.adapter
 
 import android.view.View
 import androidx.core.text.HtmlCompat
-import app.pachli.R
 import app.pachli.core.data.model.IStatusViewData
 import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.model.ContentFilter
@@ -63,7 +62,7 @@ open class FilterableStatusViewHolder<T : IStatusViewData>(
 
             val label = HtmlCompat.fromHtml(
                 context.getString(
-                    R.string.status_filter_placeholder_label_format,
+                    app.pachli.core.ui.R.string.status_filter_placeholder_label_format,
                     result.filter.title,
                 ),
                 HtmlCompat.FROM_HTML_MODE_LEGACY,

--- a/app/src/main/java/app/pachli/components/filters/EditContentFilterActivity.kt
+++ b/app/src/main/java/app/pachli/components/filters/EditContentFilterActivity.kt
@@ -122,7 +122,7 @@ class EditContentFilterActivity : BaseActivity() {
         setTitle(
             when (viewModel.uiMode) {
                 UiMode.CREATE -> R.string.filter_addition_title
-                UiMode.EDIT -> R.string.filter_edit_title
+                UiMode.EDIT -> app.pachli.core.ui.R.string.filter_edit_title
             },
         )
 

--- a/app/src/main/java/app/pachli/util/ListStatusAccessibilityDelegate.kt
+++ b/app/src/main/java/app/pachli/util/ListStatusAccessibilityDelegate.kt
@@ -372,12 +372,12 @@ class ListStatusAccessibilityDelegate<T : IStatusViewData>(
 
     private val showAnywayAction = AccessibilityActionCompat(
         app.pachli.core.ui.R.id.action_show_anyway,
-        context.getString(R.string.status_filtered_show_anyway),
+        context.getString(app.pachli.core.ui.R.string.status_filtered_show_anyway),
     )
 
     private val editFilterAction = AccessibilityActionCompat(
         app.pachli.core.ui.R.id.action_edit_filter,
-        context.getString(R.string.filter_edit_title),
+        context.getString(app.pachli.core.ui.R.string.filter_edit_title),
     )
 
     private val showAttachmentsAction = AccessibilityActionCompat(

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -184,7 +184,6 @@
     <string name="pref_title_public_filter_keywords">الخطوط الزمنية العمومية</string>
     <string name="pref_title_thread_filter_keywords">خيوط المحادثات</string>
     <string name="filter_addition_title">إضافة عامل تصفية</string>
-    <string name="filter_edit_title">تعديل عامل التصفية</string>
     <string name="filter_dialog_remove_button">إزالة</string>
     <string name="filter_dialog_update_button">تحديث</string>
     <string name="filter_add_description">العبارة التي يلزم تصفيتها</string>
@@ -437,7 +436,6 @@
     <string name="filter_action_warn">تحذير</string>
     <string name="title_public_trending_links">الروابط الشائعة</string>
     <string name="title_tab_public_trending_links">الروابط</string>
-    <string name="status_filter_placeholder_label_format">مُصفّى: &lt;b&gt;%1$s&lt;/b&gt;</string>
     <string name="update_dialog_neutral">لا تذكرني بهذه النسخة</string>
     <string name="ui_error_reject_follow_request">فشل رفض طلب المتابعة: %s</string>
     <string name="reaction_name_and_count">%1$s %2$d</string>
@@ -465,7 +463,6 @@
     <string name="label_filter_title">العنوان</string>
     <string name="pref_title_font_family">عائلة الخطوط</string>
     <string name="notification_listenable_worker_description">إشعارات عندما يعمل Pachli (باكلي) في الخلفية</string>
-    <string name="status_filtered_show_anyway">إظهار على أي حال</string>
     <string name="action_translate">ترجمة</string>
     <string name="select_list_empty">ليس لديك قوائم بعد</string>
     <string name="pref_title_account_filter_keywords">الملفات التعريفية</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -250,7 +250,6 @@
     <string name="filter_addition_title">Дадаць фільтр</string>
     <string name="follows_you">Вашы падпісчыкі</string>
     <string name="pref_title_alway_show_sensitive_media">Заўсёды паказваць далікатны змест</string>
-    <string name="filter_edit_title">Рэдагаваць фільтр</string>
     <string name="filter_dialog_remove_button">Выдаліць</string>
     <string name="filter_dialog_update_button">Абнавіць</string>
     <string name="filter_dialog_whole_word">Цэлае слова</string>
@@ -422,8 +421,6 @@
     <string name="action_post_failed_do_nothing">Адмяніць</string>
     <string name="description_login">Працуе амаль заўсёды. Даныя не ўцякаюць у іншыя праграмы.</string>
     <string name="notification_unknown_name">Невядома</string>
-    <string name="status_filtered_show_anyway">Усё роўна паказаць</string>
-    <string name="status_filter_placeholder_label_format">Адфільтрована: &lt;b&gt;%1$s&lt;/b&gt;</string>
     <string name="pref_title_account_filter_keywords">Профілі</string>
     <string name="title_public_trending_hashtags">Папулярныя хэштэгі</string>
     <string name="description_browser_login">Можа падтрымліваць дадатковыя метады праверкі сапраўднасці, але для гэтага патрэбны адпаведны браузер.</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -77,7 +77,6 @@
     <string name="filter_dialog_whole_word">Цяла дума</string>
     <string name="filter_dialog_update_button">Актуализиране</string>
     <string name="filter_dialog_remove_button">Премахване</string>
-    <string name="filter_edit_title">Редакция на филтър</string>
     <string name="filter_addition_title">Добавяне на филтър</string>
     <string name="pref_title_thread_filter_keywords">Разговори</string>
     <string name="pref_title_public_filter_keywords">Публични емисии</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -38,7 +38,6 @@
     <string name="filter_add_description">বাক্য ফিল্টার কর</string>
     <string name="filter_dialog_update_button">আপডেট</string>
     <string name="filter_dialog_remove_button">সরাও</string>
-    <string name="filter_edit_title">ফিল্টার সম্পাদনা করুন</string>
     <string name="filter_addition_title">ফিল্টার যোগ করুন</string>
     <string name="pref_title_thread_filter_keywords">কথাবার্তা</string>
     <string name="pref_title_public_filter_keywords">পাবলিক টাইমলাইন</string>

--- a/app/src/main/res/values-bn-rIN/strings.xml
+++ b/app/src/main/res/values-bn-rIN/strings.xml
@@ -190,7 +190,6 @@
     <string name="pref_title_public_filter_keywords">পাবলিক টাইমলাইন</string>
     <string name="pref_title_thread_filter_keywords">কথাবার্তা</string>
     <string name="filter_addition_title">ফিল্টার যোগ করুন</string>
-    <string name="filter_edit_title">ফিল্টার সম্পাদনা করুন</string>
     <string name="filter_dialog_remove_button">সরাও</string>
     <string name="filter_dialog_update_button">আপডেট</string>
     <string name="filter_add_description">বাক্য ফিল্টার কর</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -179,7 +179,6 @@
     <string name="notification_poll_name">Enquestes</string>
     <string name="pref_title_thread_filter_keywords">Converses</string>
     <string name="filter_addition_title">Afegir un filtre</string>
-    <string name="filter_edit_title">Modificar un filtre</string>
     <string name="filter_dialog_remove_button">Eliminar</string>
     <string name="action_open_reblogger">Obre l\'autor de l\'impuls</string>
     <string name="action_open_reblogged_by">Mostra els impulsos</string>
@@ -428,8 +427,6 @@
     <string name="dialog_follow_hashtag_title">Segueix hashtag</string>
     <string name="dialog_follow_hashtag_hint">#hashtag</string>
     <string name="notification_unknown_name">Desconegut</string>
-    <string name="status_filter_placeholder_label_format">Filtrat: &lt;b&gt;%1$s&lt;/b&gt;</string>
     <string name="pref_title_account_filter_keywords">Perfils</string>
-    <string name="status_filtered_show_anyway">Mostra de totes maneres</string>
     <string name="socket_timeout_exception">El contacte amb el teu servidor ha trigat massa</string>
 </resources>

--- a/app/src/main/res/values-ckb/strings.xml
+++ b/app/src/main/res/values-ckb/strings.xml
@@ -267,7 +267,6 @@
     <string name="filter_dialog_whole_word">هەموو وشەکە</string>
     <string name="filter_dialog_update_button">نوێکردنەوە</string>
     <string name="filter_dialog_remove_button">لابردن</string>
-    <string name="filter_edit_title">دەستکاریکردنی فلتەر</string>
     <string name="filter_addition_title">زیادکردنی فلتەر</string>
     <string name="pref_title_thread_filter_keywords">گفتوگۆکان</string>
     <string name="pref_title_public_filter_keywords">هێڵی کاتی گشتی</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -185,7 +185,6 @@
     <string name="pref_title_public_filter_keywords">Veřejné časové osy</string>
     <string name="pref_title_thread_filter_keywords">Konverzace</string>
     <string name="filter_addition_title">Přidat filtr</string>
-    <string name="filter_edit_title">Upravit filtr</string>
     <string name="filter_dialog_remove_button">Odstranit</string>
     <string name="filter_dialog_update_button">Aktualizovat</string>
     <string name="filter_add_description">Fráze k filtrování</string>

--- a/app/src/main/res/values-cy/strings.xml
+++ b/app/src/main/res/values-cy/strings.xml
@@ -246,7 +246,6 @@
     <string name="notification_sign_up_name">Cofrestriadau</string>
     <string name="pref_title_public_filter_keywords">Ffrydiau cyhoeddus</string>
     <string name="filter_addition_title">Ychwanegu hidlydd</string>
-    <string name="filter_edit_title">Golygu hidlydd</string>
     <string name="filter_dialog_update_button">Diweddaru</string>
     <string name="pref_title_notification_filter_updates">golygwyd neges rwy wedi rhyngweithio ag ef</string>
     <string name="notification_update_format">Golygodd %s ei neges</string>
@@ -441,8 +440,6 @@
     <string name="dialog_follow_hashtag_title">Dilyn hashnod</string>
     <string name="dialog_follow_hashtag_hint">#hashnod</string>
     <string name="notification_unknown_name">Anhysbys</string>
-    <string name="status_filtered_show_anyway">Dangos beth bynnag</string>
-    <string name="status_filter_placeholder_label_format">Hidlwyd: &lt;b&gt;%1$s&lt;/b&gt;</string>
     <string name="pref_title_account_filter_keywords">Proffiliau</string>
     <string name="socket_timeout_exception">Cymrodd hi\'n rhy hir i gysylltu â\'ch gweinydd</string>
     <string name="ui_error_bookmark_fmt">Methodd tudalnodi\'r neges: %1$s</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -182,7 +182,6 @@
     <string name="title_media">Medien</string>
     <string name="pref_title_thread_filter_keywords">Unterhaltungen</string>
     <string name="filter_addition_title">Filter hinzufügen</string>
-    <string name="filter_edit_title">Filter bearbeiten</string>
     <string name="filter_dialog_remove_button">Entfernen</string>
     <string name="filter_dialog_update_button">Aktualisieren</string>
     <string name="add_account_description">Neues Mastodonkonto hinzufügen</string>
@@ -447,7 +446,6 @@
     <string name="notification_unknown_name">Unbekannt</string>
     <string name="ui_error_clear_notifications">Löschen der Benachrichtigungen schlug fehl: %s</string>
     <string name="ui_error_reject_follow_request">Ablehnen der Folgeanfrage schlug fehl: %s</string>
-    <string name="status_filter_placeholder_label_format">Gefiltert: &lt;b&gt;%1$s&lt;/b&gt;</string>
     <string name="pref_title_account_filter_keywords">Profile</string>
     <string name="hint_filter_title">Mein Filter</string>
     <string name="label_filter_title">Titel</string>
@@ -463,7 +461,6 @@
     <string name="filter_keyword_addition_title">Schlagwort hinzufügen</string>
     <string name="filter_edit_keyword_title">Schlagwort bearbeiten</string>
     <string name="filter_description_format">%s: %s</string>
-    <string name="status_filtered_show_anyway">Trotzdem anzeigen</string>
     <string name="help_empty_home">Dies ist deine <b>Startseite</b>. Sie zeigt die neuesten Beiträge von Konten, denen du folgst. \n \nDamit du andere Konten entdeckst, kannst du entweder andere Timelines lesen – z. B. die Lokale Timeline deiner Instanz [iconics gmd_group] – oder du suchst nach Namen [iconics gmd_search] – z. B. Pachli, um unser Mastodon-Konto zu finden.</string>
     <string name="pref_title_show_stat_inline">Beitragsstatistiken in der Timeline anzeigen</string>
     <string name="pref_ui_text_size">Schriftgröße der Oberfläche</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -184,7 +184,6 @@
     <string name="pref_title_public_filter_keywords">Publikaj tempolinioj</string>
     <string name="pref_title_thread_filter_keywords">Konversacioj</string>
     <string name="filter_addition_title">Aldoni filtrilon</string>
-    <string name="filter_edit_title">Redakti filtrilon</string>
     <string name="filter_dialog_remove_button">Forigi</string>
     <string name="filter_dialog_update_button">Aktualigi</string>
     <string name="filter_add_description">Frazo filtrota</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -229,7 +229,6 @@
     <string name="pref_title_public_filter_keywords">Cronologías públicas</string>
     <string name="pref_title_thread_filter_keywords">Conversaciones</string>
     <string name="filter_addition_title">Añadir filtro</string>
-    <string name="filter_edit_title">Editar filtro</string>
     <string name="filter_dialog_update_button">Actualizar</string>
     <string name="filter_add_description">Frase para filtrar</string>
     <string name="edit_hashtag_hint">Etiqueta sin #</string>
@@ -434,8 +433,6 @@
     <string name="hint_description">Descripción</string>
     <string name="pref_title_account_filter_keywords">Perfiles</string>
     <string name="notification_unknown_name">Desconocido</string>
-    <string name="status_filtered_show_anyway">Mostrar de todas formas</string>
-    <string name="status_filter_placeholder_label_format">Filtrado: &lt;b&gt;%1$s&lt;/b&gt;</string>
     <string name="pref_title_show_stat_inline">Mostrar estadísticas de la publicación en la cronología</string>
     <string name="socket_timeout_exception">Contactar con tu servidor ha tardado demasiado tiempo</string>
     <string name="select_list_empty">Todavía no tienes listas</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -424,8 +424,6 @@
     <string name="description_account_locked">Lukustatud kasutajakonto</string>
     <string name="post_share_content">Jaga postituse sisu</string>
     <string name="post_share_link">Jaga postituse linki</string>
-    <string name="status_filtered_show_anyway">Näita ikkagi</string>
-    <string name="status_filter_placeholder_label_format">Filtreeritud: &lt;b>%1$s&lt;/b></string>
     <string name="state_follow_requested">Oled saanud jälgimispäringu</string>
     <string name="follows_you">Jälgib sind</string>
     <string name="pref_title_alway_show_sensitive_media">Alati näita delikaatset sisu</string>
@@ -438,7 +436,6 @@
     <string name="pref_title_thread_filter_keywords">Vestlused</string>
     <string name="pref_title_account_filter_keywords">Profiilid</string>
     <string name="filter_addition_title">Lisa filter</string>
-    <string name="filter_edit_title">Muuda filtrit</string>
     <string name="filter_dialog_remove_button">Eemalda</string>
     <string name="filter_dialog_update_button">Uuenda</string>
     <string name="filter_dialog_whole_word">Terve sõna</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -236,7 +236,6 @@
     <string name="pref_title_alway_open_spoiler">Beti zabaldu edukien abisuekin markatutako tootak</string>
     <string name="pref_title_thread_filter_keywords">Elkarrizketak</string>
     <string name="filter_addition_title">Gehitu iragazkia</string>
-    <string name="filter_edit_title">Editatu iragazkia</string>
     <string name="filter_dialog_remove_button">Ezabatu</string>
     <string name="filter_dialog_update_button">Eguneratu</string>
     <string name="filter_dialog_whole_word">Hitz osoa</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -232,7 +232,6 @@
     <string name="pref_title_public_filter_keywords">خط زمانی‌های عمومی</string>
     <string name="pref_title_thread_filter_keywords">گفت‌وگوها</string>
     <string name="filter_addition_title">افزودن پالایه</string>
-    <string name="filter_edit_title">ویرایش پالایه</string>
     <string name="filter_dialog_remove_button">برداشتن</string>
     <string name="filter_dialog_update_button">به‌روز رسانی</string>
     <string name="filter_dialog_whole_word">تمام واژه</string>
@@ -443,8 +442,6 @@
     <string name="ui_success_rejected_follow_request">درخواست پی‌گیری مسدود شد</string>
     <string name="ui_error_reblog_fmt">%1$s: تقویت فرسته شکست خورد</string>
     <string name="ui_error_reject_follow_request">رد کردن درخواست پی‌گیری شکست خورد: %s</string>
-    <string name="status_filtered_show_anyway">نمایش به هر روی</string>
-    <string name="status_filter_placeholder_label_format">پالوده: &lt;b&gt;%1$s&lt;/b&gt;</string>
     <string name="pref_title_account_filter_keywords">نمایه‌ها</string>
     <string name="hint_filter_title">پالایه‌ام</string>
     <string name="label_filter_title">عنوان</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -198,7 +198,6 @@
     <string name="notification_favourite_name">Suosikit</string>
     <string name="notification_poll_name">Äänestykset</string>
     <string name="notification_poll_description">Ilmoitukset päättyneistä äänestyksistä</string>
-    <string name="filter_edit_title">Muokkaa suodatinta</string>
     <string name="action_add_reaction">lisää reaktio</string>
     <string name="confirmation_reported">Lähetetty!</string>
     <string name="post_sent">Lähetetty!</string>
@@ -312,7 +311,6 @@
     <string name="send_post_notification_error_title">Julkaisun lähettäminen epäonnistui</string>
     <string name="pref_title_notification_filter_follow_requests">Seuraamista pyydetty</string>
     <string name="pref_title_notification_filters">Ilmoita kun</string>
-    <string name="status_filter_placeholder_label_format">Suodatettu: &lt;b&gt;%1$s&lt;/b&gt;</string>
     <string name="pref_title_notification_filter_poll">Päättyneet äänestykset</string>
     <string name="failed_to_unpin">Irrottaminen epäonnistui</string>
     <string name="unsaved_changes">Sinulla on tallentamattomia muutoksia.</string>
@@ -344,7 +342,6 @@
     <string name="notification_listenable_worker_description">Ilmoitukset Pachlin toimiessa taustalla</string>
     <string name="pref_title_notification_filter_reblogs">Tehostetut julkaisut</string>
     <string name="post_share_content">Jaa julkaisun sisältö</string>
-    <string name="status_filtered_show_anyway">Näytä joka tapauksessa</string>
     <string name="pref_title_http_proxy_port">HTTP-välityspalvelimen portti</string>
     <string name="profile_metadata_content_label">Sisältö</string>
     <string name="pref_title_notification_filter_updates">Julkaisua, johon olen reagoinut, on muokattu</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -185,7 +185,6 @@
     <string name="pref_title_public_filter_keywords">Fils publics</string>
     <string name="pref_title_thread_filter_keywords">Conversations</string>
     <string name="filter_addition_title">Ajouter un filtre</string>
-    <string name="filter_edit_title">Modifier un filtre</string>
     <string name="filter_dialog_remove_button">Supprimer</string>
     <string name="filter_dialog_update_button">Mettre à jour</string>
     <string name="filter_add_description">Phrase à filtrer</string>
@@ -410,8 +409,6 @@
     <string name="title_followed_hashtags">Hashtags suivis</string>
     <string name="pref_title_notification_filter_reports">il y a un nouveau signalement</string>
     <string name="pref_title_account_filter_keywords">Profils</string>
-    <string name="status_filtered_show_anyway">Montrer quand même</string>
-    <string name="status_filter_placeholder_label_format">Caché : &lt;b&gt;%1$s&lt;/b&gt;</string>
     <string name="title_public_trending_hashtags">Hashtags tendance</string>
     <string name="send_account_username_to">Partager le nom du compte avec…</string>
     <string name="action_unfollow_hashtag_format">Arrêter de suivre #%s \?</string>

--- a/app/src/main/res/values-fy/strings.xml
+++ b/app/src/main/res/values-fy/strings.xml
@@ -13,7 +13,6 @@
     <string name="add_account_description">Nij Mastodon Account Tafoegje</string>
     <string name="filter_dialog_update_button">Fernije</string>
     <string name="filter_dialog_remove_button">Fuortsmite</string>
-    <string name="filter_edit_title">Filter oanpasse</string>
     <string name="filter_addition_title">Filter tafoegje</string>
     <string name="pref_title_thread_filter_keywords">Petearen</string>
     <string name="title_media">Media</string>

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -212,7 +212,6 @@
     <string name="title_media">Meáin</string>
     <string name="pref_title_thread_filter_keywords">Comhráite</string>
     <string name="filter_addition_title">Cuir scagaire leis</string>
-    <string name="filter_edit_title">Cuir scagaire in eagar</string>
     <string name="filter_dialog_remove_button">Bain</string>
     <string name="pref_title_public_filter_keywords">Amlínte poiblí</string>
     <string name="expand_collapse_all_posts">Leathnaigh/Fill na postálacha go léir</string>
@@ -436,7 +435,6 @@
     <string name="notification_severed_relationships_description">Fógraí faoi chaidrimh throma</string>
     <string name="notification_report_name">Tuarascálacha</string>
     <string name="notification_report_description">Fógraí faoi thuarascálacha modhnóireachta</string>
-    <string name="status_filtered_show_anyway">Taispeáin ar aon nós</string>
     <string name="pref_title_account_filter_keywords">Próifílí</string>
     <string name="failed_to_pin">Theip ar phionnáil</string>
     <string name="duration_no_change">(Gan athrú)</string>
@@ -526,7 +524,6 @@
     <string name="pref_default_post_language">Teanga phostála réamhshocraithe</string>
     <string name="notification_listenable_worker_name">Gníomhaíocht chúlra</string>
     <string name="notification_listenable_worker_description">Fógraí nuair atá Pachli ag obair sa chúlra</string>
-    <string name="status_filter_placeholder_label_format">Scagtha: &lt;b&gt;%1$s&lt;/b&gt;</string>
     <string name="compose_save_draft_loses_media">Uaslódálfar ceangaltáin arís nuair a chuirfidh tú an dréacht ar ais.</string>
     <string name="update_dialog_title">Tá nuashonrú ar fáil</string>
     <string name="update_dialog_neutral">Ná cuir an leagan seo i gcuimhne dom</string>

--- a/app/src/main/res/values-gd/strings.xml
+++ b/app/src/main/res/values-gd/strings.xml
@@ -7,7 +7,6 @@
     <string name="title_drafts">Dreachdan</string>
     <string name="title_favourites">Annsachdan</string>
     <string name="edit_poll">Deasaich</string>
-    <string name="filter_edit_title">Deasaich a’ chriathrag</string>
     <string name="pref_title_edit_notification_settings">Brathan</string>
     <string name="action_edit_own_profile">Deasaich</string>
     <string name="action_edit">Deasaich</string>
@@ -441,8 +440,6 @@
     <string name="ui_success_rejected_follow_request">Chaidh iarrtas leantainn a bhacadh</string>
     <string name="select_list_manage">Stiùirich na liostaichean</string>
     <string name="select_list_empty">Chan eil liosta agad fhathast</string>
-    <string name="status_filtered_show_anyway">Seall e co-dhiù</string>
-    <string name="status_filter_placeholder_label_format">Criathraichte: &lt;b&gt;%1$s&lt;/b&gt;</string>
     <string name="pref_title_account_filter_keywords">Pròifilean</string>
     <string name="hint_filter_title">A’ chriathrag agam</string>
     <string name="filter_description_warn">Falaich le rabhadh</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -164,7 +164,6 @@
     <string name="filter_dialog_whole_word">Palabra completa</string>
     <string name="filter_dialog_update_button">Actualizar</string>
     <string name="filter_dialog_remove_button">Eliminar</string>
-    <string name="filter_edit_title">Editar filtro</string>
     <string name="filter_addition_title">Engadir filtro</string>
     <string name="pref_title_thread_filter_keywords">Conversas</string>
     <string name="pref_title_public_filter_keywords">Cronoloxías públicas</string>
@@ -439,8 +438,6 @@
     <string name="ui_error_reject_follow_request">Fallou o rexeitamento da solicitude de seguimento: %s</string>
     <string name="ui_success_accepted_follow_request">Aceptado o seguimento</string>
     <string name="ui_success_rejected_follow_request">Bloqueada a solicitude de seguimento</string>
-    <string name="status_filtered_show_anyway">Mostrar igualmente</string>
-    <string name="status_filter_placeholder_label_format">Filtrado: &lt;b&gt;%1$s&lt;/b&gt;</string>
     <string name="pref_title_account_filter_keywords">Perfís</string>
     <string name="label_filter_title">Título</string>
     <string name="filter_action_warn">Aviso</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -168,7 +168,6 @@
     <string name="compose_save_draft">लिखने को सुरक्षित करें\?</string>
     <string name="lock_account_label">खाता लॉक करें</string>
     <string name="filter_dialog_whole_word">पूरा शब्द</string>
-    <string name="filter_edit_title">फ़िल्टर संपादित करें</string>
     <string name="filter_addition_title">फिल्टर लगाएं</string>
     <string name="pref_title_public_filter_keywords">सार्वजनिक टाइमलाइन</string>
     <string name="pref_title_show_cards_in_timelines">टाइमलाइन में लिंक प्रीव्यू दिखाएं</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -216,7 +216,6 @@
     <string name="pref_title_public_filter_keywords">Nyilvános idővonalak</string>
     <string name="pref_title_thread_filter_keywords">Beszélgetések</string>
     <string name="filter_addition_title">Szűrő hozzáadása</string>
-    <string name="filter_edit_title">Szűrő szerkesztése</string>
     <string name="filter_dialog_remove_button">Eltávolítás</string>
     <string name="filter_dialog_update_button">Frissítés</string>
     <string name="filter_add_description">Szűrendő kifejezés</string>
@@ -437,8 +436,6 @@
     <string name="ui_error_reblog_fmt">Bejegyzés megtolása sikertelen: %1$s</string>
     <string name="ui_error_vote_fmt">Szavazat leadása a szavazásba sikertelen: %1$s</string>
     <string name="ui_error_accept_follow_request">Követési kérelem elfogadása sikertelen: %s</string>
-    <string name="status_filtered_show_anyway">Mutatás mindenképpen</string>
-    <string name="status_filter_placeholder_label_format">Szűrve: &lt;b&gt;%1$s&lt;/b&gt;</string>
     <string name="pref_title_account_filter_keywords">Profil</string>
     <string name="socket_timeout_exception">A kapcsolatfelvétel a kiszolgálóddal túl sokáig tartott</string>
     <string name="ui_error_bookmark_fmt">Bejegyzés könyvjelzőzése sikertelen: %1$s</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -257,7 +257,6 @@
     <string name="notification_listenable_worker_description">Pemberitahuan saat Pachli bekerja di latar belakang</string>
     <string name="pref_title_alway_open_spoiler">Selalu perluas postingan yg ditandai dengan peringatan konten</string>
     <string name="action_set_focus">Menetapkan titik fokus</string>
-    <string name="status_filtered_show_anyway">Tampilkan kapan saja</string>
     <string name="state_follow_requested">Ikuti yang diminta</string>
     <string name="pref_title_thread_filter_keywords">Percakapan</string>
     <string name="pref_title_account_filter_keywords">Profil</string>
@@ -275,7 +274,6 @@
     <string name="title_media">Media</string>
     <string name="pref_title_alway_show_sensitive_media">Selalu tampilkan konten sensitif</string>
     <string name="pref_title_public_filter_home_and_lists">Beranda dan list</string>
-    <string name="filter_edit_title">Edit penyaring</string>
     <string name="filter_expiration_format">%s %s</string>
     <string name="filter_dialog_remove_button">Buang</string>
     <string name="lock_account_label_description">Mengharuskan Anda untuk menyetujui pengikut secara manual</string>
@@ -341,7 +339,6 @@
     <string name="notification_summary_small">%1$s dan %2$s</string>
     <string name="notification_notification_worker">Mengambil notifikasi…</string>
     <string name="post_share_content">Bagikan konten postingan</string>
-    <string name="status_filter_placeholder_label_format">Disaring: &lt;b>%1$s&lt;/b></string>
     <string name="set_focus_description">Ketuk atau seret lingkaran untuk memilih titik fokus yang akan selalu terlihat dalam gambar mini.</string>
     <string name="download_fonts">Anda harus mengunduh set emoji ini terlebih dahulu</string>
     <string name="expand_collapse_all_posts">Memperluas/Memperkecil semua tulisan</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -199,7 +199,6 @@
     <string name="pref_title_public_filter_keywords">Opinberar tímalínur</string>
     <string name="pref_title_thread_filter_keywords">Samtöl</string>
     <string name="filter_addition_title">Bæta við síu</string>
-    <string name="filter_edit_title">Breyta síu</string>
     <string name="filter_dialog_remove_button">Fjarlægja</string>
     <string name="filter_dialog_update_button">Uppfæra</string>
     <string name="filter_dialog_whole_word">Heil orð</string>
@@ -426,8 +425,6 @@
     <string name="dialog_follow_hashtag_title">Fylgjast með myllumerki</string>
     <string name="dialog_follow_hashtag_hint">#myllumerki</string>
     <string name="notification_unknown_name">Óþekkt</string>
-    <string name="status_filtered_show_anyway">Birta samt</string>
-    <string name="status_filter_placeholder_label_format">Síað: &lt;b&gt;%1$s&lt;/b&gt;</string>
     <string name="pref_title_account_filter_keywords">Notendasnið</string>
     <string name="pref_title_show_stat_inline">Sýna tölfræði færslu í tímalínu</string>
     <string name="ui_error_favourite_fmt">Mistókst að setja færslu í eftirlæti: %1$s</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -198,7 +198,6 @@
     <string name="pref_title_public_filter_keywords">Timeline pubbliche</string>
     <string name="pref_title_thread_filter_keywords">Conversazioni</string>
     <string name="filter_addition_title">Aggiungi filtro</string>
-    <string name="filter_edit_title">Modifica filtro</string>
     <string name="filter_dialog_remove_button">Rimuovi</string>
     <string name="filter_dialog_update_button">Aggiorna</string>
     <string name="filter_add_description">Frase da filtrare</string>
@@ -471,8 +470,6 @@
     <string name="ui_success_rejected_follow_request">Richiesta di follow bloccata</string>
     <string name="select_list_empty">Non hai ancora alcuna lista</string>
     <string name="select_list_manage">Gestisci liste</string>
-    <string name="status_filtered_show_anyway">Mostra comunque</string>
-    <string name="status_filter_placeholder_label_format">Filtrato: &lt;b&gt;%1$s&lt;/b&gt;</string>
     <string name="pref_title_account_filter_keywords">Profili</string>
     <string name="hint_filter_title">I miei filtri</string>
     <string name="action_add">Aggiungi</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -176,7 +176,6 @@
     <string name="pref_title_alway_show_sensitive_media">閲覧注意のメディアを常に表示</string>
     <string name="title_media">メディア</string>
     <string name="filter_addition_title">フィルターを追加</string>
-    <string name="filter_edit_title">フィルターを編集</string>
     <string name="add_account_description">新しいMastodonアカウントを追加</string>
     <string name="compose_active_account_description">%1$sとして投稿</string>
     <string name="action_remove">消去</string>
@@ -427,7 +426,6 @@
     <string name="notification_unknown_name">不明</string>
     <string name="select_list_manage">リストを管理する</string>
     <string name="select_list_empty">リストはまだありません</string>
-    <string name="status_filtered_show_anyway">とにかく表示する</string>
     <string name="pref_title_account_filter_keywords">プロフィール</string>
     <string name="title_public_trending_hashtags">トレンドのハッシュタグ</string>
     <string name="pref_title_show_stat_inline">タイムラインに投稿の統計情報を表示する</string>
@@ -487,7 +485,6 @@
     <string name="help_empty_home">これはあなたの<b>ホームタイムライン</b>です。あなたがフォローしているアカウントの最新のポストが表示されます。 \n \nあなたのインスタンスのローカルタイムラインや他のタイムラインから、他のアカウントを見つけることができます（[iconics gmd_group]）。また、名前で検索することもできます（[iconics gmd_search]）；例えば、Pachliを検索すると、当社のMastodonアカウントを見つけることができます。</string>
     <string name="pref_title_font_family">フォント</string>
     <string name="label_image">画像</string>
-    <string name="status_filter_placeholder_label_format">フィルタ済み: &lt;b&gt;%1$s&lt;/b&gt;</string>
     <string name="pref_title_show_self_boosts_description">自分の投稿をブーストすること</string>
     <string name="confirmation_hashtag_unmuted">%s を非表示にしました</string>
     <string name="pref_title_show_self_boosts">セルフブーストを表示</string>

--- a/app/src/main/res/values-kab/strings.xml
+++ b/app/src/main/res/values-kab/strings.xml
@@ -88,7 +88,6 @@
     <string name="post_share_content">Bḍu agbur n tijewwiqt-a</string>
     <string name="post_share_link">Bḍu aseɣwen ɣer tijewwiqt</string>
     <string name="filter_addition_title">Rnu amsizdeg</string>
-    <string name="filter_edit_title">Ẓreg amsizdeg</string>
     <string name="profile_metadata_add">Rnu isefka</string>
     <string name="select_list_title">Fren tabdart</string>
     <string name="list">Tabdart</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -196,7 +196,6 @@
     <string name="pref_title_public_filter_keywords">공개 타임라인</string>
     <string name="pref_title_thread_filter_keywords">대화</string>
     <string name="filter_addition_title">필터 추가</string>
-    <string name="filter_edit_title">필터 편집</string>
     <string name="filter_dialog_remove_button">삭제</string>
     <string name="filter_dialog_update_button">변경 사항 저장</string>
     <string name="filter_dialog_whole_word">단어 전체에 매칭</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -89,7 +89,6 @@
     <string name="pref_title_thread_filter_keywords">Sarunas</string>
     <string name="filter_dialog_remove_button">Noņemt</string>
     <string name="filter_dialog_update_button">Atjaunināt</string>
-    <string name="filter_edit_title">Labot filtru</string>
     <string name="action_edit_image">Labot attēlu</string>
     <string name="send_post_notification_title">Sūta ierakstu…</string>
     <string name="send_post_notification_cancel_title">Sūtīšana atcelta</string>
@@ -454,8 +453,6 @@
     <string name="action_suggestions">Ieteiktie konti</string>
     <string name="action_refresh_account">Atsvaidzināt kontu</string>
     <string name="confirmation_hashtag_muted">#%s paslēpts</string>
-    <string name="status_filtered_show_anyway">Vienalga parādīt</string>
-    <string name="status_filter_placeholder_label_format">Atlasīts: &lt;b>%1$s&lt;/b></string>
     <string name="notification_prune_cache">Kešatmiņas uzturēšanas darbi…</string>
     <string name="notification_listenable_worker_description">Paziņojumi, kad Pachli darbojas fonā</string>
     <string name="profile_metadata_label_label">Iezīme</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -166,7 +166,6 @@
     <string name="pref_title_public_filter_keywords">Offentlige tidslinjer</string>
     <string name="pref_title_thread_filter_keywords">Samtaler</string>
     <string name="filter_addition_title">Legg til filter</string>
-    <string name="filter_edit_title">Rediger filter</string>
     <string name="filter_dialog_remove_button">Fjern</string>
     <string name="filter_dialog_update_button">Oppdater</string>
     <string name="filter_add_description">Filtrer frase</string>
@@ -450,8 +449,6 @@
     <string name="send_account_username_to">Del kontoens brukernavn med…</string>
     <string name="account_username_copied">Brukernavn kopiert</string>
     <string name="error_status_source_load">Kunne ikke laste inn statuskilden fra serveren.</string>
-    <string name="status_filtered_show_anyway">Vis allikevel</string>
-    <string name="status_filter_placeholder_label_format">Filtrert: &lt;b&gt;%1$s&lt;/b&gt;</string>
     <string name="pref_title_account_filter_keywords">Profiler</string>
     <string name="action_add">Legg til</string>
     <string name="filter_keyword_display_format">%s (helt ord)</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -223,7 +223,6 @@
     <string name="pref_title_public_filter_keywords">Openbare tijdlijnen</string>
     <string name="pref_title_thread_filter_keywords">Gesprekken</string>
     <string name="filter_addition_title">Filter toevoegen</string>
-    <string name="filter_edit_title">Filter bewerken</string>
     <string name="filter_dialog_remove_button">Verwijderen</string>
     <string name="filter_dialog_update_button">Bijwerken</string>
     <string name="filter_add_description">Zinsdeel om te filteren</string>
@@ -433,8 +432,6 @@
     <string name="select_list_empty">Je hebt nog geen lijsten</string>
     <string name="select_list_manage">Lijsten beheren</string>
     <string name="pref_title_account_filter_keywords">Profielen</string>
-    <string name="status_filtered_show_anyway">Toch tonen</string>
-    <string name="status_filter_placeholder_label_format">Gefilterd: &lt;b&gt;%1$s&lt;/b&gt;</string>
     <string name="hint_filter_title">Mijn filter</string>
     <string name="label_filter_action">Filteractie</string>
     <string name="filter_action_warn">Waarschuwen</string>

--- a/app/src/main/res/values-nn/strings.xml
+++ b/app/src/main/res/values-nn/strings.xml
@@ -183,7 +183,6 @@
         <item quantity="one">%d ny interaksjon</item>
         <item quantity="other">%d nye interaksjonar</item>
     </plurals>
-    <string name="filter_edit_title">Brigd filter</string>
     <string name="pref_title_public_filter_keywords">Offentlege tidslinjer</string>
     <string name="pref_title_thread_filter_keywords">Samtaler</string>
     <string name="filter_addition_title">Legg til filter</string>
@@ -217,8 +216,6 @@
     <string name="notification_summary_medium">%1$s, %2$s, og %3$s</string>
     <string name="notification_summary_small">%1$s og %2$s</string>
     <string name="notification_prune_cache">Hurtiglagringsvedlikehald…</string>
-    <string name="status_filtered_show_anyway">Syn likevel</string>
-    <string name="status_filter_placeholder_label_format">Filtrert: &lt;b&gt;%1$s&lt;/b&gt;</string>
     <string name="state_follow_requested">Fylgjeførespurnad send</string>
     <string name="follows_you">Fylgjer deg</string>
     <string name="pref_title_alway_show_sensitive_media">Syn alltid sensitivt innhald</string>

--- a/app/src/main/res/values-oc/strings.xml
+++ b/app/src/main/res/values-oc/strings.xml
@@ -218,7 +218,6 @@
     <string name="pref_title_public_filter_keywords">Flux publics</string>
     <string name="pref_title_thread_filter_keywords">Discutidas</string>
     <string name="filter_addition_title">Ajustar un filtre</string>
-    <string name="filter_edit_title">Modificar un filtre</string>
     <string name="filter_dialog_remove_button">Suprimir</string>
     <string name="filter_dialog_update_button">Actualizar</string>
     <string name="filter_add_description">Frasa de filtrar</string>
@@ -438,8 +437,6 @@
     <string name="ui_error_clear_notifications">Netejatge de las notificacions fracassat : %s</string>
     <string name="ui_success_accepted_follow_request">Demanda d’abonament acceptada</string>
     <string name="ui_success_rejected_follow_request">Demanda d’abonament blocada</string>
-    <string name="status_filtered_show_anyway">Afichar ça que la</string>
-    <string name="status_filter_placeholder_label_format">Filtrat : &lt;b&gt;%1$s&lt;/b&gt;</string>
     <string name="pref_title_account_filter_keywords">Perfils</string>
     <string name="hint_filter_title">Mon filtre</string>
     <string name="label_filter_title">Títol</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -231,7 +231,6 @@
     <string name="pref_title_public_filter_keywords">Publiczne osi czasu</string>
     <string name="pref_title_thread_filter_keywords">Rozmowy</string>
     <string name="filter_addition_title">Dodaj filtr</string>
-    <string name="filter_edit_title">Edytuj filtr</string>
     <string name="filter_dialog_remove_button">Usuń</string>
     <string name="filter_dialog_update_button">Aktualizuj</string>
     <string name="filter_dialog_whole_word">Całe słowo</string>
@@ -442,7 +441,6 @@
     <string name="filter_action_hide">Ukryj</string>
     <string name="label_filter_title">Tytuł</string>
     <string name="pref_title_font_family">Czcionka</string>
-    <string name="status_filtered_show_anyway">Pokaż mimo to</string>
     <string name="pref_title_account_filter_keywords">Profile</string>
     <string name="label_filter_action">Działanie filtra</string>
     <string name="title_tab_public_trending_hashtags">Hasztagi</string>
@@ -481,7 +479,6 @@
     <string name="pref_title_show_self_boosts_description">Podbicia własnych wpisów</string>
     <string name="action_translate_undo">Pokaż oryginał</string>
     <string name="confirmation_hashtag_unmuted">Cofnięto ukrycie #%s</string>
-    <string name="status_filter_placeholder_label_format">Zastosowano filtr: &lt;b>%1$s&lt;/b></string>
     <string name="notification_severed_relationships_user_domain_block_body">Domena zablokowana przez ciebie</string>
     <string name="notification_severed_relationships_domain_block_body">Domena zawieszona przez osobę moderującą</string>
     <string name="notification_prune_cache">Zarządzanie cache…</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -223,7 +223,6 @@
     <string name="pref_title_public_filter_keywords">Linhas públicas</string>
     <string name="pref_title_thread_filter_keywords">Conversas</string>
     <string name="filter_addition_title">Criar filtro</string>
-    <string name="filter_edit_title">Editar filtro</string>
     <string name="filter_dialog_remove_button">Excluir</string>
     <string name="filter_dialog_update_button">Atualizar</string>
     <string name="filter_add_description">Frase para filtrar</string>
@@ -413,7 +412,6 @@
     <string name="title_public_trending_links">URL em alta</string>
     <string name="title_tab_public_trending_links">URL</string>
     <string name="title_public_trending_hashtags">Hashtags em alta</string>
-    <string name="status_filter_placeholder_label_format">Filtrado(s): &lt;b&gt;%1$s&lt;/b&gt;</string>
     <string name="confirmation_hashtag_unfollowed">#%s deixado de seguir</string>
     <string name="ui_error_vote_fmt">Votar na enquete falhou: %1$s</string>
     <string name="update_dialog_neutral">Não me lembre desta versão</string>
@@ -480,7 +478,6 @@
     <string name="pref_title_font_family">Família da fonte</string>
     <string name="notification_update_description">Notificações quando Toots com os quais interagiu são editados</string>
     <string name="notification_listenable_worker_description">Notificações quando Pachli está trabalhando em segundo plano</string>
-    <string name="status_filtered_show_anyway">Mostrar mesmo assim</string>
     <string name="ui_error_accept_follow_request">Falha ao aceitar a solicitação de seguir: %s</string>
     <string name="ui_success_rejected_follow_request">Pedido para seguir bloqueado</string>
     <string name="notification_sign_up_format">%s se inscreveu</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -234,7 +234,6 @@
     <string name="pref_title_public_filter_keywords">Timelines públicas</string>
     <string name="pref_title_thread_filter_keywords">Conversas</string>
     <string name="filter_addition_title">Criar filtro</string>
-    <string name="filter_edit_title">Editar filtro</string>
     <string name="filter_dialog_remove_button">Remover</string>
     <string name="filter_dialog_whole_word_description">Se a palavra ou frase for alfanumérica, só será aplicado se corresponder à palavra completa</string>
     <string name="filter_add_description">Frase para filtrar</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -186,7 +186,6 @@
     <string name="pref_title_public_filter_keywords">Публичные ленты</string>
     <string name="pref_title_thread_filter_keywords">Разговоры</string>
     <string name="filter_addition_title">Добавить фильтр</string>
-    <string name="filter_edit_title">Изм. фильтр</string>
     <string name="filter_dialog_remove_button">Удалить</string>
     <string name="filter_dialog_update_button">Обновить</string>
     <string name="filter_add_description">Слова на фильтр</string>
@@ -452,8 +451,6 @@
     <string name="notification_unknown_name">Неизвестно</string>
     <string name="notification_notification_worker">Получение уведомлений…</string>
     <string name="notification_prune_cache">Обслуживание кеша…</string>
-    <string name="status_filtered_show_anyway">Показать всё равно</string>
-    <string name="status_filter_placeholder_label_format">Фильтр: &lt;b>%1$s&lt;/b></string>
     <string name="pref_title_public_filter_home_and_lists">Домашняя и списки</string>
     <string name="pref_title_account_filter_keywords">Профили</string>
     <string name="filter_expiration_format">%s (%s)</string>

--- a/app/src/main/res/values-sa/strings.xml
+++ b/app/src/main/res/values-sa/strings.xml
@@ -146,7 +146,6 @@
     <string name="filter_dialog_whole_word">सर्वः शब्दः</string>
     <string name="filter_dialog_update_button">नवीक्रियताम्</string>
     <string name="filter_dialog_remove_button">नश्यताम्</string>
-    <string name="filter_edit_title">शोधकं सम्पाद्यताम्</string>
     <string name="filter_addition_title">शोधकं युज्यताम्</string>
     <string name="pref_title_thread_filter_keywords">आलापाः</string>
     <string name="pref_title_public_filter_keywords">सार्वजनिकतालिकाः</string>

--- a/app/src/main/res/values-si/strings.xml
+++ b/app/src/main/res/values-si/strings.xml
@@ -41,7 +41,6 @@
     <string name="action_edit_profile">පැතිකඩ සංස්කරණය</string>
     <string name="hint_display_name">දර්ශන නාමය</string>
     <string name="post_text_size_medium">මධ්‍යම</string>
-    <string name="filter_edit_title">පෙරහන සංස්කරණය</string>
     <string name="notification_summary_medium">%1$s, %2$s, සහ %3$s</string>
     <string name="lock_account_label">ගිණුම අගුළුලන්න</string>
     <string name="post_sent_long">පිළිතුර සාර්ථකව යැවිණි.</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -299,8 +299,6 @@
     <string name="notification_poll_description">Upozornenia na ukončené ankety</string>
     <string name="notification_subscription_name">Nové príspevky</string>
     <string name="notification_sign_up_name">Registrácia</string>
-    <string name="status_filtered_show_anyway">Zobraziť aj tak</string>
-    <string name="status_filter_placeholder_label_format">Filtrované: &lt;b>%1$s&lt;/b></string>
     <string name="state_follow_requested">Sledovanie vyžiadané</string>
     <string name="post_text_size_smallest">Najmenšie</string>
     <string name="notification_mention_descriptions">Upozornenia na nové zmienenia</string>
@@ -500,7 +498,6 @@
     <string name="update_dialog_neutral">Neupozorňuj ma na túto verziu</string>
     <string name="reblog_private">Zdieľať s pôvodným publikom</string>
     <string name="unreblog_private">Zrušit zdieľanie</string>
-    <string name="filter_edit_title">Upraviť filter</string>
     <string name="error_no_custom_emojis">Tvoja inštancia %s nemá žiadne vlastné emoji</string>
     <string name="emoji_style">Štýl emoji</string>
     <string name="restart_emoji">Pre uplatnenie týchto zmien je potrebné reštartovať aplikáciu</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -168,7 +168,6 @@
     <string name="pref_title_public_filter_keywords">Javne časovnice</string>
     <string name="pref_title_thread_filter_keywords">Pogovori</string>
     <string name="filter_addition_title">Dodaj filter</string>
-    <string name="filter_edit_title">Uredi filter</string>
     <string name="filter_dialog_remove_button">Odstrani</string>
     <string name="filter_dialog_update_button">Posodobi</string>
     <string name="filter_add_description">Filtriraj frazo</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -182,7 +182,6 @@
     <string name="pref_title_public_filter_keywords">Offentliga tidslinjer</string>
     <string name="pref_title_thread_filter_keywords">Trådar</string>
     <string name="filter_addition_title">Lägg till filter</string>
-    <string name="filter_edit_title">Redigera filter</string>
     <string name="filter_dialog_remove_button">Ta bort</string>
     <string name="filter_dialog_update_button">Uppdatera</string>
     <string name="filter_add_description">Filtrera fras</string>
@@ -441,8 +440,6 @@
     <string name="ui_success_rejected_follow_request">Följ begäran blockerad</string>
     <string name="select_list_manage">Hantera listor</string>
     <string name="select_list_empty">Du har inga listor, än</string>
-    <string name="status_filtered_show_anyway">Visa allafall</string>
-    <string name="status_filter_placeholder_label_format">Filtrerad: &lt;b&gt;%1$s&lt;/b&gt;</string>
     <string name="pref_title_account_filter_keywords">Profiler</string>
     <string name="label_filter_action">Filteråtgärd</string>
     <string name="label_filter_keywords">Nyckelord eller fraser att filtrera</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -450,7 +450,6 @@
     <string name="error_filter_missing_context">குறைந்தது ஒரு வடிகட்டி சூழல் தேவை</string>
     <string name="error_filter_missing_title">தலைப்பு தேவை</string>
     <string name="compose_warn_language_dialog_accept_and_dont_ask_fmt">இடுகையிடவும் (%1$s) மற்றும் மீண்டும் கேட்க வேண்டாம்</string>
-    <string name="status_filter_placeholder_label_format">வடிகட்டப்பட்டது: &lt;b>%1$s &lt;/b></string>
     <string name="search_operator_attachment_kind_video_label">ஒளிதோற்றம்</string>
     <string name="search_operator_attachment_kind_audio_label">ஒலி</string>
     <string name="search_operator_poll_only">கருத்துக் கணிப்புகளை மட்டுமே காட்டுங்கள்</string>
@@ -508,9 +507,7 @@
     <string name="notification_update_name">இடுகை திருத்தங்கள்</string>
     <string name="notification_update_description">அறிவிப்புகள் நீங்கள் தொடர்பு கொண்ட இடுகைகள் திருத்தப்படும் போது</string>
     <string name="filter_addition_title">வடிகட்டியைச் சேர்க்கவும்</string>
-    <string name="filter_edit_title">வடிகட்டியைத் திருத்து</string>
     <string name="filter_dialog_whole_word">முழு சொல்</string>
-    <string name="status_filtered_show_anyway">எப்படியும் காட்டு</string>
     <string name="filter_dialog_whole_word_description">முக்கிய சொல் அல்லது சொற்றொடர் எண்ணெழுத்து மட்டுமே இருக்கும்போது, அது முழு வார்த்தையுடனும் பொருந்தினால் மட்டுமே அது பயன்படுத்தப்படும்</string>
     <string name="set_focus_description">சிறுபடங்களில் எப்போதும் காணப்படும் மைய புள்ளியைத் தேர்வுசெய்ய வட்டத்தைத் தட்டவும் அல்லது இழுக்கவும்.</string>
     <string name="conversation_more_recipients">%1$s, %2$s மற்றும் %3$d</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -78,7 +78,6 @@
     <string name="filter_dialog_whole_word">ทั้งคำ</string>
     <string name="filter_dialog_update_button">อัปเดต</string>
     <string name="filter_dialog_remove_button">ลบ</string>
-    <string name="filter_edit_title">แก้ไขตัวคัดกรอง</string>
     <string name="filter_addition_title">เพิ่มตัวคัดกรอง</string>
     <string name="pref_title_thread_filter_keywords">การสนทนา</string>
     <string name="pref_title_public_filter_keywords">ไทม์ไลน์สาธารณะ</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -227,7 +227,6 @@
     <string name="pref_title_public_filter_keywords">Genel ağ akışı</string>
     <string name="pref_title_thread_filter_keywords">Konuşmalar</string>
     <string name="filter_addition_title">Süzgeç ekle</string>
-    <string name="filter_edit_title">Süzgeci düzenle</string>
     <string name="filter_dialog_remove_button">Kaldır</string>
     <string name="filter_dialog_update_button">Güncelle</string>
     <string name="filter_dialog_whole_word">Tüm dünya</string>
@@ -456,8 +455,6 @@
     <string name="filter_action_warn">Uyar</string>
     <string name="filter_action_hide">Gizle</string>
     <string name="filter_description_warn">Bir uyarı ile gizle</string>
-    <string name="status_filtered_show_anyway">Yine de göster</string>
-    <string name="status_filter_placeholder_label_format">Süzgeçlendi: &lt;b&gt;%1$s&lt;/b&gt;</string>
     <string name="filter_edit_keyword_title">Anahtar kelimeyi düzenle</string>
     <string name="filter_description_format">%s: %s</string>
     <string name="pref_title_show_stat_inline">Gönderi istatistiklerini sğ akışında göster</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -172,7 +172,6 @@
     <string name="lock_account_label">Заблокувати обліковий запис</string>
     <string name="action_remove">Вилучити</string>
     <string name="filter_dialog_remove_button">Вилучити</string>
-    <string name="filter_edit_title">Редагувати фільтр</string>
     <string name="filter_addition_title">Додати фільтр</string>
     <string name="pref_title_thread_filter_keywords">Розмови</string>
     <string name="pref_title_public_filter_keywords">Загальнодоступні стрічки</string>
@@ -437,8 +436,6 @@
     <string name="ui_error_reject_follow_request">Не вдалося відхилити запит на стеження: %s</string>
     <string name="ui_success_accepted_follow_request">Запит на стеження погоджено</string>
     <string name="ui_success_rejected_follow_request">Запит на стеження заблоковано</string>
-    <string name="status_filtered_show_anyway">Усе одно показати</string>
-    <string name="status_filter_placeholder_label_format">Відфільтровано: &lt;b&gt;%1$s&lt;/b&gt;</string>
     <string name="pref_title_account_filter_keywords">Профілі</string>
     <string name="label_filter_title">Заголовок</string>
     <string name="filter_action_warn">Попередження</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -209,7 +209,6 @@
     <string name="notification_favourite_description">Thông báo khi ai đó thích tút của bạn</string>
     <string name="notification_favourite_name">Lượt thích</string>
     <string name="filter_dialog_whole_word">Toàn bộ chữ có chứa cụm từ này</string>
-    <string name="filter_edit_title">Sửa bộ lọc</string>
     <string name="filter_addition_title">Thêm bộ lọc</string>
     <string name="pref_title_thread_filter_keywords">Thảo luận</string>
     <string name="pref_title_public_filter_keywords">Liên hợp</string>
@@ -434,8 +433,6 @@
     <string name="ui_error_reject_follow_request">Từ chối theo dõi không thành công: %s</string>
     <string name="ui_success_accepted_follow_request">Đã chấp nhận yêu cầu theo dõi</string>
     <string name="ui_success_rejected_follow_request">Đã từ chối yêu cầu theo dõi</string>
-    <string name="status_filtered_show_anyway">Vẫn hiện</string>
-    <string name="status_filter_placeholder_label_format">Đã lọc: &lt;b&gt;%1$s&lt;/b&gt;</string>
     <string name="pref_title_account_filter_keywords">Người</string>
     <string name="hint_filter_title">Bộ lọc của tôi</string>
     <string name="label_filter_title">Tên bộ lọc</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -188,7 +188,6 @@
     <string name="pref_title_public_filter_keywords">公共时间轴</string>
     <string name="pref_title_thread_filter_keywords">对话</string>
     <string name="filter_addition_title">添加新的过滤器</string>
-    <string name="filter_edit_title">编辑过滤器</string>
     <string name="filter_dialog_remove_button">移除</string>
     <string name="filter_dialog_update_button">更新</string>
     <string name="filter_add_description">需要过滤的文字</string>
@@ -442,8 +441,6 @@
     <string name="ui_error_reject_follow_request">未能拒绝关注请求：%s</string>
     <string name="ui_success_accepted_follow_request">关注请求被接受</string>
     <string name="ui_success_rejected_follow_request">关注请求被拦截</string>
-    <string name="status_filtered_show_anyway">仍要显示</string>
-    <string name="status_filter_placeholder_label_format">已过滤：&lt;b&gt;%1$s&lt;/b&gt;</string>
     <string name="pref_title_account_filter_keywords">个人资料</string>
     <string name="hint_filter_title">我的筛选器</string>
     <string name="label_filter_title">标题</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -188,7 +188,6 @@
     <string name="pref_title_public_filter_keywords">公共時間軸</string>
     <string name="pref_title_thread_filter_keywords">對話</string>
     <string name="filter_addition_title">添加新的過濾器</string>
-    <string name="filter_edit_title">編輯過濾器</string>
     <string name="filter_dialog_remove_button">移除</string>
     <string name="filter_dialog_update_button">更新</string>
     <string name="filter_add_description">需要過濾的文字</string>

--- a/app/src/main/res/values-zh-rMO/strings.xml
+++ b/app/src/main/res/values-zh-rMO/strings.xml
@@ -188,7 +188,6 @@
     <string name="pref_title_public_filter_keywords">公共時間軸</string>
     <string name="pref_title_thread_filter_keywords">對話</string>
     <string name="filter_addition_title">添加新的過濾器</string>
-    <string name="filter_edit_title">編輯過濾器</string>
     <string name="filter_dialog_remove_button">移除</string>
     <string name="filter_dialog_update_button">更新</string>
     <string name="filter_add_description">需要過濾的文字</string>

--- a/app/src/main/res/values-zh-rSG/strings.xml
+++ b/app/src/main/res/values-zh-rSG/strings.xml
@@ -188,7 +188,6 @@
     <string name="pref_title_public_filter_keywords">公共时间轴</string>
     <string name="pref_title_thread_filter_keywords">对话</string>
     <string name="filter_addition_title">添加新的过滤器</string>
-    <string name="filter_edit_title">编辑过滤器</string>
     <string name="filter_dialog_remove_button">移除</string>
     <string name="filter_dialog_update_button">更新</string>
     <string name="filter_add_description">需要过滤的文字</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -188,7 +188,6 @@
     <string name="pref_title_public_filter_keywords">公共時間軸</string>
     <string name="pref_title_thread_filter_keywords">對話</string>
     <string name="filter_addition_title">添加新的過濾器</string>
-    <string name="filter_edit_title">編輯過濾器</string>
     <string name="filter_dialog_remove_button">移除</string>
     <string name="filter_dialog_update_button">更新</string>
     <string name="filter_add_description">需要過濾的文字</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -370,8 +370,6 @@
     -->
     <string name="post_share_content">Share content of post</string>
     <string name="post_share_link">Share link to post</string>
-    <string name="status_filtered_show_anyway">Show anyway</string>
-    <string name="status_filter_placeholder_label_format">Filtered: &lt;b>%1$s&lt;/b></string>
     <string name="state_follow_requested">Follow requested</string>
     <!--These are for timestamps on posts. For example: "16s" or "2d"-->
     <string name="follows_you">Follows you</string>
@@ -383,7 +381,6 @@
     <string name="pref_title_thread_filter_keywords">Conversations</string>
     <string name="pref_title_account_filter_keywords">Profiles</string>
     <string name="filter_addition_title">Add filter</string>
-    <string name="filter_edit_title">Edit filter</string>
     <string name="filter_dialog_remove_button">Remove</string>
     <string name="filter_dialog_update_button">Update</string>
     <string name="filter_dialog_whole_word">Whole word</string>

--- a/core/ui/src/main/res/values-ar/strings.xml
+++ b/core/ui/src/main/res/values-ar/strings.xml
@@ -130,4 +130,7 @@
     </plurals>
     <string name="post_boosted_fmt">شاركه &lt;b&gt;%1$s&lt;/b&gt;</string>
     <string name="post_edited">عدَّلَ %s</string>
+    <string name="filter_edit_title">تعديل عامل التصفية</string>
+    <string name="status_filtered_show_anyway">إظهار على أي حال</string>
+    <string name="status_filter_placeholder_label_format">مُصفّى: &lt;b&gt;%1$s&lt;/b&gt;</string>
 </resources>

--- a/core/ui/src/main/res/values-be/strings.xml
+++ b/core/ui/src/main/res/values-be/strings.xml
@@ -112,4 +112,7 @@
     </plurals>
     <string name="post_boosted_fmt">&lt;b&gt;%1$s&lt;/b&gt; пашырыў(-ла)</string>
     <string name="post_edited">Рэдагаваны %s</string>
+    <string name="filter_edit_title">Рэдагаваць фільтр</string>
+    <string name="status_filtered_show_anyway">Усё роўна паказаць</string>
+    <string name="status_filter_placeholder_label_format">Адфільтрована: &lt;b&gt;%1$s&lt;/b&gt;</string>
 </resources>

--- a/core/ui/src/main/res/values-bg/strings.xml
+++ b/core/ui/src/main/res/values-bg/strings.xml
@@ -89,4 +89,5 @@
         <item quantity="other">&lt;b&gt;%1$s&lt;/b&gt; Любими</item>
     </plurals>
     <string name="post_boosted_fmt">&lt;b&gt;%1$s&lt;/b&gt; сподели</string>
+    <string name="filter_edit_title">Редакция на филтър</string>
 </resources>

--- a/core/ui/src/main/res/values-bn-rBD/strings.xml
+++ b/core/ui/src/main/res/values-bn-rBD/strings.xml
@@ -89,4 +89,5 @@
         <item quantity="other">&lt;b&gt;%1$s&lt;/b&gt;টি পছন্দ</item>
     </plurals>
     <string name="post_boosted_fmt">&lt;b&gt;%1$s&lt;/b&gt; বুস্টকৃত</string>
+    <string name="filter_edit_title">ফিল্টার সম্পাদনা করুন</string>
 </resources>

--- a/core/ui/src/main/res/values-bn-rIN/strings.xml
+++ b/core/ui/src/main/res/values-bn-rIN/strings.xml
@@ -87,4 +87,5 @@
         <item quantity="other">&lt;b&gt;%1$s&lt;/b&gt; পছন্দসই</item>
     </plurals>
     <string name="post_boosted_fmt">&lt;b&gt;%1$s&lt;/b&gt; সমর্থন দিয়েছে</string>
+    <string name="filter_edit_title">ফিল্টার সম্পাদনা করুন</string>
 </resources>

--- a/core/ui/src/main/res/values-ca/strings.xml
+++ b/core/ui/src/main/res/values-ca/strings.xml
@@ -96,4 +96,7 @@
     </plurals>
     <string name="post_boosted_fmt">&lt;b&gt;%1$s&lt;/b&gt; ha impulsat</string>
     <string name="post_edited">S\'ha editat %s</string>
+    <string name="filter_edit_title">Modificar un filtre</string>
+    <string name="status_filtered_show_anyway">Mostra de totes maneres</string>
+    <string name="status_filter_placeholder_label_format">Filtrat: &lt;b&gt;%1$s&lt;/b&gt;</string>
 </resources>

--- a/core/ui/src/main/res/values-ckb/strings.xml
+++ b/core/ui/src/main/res/values-ckb/strings.xml
@@ -87,4 +87,5 @@
         <item quantity="other">&lt;b&gt;%1$s&lt;/b&gt; دڵخواز</item>
     </plurals>
     <string name="post_boosted_fmt">&lt;b&gt;%1$s&lt;/b&gt; پۆستی کردەوە</string>
+    <string name="filter_edit_title">دەستکاریکردنی فلتەر</string>
 </resources>

--- a/core/ui/src/main/res/values-cs/strings.xml
+++ b/core/ui/src/main/res/values-cs/strings.xml
@@ -99,4 +99,5 @@
         <item quantity="other">&lt;b&gt;%1$s&lt;/b&gt; oblíbení</item>
     </plurals>
     <string name="post_boosted_fmt">&lt;b&gt;%1$s&lt;/b&gt; boostnul/a</string>
+    <string name="filter_edit_title">Upravit filtr</string>
 </resources>

--- a/core/ui/src/main/res/values-cy/strings.xml
+++ b/core/ui/src/main/res/values-cy/strings.xml
@@ -128,4 +128,7 @@
     </plurals>
     <string name="post_boosted_fmt">Hybodd &lt;b&gt;%1$s&lt;/b&gt;</string>
     <string name="post_edited">Golygwyd %s</string>
+    <string name="filter_edit_title">Golygu hidlydd</string>
+    <string name="status_filtered_show_anyway">Dangos beth bynnag</string>
+    <string name="status_filter_placeholder_label_format">Hidlwyd: &lt;b&gt;%1$s&lt;/b&gt;</string>
 </resources>

--- a/core/ui/src/main/res/values-de/strings.xml
+++ b/core/ui/src/main/res/values-de/strings.xml
@@ -133,4 +133,7 @@
     <string name="post_replied_to_fmt">Antwort auf &lt;b>%1$s&lt;/b></string>
     <string name="post_continued_thread">Fortgeführter Thread</string>
     <string name="post_replied">Beantwortet</string>
+    <string name="filter_edit_title">Filter bearbeiten</string>
+    <string name="status_filtered_show_anyway">Trotzdem anzeigen</string>
+    <string name="status_filter_placeholder_label_format">Gefiltert: &lt;b&gt;%1$s&lt;/b&gt;</string>
 </resources>

--- a/core/ui/src/main/res/values-eo/strings.xml
+++ b/core/ui/src/main/res/values-eo/strings.xml
@@ -98,4 +98,5 @@
         <item quantity="other">&lt;b&gt;%1$s&lt;/b&gt; Stelumoj</item>
     </plurals>
     <string name="post_boosted_fmt">&lt;b&gt;%1$s&lt;/b&gt; diskonigis</string>
+    <string name="filter_edit_title">Redakti filtrilon</string>
 </resources>

--- a/core/ui/src/main/res/values-es/strings.xml
+++ b/core/ui/src/main/res/values-es/strings.xml
@@ -144,4 +144,7 @@
     <string name="post_continued_thread">Continuó hilo</string>
     <string name="post_replied_to_fmt">Respondió a &lt;b>%1$s&lt;/b></string>
     <string name="post_replied">Respondió</string>
+    <string name="filter_edit_title">Editar filtro</string>
+    <string name="status_filtered_show_anyway">Mostrar de todas formas</string>
+    <string name="status_filter_placeholder_label_format">Filtrado: &lt;b&gt;%1$s&lt;/b&gt;</string>
 </resources>

--- a/core/ui/src/main/res/values-et/strings.xml
+++ b/core/ui/src/main/res/values-et/strings.xml
@@ -136,4 +136,7 @@
     <string name="post_continued_thread">Jutulõnga jätk</string>
     <string name="post_replied_to_fmt">Vastuseks sõnumile: &lt;b&gt;%1$s&lt;/b&gt;</string>
     <string name="action_show_pronouns">Näita asesõnu</string>
+    <string name="filter_edit_title">Muuda filtrit</string>
+    <string name="status_filtered_show_anyway">Näita ikkagi</string>
+    <string name="status_filter_placeholder_label_format">Filtreeritud: &lt;b>%1$s&lt;/b></string>
 </resources>

--- a/core/ui/src/main/res/values-eu/strings.xml
+++ b/core/ui/src/main/res/values-eu/strings.xml
@@ -91,4 +91,5 @@
     </plurals>
     <string name="post_boosted_fmt">&lt;b&gt;%1$s&lt;/b&gt;-(e)k bultzatu du</string>
     <string name="post_edited">%s editatua</string>
+    <string name="filter_edit_title">Editatu iragazkia</string>
 </resources>

--- a/core/ui/src/main/res/values-fa/strings.xml
+++ b/core/ui/src/main/res/values-fa/strings.xml
@@ -96,4 +96,7 @@
     </plurals>
     <string name="post_boosted_fmt">&lt;b&gt;%1$s&lt;/b&gt; تقویت کرد</string>
     <string name="post_edited">%s را ویراست</string>
+    <string name="filter_edit_title">ویرایش پالایه</string>
+    <string name="status_filtered_show_anyway">نمایش به هر روی</string>
+    <string name="status_filter_placeholder_label_format">پالوده: &lt;b&gt;%1$s&lt;/b&gt;</string>
 </resources>

--- a/core/ui/src/main/res/values-fi/strings.xml
+++ b/core/ui/src/main/res/values-fi/strings.xml
@@ -133,4 +133,7 @@
     <string name="handle_contentdescription_fmt">Tili, @%1$s</string>
     <string name="role_content_description_fmt">%1$s, aikaan %2$s</string>
     <string name="dot_in_name">piste</string>
+    <string name="filter_edit_title">Muokkaa suodatinta</string>
+    <string name="status_filtered_show_anyway">Näytä joka tapauksessa</string>
+    <string name="status_filter_placeholder_label_format">Suodatettu: &lt;b&gt;%1$s&lt;/b&gt;</string>
 </resources>

--- a/core/ui/src/main/res/values-fr/strings.xml
+++ b/core/ui/src/main/res/values-fr/strings.xml
@@ -108,4 +108,7 @@
     </plurals>
     <string name="post_boosted_fmt">&lt;b&gt;%1$s&lt;/b&gt; a partagé</string>
     <string name="post_edited">Modifié le %s</string>
+    <string name="filter_edit_title">Modifier un filtre</string>
+    <string name="status_filtered_show_anyway">Montrer quand même</string>
+    <string name="status_filter_placeholder_label_format">Caché : &lt;b&gt;%1$s&lt;/b&gt;</string>
 </resources>

--- a/core/ui/src/main/res/values-fy/strings.xml
+++ b/core/ui/src/main/res/values-fy/strings.xml
@@ -30,4 +30,5 @@
     <string name="post_content_warning_show_less">Minder sjen litte</string>
     <string name="post_content_warning_show_more">Mear sjen litte</string>
     <string name="post_content_show_less">Yntearre</string>
+    <string name="filter_edit_title">Filter oanpasse</string>
 </resources>

--- a/core/ui/src/main/res/values-ga/strings.xml
+++ b/core/ui/src/main/res/values-ga/strings.xml
@@ -162,4 +162,7 @@
     <string name="post_replied">D’fhreagair</string>
     <string name="post_continued_thread">Snáithe leanúnach</string>
     <string name="post_replied_to_fmt">D’fhreagair &lt;b>%1$s&lt;/b></string>
+    <string name="filter_edit_title">Cuir scagaire in eagar</string>
+    <string name="status_filtered_show_anyway">Taispeáin ar aon nós</string>
+    <string name="status_filter_placeholder_label_format">Scagtha: &lt;b&gt;%1$s&lt;/b&gt;</string>
 </resources>

--- a/core/ui/src/main/res/values-gd/strings.xml
+++ b/core/ui/src/main/res/values-gd/strings.xml
@@ -112,4 +112,7 @@
     </plurals>
     <string name="post_boosted_fmt">’Ga bhrosnachadh le &lt;b&gt;%1$s&lt;/b&gt;</string>
     <string name="post_edited">Air a dheasachadh %s</string>
+    <string name="filter_edit_title">Deasaich a’ chriathrag</string>
+    <string name="status_filtered_show_anyway">Seall e co-dhiù</string>
+    <string name="status_filter_placeholder_label_format">Criathraichte: &lt;b&gt;%1$s&lt;/b&gt;</string>
 </resources>

--- a/core/ui/src/main/res/values-gl/strings.xml
+++ b/core/ui/src/main/res/values-gl/strings.xml
@@ -108,4 +108,7 @@
     </plurals>
     <string name="post_boosted_fmt">&lt;b&gt;%1$s&lt;/b&gt; promoveu</string>
     <string name="post_edited">Editado %s</string>
+    <string name="filter_edit_title">Editar filtro</string>
+    <string name="status_filtered_show_anyway">Mostrar igualmente</string>
+    <string name="status_filter_placeholder_label_format">Filtrado: &lt;b&gt;%1$s&lt;/b&gt;</string>
 </resources>

--- a/core/ui/src/main/res/values-hi/strings.xml
+++ b/core/ui/src/main/res/values-hi/strings.xml
@@ -67,4 +67,5 @@
         <item quantity="one">&lt;b&gt;%1$s&lt;/b&gt; ने पसंद किया</item>
         <item quantity="other">&lt;b&gt;%1$s&lt;/b&gt; ने पसंद किया</item>
     </plurals>
+    <string name="filter_edit_title">फ़िल्टर संपादित करें</string>
 </resources>

--- a/core/ui/src/main/res/values-hu/strings.xml
+++ b/core/ui/src/main/res/values-hu/strings.xml
@@ -96,4 +96,7 @@
     </plurals>
     <string name="post_boosted_fmt">&lt;b&gt;%1$s&lt;/b&gt; megtolta</string>
     <string name="post_edited">%s szerkesztve</string>
+    <string name="filter_edit_title">Szűrő szerkesztése</string>
+    <string name="status_filtered_show_anyway">Mutatás mindenképpen</string>
+    <string name="status_filter_placeholder_label_format">Szűrve: &lt;b&gt;%1$s&lt;/b&gt;</string>
 </resources>

--- a/core/ui/src/main/res/values-in/strings.xml
+++ b/core/ui/src/main/res/values-in/strings.xml
@@ -44,4 +44,7 @@
     <string name="post_content_show_less">Tutup</string>
     <string name="post_boosted_fmt">&lt;b&gt;%1$s&lt;/b&gt; ter-boost</string>
     <string name="post_edited">Diedit %s</string>
+    <string name="filter_edit_title">Edit penyaring</string>
+    <string name="status_filtered_show_anyway">Tampilkan kapan saja</string>
+    <string name="status_filter_placeholder_label_format">Disaring: &lt;b>%1$s&lt;/b></string>
 </resources>

--- a/core/ui/src/main/res/values-is/strings.xml
+++ b/core/ui/src/main/res/values-is/strings.xml
@@ -96,4 +96,7 @@
     </plurals>
     <string name="post_boosted_fmt">&lt;b&gt;%1$s&lt;/b&gt; endurbirti</string>
     <string name="post_edited">Breytti %s</string>
+    <string name="filter_edit_title">Breyta síu</string>
+    <string name="status_filtered_show_anyway">Birta samt</string>
+    <string name="status_filter_placeholder_label_format">Síað: &lt;b&gt;%1$s&lt;/b&gt;</string>
 </resources>

--- a/core/ui/src/main/res/values-it/strings.xml
+++ b/core/ui/src/main/res/values-it/strings.xml
@@ -122,4 +122,7 @@
     </plurals>
     <string name="post_boosted_fmt">&lt;b&gt;%1$s&lt;/b&gt; ha condiviso</string>
     <string name="post_edited">Modificato %s</string>
+    <string name="filter_edit_title">Modifica filtro</string>
+    <string name="status_filtered_show_anyway">Mostra comunque</string>
+    <string name="status_filter_placeholder_label_format">Filtrato: &lt;b&gt;%1$s&lt;/b&gt;</string>
 </resources>

--- a/core/ui/src/main/res/values-ja/strings.xml
+++ b/core/ui/src/main/res/values-ja/strings.xml
@@ -93,4 +93,7 @@
     </plurals>
     <string name="post_boosted_fmt">&lt;b&gt;%1$s&lt;/b&gt;さんがブーストしました</string>
     <string name="post_edited">%s を編集しました</string>
+    <string name="filter_edit_title">フィルターを編集</string>
+    <string name="status_filtered_show_anyway">とにかく表示する</string>
+    <string name="status_filter_placeholder_label_format">フィルタ済み: &lt;b&gt;%1$s&lt;/b&gt;</string>
 </resources>

--- a/core/ui/src/main/res/values-kab/strings.xml
+++ b/core/ui/src/main/res/values-kab/strings.xml
@@ -78,4 +78,5 @@
         <item quantity="other">&lt;b&gt;%1$s&lt;/b&gt; n ismenyifen</item>
     </plurals>
     <string name="post_boosted_fmt">Yebḍa-t &lt;b&gt;%1$s&lt;/b&gt;</string>
+    <string name="filter_edit_title">Ẓreg amsizdeg</string>
 </resources>

--- a/core/ui/src/main/res/values-ko/strings.xml
+++ b/core/ui/src/main/res/values-ko/strings.xml
@@ -74,4 +74,5 @@
         <item quantity="other">&lt;b&gt;%1$s&lt;/b&gt; 좋아요</item>
     </plurals>
     <string name="post_boosted_fmt">&lt;b&gt;%1$s&lt;/b&gt;님이 부스트 했습니다</string>
+    <string name="filter_edit_title">필터 편집</string>
 </resources>

--- a/core/ui/src/main/res/values-lv/strings.xml
+++ b/core/ui/src/main/res/values-lv/strings.xml
@@ -144,4 +144,7 @@
     <string name="post_replied">Atbildēts</string>
     <string name="post_continued_thread">Turpināts pavediens</string>
     <string name="post_replied_to_fmt">Atbildēja &lt;b>%1$s&lt;/b></string>
+    <string name="filter_edit_title">Labot filtru</string>
+    <string name="status_filtered_show_anyway">Vienalga parādīt</string>
+    <string name="status_filter_placeholder_label_format">Atlasīts: &lt;b>%1$s&lt;/b></string>
 </resources>

--- a/core/ui/src/main/res/values-nb-rNO/strings.xml
+++ b/core/ui/src/main/res/values-nb-rNO/strings.xml
@@ -110,4 +110,7 @@
     </plurals>
     <string name="post_boosted_fmt">&lt;b&gt;%1$s&lt;/b&gt; delte</string>
     <string name="post_edited">Redigert %s</string>
+    <string name="filter_edit_title">Rediger filter</string>
+    <string name="status_filtered_show_anyway">Vis allikevel</string>
+    <string name="status_filter_placeholder_label_format">Filtrert: &lt;b&gt;%1$s&lt;/b&gt;</string>
 </resources>

--- a/core/ui/src/main/res/values-nl/strings.xml
+++ b/core/ui/src/main/res/values-nl/strings.xml
@@ -99,4 +99,7 @@
     </plurals>
     <string name="post_boosted_fmt">&lt;b&gt;%1$s&lt;/b&gt; boostte</string>
     <string name="post_edited">Bewerkt %s</string>
+    <string name="filter_edit_title">Filter bewerken</string>
+    <string name="status_filtered_show_anyway">Toch tonen</string>
+    <string name="status_filter_placeholder_label_format">Gefilterd: &lt;b&gt;%1$s&lt;/b&gt;</string>
 </resources>

--- a/core/ui/src/main/res/values-nn/strings.xml
+++ b/core/ui/src/main/res/values-nn/strings.xml
@@ -135,4 +135,7 @@
     <string name="post_replied">Svara</string>
     <string name="post_continued_thread">Framhalden tråd</string>
     <string name="post_replied_to_fmt">Svara på &lt;b&gt;%1$s&lt;/b&gt;</string>
+    <string name="filter_edit_title">Brigd filter</string>
+    <string name="status_filtered_show_anyway">Syn likevel</string>
+    <string name="status_filter_placeholder_label_format">Filtrert: &lt;b&gt;%1$s&lt;/b&gt;</string>
 </resources>

--- a/core/ui/src/main/res/values-oc/strings.xml
+++ b/core/ui/src/main/res/values-oc/strings.xml
@@ -96,4 +96,7 @@
     </plurals>
     <string name="post_boosted_fmt">&lt;b&gt;%1$s&lt;/b&gt; a partejat</string>
     <string name="post_edited">%s modificat</string>
+    <string name="filter_edit_title">Modificar un filtre</string>
+    <string name="status_filtered_show_anyway">Afichar ça que la</string>
+    <string name="status_filter_placeholder_label_format">Filtrat : &lt;b&gt;%1$s&lt;/b&gt;</string>
 </resources>

--- a/core/ui/src/main/res/values-pl/strings.xml
+++ b/core/ui/src/main/res/values-pl/strings.xml
@@ -147,4 +147,7 @@
     </plurals>
     <string name="post_boosted_fmt">Podbicie od &lt;b&gt;%1$s&lt;/b&gt;</string>
     <string name="post_edited">Edytowano %s</string>
+    <string name="filter_edit_title">Edytuj filtr</string>
+    <string name="status_filtered_show_anyway">Pokaż mimo to</string>
+    <string name="status_filter_placeholder_label_format">Zastosowano filtr: &lt;b>%1$s&lt;/b></string>
 </resources>

--- a/core/ui/src/main/res/values-pt-rBR/strings.xml
+++ b/core/ui/src/main/res/values-pt-rBR/strings.xml
@@ -106,4 +106,7 @@
     </plurals>
     <string name="post_boosted_fmt">&lt;b&gt;%1$s&lt;/b&gt; deu Boost</string>
     <string name="post_edited">Editado %s</string>
+    <string name="filter_edit_title">Editar filtro</string>
+    <string name="status_filtered_show_anyway">Mostrar mesmo assim</string>
+    <string name="status_filter_placeholder_label_format">Filtrado(s): &lt;b&gt;%1$s&lt;/b&gt;</string>
 </resources>

--- a/core/ui/src/main/res/values-pt-rPT/strings.xml
+++ b/core/ui/src/main/res/values-pt-rPT/strings.xml
@@ -101,4 +101,5 @@
     </plurals>
     <string name="post_boosted_fmt">&lt;b&gt;%1$s&lt;/b&gt; deu boost</string>
     <string name="post_edited">Editado %s</string>
+    <string name="filter_edit_title">Editar filtro</string>
 </resources>

--- a/core/ui/src/main/res/values-ru/strings.xml
+++ b/core/ui/src/main/res/values-ru/strings.xml
@@ -150,4 +150,7 @@
     </plurals>
     <string name="post_boosted_fmt">&lt;b&gt;%1$s&lt;/b&gt; продвинул(а)</string>
     <string name="post_edited">Изменено %s</string>
+    <string name="filter_edit_title">Изм. фильтр</string>
+    <string name="status_filtered_show_anyway">Показать всё равно</string>
+    <string name="status_filter_placeholder_label_format">Фильтр: &lt;b>%1$s&lt;/b></string>
 </resources>

--- a/core/ui/src/main/res/values-sa/strings.xml
+++ b/core/ui/src/main/res/values-sa/strings.xml
@@ -95,4 +95,5 @@
     </plurals>
     <string name="post_boosted_fmt">&lt;b&gt;%1$s&lt;/b&gt; अप्रकाशयत्</string>
     <string name="post_edited">%s सम्पादितम्</string>
+    <string name="filter_edit_title">शोधकं सम्पाद्यताम्</string>
 </resources>

--- a/core/ui/src/main/res/values-si/strings.xml
+++ b/core/ui/src/main/res/values-si/strings.xml
@@ -67,4 +67,5 @@
         <item quantity="one">ප්‍රියතමයන් &lt;b&gt;%1$s&lt;/b&gt;</item>
         <item quantity="other">ප්‍රියතමයන් &lt;b&gt;%1$s&lt;/b&gt;</item>
     </plurals>
+    <string name="filter_edit_title">පෙරහන සංස්කරණය</string>
 </resources>

--- a/core/ui/src/main/res/values-sk/strings.xml
+++ b/core/ui/src/main/res/values-sk/strings.xml
@@ -144,4 +144,7 @@
     <string name="post_replied">Odpovedané</string>
     <string name="post_continued_thread">Pokračovanie vlákna</string>
     <string name="post_replied_to_fmt">Odpoveď pre &lt;b>%1$s&lt;/b></string>
+    <string name="filter_edit_title">Upraviť filter</string>
+    <string name="status_filtered_show_anyway">Zobraziť aj tak</string>
+    <string name="status_filter_placeholder_label_format">Filtrované: &lt;b>%1$s&lt;/b></string>
 </resources>

--- a/core/ui/src/main/res/values-sl/strings.xml
+++ b/core/ui/src/main/res/values-sl/strings.xml
@@ -95,4 +95,5 @@
         <item quantity="other">&lt;b&gt;%1$s&lt;/b&gt; Priljubljenih</item>
     </plurals>
     <string name="post_boosted_fmt">&lt;b&gt;%1$s&lt;/b&gt; spodbudil</string>
+    <string name="filter_edit_title">Uredi filter</string>
 </resources>

--- a/core/ui/src/main/res/values-sv/strings.xml
+++ b/core/ui/src/main/res/values-sv/strings.xml
@@ -105,4 +105,7 @@
     </plurals>
     <string name="post_boosted_fmt">&lt;b&gt;%1$s&lt;/b&gt; knuffade</string>
     <string name="post_edited">Redigerade %s</string>
+    <string name="filter_edit_title">Redigera filter</string>
+    <string name="status_filtered_show_anyway">Visa allafall</string>
+    <string name="status_filter_placeholder_label_format">Filtrerad: &lt;b&gt;%1$s&lt;/b&gt;</string>
 </resources>

--- a/core/ui/src/main/res/values-ta/strings.xml
+++ b/core/ui/src/main/res/values-ta/strings.xml
@@ -115,4 +115,7 @@
     </plurals>
     <string name="post_boosted_fmt">&lt;b&gt;%1$s&lt;/b&gt; மேலேற்றப்பட்டது</string>
     <string name="post_edited">திருத்தப்பட்ட %s</string>
+    <string name="filter_edit_title">வடிகட்டியைத் திருத்து</string>
+    <string name="status_filtered_show_anyway">எப்படியும் காட்டு</string>
+    <string name="status_filter_placeholder_label_format">வடிகட்டப்பட்டது: &lt;b>%1$s &lt;/b></string>
 </resources>

--- a/core/ui/src/main/res/values-th/strings.xml
+++ b/core/ui/src/main/res/values-th/strings.xml
@@ -81,4 +81,5 @@
         <item quantity="other">&lt;b&gt;%1$s&lt;/b&gt; ชื่นชอบ</item>
     </plurals>
     <string name="post_boosted_fmt">&lt;b&gt;%1$s&lt;/b&gt; ได้ดัน</string>
+    <string name="filter_edit_title">แก้ไขตัวคัดกรอง</string>
 </resources>

--- a/core/ui/src/main/res/values-tr/strings.xml
+++ b/core/ui/src/main/res/values-tr/strings.xml
@@ -96,4 +96,7 @@
     </plurals>
     <string name="post_boosted_fmt">&lt;b&gt;%1$s&lt;/b&gt; yeniden paylaştı</string>
     <string name="post_edited">Düzenleme %s</string>
+    <string name="filter_edit_title">Süzgeci düzenle</string>
+    <string name="status_filtered_show_anyway">Yine de göster</string>
+    <string name="status_filter_placeholder_label_format">Süzgeçlendi: &lt;b&gt;%1$s&lt;/b&gt;</string>
 </resources>

--- a/core/ui/src/main/res/values-uk/strings.xml
+++ b/core/ui/src/main/res/values-uk/strings.xml
@@ -112,4 +112,7 @@
     </plurals>
     <string name="post_boosted_fmt">&lt;b&gt;%1$s&lt;/b&gt; поширює</string>
     <string name="post_edited">Змінено %s</string>
+    <string name="filter_edit_title">Редагувати фільтр</string>
+    <string name="status_filtered_show_anyway">Усе одно показати</string>
+    <string name="status_filter_placeholder_label_format">Відфільтровано: &lt;b&gt;%1$s&lt;/b&gt;</string>
 </resources>

--- a/core/ui/src/main/res/values-vi/strings.xml
+++ b/core/ui/src/main/res/values-vi/strings.xml
@@ -88,4 +88,7 @@
     </plurals>
     <string name="post_boosted_fmt">&lt;b&gt;%1$s&lt;/b&gt; đăng lại</string>
     <string name="post_edited">Sửa %s</string>
+    <string name="filter_edit_title">Sửa bộ lọc</string>
+    <string name="status_filtered_show_anyway">Vẫn hiện</string>
+    <string name="status_filter_placeholder_label_format">Đã lọc: &lt;b&gt;%1$s&lt;/b&gt;</string>
 </resources>

--- a/core/ui/src/main/res/values-zh-rCN/strings.xml
+++ b/core/ui/src/main/res/values-zh-rCN/strings.xml
@@ -103,4 +103,7 @@
     </plurals>
     <string name="post_boosted_fmt">&lt;b&gt;%1$s&lt;/b&gt; 转嘟了</string>
     <string name="post_edited">编辑了 %s</string>
+    <string name="filter_edit_title">编辑过滤器</string>
+    <string name="status_filtered_show_anyway">仍要显示</string>
+    <string name="status_filter_placeholder_label_format">已过滤：&lt;b&gt;%1$s&lt;/b&gt;</string>
 </resources>

--- a/core/ui/src/main/res/values-zh-rHK/strings.xml
+++ b/core/ui/src/main/res/values-zh-rHK/strings.xml
@@ -100,4 +100,5 @@
         <item quantity="other">&lt;b&gt;%1$s&lt;/b&gt; 次收藏</item>
     </plurals>
     <string name="post_boosted_fmt">&lt;b&gt;%1$s&lt;/b&gt; 轉嘟了</string>
+    <string name="filter_edit_title">編輯過濾器</string>
 </resources>

--- a/core/ui/src/main/res/values-zh-rMO/strings.xml
+++ b/core/ui/src/main/res/values-zh-rMO/strings.xml
@@ -87,4 +87,5 @@
         <item quantity="other">&lt;b&gt;%1$s&lt;/b&gt; 次收藏</item>
     </plurals>
     <string name="post_boosted_fmt">&lt;b&gt;%1$s&lt;/b&gt; 轉嘟了</string>
+    <string name="filter_edit_title">編輯過濾器</string>
 </resources>

--- a/core/ui/src/main/res/values-zh-rSG/strings.xml
+++ b/core/ui/src/main/res/values-zh-rSG/strings.xml
@@ -85,4 +85,5 @@
         <item quantity="other">&lt;b&gt;%1$s&lt;/b&gt; 次喜欢</item>
     </plurals>
     <string name="post_boosted_fmt">&lt;b&gt;%1$s&lt;/b&gt; 转嘟了</string>
+    <string name="filter_edit_title">编辑过滤器</string>
 </resources>

--- a/core/ui/src/main/res/values-zh-rTW/strings.xml
+++ b/core/ui/src/main/res/values-zh-rTW/strings.xml
@@ -100,4 +100,5 @@
         <item quantity="other">&lt;b&gt;%1$s&lt;/b&gt; 次最愛</item>
     </plurals>
     <string name="post_boosted_fmt">&lt;b&gt;%1$s&lt;/b&gt; 轉嘟了</string>
+    <string name="filter_edit_title">編輯過濾器</string>
 </resources>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -163,4 +163,7 @@
     <string name="post_continued_thread">Continued thread</string>
     <string name="post_replied_to_fmt">Replied to &lt;b&gt;%1$s&lt;/b&gt;</string>
     <string name="post_edited">Edited %s</string>
+    <string name="filter_edit_title">Edit filter</string>
+    <string name="status_filtered_show_anyway">Show anyway</string>
+    <string name="status_filter_placeholder_label_format">Filtered: &lt;b>%1$s&lt;/b></string>
 </resources>


### PR DESCRIPTION
`filter_edit_title`, `status_filter_placeholder_label_format`, and `status_filtered_show_anyway` are all used in the upcoming quote posts change, and need to be in `core.ui`.

Move them in this change, to reduce the size of the quote posts change.