### PR TITLE
change: Log the loadState in fragments that use it

### DIFF
--- a/app/src/main/java/app/pachli/components/conversation/ConversationsFragment.kt
+++ b/app/src/main/java/app/pachli/components/conversation/ConversationsFragment.kt
@@ -88,6 +88,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 /**
  * Actions taken from the broader UI (which can include actions triggered by the
@@ -191,6 +192,8 @@ class ConversationsFragment :
             initSwipeToRefresh()
 
             adapter.addLoadStateListener { loadState ->
+                Timber.d("loadState: $loadState")
+
                 if (loadState.refresh != LoadState.Loading && loadState.source.refresh != LoadState.Loading) {
                     binding.swipeRefreshLayout.isRefreshing = false
                 }

--- a/app/src/main/java/app/pachli/components/notifications/NotificationsFragment.kt
+++ b/app/src/main/java/app/pachli/components/notifications/NotificationsFragment.kt
@@ -99,6 +99,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.launch
 import postPrepend
+import timber.log.Timber
 
 @AndroidEntryPoint
 class NotificationsFragment :
@@ -362,6 +363,8 @@ class NotificationsFragment :
      * to show/hide Error, Loading, and NotLoading states.
      */
     private fun bindLoadState(loadState: CombinedLoadStates) {
+        Timber.d("bindLoadState: $loadState")
+
         // CombinedLoadStates doesn't handle the case when the mediator load completes
         // successfully but the source load fails. See
         // https://issuetracker.google.com/issues/460960009 for details.

--- a/app/src/main/java/app/pachli/components/timeline/TimelineFragment.kt
+++ b/app/src/main/java/app/pachli/components/timeline/TimelineFragment.kt
@@ -409,6 +409,8 @@ class TimelineFragment :
      * to show/hide Error, Loading, and NotLoading states.
      */
     private fun bindLoadState(loadState: CombinedLoadStates) {
+        Timber.d("bindLoadState: $loadState")
+
         // CombinedLoadStates doesn't handle the case when the mediator load completes
         // successfully but the source load fails. See
         // https://issuetracker.google.com/issues/460960009 for details.


### PR DESCRIPTION
Might help identify unexpected states preventing the UI from progressing.