### PR TITLE
fix: Show "boost" status info in preference to "reply" status info

### DIFF
--- a/app/src/main/java/app/pachli/adapter/StatusViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/StatusViewHolder.kt
@@ -63,25 +63,24 @@ open class StatusViewHolder<T : IStatusViewData>(
         statusDisplayOptions: StatusDisplayOptions,
         listener: StatusActionListener,
     ) {
-        if (!statusDisplayOptions.showStatusInfo) {
+        if (!statusDisplayOptions.showStatusInfo || viewData.contentFilterAction == FilterAction.WARN) {
             statusInfo.hide()
             return
         }
 
         val status = viewData.actionable
 
+        viewData.rebloggingStatus?.let { reblogging ->
+            setStatusInfoAsReblog(viewData, reblogging.account, statusDisplayOptions, listener)
+            return
+        }
+
         if (status.inReplyToAccountId != null) {
             setStatusInfoAsReply(viewData, statusDisplayOptions)
             return
         }
 
-        val reblogging = viewData.rebloggingStatus
-        if (reblogging == null || viewData.contentFilterAction === FilterAction.WARN) {
-            statusInfo.hide()
-            return
-        }
-
-        setStatusInfoAsReblog(viewData, reblogging.account, statusDisplayOptions, listener)
+        statusInfo.hide()
     }
 
     /**


### PR DESCRIPTION
Previously, if someone boosted a reply the status info section showed "replied", which was technically true, but didn't explain why the boost was appearing in your timeline.

Swap the display order, so now "... boosted" is shown in preference to "... replied", to make this less confusing.