### PR TITLE
fix: Don't show quotes if the quoting post has a closed content warning

### DIFF
--- a/core/data/src/main/kotlin/app/pachli/core/data/model/StatusViewData.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/model/StatusViewData.kt
@@ -140,6 +140,14 @@ sealed interface IStatusViewData : IStatus {
      * otherwise false.
      */
     val isUsersStatus: Boolean
+
+    /**
+     * True if this status' content is being shown (either because the status has no
+     * spoiler warning, or because the user has clicked through the spoiler warning).
+     * False if the content is not shown because the status has a warning and the user
+     * has clicked through.
+     */
+    val isShowingContent: Boolean
 }
 
 /**
@@ -262,6 +270,9 @@ data class StatusViewData(
         get() = if (translationState == TranslationState.SHOW_TRANSLATION) _translatedSpoilerText else _spoilerText
 
     override val username: String
+
+    override val isShowingContent: Boolean
+        get() = (_spoilerText.isEmpty() || isExpanded)
 
     override val rebloggedAvatar: String?
         get() = if (status.reblog != null) {

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/ConversationStatusView.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/ConversationStatusView.kt
@@ -101,7 +101,7 @@ class ConversationStatusView @JvmOverloads constructor(
         binding.statusAvatar.setPaddingRelative(avatarPadding, avatarPadding, avatarPadding, avatarPadding)
 
         val quotedViewData = (viewData as? IStatusItemViewData)?.asQuotedStatusViewData()
-        if (quotedViewData == null) {
+        if (quotedViewData == null || !viewData.isShowingContent) {
             binding.statusQuote.hide()
             return
         }

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/DetailedStatusView.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/DetailedStatusView.kt
@@ -101,7 +101,7 @@ class DetailedStatusView @JvmOverloads constructor(
         }
 
         val quotedViewData = (viewData as? IStatusItemViewData)?.asQuotedStatusViewData()
-        if (quotedViewData == null) {
+        if (quotedViewData == null || !viewData.isShowingContent) {
             binding.statusQuote.hide()
             return
         }

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/NotificationStatusView.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/NotificationStatusView.kt
@@ -67,7 +67,7 @@ class NotificationStatusView @JvmOverloads constructor(
         super.setupWithStatus(setStatusContent, glide, viewData, listener, statusDisplayOptions)
 
         val quotedViewData = (viewData as? IStatusItemViewData)?.asQuotedStatusViewData()
-        if (quotedViewData == null) {
+        if (quotedViewData == null || !viewData.isShowingContent) {
             binding.statusQuote.hide()
             return
         }

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/ReportStatusView.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/ReportStatusView.kt
@@ -72,7 +72,7 @@ class ReportStatusView @JvmOverloads constructor(
         binding.statusPoll.isEnabled = false
 
         val quotedViewData = (viewData as? IStatusItemViewData)?.asQuotedStatusViewData()
-        if (quotedViewData == null) {
+        if (quotedViewData == null || !viewData.isShowingContent) {
             binding.statusQuote.hide()
             return
         }

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/TimelineStatusView.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/TimelineStatusView.kt
@@ -61,7 +61,7 @@ class TimelineStatusView @JvmOverloads constructor(
         super.setupWithStatus(setStatusContent, glide, viewData, listener, statusDisplayOptions)
 
         val quotedViewData = viewData.asQuotedStatusViewData()
-        if (quotedViewData == null) {
+        if (quotedViewData == null || !viewData.isShowingContent) {
             binding.statusQuote.hide()
             return
         }


### PR DESCRIPTION
Previous code always showed the quoted post if present, even if the quoting post had a content warning and the user hadn't clicked through.

This breaks a quote use-case -- boosting a post but adding a content warning.

Fix this by checking to see if the quoting post has a content warning, and hiding the quote unless the user has clicked through.

Fixes #2037