### PR TITLE
fix: Allow attachments/polls when composing from scratch

### DIFF
--- a/app/src/main/java/app/pachli/components/compose/ComposeViewModel.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeViewModel.kt
@@ -279,7 +279,7 @@ class ComposeViewModel @AssistedInject constructor(
      * In addition, multiple attachments can only be added if they are all images.
      */
     val canAttachMedia = combine(instanceInfo, media, poll) { instanceInfo, media, poll ->
-        composeOptions?.referencingStatus?.isQuoting() == false &&
+        composeOptions?.referencingStatus?.isQuoting() != true &&
             poll == null &&
             media.size < instanceInfo.maxMediaAttachments &&
             (media.isEmpty() || media.first().type == QueuedMedia.Type.IMAGE)
@@ -295,7 +295,7 @@ class ComposeViewModel @AssistedInject constructor(
      * 3. There are no media attachments.
      */
     val canAttachPoll = combine(poll, media) { poll, media ->
-        composeOptions?.referencingStatus?.isQuoting() == false &&
+        composeOptions?.referencingStatus?.isQuoting() != true &&
             poll == null &&
             media.isEmpty()
     }


### PR DESCRIPTION
Previous code checked a nullable against false, which returned false whenever it was null. Rewrite the test as != true, which returns true when null or false.