### PR TITLE
feat: Show quote counts, click through to view quoting posts

### DIFF
--- a/app/src/main/java/app/pachli/TabViewData.kt
+++ b/app/src/main/java/app/pachli/TabViewData.kt
@@ -171,6 +171,12 @@ data class TabViewData(
             is Timeline.User.Pinned -> throw IllegalArgumentException("can't add to tab: $timeline")
             is Timeline.User.Posts -> throw IllegalArgumentException("can't add to tab: $timeline")
             is Timeline.User.Replies -> throw IllegalArgumentException("can't add to tab: $timeline")
+            is Timeline.Quote -> TabViewData(
+                timeline = timeline,
+                text = R.string.title_quotes,
+                icon = -1,
+                fragment = { TimelineFragment.newInstance(pachliAccountId, timeline) },
+            )
         }
     }
 }

--- a/app/src/main/java/app/pachli/TimelineActivity.kt
+++ b/app/src/main/java/app/pachli/TimelineActivity.kt
@@ -160,10 +160,10 @@ class TimelineActivity : ViewUrlActivity(), ActionButtonActivity, MenuProvider {
 
     override fun onPrepareMenu(menu: Menu) {
         // Check if this timeline is in a tab; if not, enable the add_to_tab menu item
-        // Timeline.Link (all posts about a specific link) is special-cased to not be
-        // addable to a tab)
+        // Timeline.Link (all posts about a specific link) and Timeline.Quote are
+        // special-cased to not be addable to a tab).
         val currentTabs = accountManager.activeAccount?.tabPreferences.orEmpty()
-        val hideMenu = timeline is Timeline.Link || currentTabs.contains(timeline)
+        val hideMenu = timeline is Timeline.Link || timeline is Timeline.Quote || currentTabs.contains(timeline)
         menu.findItem(R.id.action_add_to_tab)?.isVisible = !hideMenu
     }
 

--- a/app/src/main/java/app/pachli/components/timeline/TimelineFragment.kt
+++ b/app/src/main/java/app/pachli/components/timeline/TimelineFragment.kt
@@ -73,6 +73,7 @@ import app.pachli.core.model.Timeline
 import app.pachli.core.navigation.AccountListActivityIntent
 import app.pachli.core.navigation.AttachmentViewData
 import app.pachli.core.navigation.EditContentFilterActivityIntent
+import app.pachli.core.navigation.TimelineActivityIntent
 import app.pachli.core.preferences.TabTapBehaviour
 import app.pachli.core.ui.ActionButtonScrollListener
 import app.pachli.core.ui.BackgroundMessage.Empty
@@ -659,6 +660,11 @@ class TimelineFragment :
         startActivityWithDefaultTransition(intent)
     }
 
+    override fun onShowQuotes(statusId: String) {
+        val intent = TimelineActivityIntent.quote(requireContext(), pachliAccountId, statusId)
+        startActivityWithDefaultTransition(intent)
+    }
+
     override fun onContentCollapsedChange(viewData: IStatusViewData, isCollapsed: Boolean) {
         viewModel.onContentCollapsed(isCollapsed, viewData)
     }
@@ -734,6 +740,7 @@ class TimelineFragment :
             Timeline.TrendingHashtags,
             Timeline.TrendingLinks,
             is Timeline.Link,
+            is Timeline.Quote,
             -> return
         }
     }

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelineRemoteMediator.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelineRemoteMediator.kt
@@ -300,6 +300,7 @@ class NetworkTimelineRemoteMediator(
                 minId = minId,
                 limit = loadSize,
             )
+            is Timeline.Quote -> api.quotes(statusId = timeline.statusId, maxId = maxId, limit = loadSize)
             else -> throw IllegalStateException("NetworkTimelineRemoteMediator does not support $timeline")
         }
     }

--- a/app/src/main/java/app/pachli/components/viewthread/ViewThreadFragment.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/ViewThreadFragment.kt
@@ -54,6 +54,7 @@ import app.pachli.core.model.Status
 import app.pachli.core.navigation.AccountListActivityIntent
 import app.pachli.core.navigation.AttachmentViewData
 import app.pachli.core.navigation.EditContentFilterActivityIntent
+import app.pachli.core.navigation.TimelineActivityIntent
 import app.pachli.core.preferences.SharedPreferencesRepository
 import app.pachli.core.ui.SetMarkdownContent
 import app.pachli.core.ui.SetMastodonHtmlContent
