### PR TITLE
fix: Show data types table in the privacy policy

### DIFF
--- a/feature/about/src/main/kotlin/app/pachli/feature/about/AboutActivity.kt
+++ b/feature/about/src/main/kotlin/app/pachli/feature/about/AboutActivity.kt
@@ -78,6 +78,9 @@ class AboutActivity : ViewUrlActivity(), MenuProvider {
         addMenuProvider(this)
 
         val adapter = AboutFragmentAdapter(this)
+        // Ensure privacy policy table displays correctly, possibly due to
+        // https://issuetracker.google.com/issues/432664597.
+        binding.pager.offscreenPageLimit = 1
         binding.pager.adapter = adapter
         binding.pager.reduceSwipeSensitivity()
 


### PR DESCRIPTION
Sometimes the data types table in the privacy policy had a corrupted appearance, rendering as one line per row, with the additional lines appearing over the top of each other.

This might be another instance of the bug reported in https://issuetracker.google.com/issues/432664597. Setting the view pager's offscreen limit to 1 appears to fix the problem.