### PR TITLE
feat: Show an explanation for quotes the user can't see

### DIFF
--- a/core/data/src/main/kotlin/app/pachli/core/data/model/StatusViewData.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/model/StatusViewData.kt
@@ -154,10 +154,11 @@ sealed interface IStatusItemViewData : IStatusViewData {
     /**
      * @return [quotedViewData] as a [QuotedStatusViewData].
      */
-    fun asQuotedStatusViewData() = quotedViewData?.let {
+    fun asQuotedStatusViewData() = quotedViewData?.let { quotedViewData ->
         QuotedStatusViewData(
             parentId = statusViewData.actionableId,
-            statusViewData = it,
+            statusViewData = quotedViewData,
+            quoteState = statusViewData.quote!!.state,
         )
     }
 }
@@ -338,8 +339,11 @@ data class StatusViewData(
  * @property parentId Actionable ID of the status that is quoting this
  * status. Required to revoke the quote.
  * @property statusViewData [StatusViewData] of the quoted status.
+ * @property quoteState [Status.QuoteState] for the quote. Not all quotes are
+ * displayed.
  */
 data class QuotedStatusViewData(
     val parentId: String,
     val statusViewData: StatusViewData,
+    val quoteState: Status.QuoteState,
 ) : IStatusViewData by statusViewData

--- a/core/model/src/main/kotlin/app/pachli/core/model/Status.kt
+++ b/core/model/src/main/kotlin/app/pachli/core/model/Status.kt
@@ -209,11 +209,63 @@ data class Status(
 
     enum class QuoteState {
         UNKNOWN,
+
+        /**
+         * The quote has not been acknowledged by the quoted account yet, and
+         * requires authorization before being displayed.
+         */
         PENDING,
+
+        /**
+         * The quote has been accepted and can be displayed. This is one of the
+         * few cases where status is non-null.
+         */
         ACCEPTED,
+
+        /**
+         * The quote has been explicitly rejected by the quoted account, and
+         * cannot be displayed.
+         */
         REJECTED,
+
+        /**
+         * The quote has been previously accepted, but is now revoked, and
+         * thus cannot be displayed.
+         */
         REVOKED,
+
+        /**
+         * The quote has been approved, but the quoted post itself has now
+         * been deleted.
+         */
+        DELETED,
+
+        /**
+         * The quote has been approved, but cannot be displayed because the
+         * user is not authorized to see it.
+         */
         UNAUTHORIZED,
+
+        /**
+         * The quote has been approved, but should not be displayed because
+         * the user has blocked the account being quoted. This is one of the
+         * few cases where status is non-null.
+         */
+        BLOCKED_ACCOUNT,
+
+        /**
+         * The quote has been approved, but should not be displayed because
+         * the user has blocked the domain of the account being quoted.
+         * This is one of the few cases where status is non-null.
+         */
+        BLOCKED_DOMAIN,
+
+        /**
+         * The quote has been approved, but should not be displayed because
+         * the user has muted the the account being quoted. This is one of
+         * the few cases where status is non-null.
+         */
+        MUTED_ACCOUNT,
     }
 
     sealed interface Quote {

--- a/core/network/src/main/kotlin/app/pachli/core/network/model/Status.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/Status.kt
@@ -168,20 +168,71 @@ data class Status(
         @Default
         UNKNOWN,
 
+        /**
+         * The quote has not been acknowledged by the quoted account yet, and
+         * requires authorization before being displayed.
+         */
         @Json(name = "pending")
         PENDING,
 
+        /**
+         * The quote has been accepted and can be displayed. This is one of the
+         * few cases where status is non-null.
+         */
         @Json(name = "accepted")
         ACCEPTED,
 
+        /**
+         * The quote has been explicitly rejected by the quoted account, and
+         * cannot be displayed.
+         */
         @Json(name = "rejected")
         REJECTED,
 
+        /**
+         * The quote has been previously accepted, but is now revoked, and
+         * thus cannot be displayed.
+         */
         @Json(name = "revoked")
         REVOKED,
 
+        /**
+         * The quote has been approved, but the quoted post itself has now
+         * been deleted.
+         */
+        @Json(name = "deleted")
+        DELETED,
+
+        /**
+         * The quote has been approved, but cannot be displayed because the
+         * user is not authorized to see it.
+         */
         @Json(name = "unauthorized")
         UNAUTHORIZED,
+
+        /**
+         * The quote has been approved, but should not be displayed because
+         * the user has blocked the account being quoted. This is one of the
+         * few cases where status is non-null.
+         */
+        @Json(name = "blocked_account")
+        BLOCKED_ACCOUNT,
+
+        /**
+         * The quote has been approved, but should not be displayed because
+         * the user has blocked the domain of the account being quoted.
+         * This is one of the few cases where status is non-null.
+         */
+        @Json(name = "blocked_domain")
+        BLOCKED_DOMAIN,
+
+        /**
+         * The quote has been approved, but should not be displayed because
+         * the user has muted the account being quoted. This is one of
+         * the few cases where status is non-null.
+         */
+        @Json(name = "muted_account")
+        MUTED_ACCOUNT,
 
         ;
 
@@ -191,7 +242,11 @@ data class Status(
             ACCEPTED -> app.pachli.core.model.Status.QuoteState.ACCEPTED
             REJECTED -> app.pachli.core.model.Status.QuoteState.REJECTED
             REVOKED -> app.pachli.core.model.Status.QuoteState.REVOKED
+            DELETED -> app.pachli.core.model.Status.QuoteState.DELETED
             UNAUTHORIZED -> app.pachli.core.model.Status.QuoteState.UNAUTHORIZED
+            BLOCKED_ACCOUNT -> app.pachli.core.model.Status.QuoteState.BLOCKED_ACCOUNT
+            BLOCKED_DOMAIN -> app.pachli.core.model.Status.QuoteState.BLOCKED_DOMAIN
+            MUTED_ACCOUNT -> app.pachli.core.model.Status.QuoteState.MUTED_ACCOUNT
         }
     }
 

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/QuotedStatusView.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/QuotedStatusView.kt
@@ -28,6 +28,7 @@ import app.pachli.core.data.model.QuotedStatusViewData
 import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.data.model.StatusViewData
 import app.pachli.core.model.FilterAction
+import app.pachli.core.model.Status
 import app.pachli.core.ui.databinding.QuotedStatusContentBinding
 import com.bumptech.glide.RequestManager
 import com.mikepenz.iconics.typeface.library.googlematerial.GoogleMaterial
@@ -69,10 +70,34 @@ class QuotedStatusView @JvmOverloads constructor(
     private val paddingBottomWithoutRemoveQuote = dpToPx(14f, context.resources.displayMetrics).toInt()
 
     override fun setupWithStatus(setStatusContent: SetStatusContent, glide: RequestManager, viewData: QuotedStatusViewData, listener: StatusActionListener, statusDisplayOptions: StatusDisplayOptions) {
+        // Don't show the quote unless the state is ACCEPTED. Every other state
+        // has a custom explanation.
+        val blockedRes = when (viewData.quoteState) {
+            Status.QuoteState.ACCEPTED -> -1
+            Status.QuoteState.UNKNOWN -> R.string.label_quote_state_unknown
+            Status.QuoteState.PENDING -> R.string.label_quote_state_pending
+            Status.QuoteState.REJECTED -> R.string.label_quote_state_rejected
+            Status.QuoteState.REVOKED -> R.string.label_quote_state_revoked
+            Status.QuoteState.DELETED -> R.string.label_quote_state_deleted
+            Status.QuoteState.UNAUTHORIZED -> R.string.label_quote_state_unauthorized
+            Status.QuoteState.BLOCKED_ACCOUNT -> R.string.label_quote_state_blocked_account
+            Status.QuoteState.BLOCKED_DOMAIN -> R.string.label_quote_state_blocked_domain
+            Status.QuoteState.MUTED_ACCOUNT -> R.string.label_quote_state_muted_account
+        }
+
+        if (blockedRes != -1) {
+            binding.quotedStatusFiltered.root.hide()
+            binding.quotedStatusContainer.root.hide()
+            binding.quotedStatusHidden.setText(blockedRes)
+            binding.quotedStatusHidden.show()
+            return
+        }
+
         when (viewData.contentFilterAction) {
             FilterAction.HIDE -> {
                 binding.quotedStatusFiltered.root.hide()
                 binding.quotedStatusContainer.root.hide()
+                binding.quotedStatusHidden.setText(R.string.label_quoted_status_hidden)
                 binding.quotedStatusHidden.show()
                 return
             }

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -176,4 +176,14 @@
     <string name="status_filter_placeholder_label_format">Filtered: &lt;b>%1$s&lt;/b></string>
     <string name="label_quoted_status_hidden">Quote of a post hidden by one of your filters</string>
     <string name="detach_quote">Remove quote</string>
+
+    <string name="label_quote_state_unknown">Quoted post cannot be displayed</string>
+    <string name="label_quote_state_pending">Quote is waiting to be approved</string>
+    <string name="label_quote_state_rejected">Quoted account blocked this quote from being displayed</string>
+    <string name="label_quote_state_revoked">Quoted account blocked this quote from being displayed</string>
+    <string name="label_quote_state_deleted">Quoted post has been deleted</string>
+    <string name="label_quote_state_unauthorized">Quoted post is not visible to you</string>
+    <string name="label_quote_state_blocked_account">Quoted post is from an account you blocked</string>
+    <string name="label_quote_state_blocked_domain">Quoted post is from a server you blocked</string>
+    <string name="label_quote_state_muted_account">Quoted post is from an account you muted</string>
 </resources>


### PR DESCRIPTION
If the quote is not in `QuoteState.ACCEPTED` then hide the content and replace it with a message explaining why the quote is not visible.