### PR TITLE
fix: Show placeholder for blocked quotes

### DIFF
--- a/app/src/main/java/app/pachli/components/search/fragments/SearchStatusesFragment.kt
+++ b/app/src/main/java/app/pachli/components/search/fragments/SearchStatusesFragment.kt
@@ -507,8 +507,12 @@ class SearchStatusesFragment : SearchFragment<StatusItemViewData>(), StatusActio
                                     content = redraftStatus.text.orEmpty(),
                                     referencingStatus = redraftStatus.inReplyToId?.let {
                                         ReferencingStatus.ReplyId(it)
-                                    } ?: redraftStatus.quote?.let {
-                                        ReferencingStatus.QuoteId(it.statusId)
+                                    } ?: redraftStatus.quote?.let { quote ->
+                                        when (quote) {
+                                            is Status.Quote.FullQuote -> quote.statusId
+                                            is Status.Quote.ShallowQuote -> quote.statusId
+                                            is Status.Quote.HiddenQuote -> null
+                                        }?.let { ReferencingStatus.QuoteId(it) }
                                     },
                                     visibility = redraftStatus.visibility,
                                     contentWarning = redraftStatus.spoilerText,
@@ -540,8 +544,12 @@ class SearchStatusesFragment : SearchFragment<StatusItemViewData>(), StatusActio
                     content = source.text,
                     referencingStatus = status.inReplyToId?.let {
                         ReferencingStatus.ReplyId(it)
-                    } ?: status.quote?.let {
-                        ReferencingStatus.QuoteId(it.statusId)
+                    } ?: status.quote?.let { quote ->
+                        when (quote) {
+                            is Status.Quote.FullQuote -> quote.statusId
+                            is Status.Quote.ShallowQuote -> quote.statusId
+                            is Status.Quote.HiddenQuote -> null
+                        }?.let { ReferencingStatus.QuoteId(it) }
                     },
                     visibility = status.visibility,
                     contentWarning = source.spoilerText,

--- a/app/src/main/java/app/pachli/fragment/SFragment.kt
+++ b/app/src/main/java/app/pachli/fragment/SFragment.kt
@@ -525,8 +525,12 @@ abstract class SFragment<T : IStatusViewData> : Fragment(), StatusActionListener
                             content = sourceStatus.text,
                             referencingStatus = statusViewData.status.inReplyToId?.let {
                                 ReferencingStatus.ReplyId(it)
-                            } ?: statusViewData.status.quote?.let {
-                                ReferencingStatus.QuoteId(it.statusId)
+                            } ?: statusViewData.status.quote?.let { quote ->
+                                when (quote) {
+                                    is Status.Quote.FullQuote -> quote.statusId
+                                    is Status.Quote.ShallowQuote -> quote.statusId
+                                    is Status.Quote.HiddenQuote -> null
+                                }?.let { ReferencingStatus.QuoteId(it) }
                             },
                             visibility = sourceStatus.visibility,
                             contentWarning = sourceStatus.spoilerText,
@@ -562,8 +566,12 @@ abstract class SFragment<T : IStatusViewData> : Fragment(), StatusActionListener
                     content = source.text,
                     referencingStatus = status.inReplyToId?.let {
                         ReferencingStatus.ReplyId(it)
-                    } ?: status.quote?.let {
-                        ReferencingStatus.QuoteId(it.statusId)
+                    } ?: status.quote?.let { quote ->
+                        when (quote) {
+                            is Status.Quote.FullQuote -> quote.statusId
+                            is Status.Quote.ShallowQuote -> quote.statusId
+                            is Status.Quote.HiddenQuote -> null
+                        }?.let { ReferencingStatus.QuoteId(it) }
                     },
                     visibility = status.visibility,
                     contentWarning = source.spoilerText,

--- a/core/database/src/main/kotlin/app/pachli/core/database/dao/TimelineStatusWithAccount.kt
+++ b/core/database/src/main/kotlin/app/pachli/core/database/dao/TimelineStatusWithAccount.kt
@@ -29,6 +29,7 @@ import app.pachli.core.model.Emoji
 import app.pachli.core.model.HashTag
 import app.pachli.core.model.Poll
 import app.pachli.core.model.Status
