### PR TITLE
feat: Display a different icon if reblog+quote are available

### DIFF
--- a/core/ui/src/main/kotlin/app/pachli/core/ui/StatusControlView.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/StatusControlView.kt
@@ -360,11 +360,13 @@ class StatusControlView @JvmOverloads constructor(
 
         // Decide which icons to show on the increasingly misnamed "reblog" button
         val (resActive, resInactive) = when {
-            // Reblogging has preference. If this can be reblogged then use those icons.
+            // Arrow+quote if reblogging and quoting is possible.
+            canReblog && canQuote -> (R.drawable.ic_reblog_quote_active_24dp to R.drawable.ic_reblog_quote_24dp)
+
+            // Reblogging only.
             canReblog -> (R.drawable.ic_reblog_active_24dp to R.drawable.ic_reblog_24dp)
 
-            // If it can be quoted then use the quote icon (which doesn't have active/inactive
-            // variants).
+            // Quoting only.
             canQuote -> (R.drawable.format_quote_24px to R.drawable.format_quote_24px)
 
             // Otherwise, use the relevant "can't be reblogged" icons depending on the

--- a/core/ui/src/main/res/drawable/ic_reblog_quote_24dp.xml
+++ b/core/ui/src/main/res/drawable/ic_reblog_quote_24dp.xml
@@ -1,0 +1,33 @@
+<!--
+  ~ Copyright (c) 2025 Pachli Association
+  ~
+  ~ This file is a part of Pachli.
+  ~
+  ~ This program is free software; you can redistribute it and/or modify it under the terms of the
+  ~ GNU General Public License as published by the Free Software Foundation; either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+  ~ the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+  ~ Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License along with Pachli; if not,
+  ~ see <http://www.gnu.org/licenses>.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0"
+    android:tint="?colorControlNormal">
+ <path
+     android:fillColor="@android:color/white"
+     android:pathData="m17 17h-10v-3l-4 4 4 4v-3h12v-6h-2z"/>
+ <path
+     android:fillColor="@android:color/white"
+     android:pathData="m13.752 11.576 1.8316-3.1854c-0.87599 0-1.6259-0.31191-2.2497-0.93572-0.62381-0.62381-0.93572-1.3737-0.93572-2.2497 0-0.87599 0.3119-1.6259 0.93572-2.2497 0.62381-0.62381 1.3737-0.93572 2.2497-0.93572 0.87599 0 1.6259 0.31191 2.2497 0.93572 0.62381 0.62381 0.93572 1.3737 0.93572 2.2497 0 0.30527-0.0365 0.58731-0.1095 0.84613-0.07299 0.25881-0.18249 0.50768-0.32849 0.74658l-2.7474 4.7781z" style=""/>
+ <path
+     android:fillColor="@android:color/white"
+     android:pathData="m6.5848 11.576 1.8316-3.1854c-0.87599 0-1.6259-0.31191-2.2497-0.93572-0.62381-0.62381-0.93572-1.3737-0.93572-2.2497 0-0.87599 0.31191-1.6259 0.93572-2.2497 0.62381-0.62381 1.3737-0.93572 2.2497-0.93572 0.87599 0 1.6259 0.31191 2.2497 0.93572 0.62381 0.62381 0.93572 1.3737 0.93572 2.2497 0 0.30527-0.0365 0.58731-0.1095 0.84613-0.073 0.25881-0.1825 0.50768-0.3285 0.74658l-2.7474 4.7781z" style=""/>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_reblog_quote_active_24dp.xml
+++ b/core/ui/src/main/res/drawable/ic_reblog_quote_active_24dp.xml
@@ -1,0 +1,33 @@
+<!--
+  ~ Copyright (c) 2025 Pachli Association
+  ~
+  ~ This file is a part of Pachli.
+  ~
+  ~ This program is free software; you can redistribute it and/or modify it under the terms of the
+  ~ GNU General Public License as published by the Free Software Foundation; either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+  ~ the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+  ~ Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License along with Pachli; if not,
+  ~ see <http://www.gnu.org/licenses>.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0"
+    android:tint="?colorPrimary">
+ <path
+     android:fillColor="@android:color/white"
+     android:pathData="m17 17h-10v-3l-4 4 4 4v-3h12v-6h-2z"/>
+ <path
+     android:fillColor="@android:color/white"
+     android:pathData="m13.752 11.576 1.8316-3.1854c-0.87599 0-1.6259-0.31191-2.2497-0.93572-0.62381-0.62381-0.93572-1.3737-0.93572-2.2497 0-0.87599 0.3119-1.6259 0.93572-2.2497 0.62381-0.62381 1.3737-0.93572 2.2497-0.93572 0.87599 0 1.6259 0.31191 2.2497 0.93572 0.62381 0.62381 0.93572 1.3737 0.93572 2.2497 0 0.30527-0.0365 0.58731-0.1095 0.84613-0.07299 0.25881-0.18249 0.50768-0.32849 0.74658l-2.7474 4.7781z" style=""/>
+ <path
+     android:fillColor="@android:color/white"
+     android:pathData="m6.5848 11.576 1.8316-3.1854c-0.87599 0-1.6259-0.31191-2.2497-0.93572-0.62381-0.62381-0.93572-1.3737-0.93572-2.2497 0-0.87599 0.31191-1.6259 0.93572-2.2497 0.62381-0.62381 1.3737-0.93572 2.2497-0.93572 0.87599 0 1.6259 0.31191 2.2497 0.93572 0.62381 0.62381 0.93572 1.3737 0.93572 2.2497 0 0.30527-0.0365 0.58731-0.1095 0.84613-0.073 0.25881-0.1825 0.50768-0.3285 0.74658l-2.7474 4.7781z" style=""/>
+</vector>


### PR DESCRIPTION
Add a new icon that shows the bottom part of the reblog icon below a pair of quote marks, to indicate the status can be both quoted and reblogged.