### PR TITLE
refactor: Make PreviewCardView styleable

### DIFF
--- a/checks/src/main/java/app/pachli/lint/checks/TypedArrayUseDetector.kt
+++ b/checks/src/main/java/app/pachli/lint/checks/TypedArrayUseDetector.kt
@@ -32,7 +32,7 @@ import org.jetbrains.uast.UCallExpression
 class TypedArrayUseDetector : Detector(), SourceCodeScanner {
     override fun getApplicableMethodNames() = listOf(METHOD_USE)
 
-    private val fix = LintFix.create()
+    private val fixAndroidXUse = LintFix.create()
         .name("Replace with `androidx.core.content.res.use`")
         .replace()
         .text("use")
@@ -40,6 +40,17 @@ class TypedArrayUseDetector : Detector(), SourceCodeScanner {
         .imports("androidx.core.content.res.use")
         .independent(true)
         .build()
+
+    private val fixUseInPlace = LintFix.create()
+        .name("Replace with `app.pachli.core.ui.extensions.useInPlace`")
+        .replace()
+        .text("use")
+        .with("useInPlace")
+        .imports("app.pachli.core.ui.extensions.useInPlace")
+        .independent(true)
+        .build()
+
+    private val fix = fix().alternatives(fixAndroidXUse, fixUseInPlace)
 
     override fun visitMethodCall(context: JavaContext, node: UCallExpression, method: PsiMethod) {
         if (node.receiverType?.canonicalText != CLASS_TYPED_ARRAY) return
@@ -50,7 +61,7 @@ class TypedArrayUseDetector : Detector(), SourceCodeScanner {
             issue = ISSUE,
             scope = node,
             location = context.getCallLocation(node, includeReceiver = false, includeArguments = false),
-            message = "Import `androidx.core.content.res.use`",
+            message = "Import `androidx.core.content.res.use` or `app.pachli.core.ui.extensions.useInPlace`",
             quickfixData = fix,
         )
     }
@@ -62,7 +73,7 @@ class TypedArrayUseDetector : Detector(), SourceCodeScanner {
 
         val ISSUE = Issue.create(
             id = "TypedArrayUseDetector",
-            briefDescription = "Don't use `kotlin.use`, use `androidx.core.content.res.use`",
+            briefDescription = "Don't use `kotlin.use`, use `androidx.core.content.res.use` or `app.pachli.core.ui.extensions.useInPlace`",
             explanation = """
                 TypedArray implements AutoCloseable but doesn't have a desugared `close` on older devices,
                 and will cause a class cast exception at runtime on older devices.

--- a/core/designsystem/src/main/res/values/attrs.xml
+++ b/core/designsystem/src/main/res/values/attrs.xml
@@ -42,4 +42,32 @@
     <declare-styleable name="PollView">
         <attr name="android:textSize" format="reference|dimension" />
     </declare-styleable>
+
+    <attr name="previewCardViewStyle" format="reference" />
+    <declare-styleable name="PreviewCardView">
+        <attr name="android:background" />
+        <attr name="android:foreground" />
+
+        <!-- Height of the preview image, if the image is stacked vertically above
+             the preview content. -->
+        <attr name="previewCardImageVerticalHeight" format="reference|dimension" />
+        <!-- Width of the preview image, if the image is laid out horizontally next
+             to the preview content. -->
+        <attr name="previewCardImageHorizontalWidth" format="reference|dimension" />
+
+        <attr name="previewCardTitleTextColor" format="reference|color" />
+        <attr name="previewCardTitleTextSize" format="reference|dimension" />
+
+        <attr name="previewCardDescriptionTextColor" format="reference|color" />
+        <attr name="previewCardDescriptionTextSize" format="reference|dimension" />
+
+        <attr name="previewCardAuthorTextColor" format="reference|color" />
+        <attr name="previewCardAuthorTextSize" format="reference|dimension" />
+
+        <attr name="previewCardAuthorTimelineLinkTextColor" format="reference|color" />
+        <attr name="previewCardAuthorTimelineLinkTextSize" format="reference|dimension" />
+
+        <attr name="previewCardAvatarSize" format="reference|dimension" />
+        <attr name="previewCardAvatarCornerRadius" format="reference|dimension" />
+    </declare-styleable>
 </resources>

--- a/core/designsystem/src/main/res/values/styles.xml
+++ b/core/designsystem/src/main/res/values/styles.xml
@@ -95,6 +95,8 @@
         <item name="pronounsChipStyle">@style/Pachli.Widget.PronounChip</item>
 
         <item name="pollViewStyle">@style/Pachli.Widget.PollView</item>
+
+        <item name="previewCardViewStyle">@style/Pachli.Widget.PreviewCardView</item>
     </style>
 
     <style name="Pachli.Widget.Material3.AppBarLayout" parent="Widget.Material3.AppBarLayout">
@@ -232,6 +234,23 @@
 
     <style name="Pachli.Widget.PollView.Detailed">
         <item name="android:textSize">?status_text_large</item>
+    </style>
+
+    <style name="Pachli.Widget.PreviewCardView" parent="">
+        <item name="android:background">@drawable/card_frame</item>
+        <item name="android:foreground">?selectableItemBackground</item>
+        <item name="previewCardImageVerticalHeight">@dimen/card_image_vertical_height</item>
+        <item name="previewCardImageHorizontalWidth">@dimen/card_image_horizontal_width</item>
+        <item name="previewCardTitleTextColor">?android:textColorSecondary</item>
+        <item name="previewCardTitleTextSize">?status_text_medium</item>
+        <item name="previewCardDescriptionTextColor">?android:textColorSecondary</item>
+        <item name="previewCardDescriptionTextSize">?status_text_medium</item>
+        <item name="previewCardAuthorTextColor">?android:textColorSecondary</item>
+        <item name="previewCardAuthorTextSize">?status_text_medium</item>
+        <item name="previewCardAuthorTimelineLinkTextColor">?android:textColorSecondary</item>
+        <item name="previewCardAuthorTimelineLinkTextSize">?status_text_medium</item>
+        <item name="previewCardAvatarSize">@dimen/card_byline_avatar_dimen</item>
+        <item name="previewCardAvatarCornerRadius">@dimen/avatar_radius_36dp</item>
     </style>
 
     <!-- customize the shape of the avatars in account selection list -->

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/extensions/TypedArrayExtensions.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/extensions/TypedArrayExtensions.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.core.ui.extensions
+
+import android.content.res.TypedArray
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+
+// Work around for https://issuetracker.google.com/issues/459840686
+@OptIn(ExperimentalContracts::class)
+inline fun <R> TypedArray.useInPlace(block: (TypedArray) -> R): R {
+    contract {
+        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+    }
+    return block(this).also { recycle() }
+}

--- a/core/ui/src/main/res/layout/preview_card.xml
+++ b/core/ui/src/main/res/layout/preview_card.xml
@@ -17,134 +17,116 @@
 
 <merge xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout">
+
+    <com.google.android.material.imageview.ShapeableImageView
+        android:id="@+id/card_image"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/card_image_vertical_height"
+        android:layout_margin="1dp"
+        android:importantForAccessibility="no"
+        android:scaleType="centerCrop"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:srcCompat="@tools:sample/backgrounds/scenic" />
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/preview_card_wrapper"
-        android:layout_width="match_parent"
+        android:id="@+id/card_info"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:background="@drawable/card_frame"
-        android:clipChildren="true"
-        android:foreground="?attr/selectableItemBackground"
-        android:minHeight="48dp"
-        android:orientation="vertical">
+        android:paddingLeft="6dp"
+        android:paddingTop="6dp"
+        android:paddingRight="6dp"
+        android:paddingBottom="6dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/card_image">
 
-        <com.google.android.material.imageview.ShapeableImageView
-            android:id="@+id/card_image"
-            android:layout_width="match_parent"
-            android:layout_height="300dp"
-            android:layout_margin="1dp"
-            android:importantForAccessibility="no"
-            android:scaleType="centerCrop"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            tools:srcCompat="@tools:sample/backgrounds/scenic" />
-
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/card_info"
+        <TextView
+            android:id="@+id/card_title"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:paddingLeft="6dp"
-            android:paddingTop="6dp"
-            android:paddingRight="6dp"
-            android:paddingBottom="6dp"
+            android:ellipsize="end"
+            android:fontFamily="sans-serif-medium"
+            android:maxLines="2"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/card_image">
+            app:layout_constraintTop_toTopOf="parent"
+            tools:ignore="SelectableText"
+            tools:text="@tools:sample/lorem" />
 
-            <TextView
-                android:id="@+id/card_title"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:ellipsize="end"
-                android:fontFamily="sans-serif-medium"
-                android:maxLines="2"
-                android:textColor="?android:textColorSecondary"
-                android:textSize="?attr/status_text_medium"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                tools:ignore="SelectableText"
-                tools:text="@tools:sample/lorem" />
+        <TextView
+            android:id="@+id/card_description"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:ellipsize="end"
+            android:lineSpacingMultiplier="1.1"
+            android:maxLines="3"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/card_title"
+            tools:ignore="SelectableText"
+            tools:text="@tools:sample/lorem" />
 
-            <TextView
-                android:id="@+id/card_description"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="4dp"
-                android:ellipsize="end"
-                android:lineSpacingMultiplier="1.1"
-                android:maxLines="3"
-                android:textColor="?android:textColorSecondary"
-                android:textSize="?attr/status_text_medium"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/card_title"
-                tools:ignore="SelectableText"
-                tools:text="@tools:sample/lorem" />
+        <TextView
+            android:id="@+id/card_link"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:ellipsize="end"
+            android:lines="1"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/card_description"
+            tools:ignore="SelectableText"
+            tools:text="@tools:sample/lorem" />
 
-            <TextView
-                android:id="@+id/card_link"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="4dp"
-                android:ellipsize="end"
-                android:lines="1"
-                android:textColor="?android:attr/textColorLink"
-                android:textSize="?attr/status_text_small"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/card_description"
-                tools:ignore="SelectableText"
-                tools:text="@tools:sample/lorem" />
+        <com.google.android.material.divider.MaterialDivider
+            android:id="@+id/byline_divider"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/card_link" />
 
-            <com.google.android.material.divider.MaterialDivider
-                android:id="@+id/byline_divider"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="6dp"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/card_link" />
+        <TextView
+            android:id="@+id/author_info"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:background="?selectableItemBackground"
+            android:drawablePadding="10dp"
+            android:ellipsize="end"
+            android:gravity="start|center"
+            android:lines="1"
+            android:paddingStart="2dp"
+            android:paddingTop="6dp"
+            android:paddingEnd="2dp"
+            android:paddingBottom="2dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/byline_divider"
+            tools:ignore="SelectableText"
+            tools:text="By John Doe. See more posts" />
 
-            <TextView
-                android:id="@+id/author_info"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:background="?selectableItemBackground"
-                android:drawablePadding="10dp"
-                android:ellipsize="end"
-                android:gravity="start|center"
-                android:lines="1"
-                android:paddingStart="2dp"
-                android:paddingTop="6dp"
-                android:paddingEnd="2dp"
-                android:paddingBottom="2dp"
-                android:textSize="?attr/status_text_medium"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/byline_divider"
-                tools:ignore="SelectableText"
-                tools:text="@tools:sample/lorem" />
-
-            <TextView
-                android:id="@+id/timeline_link"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:background="?selectableItemBackground"
-                android:drawablePadding="10dp"
-                android:ellipsize="end"
-                android:gravity="start|center"
-                android:lines="1"
-                android:paddingStart="2dp"
-                android:paddingTop="6dp"
-                android:paddingEnd="2dp"
-                android:paddingBottom="2dp"
-                android:textSize="?attr/status_text_medium"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/author_info"
-                tools:ignore="SelectableText"
-                tools:text="@tools:sample/lorem" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
+        <TextView
+            android:id="@+id/timeline_link"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:background="?selectableItemBackground"
+            android:drawablePadding="10dp"
+            android:ellipsize="end"
+            android:gravity="start|center"
+            android:lines="1"
+            android:paddingStart="2dp"
+            android:paddingTop="6dp"
+            android:paddingEnd="2dp"
+            android:paddingBottom="2dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/author_info"
+            tools:ignore="SelectableText"
+            tools:text="See N posts about this link" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </merge>


### PR DESCRIPTION
Allow PreviewCard to be styleable, accepting multiple attributes to control the size of the text and image elements.

This uncovered https://issuetracker.google.com/issues/459840686, a problem with `androidx.core.content.res.use`, so work around that and add a lint fix.