@@ -412,6 +413,11 @@ class ViewThreadFragment :
 
     override fun onShowFavs(statusId: String) {
         val intent = AccountListActivityIntent(requireContext(), pachliAccountId, AccountListActivityIntent.Kind.FAVOURITED, statusId)
+        startActivityWithDefaultTransition(intent)
+    }
+
+    override fun onShowQuotes(statusId: String) {
+        val intent = TimelineActivityIntent.quote(requireContext(), pachliAccountId, statusId)
         startActivityWithDefaultTransition(intent)
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,6 +54,7 @@
     <string name="title_follows">Follows</string>
     <string name="title_followers">Followers</string>
     <string name="title_favourites">Favorites</string>
+    <string name="title_quotes">Quotes</string>
     <string name="title_bookmarks">Bookmarks</string>
     <string name="title_mutes">Muted users</string>
     <string name="title_blocks">Blocked users</string>

--- a/core/model/src/main/kotlin/app/pachli/core/model/ContentFilters.kt
+++ b/core/model/src/main/kotlin/app/pachli/core/model/ContentFilters.kt
@@ -130,7 +130,7 @@ enum class FilterContext {
          *     to this timeline.
          */
         fun from(timeline: Timeline): FilterContext? = when (timeline) {
-            is Timeline.Home, is Timeline.UserList -> HOME
+            is Timeline.Home, is Timeline.UserList, is Timeline.Quote -> HOME
             is Timeline.User -> ACCOUNT
             Timeline.Notifications -> NOTIFICATIONS
             Timeline.Bookmarks,

--- a/core/model/src/main/kotlin/app/pachli/core/model/Timeline.kt
+++ b/core/model/src/main/kotlin/app/pachli/core/model/Timeline.kt
@@ -146,6 +146,11 @@ sealed class Timeline : Parcelable {
     @JsonClass(generateAdapter = true)
     data class Link(val url: String, val title: String) : Timeline()
 
+    /** Timeline of statuses that quote [statusId]. */
+    @TypeLabel("quote")
+    @JsonClass(generateAdapter = true)
+    data class Quote(val statusId: String) : Timeline()
+
     // TODO: DRAFTS
 
     // TODO: SCHEDULED

--- a/core/navigation/src/main/kotlin/app/pachli/core/navigation/Navigation.kt
+++ b/core/navigation/src/main/kotlin/app/pachli/core/navigation/Navigation.kt
@@ -781,6 +781,13 @@ class TimelineActivityIntent private constructor(context: Context, pachliAccount
             putExtra(EXTRA_TIMELINE, Timeline.Notifications)
         }
 
+        /**
+         * Show statuses that quote [statusId].
+         */
+        fun quote(context: Context, pachliAccountId: Long, statusId: String) = TimelineActivityIntent(context, pachliAccountId).apply {
+            putExtra(EXTRA_TIMELINE, Timeline.Quote(statusId))
+        }
+
         /** @return The [Timeline] to show */
         fun getTimeline(intent: Intent) = IntentCompat.getParcelableExtra(intent, EXTRA_TIMELINE, Timeline::class.java)!!
     }

--- a/core/network/src/main/kotlin/app/pachli/core/network/retrofit/MastodonApi.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/retrofit/MastodonApi.kt
@@ -339,6 +339,13 @@ interface MastodonApi {
         @Path("id") statusId: String,
     ): ApiResult<Translation>
 
+    @GET("api/v1/statuses/{id}/quotes")
+    suspend fun quotes(
+        @Path(value = "id") statusId: String,
+        @Query("max_id") maxId: String? = null,
+        @Query("limit") limit: Int? = null,
+    ): ApiResult<List<Status>>
+
     @POST("api/v1/statuses/{quoteId}/quotes/{parentId}/revoke")
     suspend fun revokeQuote(
         @Path(value = "quoteId") quoteId: String,

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/DetailedStatusView.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/DetailedStatusView.kt
@@ -26,7 +26,6 @@ import android.text.style.DynamicDrawableSpan
 import android.text.style.ImageSpan
 import android.util.AttributeSet
 import android.view.LayoutInflater
-import androidx.core.view.isGone
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
 import app.pachli.core.data.model.IStatusItemViewData
@@ -96,7 +95,7 @@ class DetailedStatusView @JvmOverloads constructor(
         super.setupWithStatus(setStatusContent, glide, uncollapsedViewdata, listener, statusDisplayOptions)
 
         if (!statusDisplayOptions.hideStatsInDetailedView) {
-            setReblogAndFavCount(uncollapsedViewdata, listener)
+            setStatCounters(uncollapsedViewdata, listener)
         } else {
             hideQuantitativeStats()
         }
@@ -111,42 +110,62 @@ class DetailedStatusView @JvmOverloads constructor(
         binding.statusQuote.show()
     }
 
-    private fun setReblogAndFavCount(
+    private fun setStatCounters(
         viewData: StatusItemViewData,
         listener: StatusActionListener,
     ) {
         val reblogCount = viewData.actionable.reblogsCount
         val favCount = viewData.actionable.favouritesCount
+        val quotesCount = viewData.actionable.quotesCount
+
+        val showStats = reblogCount > 0 || favCount > 0 || quotesCount > 0
+
+        if (!showStats) {
+            hideQuantitativeStats()
+            return
+        }
+
+        binding.statusInfoDivider.show()
 
         if (reblogCount > 0) {
             binding.statusReblogs.text = getReblogsCountDescription(reblogCount)
             binding.statusReblogs.show()
+            binding.statusReblogs.setOnClickListener {
+                listener.onShowReblogs(viewData.actionableId)
+            }
         } else {
             binding.statusReblogs.hide()
         }
+
         if (favCount > 0) {
             binding.statusFavourites.text = getFavouritesCountDescription(favCount)
             binding.statusFavourites.show()
+            binding.statusFavourites.setOnClickListener {
+                listener.onShowFavs(viewData.actionableId)
+            }
         } else {
             binding.statusFavourites.hide()
         }
-        if (binding.statusReblogs.isGone && binding.statusFavourites.isGone) {
-            binding.statusInfoDivider.hide()
+
+        if (quotesCount > 0) {
+            binding.statusQuotes.text = getQuotesCountDescription(quotesCount)
+            binding.statusQuotes.show()
+            binding.statusQuotes.setOnClickListener {
+                listener.onShowQuotes(viewData.actionableId)
+            }
         } else {
-            binding.statusInfoDivider.show()
-        }
-        binding.statusReblogs.setOnClickListener {
-            listener.onShowReblogs(viewData.actionableId)
-        }
-        binding.statusFavourites.setOnClickListener {
-            listener.onShowFavs(viewData.actionableId)
+            binding.statusQuotes.hide()
         }
     }
 
     private fun hideQuantitativeStats() {
+        binding.statusInfoDivider.hide()
         binding.statusReblogs.hide()
         binding.statusFavourites.hide()
-        binding.statusInfoDivider.hide()
+        binding.statusQuotes.hide()
+        binding.statusReblogs.setOnClickListener(null)
+        binding.statusFavourites.setOnClickListener(null)
+        binding.statusQuotes.setOnClickListener(null)
     }
 
     override fun setMetaData(viewData: StatusItemViewData, statusDisplayOptions: StatusDisplayOptions, listener: StatusActionListener) {

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/StatusActionListener.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/StatusActionListener.kt
@@ -60,6 +60,13 @@ interface StatusActionListener : LinkListener {
     fun onShowFavs(statusId: String) {}
 
     /**
+     * Called when the quotes count has been clicked.
+     *
+     * @param statusId Actionable ID of the status being quoted.
+     */
+    fun onShowQuotes(statusId: String) {}
+
+    /**
      * Called when voting on a poll.
      *
      * @param viewData

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/StatusView.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/StatusView.kt
@@ -710,6 +710,16 @@ abstract class StatusView<T : IStatusViewData> @JvmOverloads constructor(
         )
     }
 
+    fun getQuotesCountDescription(count: Int): CharSequence? {
+        if (count <= 0) return null
+
+        val countString = NUMBER_FORMATTER.format(count.toLong())
+        return HtmlCompat.fromHtml(
+            context.resources.getQuantityString(R.plurals.quotes, count, countString),
+            HtmlCompat.FROM_HTML_MODE_LEGACY,
+        )
+    }
+
     open fun setupCard(
         glide: RequestManager,
         viewData: T,

--- a/core/ui/src/main/res/layout/status_content_detailed.xml
+++ b/core/ui/src/main/res/layout/status_content_detailed.xml
@@ -313,4 +313,21 @@
         tools:text="8 favs"
         tools:visibility="visible"
         tools:ignore="SelectableText" />
+
+    <TextView
+        android:id="@+id/status_quotes"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:layout_marginTop="6dp"
+        android:background="?attr/selectableItemBackground"
+        android:importantForAccessibility="no"
+        android:padding="4dp"
+        android:textSize="?attr/status_text_medium"
+        app:layout_constraintStart_toEndOf="@id/status_favourites"
+        app:layout_constraintTop_toBottomOf="@id/status_info_divider"
+        app:layout_goneMarginStart="0dp"
+        tools:text="0 quotes"
+        tools:visibility="visible"
+        tools:ignore="SelectableText" />
 </merge>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -159,6 +159,10 @@
         <item quantity="one">&lt;b&gt;%1$s&lt;/b&gt; Favorite</item>
         <item quantity="other">&lt;b&gt;%1$s&lt;/b&gt; Favorites</item>
     </plurals>
+    <plurals name="quotes">
+        <item quantity="one">&lt;b&gt;%1$s&lt;/b&gt; Quote</item>
+        <item quantity="other">&lt;b&gt;%1$s&lt;/b&gt; Quotes</item>
+    </plurals>
     <string name="post_boosted_fmt">&lt;b&gt;%1$s&lt;/b&gt; boosted</string>
     <string name="post_replied">Replied</string>
     <string name="post_continued_thread">Continued thread</string>


### PR DESCRIPTION
Update the "Detailed" status view to show the number of statuses quoting the detailed status (if non-zero).

If the user clicks through they see a timeline of statuses that quote the status.