### PR TITLE
fix: Load images from sites that use LetsEncrypt certificates on Android 6

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -168,6 +168,8 @@ dependencies {
 
     implementation(libs.conscrypt.android)
 
+    ksp(libs.glide.compiler)
+
     implementation(libs.touchimageview)
 
     implementation(libs.bundles.material.drawer)

--- a/app/src/main/java/app/pachli/util/GlideModule.kt
+++ b/app/src/main/java/app/pachli/util/GlideModule.kt
@@ -1,7 +1,42 @@
 package app.pachli.util
 
+import android.content.Context
+import com.bumptech.glide.Glide
+import com.bumptech.glide.Registry
+import com.bumptech.glide.annotation.Excludes
 import com.bumptech.glide.annotation.GlideModule
+import com.bumptech.glide.integration.okhttp3.OkHttpLibraryGlideModule
+import com.bumptech.glide.integration.okhttp3.OkHttpUrlLoader
+import com.bumptech.glide.load.model.GlideUrl
 import com.bumptech.glide.module.AppGlideModule
+import dagger.hilt.EntryPoint
+import dagger.hilt.EntryPoints
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import java.io.InputStream
+import okhttp3.OkHttpClient
 
 @GlideModule
-class GlideModule : AppGlideModule()
+@Excludes(OkHttpLibraryGlideModule::class)
+class GlideModule : AppGlideModule() {
+    // Replace the stock Glide OkHttpClient with the client configured in
+    // NetworkModule. This shares the cache, and ensures any customisations
+    // like proxy and SSL certificates are used.
+    override fun registerComponents(context: Context, glide: Glide, registry: Registry) {
+        val entryPoint = EntryPoints.get(context, GlideEntryPoint::class.java)
+        val httpClient = entryPoint.provideOkHttpClient()
+
+        registry.replace(
+            GlideUrl::class.java,
+            InputStream::class.java,
+            OkHttpUrlLoader.Factory(httpClient),
+        )
+    }
+
+    // Hilt can't inject into GlideModule, provide an entry point to inject into.
+    @EntryPoint
+    @InstallIn(SingletonComponent::class)
+    interface GlideEntryPoint {
+        fun provideOkHttpClient(): OkHttpClient
+    }
+}


### PR DESCRIPTION
Previous code loaded embedded LetsEncrypt certificates on Android 6 / API 23 for the OkHttpClient used for API requests, but the client used by Glide was not affected, so requests to load images from those sites would fail due to SSL errors.

Fix that, and have Glide use the same OkHttpClient as the rest of the app. That should use fewer resources, share the cache between the two, and pick up the special SSL certificate customisation.