### PR TITLE
feat: Add a "..." menu to open the quoted post

### DIFF
--- a/app/src/main/res/menu/status_more.xml
+++ b/app/src/main/res/menu/status_more.xml
@@ -18,6 +18,11 @@
     <item
         android:id="@+id/status_open_as"
         android:title="@string/action_open_as" />
+
+    <item
+        android:id="@+id/status_open_quoted_post"
+        android:title="@string/action_open_quoted_post" />
+
     <item
         android:id="@+id/status_download_media"
         android:title="@string/download_media" />

--- a/core/activity/src/main/res/values/strings.xml
+++ b/core/activity/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
     <string name="post_lookup_error_format">Error looking up %s</string>
     <string name="action_open_as">Open as %s</string>
     <string name="action_open_as_ellipsis">Open as…</string>
+    <string name="action_open_quoted_post">Open quoted post</string>
     <string name="performing_lookup_title">Performing lookup…</string>
     <string name="send_error_report">Send error report</string>
 </resources>


### PR DESCRIPTION
If a quoted post is just attachments (e.g., just a single image) you can't open the quoted post -- tapping on the header area takes you to the account, tapping on the attachment opens it for viewing.

Add an "Open quoted post" item to the "..." menu, displayed if there is a quoted post. If tapped it opens the thread for the quoted post.

Reported by @jandi@mastodon.social.