### PR TITLE
fix: Prevent crash (maybe) when cropping images

### DIFF
--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths>
     <external-path name="my_images" path="." />
+    <external-files-path
+        name="my_images"
+        path="." />
     <cache-path name="*" path="." />
 </paths>


### PR DESCRIPTION
The image cropper is sometimes crashing in production with this error:

```
Exception java.lang.SecurityException: Only content:// URIs are allowed for security reasons. Received: file://
  at com.canhub.cropper.BitmapUtils.validateOutputUri$cropper_release (BitmapUtils.kt:437)
  at com.canhub.cropper.BitmapUtils.writeBitmapToUri (BitmapUtils.kt:476)
  at com.canhub.cropper.BitmapCroppingWorkerJob$start$1$1.invokeSuspend (BitmapCroppingWorkerJob.kt:96)
```

Not sure what's generating the file:// URL scheme, but the calling code looks like this:

```kotlin
val tempFile = createNewImageFile(this, if (isPng) ".png" else ".jpg")
val uriNew = FileProvider.getUriForFile(this, BuildConfig.APPLICATION_ID + ".fileprovider", tempFile)

viewModel.cropImageItemOld = item

cropImage.launch(
    CropImageContractOptions(
        uri = item.uri,
        cropImageOptions = CropImageOptions(
            customOutputUri = uriNew,
            outputCompressFormat = if (isPng) Bitmap.CompressFormat.PNG else Bitmap.CompressFormat.JPEG,
        ),
    ),
)
```

`createNewImageFile(...)` creates the new file in a directory obtained with `context.getExternalFilesDir(Environment.DIRECTORY_PICTURES)`, and according to https://developer.android.com/reference/androidx/core/content/FileProvider `getExternalFilesDir` is equivalent to `<external-files-path ... />` in this XML file.

The existing `<external-path ... />` is equivalent to `getExternalStorageDirectory`, which isn't used anywhere in Pachli.