### PR TITLE
fix: Correctly prune database cache

### DIFF
--- a/app/src/main/java/app/pachli/MainActivity.kt
+++ b/app/src/main/java/app/pachli/MainActivity.kt
@@ -935,6 +935,7 @@ class MainActivity : ViewUrlActivity(), ActionButtonActivity, MenuProvider {
                 arrayOf(
                     "Clear home timeline cache",
                     "Remove first 40 statuses",
+                    "Prune cache",
                 ),
             ) { _, which ->
                 Timber.d("Developer tools: %d", which)
@@ -949,6 +950,12 @@ class MainActivity : ViewUrlActivity(), ActionButtonActivity, MenuProvider {
                         Timber.d("Removing most recent 40 statuses")
                         lifecycleScope.launch {
                             developerToolsUseCase.deleteFirstKStatuses(pachliAccountId, 40)
+                        }
+                    }
+                    2 -> {
+                        Timber.d("Pruning cache")
+                        lifecycleScope.launch {
+                            developerToolsUseCase.pruneCache(pachliAccountId)
                         }
                     }
                 }

--- a/app/src/main/java/app/pachli/usecase/DeveloperToolsUseCase.kt
+++ b/app/src/main/java/app/pachli/usecase/DeveloperToolsUseCase.kt
@@ -45,4 +45,16 @@ class DeveloperToolsUseCase @Inject constructor(
             timelineDao.deleteRange(accountId, ids.last(), ids.first())
         }
     }
+
+    /**
+     * Cleanup the database, almost identically to [PruneCacheWorker].
+     *
+     * This operates on the given [pachliAccountId], [PruneCacheWorker] operates on all
+     * accounts.
+     */
+    suspend fun pruneCache(pachliAccountId: Long) {
+        transactionProvider {
+            timelineDao.cleanup(pachliAccountId)
+        }
+    }
 }

--- a/core/database/src/main/kotlin/app/pachli/core/database/dao/TimelineDao.kt
+++ b/core/database/src/main/kotlin/app/pachli/core/database/dao/TimelineDao.kt
@@ -766,7 +766,7 @@ WHERE timelineUserId = :accountId AND serverId NOT IN (
     UNION
     SELECT statusServerId
     FROM NotificationEntity
-    WHERE pachliAccountId = :accountId
+    WHERE pachliAccountId = :accountId AND statusServerId IS NOT NULL
     UNION
     SELECT lastStatusServerId
     FROM ConversationEntity
@@ -822,7 +822,7 @@ WHERE
         UNION
         SELECT statusServerId
         FROM NotificationEntity
-        WHERE pachliAccountId = :accountId
+        WHERE pachliAccountId = :accountId AND statusServerId IS NOT NULL
     )
 """,
     )
@@ -845,7 +845,7 @@ WHERE
         UNION
         SELECT statusServerId
         FROM NotificationEntity
-        WHERE pachliAccountId = :accountId
+        WHERE pachliAccountId = :accountId AND statusServerId IS NOT NULL
     )
 """,
     )

