### PR TITLE
change: Don't return an error if the status-to-restore is not found

### DIFF
--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/CachedTimelineRemoteMediator.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/CachedTimelineRemoteMediator.kt
@@ -40,6 +40,7 @@ import app.pachli.core.network.retrofit.apiresult.ApiResponse
 import app.pachli.core.network.retrofit.apiresult.ApiResult
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.get
 import com.github.michaelbull.result.getOrElse
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -183,7 +184,7 @@ class CachedTimelineRemoteMediator(
 
         val statuses = buildList {
             prevPage.await().getOrElse { return@coroutineScope Err(it) }.let { this.addAll(it.body) }
-            status.await().getOrElse { return@coroutineScope Err(it) }.let { this.add(it.body) }
+            status.await().get()?.let { this.add(it.body) }
             nextPage.await().getOrElse { return@coroutineScope Err(it) }.let { this.addAll(it.body) }
         }
 

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelineRemoteMediator.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelineRemoteMediator.kt
@@ -35,6 +35,7 @@ import app.pachli.core.network.retrofit.apiresult.ApiResponse
 import app.pachli.core.network.retrofit.apiresult.ApiResult
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.get
 import com.github.michaelbull.result.getOrElse
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -231,7 +232,7 @@ class NetworkTimelineRemoteMediator(
 
         val statuses = buildList {
             prevPage.await().getOrElse { return@coroutineScope Err(it) }.let { this.addAll(it.body) }
-            status.await().getOrElse { return@coroutineScope Err(it) }.let { this.add(it.body) }
+            status.await().get()?.let { this.add(it.body) }
             nextPage.await().getOrElse { return@coroutineScope Err(it) }.let { this.addAll(it.body) }
         }
 


### PR DESCRIPTION
This indicates the status to restore the user's reading position to has been deleted or is no longer accessible to them. We can still restore the "page" of statuses around that status.