### PR TITLE
fix: Show display names with some RTL characters correctly

### DIFF
--- a/core/ui/src/main/kotlin/app/pachli/core/ui/StatusView.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/StatusView.kt
@@ -162,7 +162,7 @@ abstract class StatusView<T : IStatusViewData> @JvmOverloads constructor(
         customEmojis: List<Emoji>?,
         statusDisplayOptions: StatusDisplayOptions,
     ) {
-        displayName.text = name.emojify(glide, customEmojis, displayName, statusDisplayOptions.animateEmojis)
+        displayName.text = name.unicodeWrap().emojify(glide, customEmojis, displayName, statusDisplayOptions.animateEmojis)
     }
 
     fun setUsername(name: String) {


### PR DESCRIPTION
Display names that started with LTR characters, but contained some RTL characters (e.g., a name using Latin characters first, then Hebrew) was being shown in RTL direction.

Fix this by calling `unicodeWrap()` on the text before emojifying it.