### PR TITLE
feat: Show compose action in task label in "Recents" view

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -826,4 +826,7 @@
     <string name="compose_quote_policy_dialog_title">Change quote setting?</string>
     <string name="compose_quote_policy_dialog_body_fmt">Posts marked \"%1$s\" or \"%2$s\" must have a quote setting of \"%3$s\".\n\nChange the quote setting now?</string>
 
+    <string name="compose_task_description_writing_post">Writing post</string>
+    <string name="compose_task_description_replying_fmt">Replying to %1$s</string>
+    <string name="compose_task_description_quoting_fmt">Quoting %1$s</string>
 </resources>


### PR DESCRIPTION
Now `ComposeActivity` appears as its own task in the "Recents" view the label can be set differently to distinguish between the different tasks.

Do this, with one of either:

- Writing post
- Replying to (name)
- Quoting (name)

This always affects Talkback. It doesn't affect the UI on some devices because of https://issuetracker.google.com/issues/340133008.

Suggested by @jonathan859@someplace.social