+import app.pachli.core.model.Status.Quote.ShallowQuote
 import java.util.Date
 
 @DatabaseView(
@@ -194,10 +195,20 @@ data class TimelineStatusWithAccount(
                 muted = status.muted,
                 poll = poll,
                 card = card,
-                quote = status.quoteState?.let { quoteState ->
-                    status.quoteServerId?.let { quoteServerId ->
-                        Status.Quote.ShallowQuote(quoteState, quoteServerId)
-                    }
+                quote = when (status.quoteState) {
+                    Status.QuoteState.ACCEPTED -> ShallowQuote(status.quoteState, status.quoteServerId!!)
+                    Status.QuoteState.UNKNOWN,
+                    Status.QuoteState.PENDING,
+                    Status.QuoteState.REJECTED,
+                    Status.QuoteState.REVOKED,
+                    Status.QuoteState.DELETED,
+                    Status.QuoteState.UNAUTHORIZED,
+                    Status.QuoteState.BLOCKED_ACCOUNT,
+                    Status.QuoteState.BLOCKED_DOMAIN,
+                    Status.QuoteState.MUTED_ACCOUNT,
+                    -> Status.Quote.HiddenQuote(state = status.quoteState)
+
+                    null -> null
                 },
                 quoteApproval = status.quoteApproval,
                 repliesCount = status.repliesCount,
@@ -236,10 +247,20 @@ data class TimelineStatusWithAccount(
                 muted = status.muted,
                 poll = null,
                 card = null,
-                quote = status.quoteState?.let { quoteState ->
-                    status.quoteServerId?.let { quoteServerId ->
-                        Status.Quote.ShallowQuote(quoteState, quoteServerId)
-                    }
+                quote = when (status.quoteState) {
+                    Status.QuoteState.ACCEPTED -> ShallowQuote(status.quoteState, status.quoteServerId!!)
+                    Status.QuoteState.UNKNOWN,
+                    Status.QuoteState.PENDING,
+                    Status.QuoteState.REJECTED,
+                    Status.QuoteState.REVOKED,
+                    Status.QuoteState.DELETED,
+                    Status.QuoteState.UNAUTHORIZED,
+                    Status.QuoteState.BLOCKED_ACCOUNT,
+                    Status.QuoteState.BLOCKED_DOMAIN,
+                    Status.QuoteState.MUTED_ACCOUNT,
+                    -> Status.Quote.HiddenQuote(state = status.quoteState)
+
+                    null -> null
                 },
                 quoteApproval = status.quoteApproval,
                 repliesCount = status.repliesCount,
@@ -275,10 +296,20 @@ data class TimelineStatusWithAccount(
                 muted = status.muted,
                 poll = poll,
                 card = card,
-                quote = status.quoteState?.let { quoteState ->
-                    status.quoteServerId?.let { quoteServerId ->
-                        Status.Quote.ShallowQuote(quoteState, quoteServerId)
-                    }
+                quote = when (status.quoteState) {
+                    Status.QuoteState.ACCEPTED -> ShallowQuote(status.quoteState, status.quoteServerId!!)
+                    Status.QuoteState.UNKNOWN,
+                    Status.QuoteState.PENDING,
+                    Status.QuoteState.REJECTED,
+                    Status.QuoteState.REVOKED,
+                    Status.QuoteState.DELETED,
+                    Status.QuoteState.UNAUTHORIZED,
+                    Status.QuoteState.BLOCKED_ACCOUNT,
+                    Status.QuoteState.BLOCKED_DOMAIN,
+                    Status.QuoteState.MUTED_ACCOUNT,
+                    -> Status.Quote.HiddenQuote(state = status.quoteState)
+
+                    null -> null
                 },
                 quoteApproval = status.quoteApproval,
                 repliesCount = status.repliesCount,

--- a/core/database/src/main/kotlin/app/pachli/core/database/model/StatusEntity.kt
+++ b/core/database/src/main/kotlin/app/pachli/core/database/model/StatusEntity.kt
@@ -166,7 +166,12 @@ fun Status.asEntity(pachliAccountId: Long) = StatusEntity(
     pinned = actionableStatus.pinned == true,
     card = actionableStatus.card,
     quoteState = actionableStatus.quote?.state,
-    quoteServerId = actionableStatus.quote?.statusId,
+    quoteServerId = when (actionableStatus.quote) {
+        is Status.Quote.FullQuote -> (actionableStatus.quote as Status.Quote.FullQuote).statusId
+        is Status.Quote.ShallowQuote -> (actionableStatus.quote as Status.Quote.ShallowQuote).statusId
+        is Status.Quote.HiddenQuote -> null
+        null -> null
+    },
     quoteApproval = actionableStatus.quoteApproval,
     repliesCount = actionableStatus.repliesCount,
     language = actionableStatus.language,

--- a/core/model/src/main/kotlin/app/pachli/core/model/Status.kt
+++ b/core/model/src/main/kotlin/app/pachli/core/model/Status.kt
@@ -207,7 +207,11 @@ data class Status(
         val website: String?,
     )
 
+    /** The quote's acceptance state. */
     enum class QuoteState {
+        /**
+         * The quote state is not recognised, and will not be displayed.
+         */
         UNKNOWN,
 
         /**
@@ -269,20 +273,42 @@ data class Status(
     }
 
     sealed interface Quote {
+        /** The quote's acceptance state. */
         val state: QuoteState
-        val statusId: String
 
+        /**
+         * Full quote.
+         *
+         * @property state
+         * @property status The quoted status.
+         */
         data class FullQuote(
             override val state: QuoteState,
             val status: Status,
         ) : Quote {
-            override val statusId: String
+            val statusId: String
                 get() = status.actionableId
         }
 
+        /**
+         * Shallow quote.
+         *
+         * @property state
+         * @property statusId ID of the quoted status.
+         */
         data class ShallowQuote(
             override val state: QuoteState,
-            override val statusId: String,
+            val statusId: String,
+        ) : Quote
+
+        /**
+         * Hidden quote; the existence is disclosed to the user, but they can't
+         * click through it.
+         *
+         * @property state Why the quote is hidden.
+         */
+        data class HiddenQuote(
+            override val state: QuoteState,
         ) : Quote
     }
 

--- a/core/network/src/main/kotlin/app/pachli/core/network/model/Status.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/Status.kt
@@ -23,7 +23,6 @@ import app.pachli.core.network.json.HasDefault
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import java.util.Date
-import timber.log.Timber
 
 @JsonClass(generateAdapter = true)
 data class Status(
@@ -256,7 +255,7 @@ data class Status(
         @Json(name = "quoted_status") val quotedStatus: Status? = null,
         @Json(name = "quoted_status_id") val quotedStatusId: String? = null,
     ) {
-        fun asModel(): app.pachli.core.model.Status.Quote? {
+        fun asModel(): app.pachli.core.model.Status.Quote {
             if (quotedStatus != null) {
                 return app.pachli.core.model.Status.Quote.FullQuote(
                     state = state.asModel(),
@@ -271,8 +270,7 @@ data class Status(
                 )
             }
 
-            Timber.e("Could not convert network Quote to model Quote: $this")
-            return null
+            return app.pachli.core.model.Status.Quote.HiddenQuote(state = state.asModel())
         }
     }
 

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/ConversationStatusView.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/ConversationStatusView.kt
@@ -26,7 +26,6 @@ import androidx.core.util.TypedValueCompat
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
 import app.pachli.core.data.model.ConversationViewData
-import app.pachli.core.data.model.IStatusItemViewData
 import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.ui.databinding.StatusContentConversationBinding
 import com.bumptech.glide.RequestManager
@@ -100,13 +99,14 @@ class ConversationStatusView @JvmOverloads constructor(
         // setAvatar will have cleared the padding on the first avatar, set it back.
         binding.statusAvatar.setPaddingRelative(avatarPadding, avatarPadding, avatarPadding, avatarPadding)
 
-        val quotedViewData = (viewData as? IStatusItemViewData)?.asQuotedStatusViewData()
-        if (quotedViewData == null || !viewData.isShowingContent) {
+        val quote = viewData.actionable.quote
+        if (!viewData.isShowingContent || quote == null) {
             binding.statusQuote.hide()
             return
         }
 
-        binding.statusQuote.setupWithStatus(setStatusContent, glide, quotedViewData, listener, statusDisplayOptions)
+        val quotedViewData = viewData.asQuotedStatusViewData()
+        binding.statusQuote.setupWithStatus(setStatusContent, glide, quote.state, quotedViewData, listener, statusDisplayOptions)
         binding.statusQuote.show()
     }
 }

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/DetailedStatusView.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/DetailedStatusView.kt
@@ -100,13 +100,14 @@ class DetailedStatusView @JvmOverloads constructor(
             hideQuantitativeStats()
         }
 
-        val quotedViewData = (viewData as? IStatusItemViewData)?.asQuotedStatusViewData()
-        if (quotedViewData == null || !viewData.isShowingContent) {
+        val quote = viewData.actionable.quote
+        if (!viewData.isShowingContent || quote == null) {
             binding.statusQuote.hide()
             return
         }
 
-        binding.statusQuote.setupWithStatus(setStatusContent, glide, quotedViewData, listener, statusDisplayOptions)
+        val quotedViewData = (viewData as? IStatusItemViewData)?.asQuotedStatusViewData()
+        binding.statusQuote.setupWithStatus(setStatusContent, glide, quote.state, quotedViewData, listener, statusDisplayOptions)
         binding.statusQuote.show()
     }
 

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/NotificationStatusView.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/NotificationStatusView.kt
@@ -23,7 +23,6 @@ import android.view.LayoutInflater
 import android.widget.Button
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
-import app.pachli.core.data.model.IStatusItemViewData
 import app.pachli.core.data.model.NotificationViewData
 import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.ui.databinding.StatusContentBinding
@@ -66,13 +65,14 @@ class NotificationStatusView @JvmOverloads constructor(
     override fun setupWithStatus(setStatusContent: SetStatusContent, glide: RequestManager, viewData: NotificationViewData.WithStatus, listener: StatusActionListener, statusDisplayOptions: StatusDisplayOptions) {
         super.setupWithStatus(setStatusContent, glide, viewData, listener, statusDisplayOptions)
 
-        val quotedViewData = (viewData as? IStatusItemViewData)?.asQuotedStatusViewData()
-        if (quotedViewData == null || !viewData.isShowingContent) {
+        val quote = viewData.actionable.quote
+        if (!viewData.isShowingContent || quote == null) {
             binding.statusQuote.hide()
             return
         }
 
-        binding.statusQuote.setupWithStatus(setStatusContent, glide, quotedViewData, listener, statusDisplayOptions)
+        val quotedViewData = viewData.asQuotedStatusViewData()
+        binding.statusQuote.setupWithStatus(setStatusContent, glide, quote.state, quotedViewData, listener, statusDisplayOptions)
         binding.statusQuote.show()
     }
 }

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/QuotedStatusView.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/QuotedStatusView.kt
@@ -69,10 +69,22 @@ class QuotedStatusView @JvmOverloads constructor(
     /** Bottom padding to use on the root view if the "Remove quote" button is not shown. */
     private val paddingBottomWithoutRemoveQuote = dpToPx(14f, context.resources.displayMetrics).toInt()
 
-    override fun setupWithStatus(setStatusContent: SetStatusContent, glide: RequestManager, viewData: QuotedStatusViewData, listener: StatusActionListener, statusDisplayOptions: StatusDisplayOptions) {
-        // Don't show the quote unless the state is ACCEPTED. Every other state
-        // has a custom explanation.
-        val blockedRes = when (viewData.quoteState) {
+    /**
+     * Binds the [viewData] to the view, respecting [quoteState].
+     *
+     * Call this instead of [setupWithStatus(setStatusContent: SetStatusContent, glide: RequestManager, viewData: QuotedStatusViewData, listener: StatusActionListener, statusDisplayOptions: StatusDisplayOptions)].
+     *
+     * @param setStatusContent
+     * @param glide
+     * @param quoteState Whether to display the quote. If not
+     * [QuoteState.ACCEPTED][Status.QuoteState.ACCEPTED] the quote is hidden and an
+     * explanatory message is shown.
+     * @param viewData
+     * @param listener
+     * @param statusDisplayOptions
+     */
+    fun setupWithStatus(setStatusContent: SetStatusContent, glide: RequestManager, quoteState: Status.QuoteState, viewData: QuotedStatusViewData?, listener: StatusActionListener, statusDisplayOptions: StatusDisplayOptions) {
+        val blockedRes = when (quoteState) {
             Status.QuoteState.ACCEPTED -> -1
             Status.QuoteState.UNKNOWN -> R.string.label_quote_state_unknown
             Status.QuoteState.PENDING -> R.string.label_quote_state_pending
@@ -93,6 +105,10 @@ class QuotedStatusView @JvmOverloads constructor(
             return
         }
 
+        setupWithStatus(setStatusContent, glide, viewData!!, listener, statusDisplayOptions)
+    }
+
+    override fun setupWithStatus(setStatusContent: SetStatusContent, glide: RequestManager, viewData: QuotedStatusViewData, listener: StatusActionListener, statusDisplayOptions: StatusDisplayOptions) {
         when (viewData.contentFilterAction) {
             FilterAction.HIDE -> {
                 binding.quotedStatusFiltered.root.hide()

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/ReportStatusView.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/ReportStatusView.kt
@@ -22,7 +22,6 @@ import android.util.AttributeSet
 import android.view.LayoutInflater
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
-import app.pachli.core.data.model.IStatusItemViewData
 import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.data.model.StatusItemViewData
 import app.pachli.core.data.model.StatusViewData
@@ -71,13 +70,14 @@ class ReportStatusView @JvmOverloads constructor(
         // Can't vote while reporting statuses.
         binding.statusPoll.isEnabled = false
 
-        val quotedViewData = (viewData as? IStatusItemViewData)?.asQuotedStatusViewData()
-        if (quotedViewData == null || !viewData.isShowingContent) {
+        val quote = viewData.actionable.quote
+        if (!viewData.isShowingContent || quote == null) {
             binding.statusQuote.hide()
             return
         }
 
-        binding.statusQuote.setupWithStatus(setStatusContent, glide, quotedViewData, listener, statusDisplayOptions)
+        val quotedViewData = viewData.asQuotedStatusViewData()
+        binding.statusQuote.setupWithStatus(setStatusContent, glide, quote.state, quotedViewData, listener, statusDisplayOptions)
         binding.statusQuote.show()
     }
 }

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/TimelineStatusView.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/TimelineStatusView.kt
@@ -60,13 +60,14 @@ class TimelineStatusView @JvmOverloads constructor(
     override fun setupWithStatus(setStatusContent: SetStatusContent, glide: RequestManager, viewData: IStatusItemViewData, listener: StatusActionListener, statusDisplayOptions: StatusDisplayOptions) {
         super.setupWithStatus(setStatusContent, glide, viewData, listener, statusDisplayOptions)
 
-        val quotedViewData = viewData.asQuotedStatusViewData()
-        if (quotedViewData == null || !viewData.isShowingContent) {
+        val quote = viewData.actionable.quote
+        if (!viewData.isShowingContent || quote == null) {
             binding.statusQuote.hide()
             return
         }
 
-        binding.statusQuote.setupWithStatus(setStatusContent, glide, quotedViewData, listener, statusDisplayOptions)
+        val quotedViewData = viewData.asQuotedStatusViewData()
+        binding.statusQuote.setupWithStatus(setStatusContent, glide, quote.state, quotedViewData, listener, statusDisplayOptions)
         binding.statusQuote.show()
     }
 }


### PR DESCRIPTION
Previous code wasn't representing hidden quotes when stored, so some types of hidden quote (those where the API wasn't returning a status ID for the quoted status) were dropped from the UI.

Fix this with an explicit representation of hidden quotes.

Fixes #2052