### PR TITLE
fix: Allow a poll option's `votesCount` to be null in JSON

### DIFF
--- a/core/network/src/main/kotlin/app/pachli/core/network/model/Poll.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/model/Poll.kt
@@ -35,11 +35,11 @@ data class Poll(
 @JsonClass(generateAdapter = true)
 data class PollOption(
     val title: String,
-    @Json(name = "votes_count") val votesCount: Int,
+    @Json(name = "votes_count") val votesCount: Int?,
 ) {
     fun asModel() = app.pachli.core.model.PollOption(
         title = title,
-        votesCount = votesCount,
+        votesCount = votesCount ?: 0,
     )
 }
 


### PR DESCRIPTION
Documented as nullable but it looks as though Mastodon always returns a non-null int. Other software might not, which is why this wasn't caught previously.

Reported by @dhamlinmusic@dragonscave.space.