### PR TITLE
fix: Set correct padding, margins, etc, on trending link cards

### DIFF
--- a/app/src/main/java/app/pachli/components/trending/TrendingLinksFragment.kt
+++ b/app/src/main/java/app/pachli/components/trending/TrendingLinksFragment.kt
@@ -18,6 +18,7 @@
 package app.pachli.components.trending
 
 import android.content.res.Configuration
+import android.graphics.Rect
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuInflater
@@ -32,6 +33,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.GridLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.SimpleItemAnimator
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout.OnRefreshListener
 import app.pachli.R
@@ -234,6 +236,12 @@ class TrendingLinksFragment :
             (itemAnimator as SimpleItemAnimator).supportsChangeAnimations = false
             adapter = trendingLinksAdapter
             setAccessibilityDelegateCompat(TrendingLinksAccessibilityDelegate(this, ::onOpenLink))
+
+            addItemDecoration(
+                MarginTopItemDecoration(
+                    resources.getDimensionPixelSize(DR.dimen.trendingLinks_top_margin),
+                ),
+            )
         }
     }
 
@@ -321,5 +329,12 @@ class TrendingLinksFragment :
             }
             return fragment
         }
+    }
+}
+
+/** [RecyclerView.ItemDecoration] that ensures a space of [marginTop] between items. */
+class MarginTopItemDecoration(private val marginTop: Int) : RecyclerView.ItemDecoration() {
+    override fun getItemOffsets(outRect: Rect, view: View, parent: RecyclerView, state: RecyclerView.State) {
+        outRect.top = marginTop
     }
 }

--- a/app/src/main/res/layout/item_trending_link.xml
+++ b/app/src/main/res/layout/item_trending_link.xml
@@ -15,11 +15,14 @@
   ~ see <http://www.gnu.org/licenses>.
   -->
 
-<app.pachli.core.ui.PreviewCardView
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/status_card_view"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:paddingTop="8dp"
-    android:paddingStart="14dp"
-    android:paddingEnd="14dp" />
+    android:paddingStart="?listPreferredItemPaddingStart"
+    android:paddingEnd="?listPreferredItemPaddingEnd">
+
+    <app.pachli.core.ui.PreviewCardView
+        android:id="@+id/status_card_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+</FrameLayout>

--- a/core/designsystem/src/main/res/values/dimens.xml
+++ b/core/designsystem/src/main/res/values/dimens.xml
@@ -83,6 +83,9 @@
     <dimen name="pronounChip_maxWidth">102sp</dimen>
     <dimen name="pronounChip_minHeight">24dp</dimen>
 
+    <!-- Top margin between items in the "Trending Links" view. -->
+    <dimen name="trendingLinks_top_margin">16dp</dimen>
+
     <!-- Adjust the dimensions of items in the Material drawer to provide a
          slightly tighter layout while ensuring that minimum touch sizes are
          maintained.


### PR DESCRIPTION
The changes to `PreviewCardView` highlighted some shortcomings with the use in the layout for trending links; not enough space between items and spurious borders caused by padding.

Adjust the layout to correct this, and use an item decoration to create the appropriate gap between items.