### PR TITLE
feat: Support searching for posts that quote others

### DIFF
--- a/app/src/main/java/app/pachli/components/search/SearchOperator.kt
+++ b/app/src/main/java/app/pachli/components/search/SearchOperator.kt
@@ -243,6 +243,21 @@ sealed interface SearchOperator {
         override fun query() = choice?.q
     }
 
+    /**
+     * The `has:quote` operator.
+     *
+     * @see HasEmbedOperator
+     * @see HasMediaOperator
+     */
+    data class HasQuoteOperator(override val choice: QuoteKind? = null) : SearchOperator {
+        enum class QuoteKind(val q: String) {
+            QUOTES_ONLY("has:quote"),
+            NO_QUOTES("-has:quote"),
+        }
+
+        override fun query() = choice?.q
+    }
+
     /** The `is:reply` operator. */
     class IsReplyOperator(override val choice: ReplyKind? = null) : SearchOperator {
         enum class ReplyKind(val q: String) {

--- a/app/src/main/java/app/pachli/components/search/SearchOperatorViewData.kt
+++ b/app/src/main/java/app/pachli/components/search/SearchOperatorViewData.kt
@@ -30,6 +30,7 @@ import app.pachli.components.search.SearchOperator.HasMediaOperator.HasMediaOpti
 import app.pachli.components.search.SearchOperator.HasMediaOperator.HasMediaOption.SpecificMedia
 import app.pachli.components.search.SearchOperator.HasMediaOperator.MediaKind
 import app.pachli.components.search.SearchOperator.HasPollOperator
+import app.pachli.components.search.SearchOperator.HasQuoteOperator
 import app.pachli.components.search.SearchOperator.IsReplyOperator
 import app.pachli.components.search.SearchOperator.IsSensitiveOperator
 import app.pachli.components.search.SearchOperator.LanguageOperator
@@ -58,6 +59,7 @@ sealed interface SearchOperatorViewData<out T : SearchOperator> {
             is LanguageOperator -> LanguageOperatorViewData(operator)
             is HasLinkOperator -> HasLinkOperatorViewData(operator)
             is HasPollOperator -> HasPollOperatorViewData(operator)
+            is HasQuoteOperator -> HasQuoteOperatorViewData(operator)
             is IsReplyOperator -> IsReplyOperatorViewData(operator)
             is IsSensitiveOperator -> IsSensitiveOperatorViewData(operator)
             is WhereOperator -> WhereOperatorViewData(operator)
@@ -262,6 +264,16 @@ sealed interface SearchOperatorViewData<out T : SearchOperator> {
                 null -> R.string.search_operator_poll_all
                 HasPollOperator.PollKind.POLLS_ONLY -> R.string.search_operator_poll_only
                 HasPollOperator.PollKind.NO_POLLS -> R.string.search_operator_poll_no_polls
+            },
+        )
+    }
+
+    data class HasQuoteOperatorViewData(override val operator: HasQuoteOperator) : SearchOperatorViewData<HasQuoteOperator> {
+        override fun chipLabel(context: Context) = context.getString(
+            when (operator.choice) {
+                null -> R.string.search_operator_quote_all
+                HasQuoteOperator.QuoteKind.QUOTES_ONLY -> R.string.search_operator_quote_only
+                HasQuoteOperator.QuoteKind.NO_QUOTES -> R.string.search_operator_quote_no_quotes
             },
         )
     }

--- a/app/src/main/java/app/pachli/components/search/SearchViewModel.kt
+++ b/app/src/main/java/app/pachli/components/search/SearchViewModel.kt
@@ -28,6 +28,7 @@ import app.pachli.components.search.SearchOperator.HasEmbedOperator
 import app.pachli.components.search.SearchOperator.HasLinkOperator
 import app.pachli.components.search.SearchOperator.HasMediaOperator
 import app.pachli.components.search.SearchOperator.HasPollOperator
+import app.pachli.components.search.SearchOperator.HasQuoteOperator
 import app.pachli.components.search.SearchOperator.IsReplyOperator
 import app.pachli.components.search.SearchOperator.IsSensitiveOperator
 import app.pachli.components.search.SearchOperator.LanguageOperator
@@ -60,6 +61,7 @@ import app.pachli.core.model.ServerOperation.ORG_JOINMASTODON_SEARCH_QUERY_HAS_I
 import app.pachli.core.model.ServerOperation.ORG_JOINMASTODON_SEARCH_QUERY_HAS_LINK
 import app.pachli.core.model.ServerOperation.ORG_JOINMASTODON_SEARCH_QUERY_HAS_MEDIA
 import app.pachli.core.model.ServerOperation.ORG_JOINMASTODON_SEARCH_QUERY_HAS_POLL
+import app.pachli.core.model.ServerOperation.ORG_JOINMASTODON_SEARCH_QUERY_HAS_QUOTE
 import app.pachli.core.model.ServerOperation.ORG_JOINMASTODON_SEARCH_QUERY_HAS_VIDEO
 import app.pachli.core.model.ServerOperation.ORG_JOINMASTODON_SEARCH_QUERY_IN_LIBRARY
 import app.pachli.core.model.ServerOperation.ORG_JOINMASTODON_SEARCH_QUERY_IN_PUBLIC
@@ -122,6 +124,7 @@ class SearchViewModel @Inject constructor(
             SearchOperatorViewData.from(LanguageOperator()),
             SearchOperatorViewData.from(HasLinkOperator()),
             SearchOperatorViewData.from(HasPollOperator()),
+            SearchOperatorViewData.from(HasQuoteOperator()),
             SearchOperatorViewData.from(IsReplyOperator()),
             SearchOperatorViewData.from(IsSensitiveOperator()),
             SearchOperatorViewData.from(WhereOperator()),
@@ -194,6 +197,11 @@ class SearchViewModel @Inject constructor(
                     if (server.can(ORG_JOINMASTODON_SEARCH_QUERY_HAS_POLL, constraint100)) {
                         add(HasPollOperator())
                     }
+
+                    if (server.can(ORG_JOINMASTODON_SEARCH_QUERY_HAS_QUOTE, constraint100)) {
+                        add(HasQuoteOperator())
+                    }
+
                     if (server.can(ORG_JOINMASTODON_SEARCH_QUERY_IS_REPLY, constraint100)) {
                         add(IsReplyOperator())
                     }

--- a/app/src/main/res/layout/activity_search.xml
+++ b/app/src/main/res/layout/activity_search.xml
@@ -120,6 +120,15 @@
                     android:layout_height="wrap_content"
                     app:chipIconEnabled="true"
                     android:text="@string/search_operator_embed_all" />
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/chip_has_quote"
+                    style="@style/Widget.Material3.Chip.Suggestion"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:chipIconEnabled="true"
+                    app:chipIcon="@drawable/format_quote_24px"
+                    android:text="@string/search_operator_quote_all" />
             </com.google.android.material.chip.ChipGroup>
         </HorizontalScrollView>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -730,6 +730,14 @@
     <string name="search_operator_embed_dialog_only">Only posts with preview cards</string>
     <string name="search_operator_embed_dialog_no_embeds">Only posts without preview cards</string>
 
+    <string name="search_operator_quote_all">Quotes ▾</string>
+    <string name="search_operator_quote_only">Only quotes</string>
+    <string name="search_operator_quote_no_quotes">Without quotes</string>
+    <string name="search_operator_quote_dialog_title">Show posts that quote other posts?</string>
+    <string name="search_operator_quote_dialog_all">With or without quotes</string>
+    <string name="search_operator_quote_dialog_only">Only posts with quotes</string>
+    <string name="search_operator_quote_dialog_no_quotes">Only posts without quotes</string>
+
     <string name="search_operator_link_all">Links ▾</string>
     <string name="search_operator_link_only">Only links</string>
     <string name="search_operator_no_link">Without links</string>

--- a/core/data/src/main/kotlin/app/pachli/core/data/model/Server.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/model/Server.kt
@@ -52,6 +52,7 @@ import app.pachli.core.model.ServerOperation.ORG_JOINMASTODON_SEARCH_QUERY_HAS_I
 import app.pachli.core.model.ServerOperation.ORG_JOINMASTODON_SEARCH_QUERY_HAS_LINK
 import app.pachli.core.model.ServerOperation.ORG_JOINMASTODON_SEARCH_QUERY_HAS_MEDIA
 import app.pachli.core.model.ServerOperation.ORG_JOINMASTODON_SEARCH_QUERY_HAS_POLL
+import app.pachli.core.model.ServerOperation.ORG_JOINMASTODON_SEARCH_QUERY_HAS_QUOTE
 import app.pachli.core.model.ServerOperation.ORG_JOINMASTODON_SEARCH_QUERY_HAS_VIDEO
 import app.pachli.core.model.ServerOperation.ORG_JOINMASTODON_SEARCH_QUERY_IN_LIBRARY
 import app.pachli.core.model.ServerOperation.ORG_JOINMASTODON_SEARCH_QUERY_IN_PUBLIC
@@ -299,6 +300,24 @@ data class Server(
 
                     // Search operators
                     when {
+                        v >= "4.4.5".toVersion() -> {
+                            c[ORG_JOINMASTODON_SEARCH_QUERY_IN_PUBLIC] = "1.0.0".toVersion()
+                            c[ORG_JOINMASTODON_SEARCH_QUERY_FROM] = "1.1.0".toVersion()
+                            c[ORG_JOINMASTODON_SEARCH_QUERY_LANGUAGE] = "1.0.0".toVersion()
+                            c[ORG_JOINMASTODON_SEARCH_QUERY_HAS_MEDIA] = "1.0.0".toVersion()
+                            c[ORG_JOINMASTODON_SEARCH_QUERY_HAS_IMAGE] = "1.0.0".toVersion()
+                            c[ORG_JOINMASTODON_SEARCH_QUERY_HAS_VIDEO] = "1.0.0".toVersion()
+                            c[ORG_JOINMASTODON_SEARCH_QUERY_HAS_AUDIO] = "1.0.0".toVersion()
+                            c[ORG_JOINMASTODON_SEARCH_QUERY_HAS_POLL] = "1.0.0".toVersion()
+                            c[ORG_JOINMASTODON_SEARCH_QUERY_HAS_QUOTE] = "1.0.0".toVersion()
+                            c[ORG_JOINMASTODON_SEARCH_QUERY_HAS_LINK] = "1.0.0".toVersion()
+                            c[ORG_JOINMASTODON_SEARCH_QUERY_HAS_EMBED] = "1.0.0".toVersion()
+                            c[ORG_JOINMASTODON_SEARCH_QUERY_IS_REPLY] = "1.0.0".toVersion()
+                            c[ORG_JOINMASTODON_SEARCH_QUERY_IS_SENSITIVE] = "1.0.0".toVersion()
+                            c[ORG_JOINMASTODON_SEARCH_QUERY_IN_LIBRARY] = "1.0.0".toVersion()
+                            c[ORG_JOINMASTODON_SEARCH_QUERY_BY_DATE] = "1.0.0".toVersion()
+                        }
+
                         v >= "4.3.0".toVersion() -> {
                             c[ORG_JOINMASTODON_SEARCH_QUERY_IN_PUBLIC] = "1.0.0".toVersion()
                             c[ORG_JOINMASTODON_SEARCH_QUERY_FROM] = "1.1.0".toVersion()
@@ -371,6 +390,7 @@ data class Server(
                             c[ORG_JOINMASTODON_FILTERS_CLIENT] = "1.1.0".toVersion()
                             c[ORG_JOINMASTODON_FILTERS_SERVER] = "1.0.0".toVersion()
                         }
+
                         // Implemented in https://github.com/superseriousbusiness/gotosocial/pull/2594
                         v >= "0.15.0".toVersion() -> c[ORG_JOINMASTODON_FILTERS_CLIENT] = "1.1.0".toVersion()
                     }

--- a/core/model/src/main/kotlin/app/pachli/core/model/ServerOperation.kt
+++ b/core/model/src/main/kotlin/app/pachli/core/model/ServerOperation.kt
@@ -103,6 +103,7 @@ enum class ServerOperation(id: String, versions: List<Version>) {
     ORG_JOINMASTODON_SEARCH_QUERY_HAS_VIDEO("org.joinmastodon.search.query:has:video", listOf(Version(major = 1))),
     ORG_JOINMASTODON_SEARCH_QUERY_HAS_AUDIO("org.joinmastodon.search.query:has:audio", listOf(Version(major = 1))),
     ORG_JOINMASTODON_SEARCH_QUERY_HAS_POLL("org.joinmastodon.search.query:has:poll", listOf(Version(major = 1))),
+    ORG_JOINMASTODON_SEARCH_QUERY_HAS_QUOTE("org.joinmastodon.search.query:has:quote", listOf(Version(major = 1))),
     ORG_JOINMASTODON_SEARCH_QUERY_HAS_LINK("org.joinmastodon.search.query:has:link", listOf(Version(major = 1))),
     ORG_JOINMASTODON_SEARCH_QUERY_HAS_EMBED("org.joinmastodon.search.query:has:embed", listOf(Version(major = 1))),
     ORG_JOINMASTODON_SEARCH_QUERY_IS_REPLY("org.joinmastodon.search.query:is:reply", listOf(Version(major = 1))),


### PR DESCRIPTION
Mastodon 4.4.5 added the `has:quote` search operator. Support this in the UI for choosing search operators.