### PR TITLE
feat: Allow multiple simultaneous "compose" tasks

### DIFF
--- a/core/navigation/src/main/kotlin/app/pachli/core/navigation/Navigation.kt
+++ b/core/navigation/src/main/kotlin/app/pachli/core/navigation/Navigation.kt
@@ -531,6 +531,15 @@ class ComposeActivityIntent(context: Context, pachliAccountId: Long, composeOpti
         this.pachliAccountId = pachliAccountId
 
         composeOptions?.let { putExtra(EXTRA_COMPOSE_OPTIONS, it) }
+
+        // Support multiple concurrent compositions/replies. FLAG_ACTIVITY_NEW_DOCUMENT
+        // opens ComposeActivity as a new task (selectable on the "Recents" screen), and
+        // FLAG_ACTIVITY_MULTIPLE_TASK means each unique intent gets its own task.
+        //
+        // In practical terms this means there can be one task that started from a blank
+        // draft (e.g., by tapping the FAB), and N additional ComposeActivity tasks, one
+        // per unique Intent created by replying, composing from a hashtag, etc.
+        flags = FLAG_ACTIVITY_NEW_DOCUMENT or FLAG_ACTIVITY_MULTIPLE_TASK
     }
 
     companion object {


### PR DESCRIPTION
Send each `ComposeActivity` intent with `FLAG_ACTIVITY_NEW_DOCUMENT` and `FLAG_ACTIVITY_MULTIPLE_TASK`.

Each `ComposeActivity` started with a unique intent will be placed in a different task, allowing the user to swipe between them on the "Recents" screen.

This also means that opening a notification (which navigates back to the notifications tab) doesn't close any instances of `ComposeActivity`.

Fixes #1555