### PR TITLE
fix: Render quotes on boosts

### DIFF
--- a/app/src/main/java/app/pachli/components/search/SearchViewModel.kt
+++ b/app/src/main/java/app/pachli/components/search/SearchViewModel.kt
@@ -245,7 +245,7 @@ class SearchViewModel @Inject constructor(
                         viewData = statusRepository.getStatusViewData(pachliAccount.id, status.actionableId),
                         translatedStatus = statusRepository.getTranslation(pachliAccount.id, status.actionableId),
                     ),
-                    quotedStatus = (status.quote as? Status.Quote.FullQuote)?.status?.let { q ->
+                    quotedStatus = (status.actionableStatus.quote as? Status.Quote.FullQuote)?.status?.let { q ->
                         TimelineStatusWithAccount(
                             status = q.asEntity(pachliAccount.id),
                             account = q.account.asEntity(pachliAccount.id),

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelinePagingSource.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelinePagingSource.kt
@@ -168,7 +168,7 @@ suspend fun Iterable<Status>.asTimelineStatusWithQuote(pachliAccountId: Long, st
                 viewData = viewDataCache[status.actionableId],
                 translatedStatus = translationCache[status.actionableId],
             ),
-            quotedStatus = (status.quote as? Status.Quote.FullQuote)?.status?.let { q ->
+            quotedStatus = (status.actionableStatus.quote as? Status.Quote.FullQuote)?.status?.let { q ->
                 TimelineStatusWithAccount(
                     status = q.asEntity(pachliAccountId),
                     account = q.account.asEntity(pachliAccountId),

--- a/app/src/main/java/app/pachli/components/viewthread/ViewThreadViewModel.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/ViewThreadViewModel.kt
@@ -468,7 +468,7 @@ class ViewThreadViewModel @Inject constructor(
         contentFilterAction: FilterAction? = null,
         isDetailed: Boolean = false,
     ): StatusItemViewData {
-        val quote = (quote as? Status.Quote.FullQuote)?.status
+        val quote = (this.actionableStatus.quote as? Status.Quote.FullQuote)?.status
         return StatusItemViewData.from(
             pachliAccount = pachliAccount,
             timelineStatusWithQuote = TimelineStatusWithQuote(

--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/notifications/NotificationsRemoteMediator.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/notifications/NotificationsRemoteMediator.kt
@@ -294,7 +294,7 @@ fun NotificationData.Companion.from(pachliAccountId: Long, notification: Notific
                 status = status.asEntity(pachliAccountId),
                 account = status.account.asEntity(pachliAccountId),
             ),
-            quotedStatus = (status.quote?.asModel() as? Status.Quote.FullQuote)?.let {
+            quotedStatus = (status.actionableStatus.quote?.asModel() as? Status.Quote.FullQuote)?.let {
                 TimelineStatusWithAccount(
                     status = it.status.asEntity(pachliAccountId),
                     account = it.status.account.asEntity(pachliAccountId),


### PR DESCRIPTION
The status that wraps a boost can't contain a quote (it's always null) but was being looked to for the `quote` property. This meant that if a boosted status contained a quote the quote wasn't found, which caused problems later when rendering.

This is the underlying bug that #2107 / 40735d9 worked around.

Found thanks to a detailed bug report with reproduction recipe from @badnetmask@hachyderm.io.