### PR TITLE
refactor: Update translation and menu handling in SFragment

### DIFF
--- a/app/src/main/java/app/pachli/components/conversation/ConversationsFragment.kt
+++ b/app/src/main/java/app/pachli/components/conversation/ConversationsFragment.kt
@@ -374,12 +374,25 @@ class ConversationsFragment :
         viewModel.bookmark(bookmark, viewData.actionableId)
     }
 
-    override fun onMore(view: View, viewData: IStatusViewData) {
-        // TODO: Cast here is necessary because SFragment.onMore adds an extra
-        // menu item if the viewData is ConversationViewData. This design needs
-        // to be fixed. The menu should be created here (onCreateMenu or similar)
-        // which can call through to a generic implementation in SFragment.
-        super.more(view, viewData as ConversationViewData)
+    override fun onPrepareMoreMenu(menu: Menu, viewData: IStatusViewData) {
+        menu.findItem(R.id.conversation_delete).isVisible = true
+    }
+
+    override fun onMoreMenuItemClick(item: MenuItem, viewData: IStatusViewData): Boolean {
+        return when (item.itemId) {
+            R.id.conversation_delete -> {
+                AlertDialog.Builder(requireContext())
+                    .setMessage(R.string.dialog_delete_conversation_warning)
+                    .setNegativeButton(android.R.string.cancel, null)
+                    .setPositiveButton(android.R.string.ok) { _, _ ->
+                        viewModel.remove(viewData as ConversationViewData)
+                    }
+                    .show()
+                true
+            }
+
+            else -> super.onMoreMenuItemClick(item, viewData)
+        }
     }
 
     override fun onViewAttachment(view: View?, viewData: IStatusViewData, attachmentIndex: Int) {
@@ -421,7 +434,7 @@ class ConversationsFragment :
         startActivityWithTransition(intent, TransitionKind.SLIDE_FROM_END)
     }
 
-    override fun removeItem(viewData: ConversationViewData) {
+    override fun removeItem(viewData: IStatusViewData) {
         // not needed
     }
 
@@ -458,7 +471,7 @@ class ConversationsFragment :
         }
     }
 
