### PR TITLE
fix: Show detailed error if refreshing a timeline fails

### DIFF
--- a/app/src/main/java/app/pachli/components/account/media/AccountMediaRemoteMediator.kt
+++ b/app/src/main/java/app/pachli/components/account/media/AccountMediaRemoteMediator.kt
@@ -52,7 +52,7 @@ class AccountMediaRemoteMediator(
                     return MediatorResult.Success(endOfPaginationReached = false)
                 }
             }
-        }.getOrElse { return MediatorResult.Error(it.throwable) }
+        }.getOrElse { return MediatorResult.Error(it.asThrowable()) }
 
         val statuses = statusResponse.body
         val attachments = statuses.flatMap { status ->

--- a/app/src/main/java/app/pachli/components/conversation/ConversationsRemoteMediator.kt
+++ b/app/src/main/java/app/pachli/components/conversation/ConversationsRemoteMediator.kt
@@ -46,7 +46,7 @@ class ConversationsRemoteMediator(
         }
 
         val conversationsResponse = api.getConversations(maxId = nextKey, limit = state.config.pageSize)
-            .getOrElse { return MediatorResult.Error(it.throwable) }
+            .getOrElse { return MediatorResult.Error(it.asThrowable()) }
 
         val conversations = conversationsResponse.body.filterNot { it.lastStatus == null }.asModel()
 

--- a/app/src/main/java/app/pachli/components/followedtags/FollowedTagsRemoteMediator.kt
+++ b/app/src/main/java/app/pachli/components/followedtags/FollowedTagsRemoteMediator.kt
@@ -39,7 +39,7 @@ class FollowedTagsRemoteMediator(
 
     private fun applyResponse(result: ApiResult<List<HashTag>>): MediatorResult {
         val response = result.getOrElse {
-            return MediatorResult.Error(it.throwable)
+            return MediatorResult.Error(it.asThrowable())
         }
         val tags = response.body
 

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/CachedTimelineRemoteMediator.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/CachedTimelineRemoteMediator.kt
@@ -94,7 +94,7 @@ class CachedTimelineRemoteMediator(
                     Timber.d("Append from remoteKey: %s", rke)
                     mastodonApi.homeTimeline(maxId = rke.key, limit = state.config.pageSize)
                 }
-            }.getOrElse { return@transactionProvider MediatorResult.Error(it.throwable) }
+            }.getOrElse { return@transactionProvider MediatorResult.Error(it.asThrowable()) }
 
             val statuses = response.body
 

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelineRemoteMediator.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelineRemoteMediator.kt
@@ -101,7 +101,7 @@ class NetworkTimelineRemoteMediator(
                     val key = pageCache.firstPage?.prevKey ?: return MediatorResult.Success(endOfPaginationReached = true)
                     Page.tryFrom(fetchStatusPageByKind(loadType, key, state.config.pageSize))
                 }
-            }.getOrElse { return MediatorResult.Error(it.throwable) }
+            }.getOrElse { return MediatorResult.Error(it.asThrowable()) }
 
             Timber.d("- $timeline, load(), type = %s, items: %d", loadType, page.data.size)
             Timber.d("  $timeline, first id: ${page.data.firstOrNull()?.statusId}")

--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/notifications/NotificationsRemoteMediator.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/notifications/NotificationsRemoteMediator.kt
@@ -116,7 +116,7 @@ class NotificationsRemoteMediator(
                     ) ?: return@transactionProvider MediatorResult.Success(endOfPaginationReached = true)
                     mastodonApi.notifications(maxId = rke.key, limit = state.config.pageSize, excludes = excludeTypes)
                 }
-            }.getOrElse { return@transactionProvider MediatorResult.Error(it.throwable) }
+            }.getOrElse { return@transactionProvider MediatorResult.Error(it.asThrowable()) }
 
             val links = Links.from(response.headers["link"])
 

--- a/core/network/src/main/res/values/strings.xml
+++ b/core/network/src/main/res/values/strings.xml
@@ -24,7 +24,7 @@
     <string name="error_generic_fmt">%1$s</string>
     <string name="error_404_not_found_fmt">your server does not support this feature: %1$s</string>
     <string name="error_429_rate_limit_fmt">your server is rate-limiting your requests: %1$s</string>
-    <string name="error_json_data_fmt">Your server returned an invalid response: %1$s</string>
+    <string name="error_json_data_fmt">your server returned an invalid response: %1$s</string>
     <string name="error_network_fmt">A network error occurred: %s</string>
     <string name="error_missing_content_type_fmt">your server is mis-configured, the response has no content-type: %1$s</string>
     <string name="error_wrong_content_type_fmt">your server is mis-configured and returned \'%2$s\' with the wrong content-type, \'%1$s\'</string>

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/BackgroundMessageView.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/BackgroundMessageView.kt
@@ -33,6 +33,7 @@ import android.widget.TextView
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import app.pachli.core.common.PachliError
+import app.pachli.core.common.PachliThrowable
 import app.pachli.core.common.extensions.visible
 import app.pachli.core.ui.databinding.ViewBackgroundMessageBinding
 import app.pachli.core.ui.extensions.getDrawableRes
@@ -97,11 +98,19 @@ class BackgroundMessageView @JvmOverloads constructor(
     }
 
     fun setup(throwable: Throwable, listener: ((v: View) -> Unit)? = null) {
+        if (throwable is PachliThrowable) {
+            return setup(throwable.pachliError, listener)
+        }
+
         setup(throwable.getDrawableRes(), throwable.getErrorString(context), listener)
     }
 
     fun setup(error: PachliError, listener: ((v: View) -> Unit)? = null) {
-        setup(error.getDrawableRes(), error.fmt(context), listener)
+        setup(
+            error.getDrawableRes(),
+            context.getString(app.pachli.core.network.R.string.error_network_fmt, error.fmt(context)),
+            listener,
+        )
     }
 
     fun setup(message: BackgroundMessage, listener: ((v: View) -> Unit)? = null) {
@@ -112,7 +121,14 @@ class BackgroundMessageView @JvmOverloads constructor(
         @DrawableRes imageRes: Int,
         @StringRes messageRes: Int,
         clickListener: ((v: View) -> Unit)? = null,
-    ) = setup(imageRes, context.getString(messageRes), clickListener)
+    ) = setup(
+        imageRes,
+        context.getString(
+            app.pachli.core.network.R.string.error_network_fmt,
+            context.getString(messageRes),
+        ),
+        clickListener,
+    )
 
     /**
      * Setup image, message and button.

--- a/core/ui/src/main/res/layout/view_background_message.xml
+++ b/core/ui/src/main/res/layout/view_background_message.xml
@@ -45,7 +45,6 @@
             android:paddingRight="16dp"
             android:paddingTop="16dp"
             android:text="@string/error_network"
-            android:textAlignment="center"
             android:textSize="?attr/status_text_medium" />
 
         <Button


### PR DESCRIPTION
Previous code returned the underlying network throwable if an error occurred refreshing a timeline (e.g., the `HttpException`). This is because `MediatorResult.Error` requires the error to be a `Throwable`.

This throws away the rich error data collected in the `PachliError` chain (e.g., the URL, and the error message).

Work around this with a new `PachliThrowable` class that embeds the underlying `PachliError. This allows the error display to show the full error chain.

While I'm here, left justify the error text and make sure it's grammatically correct.