### PR TITLE
refactor: Replace onEnterAnimationComplete with intent extra

### DIFF
--- a/app/src/main/java/app/pachli/components/account/media/AccountMediaFragment.kt
+++ b/app/src/main/java/app/pachli/components/account/media/AccountMediaFragment.kt
@@ -21,7 +21,6 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
-import androidx.core.app.ActivityOptionsCompat
 import androidx.core.view.MenuProvider
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -177,16 +176,17 @@ class AccountMediaFragment :
             Attachment.Type.VIDEO,
             Attachment.Type.AUDIO,
             -> {
-                val intent = ViewMediaActivityIntent(requireContext(), pachliAccountId, selected.username, attachmentsFromSameStatus, currentIndex)
-                if (activity != null) {
-                    val url = selected.attachment.url
-                    view.transitionName = url
-                    val options = ActivityOptionsCompat.makeSceneTransitionAnimation(requireActivity(), view, url)
-                    startActivityWithDefaultTransition(intent, options.toBundle())
-                } else {
-                    startActivityWithDefaultTransition(intent)
-                }
+                val (intent, options) = ViewMediaActivityIntent.withSharedElementTransition(
+                    requireActivity(),
+                    pachliAccountId,
+                    selected.username,
+                    attachmentsFromSameStatus,
+                    currentIndex,
+                    view,
+                )
+                startActivityWithDefaultTransition(intent, options)
             }
+
             Attachment.Type.UNKNOWN -> openUrl(selected.attachment.url)
         }
     }

--- a/app/src/main/java/app/pachli/components/search/fragments/SearchStatusesFragment.kt
+++ b/app/src/main/java/app/pachli/components/search/fragments/SearchStatusesFragment.kt
@@ -26,7 +26,6 @@ import android.view.View
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.PopupMenu
-import androidx.core.app.ActivityOptionsCompat
 import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -157,26 +156,30 @@ class SearchStatusesFragment : SearchFragment<StatusItemViewData>(), StatusActio
         when (actionable.attachments[attachmentIndex].type) {
             Attachment.Type.GIFV, Attachment.Type.VIDEO, Attachment.Type.IMAGE, Attachment.Type.AUDIO -> {
                 val attachments = AttachmentViewData.list(actionable)
-                val intent = ViewMediaActivityIntent(
-                    requireContext(),
+
+                if (view == null) {
+                    val intent = ViewMediaActivityIntent(
+                        requireContext(),
+                        pachliAccountId,
+                        actionable.account.username,
+                        attachments,
+                        attachmentIndex,
+                    )
+                    startActivityWithDefaultTransition(intent)
+                    return
+                }
+
+                val (intent, options) = ViewMediaActivityIntent.withSharedElementTransition(
+                    requireActivity(),
                     pachliAccountId,
                     actionable.account.username,
                     attachments,
                     attachmentIndex,
+                    view,
                 )
-                if (view != null) {
-                    val url = actionable.attachments[attachmentIndex].url
-                    view.transitionName = url
-                    val options = ActivityOptionsCompat.makeSceneTransitionAnimation(
-                        requireActivity(),
-                        view,
-                        url,
-                    )
-                    startActivityWithDefaultTransition(intent, options.toBundle())
-                } else {
-                    startActivityWithDefaultTransition(intent)
-                }
+                startActivityWithDefaultTransition(intent, options)
             }
+
             Attachment.Type.UNKNOWN -> openUrl(actionable.attachments[attachmentIndex].url)
         }
     }

--- a/app/src/main/java/app/pachli/fragment/SFragment.kt
+++ b/app/src/main/java/app/pachli/fragment/SFragment.kt
@@ -28,7 +28,6 @@ import android.widget.Toast
 import androidx.annotation.CallSuper
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.PopupMenu
-import androidx.core.app.ActivityOptionsCompat
 import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
@@ -460,19 +459,22 @@ abstract class SFragment<T : IStatusViewData> : Fragment(), StatusActionListener
         val attachment = attachments[urlIndex].attachment
         when (attachment.type) {
             Attachment.Type.GIFV, Attachment.Type.VIDEO, Attachment.Type.IMAGE, Attachment.Type.AUDIO -> {
-                val intent = ViewMediaActivityIntent(requireContext(), pachliAccountId, owningUsername, attachments, urlIndex)
-                if (view != null) {
-                    val url = attachment.url
-                    view.transitionName = url
-                    val options = ActivityOptionsCompat.makeSceneTransitionAnimation(
-                        requireActivity(),
-                        view,
-                        url,
-                    )
-                    startActivityWithDefaultTransition(intent, options.toBundle())
-                } else {
+                if (view == null) {
+                    val intent = ViewMediaActivityIntent(requireContext(), pachliAccountId, owningUsername, attachments, urlIndex)
                     startActivityWithDefaultTransition(intent)
+                    return
                 }
+
+                val (intent, options) = ViewMediaActivityIntent.withSharedElementTransition(
+                    requireActivity(),
+                    pachliAccountId,
+                    owningUsername,
+                    attachments,
+                    urlIndex,
+                    view,
+                )
+
+                startActivityWithDefaultTransition(intent, options)
             }
 
             Attachment.Type.UNKNOWN -> openUrl(attachment.url)


### PR DESCRIPTION
Contrary to documentation, `onEnterAnimationComplete` can be called before the animation is complete, and the images are loaded in to a view that is the wrong size.

Since the activity can't reliably tell if it was started with a shared element transition, and a flag to the intent used to start the activity in a new `ViewMediaActivityIntent.withSharedElementTransition` and rewrite the callers to use this function where appropriate.