-    override fun onConversationDelete(viewData: ConversationViewData) {
+    fun onConversationDelete(viewData: ConversationViewData) {
         if (viewData !is ConversationViewData) return
 
         AlertDialog.Builder(requireContext())
@@ -470,11 +483,11 @@ class ConversationsFragment :
             .show()
     }
 
-    override fun onTranslate(viewData: ConversationViewData) {
+    override fun onTranslate(viewData: IStatusViewData) {
         viewModel.translate(viewData)
     }
 
-    override fun onTranslateUndo(viewData: ConversationViewData) {
+    override fun onTranslateUndo(viewData: IStatusViewData) {
         viewModel.translateUndo(viewData)
     }
 

--- a/app/src/main/java/app/pachli/components/notifications/NotificationsFragment.kt
+++ b/app/src/main/java/app/pachli/components/notifications/NotificationsFragment.kt
@@ -530,15 +530,11 @@ class NotificationsFragment :
         viewModel.accept(FallibleStatusAction.VoteInPoll(poll, choices, viewData))
     }
 
-    override fun onMore(view: View, viewData: IStatusViewData) {
-        super.more(view, viewData as NotificationViewData.WithStatus)
-    }
-
-    override fun onTranslate(viewData: NotificationViewData.WithStatus) {
+    override fun onTranslate(viewData: IStatusViewData) {
         viewModel.accept(FallibleStatusAction.Translate(viewData))
     }
 
-    override fun onTranslateUndo(viewData: NotificationViewData.WithStatus) {
+    override fun onTranslateUndo(viewData: IStatusViewData) {
         viewModel.accept(InfallibleStatusAction.TranslateUndo(viewData))
     }
 
@@ -661,7 +657,7 @@ class NotificationsFragment :
     }
 
     // Empty -- this fragment doesn't remove items
-    override fun removeItem(viewData: NotificationViewData.WithStatus) = Unit
+    override fun removeItem(viewData: IStatusViewData) = Unit
 
     override fun onReselect() {
         if (isAdded) {

--- a/app/src/main/java/app/pachli/components/report/fragments/ReportStatusesFragment.kt
+++ b/app/src/main/java/app/pachli/components/report/fragments/ReportStatusesFragment.kt
@@ -295,7 +295,7 @@ class ReportStatusesFragment :
 
     override fun onViewUrl(url: String) = viewModel.checkClickedUrl(url)
 
-    override fun removeItem(viewData: StatusItemViewData) = Unit
+    override fun removeItem(viewData: IStatusViewData) = Unit
     override fun onReply(viewData: IStatusViewData) = Unit
     override fun onReblog(viewData: IStatusViewData, reblog: Boolean) = Unit
     override fun onFavourite(viewData: IStatusViewData, favourite: Boolean) = Unit
@@ -303,8 +303,8 @@ class ReportStatusesFragment :
     override fun onMore(view: View, viewData: IStatusViewData) = Unit
     override fun onOpenReblog(status: IStatus) = Unit
     override fun onVoteInPoll(viewData: IStatusViewData, poll: Poll, choices: List<Int>) = Unit
-    override fun onTranslate(viewData: StatusItemViewData) = Unit
-    override fun onTranslateUndo(viewData: StatusItemViewData) = Unit
+    override fun onTranslate(viewData: IStatusViewData) = Unit
+    override fun onTranslateUndo(viewData: IStatusViewData) = Unit
 
     companion object {
         private const val ARG_PACHLI_ACCOUNT_ID = "app.pachli.ARG_PACHLI_ACCOUNT_ID"

--- a/app/src/main/java/app/pachli/components/search/fragments/SearchStatusesFragment.kt
+++ b/app/src/main/java/app/pachli/components/search/fragments/SearchStatusesFragment.kt
@@ -147,10 +147,6 @@ class SearchStatusesFragment : SearchFragment<StatusItemViewData>(), StatusActio
         viewModel.bookmark(viewData, bookmark)
     }
 
-    override fun onMore(view: View, viewData: IStatusViewData) {
-        more(viewData, view)
-    }
-
     override fun onViewAttachment(view: View?, viewData: IStatusViewData, attachmentIndex: Int) {
         val actionable = viewData.actionable
         when (actionable.attachments[attachmentIndex].type) {
@@ -221,6 +217,14 @@ class SearchStatusesFragment : SearchFragment<StatusItemViewData>(), StatusActio
         )
     }
 
+    override fun onTranslate(viewData: IStatusViewData) {
+        // TODO: Implement translation in search results.
+    }
+
+    override fun onTranslateUndo(viewData: IStatusViewData) {
+        // TODO: Implement translation in search results.
+    }
+
     private fun reply(status: IStatusViewData) {
         val actionableStatus = status.actionable
         val mentionedUsernames = actionableStatus.mentions.map { it.username }
@@ -245,7 +249,7 @@ class SearchStatusesFragment : SearchFragment<StatusItemViewData>(), StatusActio
         startActivityWithDefaultTransition(intent)
     }
 
-    private fun more(statusViewData: IStatusViewData, view: View) {
+    override fun onMore(view: View, statusViewData: IStatusViewData) {
         val id = statusViewData.actionableId
         val status = statusViewData.actionable
         val accountId = status.account.id

--- a/app/src/main/java/app/pachli/components/timeline/TimelineFragment.kt
+++ b/app/src/main/java/app/pachli/components/timeline/TimelineFragment.kt
@@ -637,10 +637,6 @@ class TimelineFragment :
         )
     }
 
-    override fun onMore(view: View, viewData: IStatusViewData) {
-        super.more(view, viewData)
-    }
-
     override fun onOpenReblog(status: IStatus) {
         super.openReblog(status)
     }

--- a/app/src/main/java/app/pachli/components/viewthread/ViewThreadFragment.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/ViewThreadFragment.kt
@@ -318,11 +318,11 @@ class ViewThreadFragment :
         }
     }
 
-    override fun onTranslate(viewData: StatusItemViewData) {
+    override fun onTranslate(viewData: IStatusViewData) {
         viewModel.translate(viewData)
     }
 
-    override fun onTranslateUndo(viewData: StatusItemViewData) {
+    override fun onTranslateUndo(viewData: IStatusViewData) {
         viewModel.translateUndo(viewData)
     }
 
@@ -349,10 +349,6 @@ class ViewThreadFragment :
 
     override fun onBookmark(viewData: IStatusViewData, bookmark: Boolean) {
         viewModel.bookmark(bookmark, viewData)
-    }
-
-    override fun onMore(view: View, viewData: IStatusViewData) {
-        super.more(view, viewData as StatusItemViewData)
     }
 
     override fun onViewAttachment(view: View?, viewData: IStatusViewData, attachmentIndex: Int) {
@@ -431,7 +427,7 @@ class ViewThreadFragment :
         super.viewAccount(id)
     }
 
-    public override fun removeItem(viewData: StatusItemViewData) {
+    public override fun removeItem(viewData: IStatusViewData) {
         if (viewData.isDetailed) {
             // the main status we are viewing is being removed, finish the activity
             activity?.finish()

--- a/app/src/main/res/menu/status_more.xml
+++ b/app/src/main/res/menu/status_more.xml
@@ -27,9 +27,12 @@
     <item
         android:id="@+id/status_unmute_conversation"
         android:title="@string/action_unmute_conversation" />
+    <!-- Default is to not show this menu.
+         See ConversationsFragment.onPrepareMoreMenu -->
     <item
         android:id="@+id/conversation_delete"
-        android:title="@string/action_delete_conversation" />
+        android:title="@string/action_delete_conversation"
+        android:visible="false" />
     <item
         android:id="@+id/status_mute"
         android:title="@string/action_mute" />

--- a/app/src/main/res/menu/status_more_for_user.xml
+++ b/app/src/main/res/menu/status_more_for_user.xml
@@ -32,9 +32,12 @@
     <item
         android:id="@+id/status_unmute_conversation"
         android:title="@string/action_unmute_conversation" />
+    <!-- Default is to not show this menu.
+         See ConversationsFragment.onPrepareMoreMenu -->
     <item
         android:id="@+id/conversation_delete"
-        android:title="@string/action_delete_conversation" />
+        android:title="@string/action_delete_conversation"
+        android:visible="false" />
     <item
         android:id="@+id/status_edit"
         android:title="@string/action_edit" />

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/StatusActionListener.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/StatusActionListener.kt
@@ -83,4 +83,10 @@ interface StatusActionListener : LinkListener {
      * @param url The URL of the media.
      */
     fun onViewMedia(pachliAccountId: Long, username: String, url: String)
+
+    /** Translate [viewData]. */
+    fun onTranslate(viewData: IStatusViewData)
+
+    /** Undo the translation of [viewData]. */
+    fun onTranslateUndo(viewData: IStatusViewData)
 }


### PR DESCRIPTION
SFragment defined the methods `onTranslate` and `onTranslateUndo`, when those should have been in `StatusActionListener`, as these are actions the user may take on a status.

The "..." (more) menu handling code in SFragment had to have special cases for conversations (direct messages). Split that out and provide methods `ConversationsFragment` can call through to customise the menu and provide conversation-specific handlers for.