### PR TITLE
refactor: Remove the "isRefreshing" observable

### DIFF
--- a/app/src/main/java/app/pachli/components/account/AccountActivity.kt
+++ b/app/src/main/java/app/pachli/components/account/AccountActivity.kt
@@ -475,10 +475,14 @@ class AccountActivity :
                 launch {
                     viewModel.accountData.collect { result ->
                         result.onSuccess { loadable ->
-                            loadable.getOrNull()?.let { onAccountChanged(it) }
+                            loadable.getOrNull()?.let {
+                                binding.swipeRefreshLayout.isRefreshing = false
+                                onAccountChanged(it)
+                            }
                         }
 
                         result.onFailure {
+                            binding.swipeRefreshLayout.isRefreshing = false
                             Snackbar.make(binding.accountCoordinatorLayout, it.fmt(this@AccountActivity), Snackbar.LENGTH_LONG)
                                 .setAction(app.pachli.core.ui.R.string.action_retry) { viewModel.refresh() }
                                 .show()
@@ -529,11 +533,6 @@ class AccountActivity :
      */
     private fun setupRefreshLayout() {
         binding.swipeRefreshLayout.setOnRefreshListener { onRefresh() }
-        viewModel.isRefreshing.observe(
-            this,
-        ) { isRefreshing ->
-            binding.swipeRefreshLayout.isRefreshing = isRefreshing == true
-        }
         binding.swipeRefreshLayout.setColorSchemeColors(MaterialColors.getColor(binding.root, androidx.appcompat.R.attr.colorPrimary))
     }
 

--- a/app/src/main/java/app/pachli/components/account/AccountViewModel.kt
+++ b/app/src/main/java/app/pachli/components/account/AccountViewModel.kt
@@ -38,6 +38,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.stateIn
@@ -103,21 +104,21 @@ class AccountViewModel @AssistedInject constructor(
             accountRepository.getAccount(accountId)
                 .onSuccess { account ->
                     domain = getDomain(account.url)
-                    isRefreshing.postValue(false)
                     isFromOwnDomain = domain == pachliAccount.entity.domain
                     val isSelf = pachliAccount.entity.accountId == accountId
                     if (!isSelf) obtainRelationship(accountId)
                 }
                 .onFailure {
                     Timber.w("failed obtaining account: %s", it)
-                    isRefreshing.postValue(false)
                 }
                 .map { Loadable.Loaded(it) }
         }
 
-        // ... and merge them together. Practically, the first emission will be the data
-        // from the API, subsequent emissions will be from profileUpdates
-        merge(profileUpdates, remoteAccount).flowWhileShared(SharingStarted.WhileSubscribed(5000))
+        // ... and merge them together. Include the `reload` flow, to ensure the
+        // content transitions to a `Loadable.Loading` state before each load.
+        // Practically, the first emission will be the data from the API, subsequent
+        // emissions will be from profileUpdates
+        merge(reload.map { Ok(Loadable.Loading) }, profileUpdates, remoteAccount).flowWhileShared(SharingStarted.WhileSubscribed(5000))
     }
 
     /** True if the laoded account in [accountData] is the user's account. */


### PR DESCRIPTION
Whether a refresh has completed (to control the `binding.swipeRefreshLayout`) can be determined by checking to see if `accountData` is `Loadable.Loaded` or `Err`.