### PR TITLE
revert: Centre error and other background messages

### DIFF
--- a/core/ui/src/main/res/layout/view_background_message.xml
+++ b/core/ui/src/main/res/layout/view_background_message.xml
@@ -45,6 +45,7 @@
             android:paddingRight="16dp"
             android:paddingTop="16dp"
             android:text="@string/error_network"
+            android:textAlignment="center"
             android:textSize="?attr/status_text_medium" />
 
         <Button


### PR DESCRIPTION
Doesn't look good on screens like "You don't have any scheduled posts".