### PR TITLE
fix: Prune cache at startup if needed, prevent crashes and OOMs

### DIFF
--- a/core/worker/src/main/kotlin/app/pachli/core/worker/PruneLogEntryEntityWorker.kt
+++ b/core/worker/src/main/kotlin/app/pachli/core/worker/PruneLogEntryEntityWorker.kt
@@ -46,9 +46,7 @@ class PruneLogEntryEntityWorker @AssistedInject constructor(
         Timber.d("Started")
 
         return try {
-            val now = Instant.now()
-            val oldest = now.minusMillis(OLDEST_ENTRY.inWholeMilliseconds)
-            val count = logEntryDao.prune(oldest)
+            val count = logEntryDao.prune(Instant.now().minusMillis(OLDEST_ENTRY.inWholeMilliseconds))
             Timber.d("Pruned LogEntryEntity, deleted %d", count)
             Result.success()
         } catch (e: Exception) {

--- a/feature/intentrouter/build.gradle.kts
+++ b/feature/intentrouter/build.gradle.kts
@@ -40,4 +40,7 @@ dependencies {
         ?.because("Payload.Notification relies on the network type")
     implementation(projects.core.ui)
     implementation(libs.bundles.androidx)
+
+    implementation(libs.bundles.room)
+        ?.because("Possible cache pruning on startup")
 }

--- a/feature/intentrouter/src/main/kotlin/app/pachli/feature/intentrouter/IntentRouterActivity.kt
+++ b/feature/intentrouter/src/main/kotlin/app/pachli/feature/intentrouter/IntentRouterActivity.kt
@@ -104,6 +104,11 @@ class IntentRouterActivity : BaseActivity() {
         )
 
         lifecycleScope.launch {
+            // Work around devices that can't reliably run WorkManager jobs (see
+            // https://github.com/pachli/pachli-android/issues/2114). For the moment
+            // prune the cache at startup if needed.
+            viewModel.pruneCacheIfNeeded()
+
             repeatOnLifecycle(Lifecycle.State.RESUMED) {
                 launch {
                     // Get the first set of loaded accounts (as AccountEntity).

--- a/feature/intentrouter/src/main/kotlin/app/pachli/feature/intentrouter/IntentRouterViewModel.kt
+++ b/feature/intentrouter/src/main/kotlin/app/pachli/feature/intentrouter/IntentRouterViewModel.kt
@@ -20,17 +20,27 @@ package app.pachli.feature.intentrouter
 import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.room.support.getSupportWrapper
 import app.pachli.core.common.PachliError
 import app.pachli.core.data.repository.AccountManager
 import app.pachli.core.data.repository.Loadable
 import app.pachli.core.data.repository.RefreshAccountError
 import app.pachli.core.data.repository.SetActiveAccountError
+import app.pachli.core.database.AppDatabase
+import app.pachli.core.database.dao.LogEntryDao
+import app.pachli.core.database.dao.TimelineDao
 import app.pachli.core.database.model.AccountEntity
 import app.pachli.core.navigation.IntentRouterActivityIntent.Payload
 import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.coroutines.runSuspendCatching
+import com.github.michaelbull.result.getOrElse
 import com.github.michaelbull.result.mapEither
 import dagger.hilt.android.lifecycle.HiltViewModel
+import java.time.Instant
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.TimeSource
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -39,6 +49,8 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import timber.log.Timber
 
 internal sealed interface UiState {
     data object Loading : UiState
@@ -93,6 +105,9 @@ internal sealed class UiError(
 @HiltViewModel
 internal class IntentRouterViewModel @Inject constructor(
     private val accountManager: AccountManager,
+    private val db: AppDatabase,
+    private val timelineDao: TimelineDao,
+    private val logEntryDao: LogEntryDao,
 ) : ViewModel() {
     val accounts = accountManager.pachliAccountsFlow.map { Loadable.Loaded(it) }.stateIn(
         viewModelScope,
@@ -143,8 +158,47 @@ internal class IntentRouterViewModel @Inject constructor(
             )
     }
 
+    /**
+     * Prunes the local cache if there are more than 800 rows in TimelineStatusWithAccount.
+     *
+     * This works around buggy devices that can't reliably run WorkManager tasks. If the
+     * cache gets too large the timeline queries take too long and the user experiences
+     * crashes, out of memory errors, or other poor performance.
+     */
+    suspend fun pruneCacheIfNeeded() = withContext(Dispatchers.IO) {
+        val countTimelineStatusWithAccount = getTableCount("TimelineStatusWithAccount").getOrElse {
+            Timber.e("pruneCacheIfNeeded: getTableCount error: $it")
+            return@withContext
+        }
+        Timber.d("pruneCacheIfNeeded: TimelineStatusWithAccount = $countTimelineStatusWithAccount")
+        if (countTimelineStatusWithAccount < 800) {
+            Timber.d("pruneCacheIfNeeded: skipping")
+            return@withContext
+        }
+
+        Timber.d("pruneCacheIfNeeded: pruning")
+        val marker = TimeSource.Monotonic.markNow()
+        accountManager.accounts.forEach { timelineDao.cleanup(it.id) }
+        logEntryDao.prune(Instant.now().minusMillis(48.hours.inWholeMilliseconds))
+
+        Timber.d("pruneCacheIfNeeded: pruned, took ${marker.elapsedNow().inWholeMilliseconds} ms")
+    }
+
+    /**
+     * @return The number of rows in [tableName], or any error that occurred.
+     *
+     * Identical to [DatabaseFragmentViewModel.getTableCount]
+     */
+    private suspend fun getTableCount(tableName: String) = withContext(Dispatchers.IO) {
+        return@withContext runSuspendCatching {
+            db.getSupportWrapper().query("SELECT COUNT(*) FROM $tableName").use {
+                it.moveToFirst()
+                it.getInt(0)
+            }
+        }
+    }
+
     companion object {
-        // TODO: Copied from ComposeActivity, can be deleted from there
         fun canHandleMimeType(mimeType: String?): Boolean {
             return mimeType != null && (mimeType.startsWith("image/") || mimeType.startsWith("video/") || mimeType.startsWith("audio/") || mimeType == "text/plain")
         }


### PR DESCRIPTION
Some devices don't run WorkManager tasks reliably. See details at https://dontkillmyapp.com/.

This is a problem, as if the local database gets too large the timeline queries can take seconds to run or return too much data, leading to poor performance, OOM crashes, or others.

Work around this for the moment by pruning the cache in `IntentRouterActivity`, the `MAIN` activity.

The cache is pruned if there are more 800 rows in `TimelineStatusWithAccount`, a figure-in-the-air guess at how many rows is likely to indicate that the workers aren't running as expected.

While I'm here, update the "Prune cache" feature in `DatabaseFragmentViewModel` to prune the log as well.