### PR TITLE
fix: Ignore quote, quote_update notifications with a missing status

### DIFF
--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/notifications/NotificationsRepository.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/notifications/NotificationsRepository.kt
@@ -95,6 +95,8 @@ class NotificationsRepository @Inject constructor(
         NotificationEntity.Type.MENTION,
         NotificationEntity.Type.POLL,
         NotificationEntity.Type.UPDATE,
+        NotificationEntity.Type.QUOTE,
+        NotificationEntity.Type.QUOTED_UPDATE,
     )
 
     /**


### PR DESCRIPTION
The status is supposed to be present for these notifications, per the docs, but crash reports suggest it's missing in some cases.

Don't crash (NPE), hide the notification, on the assumption the server will eventually respond with a fixed notification.