### PR TITLE
fix: Use the correct ID when translating boosted posts

### DIFF
--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/TimelineViewModel.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/TimelineViewModel.kt
@@ -544,7 +544,7 @@ abstract class TimelineViewModel<T : Any, R : TimelineRepository<T>>(
      * and update [translation][StatusViewData.translation].     .
      * 3. Revert the status state change from (1) if the operation failed.
      */
-    abstract suspend fun onTranslate(action: FallibleStatusAction.Translate): Result<TranslatedStatus, TranslatorError> // = timelineCases.translate(action.statusViewData)
+    abstract suspend fun onTranslate(action: FallibleStatusAction.Translate): Result<TranslatedStatus, TranslatorError>
 
     /**
      * Undo translating a status.

--- a/app/src/main/java/app/pachli/usecase/TimelineCases.kt
+++ b/app/src/main/java/app/pachli/usecase/TimelineCases.kt
@@ -201,21 +201,21 @@ class TimelineCases @Inject constructor(
     }
 
     suspend fun translate(statusViewData: IStatusViewData): Result<TranslatedStatus, TranslatorError> {
-        statusRepository.setTranslationState(statusViewData.pachliAccountId, statusViewData.statusId, TranslationState.TRANSLATING)
+        statusRepository.setTranslationState(statusViewData.pachliAccountId, statusViewData.actionableId, TranslationState.TRANSLATING)
         return translationService.translate(statusViewData)
             .onSuccess {
                 translatedStatusDao.upsert(
                     it.toEntity(statusViewData.pachliAccountId, statusViewData.actionableId),
                 )
-                statusRepository.setTranslationState(statusViewData.pachliAccountId, statusViewData.statusId, TranslationState.SHOW_TRANSLATION)
+                statusRepository.setTranslationState(statusViewData.pachliAccountId, statusViewData.actionableId, TranslationState.SHOW_TRANSLATION)
             }.onFailure {
                 // Reset the translation state
-                statusRepository.setTranslationState(statusViewData.pachliAccountId, statusViewData.statusId, TranslationState.SHOW_ORIGINAL)
+                statusRepository.setTranslationState(statusViewData.pachliAccountId, statusViewData.actionableId, TranslationState.SHOW_ORIGINAL)
             }
     }
 
     suspend fun translateUndo(statusViewData: IStatusViewData) {
-        statusRepository.setTranslationState(statusViewData.pachliAccountId, statusViewData.statusId, TranslationState.SHOW_ORIGINAL)
+        statusRepository.setTranslationState(statusViewData.pachliAccountId, statusViewData.actionableId, TranslationState.SHOW_ORIGINAL)
     }
 
     /**

--- a/core/database/src/main/kotlin/app/pachli/core/database/model/TranslatedStatusEntity.kt
+++ b/core/database/src/main/kotlin/app/pachli/core/database/model/TranslatedStatusEntity.kt
@@ -22,7 +22,6 @@ import androidx.room.TypeConverters
 import app.pachli.core.database.Converters
 import app.pachli.core.model.TranslatedAttachment
 import app.pachli.core.model.TranslatedPoll
-import app.pachli.core.model.Translation
 import app.pachli.core.model.asNetworkModel
 import app.pachli.core.model.translation.TranslatedStatus
 
@@ -71,16 +70,6 @@ data class TranslatedStatusEntity(
 
     /** The service that provided the machine translation */
     val provider: String,
-)
-
-fun Translation.toEntity(pachliAccountId: Long, serverId: String) = TranslatedStatusEntity(
-    serverId = serverId,
-    timelineUserId = pachliAccountId,
-    content = content,
-    spoilerText = spoilerText,
-    poll = poll,
-    attachments = attachments,
-    provider = provider,
 )
 
 fun TranslatedStatus.toEntity(pachliAccountId: Long, serverId: String) = TranslatedStatusEntity(


### PR DESCRIPTION
Previous code was using the status ID in some cases, resulting in the
translated text of reblogged statuses being stored under the wrong ID.