### PR TITLE
fix: Always load pronoun column from the database

### DIFF
--- a/core/database/src/main/kotlin/app/pachli/core/database/dao/ConversationsDao.kt
+++ b/core/database/src/main/kotlin/app/pachli/core/database/dao/ConversationsDao.kt
@@ -204,6 +204,7 @@ SELECT
     q.a_limited AS 's_q_a_limited',
     q.a_note AS 's_q_a_note',
     q.a_roles AS 's_q_a_roles',
+    q.a_pronouns AS 's_q_a_pronouns',
 
     -- The status's reblog account (if any)
     q.rb_serverId AS 's_q_rb_serverId',
@@ -219,6 +220,7 @@ SELECT
     q.rb_limited AS 's_q_rb_limited',
     q.rb_note AS 's_q_rb_note',
     q.rb_roles AS 's_q_rb_roles',
+    q.rb_pronouns AS 's_q_rb_pronouns',
 
     -- Status view data
     q.svd_serverId AS 's_q_svd_serverId',
@@ -429,6 +431,7 @@ SELECT
     q.a_limited AS 's_q_a_limited',
     q.a_note AS 's_q_a_note',
     q.a_roles AS 's_q_a_roles',
+    q.a_pronouns AS 's_q_a_pronouns',
 
     -- The status's reblog account (if any)
     q.rb_serverId AS 's_q_rb_serverId',
@@ -444,6 +447,7 @@ SELECT
     q.rb_limited AS 's_q_rb_limited',
     q.rb_note AS 's_q_rb_note',
     q.rb_roles AS 's_q_rb_roles',
+    q.rb_pronouns AS 's_q_rb_pronouns',
 
     -- Status view data
     q.svd_serverId AS 's_q_svd_serverId',

--- a/core/database/src/main/kotlin/app/pachli/core/database/dao/TimelineDao.kt
+++ b/core/database/src/main/kotlin/app/pachli/core/database/dao/TimelineDao.kt
@@ -119,6 +119,7 @@ ORDER BY LENGTH(s.serverId) DESC, s.serverId DESC
     s.a_limited AS 's_a_limited',
     s.a_note AS 's_a_note',
     s.a_roles AS 's_a_roles',
+    s.a_pronouns AS 's_a_pronouns',
 
     -- The status's reblog account (if any)
     s.rb_serverId AS 's_rb_serverId',
@@ -134,6 +135,7 @@ ORDER BY LENGTH(s.serverId) DESC, s.serverId DESC
     s.rb_limited AS 's_rb_limited',
     s.rb_note AS 's_rb_note',
     s.rb_roles AS 's_rb_roles',
+    s.rb_pronouns AS 's_rb_pronouns',
 
     -- Status view data
     s.svd_serverId AS 's_svd_serverId',
@@ -204,6 +206,7 @@ ORDER BY LENGTH(s.serverId) DESC, s.serverId DESC
     q.a_limited AS 'q_a_limited',
     q.a_note AS 'q_a_note',
     q.a_roles AS 'q_a_roles',
+    q.a_pronouns AS 'q_a_pronouns',
 
     -- The status's reblog account (if any)
     q.rb_serverId AS 'q_rb_serverId',
@@ -219,6 +222,7 @@ ORDER BY LENGTH(s.serverId) DESC, s.serverId DESC
     q.rb_limited AS 'q_rb_limited',
     q.rb_note AS 'q_rb_note',
     q.rb_roles AS 'q_rb_roles',
+    q.rb_pronouns AS 'q_rb_pronouns',
 
     -- Status view data
     q.svd_serverId AS 'q_svd_serverId',
@@ -965,6 +969,7 @@ WHERE timelineUserId = :pachliAccountId
     s.a_limited AS 's_a_limited',
     s.a_note AS 's_a_note',
     s.a_roles AS 's_a_roles',
+    s.a_pronouns AS 's_a_pronouns',
 
     -- The status's reblog account (if any)
     s.rb_serverId AS 's_rb_serverId',
@@ -980,6 +985,7 @@ WHERE timelineUserId = :pachliAccountId
     s.rb_limited AS 's_rb_limited',
     s.rb_note AS 's_rb_note',
     s.rb_roles AS 's_rb_roles',
+    s.rb_pronouns AS 's_rb_pronouns',
 
     -- Status view data
     s.svd_serverId AS 's_svd_serverId',
@@ -1050,6 +1056,7 @@ WHERE timelineUserId = :pachliAccountId
     q.a_limited AS 'q_a_limited',
     q.a_note AS 'q_a_note',
     q.a_roles AS 'q_a_roles',
+    q.a_pronouns AS 'q_a_pronouns',
 
     -- The status's reblog account (if any)
     q.rb_serverId AS 'q_rb_serverId',
@@ -1065,6 +1072,7 @@ WHERE timelineUserId = :pachliAccountId
     q.rb_limited AS 'q_rb_limited',
     q.rb_note AS 'q_rb_note',
     q.rb_roles AS 'q_rb_roles',
