### PR TITLE
change: Use the actionable ID in more places in SFragment.kt

### DIFF
--- a/app/src/main/java/app/pachli/fragment/SFragment.kt
+++ b/app/src/main/java/app/pachli/fragment/SFragment.kt
@@ -310,7 +310,7 @@ abstract class SFragment<T : IStatusViewData> : Fragment(), StatusActionListener
                 }
                 R.id.pin -> {
                     lifecycleScope.launch {
-                        statusRepository.pin(pachliAccountId, status.statusId, !status.isPinned()).onFailure { e ->
+                        statusRepository.pin(pachliAccountId, status.actionableId, !status.isPinned()).onFailure { e ->
                             val message = e.fmt(requireContext())
                             Snackbar.make(requireView(), message, Snackbar.LENGTH_LONG).show()
                         }
@@ -319,14 +319,14 @@ abstract class SFragment<T : IStatusViewData> : Fragment(), StatusActionListener
                 }
                 R.id.status_mute_conversation -> {
                     lifecycleScope.launch {
-                        timelineCases.muteConversation(pachliAccountId, status.statusId, true)
+                        timelineCases.muteConversation(pachliAccountId, status.actionableId, true)
                     }
                     return@setOnMenuItemClickListener true
                 }
 
                 R.id.status_unmute_conversation -> {
                     lifecycleScope.launch {
-                        timelineCases.muteConversation(pachliAccountId, status.statusId, false)
+                        timelineCases.muteConversation(pachliAccountId, status.actionableId, false)
                     }
                 }
 
@@ -417,7 +417,7 @@ abstract class SFragment<T : IStatusViewData> : Fragment(), StatusActionListener
             .setMessage(R.string.dialog_delete_post_warning)
             .setPositiveButton(android.R.string.ok) { _: DialogInterface?, _: Int ->
                 lifecycleScope.launch {
-                    timelineCases.delete(viewData.status.statusId).onFailure {
+                    timelineCases.delete(viewData.status.actionableId).onFailure {
                         Timber.w("error deleting status: %s", it)
                         Toast.makeText(context, app.pachli.core.ui.R.string.error_generic, Toast.LENGTH_SHORT).show()
                     }
@@ -441,7 +441,7 @@ abstract class SFragment<T : IStatusViewData> : Fragment(), StatusActionListener
             .setMessage(R.string.dialog_redraft_post_warning)
             .setPositiveButton(android.R.string.ok) { _: DialogInterface?, _: Int ->
                 lifecycleScope.launch {
-                    timelineCases.delete(statusViewData.status.statusId).onSuccess {
+                    timelineCases.delete(statusViewData.status.actionableId).onSuccess {
                         val sourceStatus = it.body.asModel()
                         val composeOptions = ComposeOptions(
                             content = sourceStatus.text,


### PR DESCRIPTION
Existing code used the status ID, which is probably OK (the server should dereference it to the underlying actionable ID) but it's better to be explicit.