### PR TITLE
fix: Improve display of error causes on timelines

### DIFF
--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/CachedTimelineRemoteMediator.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/CachedTimelineRemoteMediator.kt
@@ -37,8 +37,8 @@ import app.pachli.core.network.model.Status
 import app.pachli.core.network.retrofit.MastodonApi
 import app.pachli.core.network.retrofit.apiresult.ApiResponse
 import app.pachli.core.network.retrofit.apiresult.ApiResult
+import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
-import com.github.michaelbull.result.get
 import com.github.michaelbull.result.getOrElse
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -180,9 +180,9 @@ class CachedTimelineRemoteMediator(
         val nextPage = async { mastodonApi.homeTimeline(maxId = statusId, limit = pageSize / 2) }
 
         val statuses = buildList {
-            prevPage.await().get()?.let { this.addAll(it.body) }
-            status.await().get()?.let { this.add(it.body) }
-            nextPage.await().get()?.let { this.addAll(it.body) }
+            prevPage.await().getOrElse { return@coroutineScope Err(it) }.let { this.addAll(it.body) }
+            status.await().getOrElse { return@coroutineScope Err(it) }.let { this.add(it.body) }
+            nextPage.await().getOrElse { return@coroutineScope Err(it) }.let { this.addAll(it.body) }
         }
 
         val minId = statuses.firstOrNull()?.id ?: statusId

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelineRemoteMediator.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelineRemoteMediator.kt
@@ -32,8 +32,8 @@ import app.pachli.core.network.model.Status as NetworkStatus
 import app.pachli.core.network.retrofit.MastodonApi
 import app.pachli.core.network.retrofit.apiresult.ApiResponse
 import app.pachli.core.network.retrofit.apiresult.ApiResult
+import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
-import com.github.michaelbull.result.get
 import com.github.michaelbull.result.getOrElse
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -228,9 +228,9 @@ class NetworkTimelineRemoteMediator(
         val nextPage = async { fetchPage(statusId, null, pageSize / 2) }
 
         val statuses = buildList {
-            prevPage.await().get()?.let { this.addAll(it.body) }
-            status.await().get()?.let { this.add(it.body) }
-            nextPage.await().get()?.let { this.addAll(it.body) }
+            prevPage.await().getOrElse { return@coroutineScope Err(it) }.let { this.addAll(it.body) }
+            status.await().getOrElse { return@coroutineScope Err(it) }.let { this.add(it.body) }
+            nextPage.await().getOrElse { return@coroutineScope Err(it) }.let { this.addAll(it.body) }
         }
 
         val minId = statuses.firstOrNull()?.id ?: statusId

--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/notifications/NotificationsRemoteMediator.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/notifications/NotificationsRemoteMediator.kt
@@ -46,8 +46,8 @@ import app.pachli.core.network.model.Report
 import app.pachli.core.network.retrofit.MastodonApi
 import app.pachli.core.network.retrofit.apiresult.ApiResponse
 import app.pachli.core.network.retrofit.apiresult.ApiResult
+import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
-import com.github.michaelbull.result.get
 import com.github.michaelbull.result.getOrElse
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -193,11 +193,11 @@ class NotificationsRemoteMediator(
         val nextPage = async { mastodonApi.notifications(maxId = notificationId, limit = pageSize * 3, excludes = excludeTypes) }
 
         val notifications = buildList {
-            prevPage.await().get()?.let { this.addAll(it.body) }
-            notification.await().get()?.let {
+            prevPage.await().getOrElse { return@coroutineScope Err(it) }.let { this.addAll(it.body) }
+            notification.await().getOrElse { return@coroutineScope Err(it) }.let {
                 if (!excludeTypes.contains(it.body.type)) this.add(it.body)
             }
-            nextPage.await().get()?.let { this.addAll(it.body) }
+            nextPage.await().getOrElse { return@coroutineScope Err(it) }.let { this.addAll(it.body) }
         }
 
         val minId = notifications.firstOrNull()?.id ?: notificationId


### PR DESCRIPTION
Previous code had a number of issues:

1. JSON decoding errors processing pages in *RemoteMediator created empty pages instead of reporting the error up the stack.

2. JSON decoding errors from Room converters didn't include enough information to determine the source of the problem.

3. Processing `CombinedLoadStates` could miss error states in `source.refresh` because of how `CombinedLoadStates` merges the states.

Fix all of these.