### PR TITLE
fix: Allow autocomplete to select accounts with pronouns

### DIFF
--- a/core/ui/src/main/kotlin/app/pachli/core/ui/PronounsChip.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/PronounsChip.kt
@@ -43,6 +43,7 @@ open class PronounsChip @JvmOverloads constructor(
     override fun setText(text: CharSequence?, type: BufferType?) {
         if (text.isNullOrBlank()) {
             hide()
+            setOnClickListener(null)
         } else {
             val formatted = HtmlCompat.fromHtml(text.toString().trim(), FROM_HTML_MODE_LEGACY)
             super.setText(formatted, type)

--- a/core/ui/src/main/res/layout/item_autocomplete_account.xml
+++ b/core/ui/src/main/res/layout/item_autocomplete_account.xml
@@ -7,7 +7,8 @@
     android:paddingStart="16dp"
     android:paddingTop="8dp"
     android:paddingEnd="16dp"
-    android:paddingBottom="8dp">
+    android:paddingBottom="8dp"
+    android:descendantFocusability="blocksDescendants">
 
     <ImageView
         android:id="@+id/avatar"


### PR DESCRIPTION
Previous code rendered autocomplete results with a pronouns chip as unclickable, which might be an Android bug.

The work around is to set `android:descendantFocusability="blocksDescendants"` on the parent view.

While I'm here, clear the click listener if the pronouns are not shown.