+    q.rb_pronouns AS 'q_rb_pronouns',
 
     -- Status view data
     q.svd_serverId AS 'q_svd_serverId',

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/ConversationStatusView.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/ConversationStatusView.kt
@@ -59,7 +59,7 @@ class ConversationStatusView @JvmOverloads constructor(
     override val displayName = binding.statusDisplayName
     override val username = binding.statusUsername
     override val metaInfo = binding.statusMetaInfo
-    override val pronouns = binding.accountPronouns
+    override val pronounsChip = binding.accountPronouns
     override val contentWarningDescription = binding.statusContentWarningDescription
     override val contentWarningButton: Button = binding.statusContentWarningButton
     override val content = binding.statusContent

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/DetailedStatusView.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/DetailedStatusView.kt
@@ -71,7 +71,7 @@ class DetailedStatusView @JvmOverloads constructor(
     override val displayName = binding.statusDisplayName
     override val metaInfo = binding.statusMetaInfo
     override val username = binding.statusUsername
-    override val pronouns = binding.accountPronouns
+    override val pronounsChip = binding.accountPronouns
     override val contentWarningDescription = binding.statusContentWarningDescription
     override val contentWarningButton = binding.statusContentWarningButton
     override val content = binding.statusContent

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/NotificationStatusView.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/NotificationStatusView.kt
@@ -50,7 +50,7 @@ class NotificationStatusView @JvmOverloads constructor(
     override val displayName = binding.statusDisplayName
     override val username = binding.statusUsername
     override val metaInfo = binding.statusMetaInfo
-    override val pronouns = binding.accountPronouns
+    override val pronounsChip = binding.accountPronouns
     override val contentWarningDescription = binding.statusContentWarningDescription
     override val contentWarningButton: Button = binding.statusContentWarningButton
     override val content = binding.statusContent

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/QuotedStatusView.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/QuotedStatusView.kt
@@ -50,7 +50,7 @@ class QuotedStatusView @JvmOverloads constructor(
     override val displayName = binding.quotedStatusContainer.quoteStatusDisplayName
     override val username = binding.quotedStatusContainer.quoteStatusUsername
     override val metaInfo = binding.quotedStatusContainer.quoteStatusMetaInfo
-    override val pronouns = binding.quotedStatusContainer.quoteAccountPronouns
+    override val pronounsChip = binding.quotedStatusContainer.quoteAccountPronouns
     override val contentWarningDescription = binding.quotedStatusContainer.quoteStatusContentWarningDescription
     override val contentWarningButton = binding.quotedStatusContainer.quoteStatusContentWarningButton
     override val content = binding.quotedStatusContainer.quoteStatusContent

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/ReportStatusView.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/ReportStatusView.kt
@@ -52,7 +52,7 @@ class ReportStatusView @JvmOverloads constructor(
     override val displayName = binding.statusDisplayName
     override val username = binding.statusUsername
     override val metaInfo = binding.statusMetaInfo
-    override val pronouns = binding.accountPronouns
+    override val pronounsChip = binding.accountPronouns
     override val contentWarningDescription = binding.statusContentWarningDescription
     override val contentWarningButton = binding.statusContentWarningButton
     override val content = binding.statusContent

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/StatusView.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/StatusView.kt
@@ -117,7 +117,7 @@ abstract class StatusView<T : IStatusViewData> @JvmOverloads constructor(
     abstract val metaInfo: TextView
 
     /** Chip to display the account's pronouns. */
-    abstract val pronouns: PronounsChip?
+    abstract val pronounsChip: PronounsChip?
 
     /** View displaying the status' content warning, if present. */
     abstract val contentWarningDescription: TextView
@@ -276,6 +276,7 @@ abstract class StatusView<T : IStatusViewData> @JvmOverloads constructor(
 
         when (viewData.translationState) {
             TranslationState.SHOW_ORIGINAL -> translationProvider.hide()
+
             TranslationState.TRANSLATING -> {
                 translationProvider.apply {
                     text = context.getString(R.string.translating)
@@ -405,17 +406,17 @@ abstract class StatusView<T : IStatusViewData> @JvmOverloads constructor(
     }
 
     open fun setPronouns(viewData: T, statusDisplayOptions: StatusDisplayOptions) {
-        val pronouns = this.pronouns ?: return
+        val pronounsChip = this.pronounsChip ?: return
 
         when (statusDisplayOptions.pronounDisplay) {
             PronounDisplay.EVERYWHERE -> {
-                pronouns.text = viewData.actionable.account.pronouns
-                pronouns.visible(viewData.actionable.account.pronouns?.isBlank() == false)
+                pronounsChip.text = viewData.actionable.account.pronouns
+                pronounsChip.visible(viewData.actionable.account.pronouns?.isBlank() == false)
             }
 
             PronounDisplay.WHEN_COMPOSING,
             PronounDisplay.HIDE,
-            -> pronouns.hide()
+            -> pronounsChip.hide()
         }
     }
 

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/TimelineStatusView.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/TimelineStatusView.kt
@@ -44,7 +44,7 @@ class TimelineStatusView @JvmOverloads constructor(
     override val displayName = binding.statusDisplayName
     override val username = binding.statusUsername
     override val metaInfo = binding.statusMetaInfo
-    override val pronouns = binding.accountPronouns
+    override val pronounsChip = binding.accountPronouns
     override val contentWarningDescription = binding.statusContentWarningDescription
     override val contentWarningButton = binding.statusContentWarningButton
     override val content = binding.statusContent


### PR DESCRIPTION
Previous queries caused pronouns to be null on some timelines, and so they weren't being displayed.