--- a/feature/about/src/main/kotlin/app/pachli/feature/about/DatabaseFragment.kt
+++ b/feature/about/src/main/kotlin/app/pachli/feature/about/DatabaseFragment.kt
@@ -69,6 +69,7 @@ class DatabaseFragment : Fragment(R.layout.fragment_database) {
         bindTableSizes(uiState.tableRowCounts)
         bindIntegrityCheck(uiState.integrityCheck)
         bindQueryTimings(uiState.queryDurations)
+        bindPruneCache(uiState.pruneCacheResult)
         bindVacuum(uiState.vacuumResult)
         bindClearCache(uiState.clearCacheResult)
 
@@ -80,6 +81,11 @@ class DatabaseFragment : Fragment(R.layout.fragment_database) {
         binding.buttonQueryTimings.setOnClickListener { v ->
             v.isEnabled = false
             viewModel.getQueryDurations(uiState.pachliAccountId)
+        }
+
+        binding.buttonPruneCache.setOnClickListener { v ->
+            binding.pruneCacheResult.hide()
+            viewModel.pruneCache()
         }
 
         binding.buttonVacuum.setOnClickListener { v ->
@@ -147,6 +153,14 @@ getConversationsWithQuote: ${queryDurations?.getConversationsWithQuote?.fmt() ?:
         return when (this) {
             is Err -> error.localizedMessage
             is Ok -> "${this.value.first.toMillis()} ms, ${this.value.second} items"
+        }
+    }
+
+    private fun bindPruneCache(pruneCacheResult: Result<Unit?, Throwable>) {
+        binding.pruneCacheResult.visible(pruneCacheResult.get() != null)
+        binding.pruneCacheResult.text = when (pruneCacheResult) {
+            is Err -> pruneCacheResult.error.localizedMessage
+            is Ok -> getString(R.string.database_prune_cache_complete)
         }
     }
 

--- a/feature/about/src/main/res/layout/fragment_database.xml
+++ b/feature/about/src/main/res/layout/fragment_database.xml
@@ -112,6 +112,42 @@
             app:layout_constraintEnd_toEndOf="@id/queryDurationsTitle" />
 
         <TextView
+            android:id="@+id/pruneCacheTitle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:layout_marginStart="@dimen/text_content_margin"
+            android:layout_marginEnd="@dimen/text_content_margin"
+            android:lineSpacingMultiplier="1.1"
+            android:text="@string/database_prune_cache"
+            android:textIsSelectable="true"
+            android:textAppearance="@style/TextAppearance.AppCompat.Large"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/queryDurations"
+            app:layout_constraintEnd_toEndOf="parent" />
+
+        <Button
+            android:id="@+id/buttonPruneCache"
+            style="@style/AppButton.Outlined"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@string/action_prune_cache"
+            android:textSize="16sp"
+            app:layout_constraintStart_toStartOf="@id/pruneCacheTitle"
+            app:layout_constraintTop_toBottomOf="@id/pruneCacheTitle" />
+
+        <TextView
+            android:id="@+id/pruneCacheResult"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:lineSpacingMultiplier="1.1"
+            android:textIsSelectable="true"
+            android:visibility="gone"
+            app:layout_constraintStart_toStartOf="@id/pruneCacheTitle"
+            app:layout_constraintTop_toBottomOf="@id/buttonPruneCache"
+            app:layout_constraintEnd_toEndOf="parent" />
+
+        <TextView
             android:id="@+id/vacuumTitle"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -123,7 +159,7 @@
             android:textIsSelectable="true"
             android:textAppearance="@style/TextAppearance.AppCompat.Large"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/queryDurations"
+            app:layout_constraintTop_toBottomOf="@id/pruneCacheResult"
             app:layout_constraintEnd_toEndOf="parent" />
 
         <Button

--- a/feature/about/src/main/res/values/strings.xml
+++ b/feature/about/src/main/res/values/strings.xml
@@ -69,12 +69,15 @@
     <string name="database_table_sizes">Table sizes</string>
     <string name="database_integrity_check">Integrity check</string>
     <string name="database_query_timings">Query timings</string>
+    <string name="database_prune_cache">Prune cache</string>
     <string name="database_vacuum">Vacuum</string>
     <string name="database_clear_cache">Clear cache</string>
     <string name="action_run_integrity_check">Run integrity check</string>
     <string name="action_run_query_timings">Run query timings</string>
+    <string name="action_prune_cache">Prune cache</string>
     <string name="action_vacuum">Vacuum</string>
     <string name="action_clear_cache">Clear cache</string>
+    <string name="database_prune_cache_complete">Prune cache complete</string>
     <string name="database_vacuum_complete">Vacuum complete</string>
     <string name="database_clear_cache_complete">Clear cache complete</string>
 </resources>


### PR DESCRIPTION
The queries used to prune the cache were returning empty results if notifications with null status IDs existed (which is highly likely). As a result of that the database wasn't being correctly pruned.

Fix that by updating the query.

In addition, add a developer tool entry to prune the cache, and add it to the new "Database" tab on the "About" screen.