### PR TITLE
fix: Move handle's content description close to end of status content description

### DIFF
--- a/core/ui/src/main/kotlin/app/pachli/core/ui/StatusView.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/StatusView.kt
@@ -53,6 +53,7 @@ import app.pachli.core.ui.extensions.contentDescription
 import app.pachli.core.ui.extensions.description
 import app.pachli.core.ui.extensions.getContentDescription
 import app.pachli.core.ui.extensions.getFormattedDescription
+import app.pachli.core.ui.extensions.handleContentDescription
 import com.bumptech.glide.RequestManager
 import com.google.android.material.color.MaterialColors
 import java.text.NumberFormat
@@ -622,9 +623,9 @@ abstract class StatusView<T : IStatusViewData> @JvmOverloads constructor(
         // The full string will look like (content in parentheses is optional),
         //
         // account.name
-        // (; "Roles: " account.roles)
-        // (. contentWarning)
-        // ; (content)
+        // (";", "Roles: " account.roles)
+        // (";", contentWarning)
+        // ";" (content)
         // (\n\n media)
         // (\n\n poll)
         // (\n\n quote)
@@ -632,6 +633,7 @@ abstract class StatusView<T : IStatusViewData> @JvmOverloads constructor(
         // relativeDate
         // (, editedAt)
         // (, reblogDescription)
+        // (, "X boosted"
         // , username
         // (, "Reblogged")
         // (, "Favourited")
@@ -640,8 +642,6 @@ abstract class StatusView<T : IStatusViewData> @JvmOverloads constructor(
         // (, "n Boost")
         return StringBuilder().apply {
             append(account.contentDescription(context))
-
-            append(".")
 
             getContentWarningDescription(context, viewData)?.let { append("; ", it) }
 
@@ -686,6 +686,8 @@ abstract class StatusView<T : IStatusViewData> @JvmOverloads constructor(
             editedAt?.let { append(", ", context.getString(R.string.description_post_edited)) }
 
             getReblogDescription(context, viewData)?.let { append(", ", it) }
+
+            append(", ", account.handleContentDescription(context))
 
             if (reblogged) {
                 append(", ", context.getString(R.string.description_post_reblogged))

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/extensions/TimelineAccountExtensions.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/extensions/TimelineAccountExtensions.kt
@@ -18,6 +18,7 @@
 package app.pachli.core.ui.extensions
 
 import android.content.Context
+import app.pachli.core.model.Role
 import app.pachli.core.model.TimelineAccount
 import app.pachli.core.ui.R
 import kotlin.text.Regex.Companion.escape
@@ -28,37 +29,25 @@ import kotlin.text.Regex.Companion.escape
  * The description looks like (content in parentheses is optional)
  *
  * "${account.name}"
- * ","
- * "Handle, @${account.username}"
- * ";"
- * ("with role: 1-n roles")
+ * (";", "with role: 1-n roles")
  *
  * When reading account names any embedded "." in the name is converted to " dot "
  * to make it explicit (otherwise TalkBack inserts a short pause, which is no use
  * for domains). See [nameContentDescription].
  */
 fun TimelineAccount.contentDescription(context: Context): String {
-    val roleString = if (roles.isNotEmpty()) {
-        StringBuilder().apply {
-            append(context.resources.getQuantityString(R.plurals.description_post_roles, roles.size))
-            append(roles.joinToString(", ") { it.contentDescription(context) })
-        }.toString()
-    } else {
-        ""
+    return buildString {
+        append(nameContentDescription(context))
+        rolesContentDescription(context)?.let {
+            append("; ")
+            append(it)
+        }
     }
-
-    return context.getString(
-        R.string.account_contentdescription_fmt,
-        // Some names have dots in them
-        nameContentDescription(context),
-        handleContentDescription(context),
-        roleString,
-    )
 }
 
 /**
  * @return A content description for the account's name. Dots in the name are
- * replaced with R.string.dot_in_name so TalkBack reads them correctly.
+ * replaced with [R.string.dot_in_name] so TalkBack reads them correctly.
  *
  * For example, for the account "@staff@mastodon.social" the display name is
  * "Mastodon.social Staff", and this ensures this is read as "Mastodon dot social
@@ -99,4 +88,19 @@ internal fun handleContentDescription(context: Context, handle: String): String 
     }
 
     return context.getString(R.string.handle_contentdescription_fmt, correctedHandle)
+}
+
+/**
+ * @return A content description for the account's roles (null if the account
+ * has no roles).
+ */
+fun TimelineAccount.rolesContentDescription(context: Context) = roles.contentDescription(context)
+
+internal fun Collection<Role>.contentDescription(context: Context): String? {
+    if (this.isEmpty()) return null
+
+    return buildString {
+        append(context.resources.getQuantityString(R.plurals.description_post_roles, size))
+        append(joinToString(", ") { it.contentDescription(context) })
+    }
 }

--- a/core/ui/src/main/res/values-de/strings.xml
+++ b/core/ui/src/main/res/values-de/strings.xml
@@ -96,7 +96,6 @@
         <item quantity="one">mit Rolle:</item>
         <item quantity="other">mit Rollen:</item>
     </plurals>
-    <string name="account_contentdescription_fmt">%1$s, %2$s; %3$s</string>
     <string name="handle_contentdescription_fmt">Handle, @%1$s</string>
     <string name="role_content_description_fmt">%1$s, bei %2$s</string>
     <string name="dot_in_name">Punkt</string>

--- a/core/ui/src/main/res/values-es/strings.xml
+++ b/core/ui/src/main/res/values-es/strings.xml
@@ -115,7 +115,6 @@
     <string name="dot_in_name">punto</string>
     <string name="role_content_description_fmt">%1$s, en %2$s</string>
     <string name="handle_contentdescription_fmt">Identificador, @%1$s</string>
-    <string name="account_contentdescription_fmt">%1$s, %2$s; %3$s</string>
     <string name="post_content_warning_show_less">Mostrar menos</string>
     <string name="post_content_warning_show_more">Mostrar más</string>
     <string name="post_content_show_less">Ocultar</string>

--- a/core/ui/src/main/res/values-et/strings.xml
+++ b/core/ui/src/main/res/values-et/strings.xml
@@ -101,7 +101,6 @@
     <string name="dot_in_name">punkt</string>
     <string name="role_content_description_fmt">%1$s, %2$s</string>
     <string name="handle_contentdescription_fmt">Võrgunimi, @%1$s</string>
-    <string name="account_contentdescription_fmt">%1$s, %2$s; %3$s</string>
     <string name="action_reply">Vasta</string>
     <string name="action_reblog">Lisa hoogu</string>
     <string name="action_favourite">Lisa lemmikuks</string>

--- a/core/ui/src/main/res/values-fr/strings.xml
+++ b/core/ui/src/main/res/values-fr/strings.xml
@@ -146,7 +146,6 @@
         <item quantity="other">avec les rôles :</item>
     </plurals>
     <string name="handle_contentdescription_fmt">Gérer, @%1$s</string>
-    <string name="account_contentdescription_fmt">%1$s, %2$s ; %3$s</string>
     <string name="action_quote">Citer</string>
     <string name="action_request_quote">Demander à citer</string>
     <string name="label_author_denied_quote">Citation interdite par la personne</string>

--- a/core/ui/src/main/res/values-ga/strings.xml
+++ b/core/ui/src/main/res/values-ga/strings.xml
@@ -122,7 +122,6 @@
     <string name="dot_in_name">ponc</string>
     <string name="role_content_description_fmt">%1$s, ag %2$s</string>
     <string name="handle_contentdescription_fmt">Láimhseáil, @%1$s</string>
-    <string name="account_contentdescription_fmt">%1$s, %2$s; %3$s</string>
     <string name="action_reply">Freagra</string>
     <string name="action_reblog">Athchraol</string>
     <string name="action_favourite">Togh</string>

--- a/core/ui/src/main/res/values-lv/strings.xml
+++ b/core/ui/src/main/res/values-lv/strings.xml
@@ -108,7 +108,6 @@
     <string name="dot_in_name">punkts</string>
     <string name="role_content_description_fmt">%1$s, %2$s</string>
     <string name="handle_contentdescription_fmt">Turis, @%1$s</string>
-    <string name="account_contentdescription_fmt">%1$s, %2$s; %3$s</string>
     <string name="action_reply">Atbildēt</string>
     <string name="action_reblog">Pastiprināt</string>
     <string name="action_favourite">Pievienot izlasei</string>

--- a/core/ui/src/main/res/values-nn/strings.xml
+++ b/core/ui/src/main/res/values-nn/strings.xml
@@ -101,7 +101,6 @@
     <string name="dot_in_name">punktum</string>
     <string name="role_content_description_fmt">%1$s på %2$s</string>
     <string name="handle_contentdescription_fmt">Brukarnamn: @%1$s</string>
-    <string name="account_contentdescription_fmt">%1$s, %2$s: %3$s</string>
     <string name="action_reply">Svar</string>
     <string name="action_reblog">Del</string>
     <string name="action_favourite">Favorittmerk</string>

--- a/core/ui/src/main/res/values-pl/strings.xml
+++ b/core/ui/src/main/res/values-pl/strings.xml
@@ -115,7 +115,6 @@
     <string name="dot_in_name">kropka</string>
     <string name="role_content_description_fmt">%1$s, na %2$s</string>
     <string name="handle_contentdescription_fmt">Konto, @%1$s</string>
-    <string name="account_contentdescription_fmt">%1$s, %2$s, %3$s</string>
     <string name="action_reply">Odpowiedz</string>
     <string name="action_reblog">Podbij</string>
     <string name="action_favourite">Polub</string>

--- a/core/ui/src/main/res/values-ru/strings.xml
+++ b/core/ui/src/main/res/values-ru/strings.xml
@@ -110,7 +110,6 @@
         <item quantity="many">с ролями:</item>
         <item quantity="other">с ролями:</item>
     </plurals>
-    <string name="account_contentdescription_fmt">%1$s, %2$s; %3$s</string>
     <string name="role_content_description_fmt">%1$s, в %2$s</string>
     <string name="action_hide_attachments">Скрыть вложения</string>
     <string name="dot_in_name">точка</string>

--- a/core/ui/src/main/res/values-sk/strings.xml
+++ b/core/ui/src/main/res/values-sk/strings.xml
@@ -108,7 +108,6 @@
     <string name="dot_in_name">bodka</string>
     <string name="role_content_description_fmt">%1$s, na %2$s</string>
     <string name="handle_contentdescription_fmt">Účet, @%1$s</string>
-    <string name="account_contentdescription_fmt">%1$s, %2$s; %3$s</string>
     <string name="action_reply">Odpovedať</string>
     <string name="action_reblog">Zdieľať</string>
     <string name="action_favourite">Obľúbiť</string>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -126,7 +126,6 @@
         <item quantity="other">with roles: </item>
     </plurals>
     <string name="handle_contentdescription_fmt">Handle, @%1$s</string>
-    <string name="account_contentdescription_fmt">%1$s, %2$s; %3$s</string>
     <string name="action_reply">Reply</string>
     <string name="action_reblog">Boost</string>
     <string name="action_quote">Quote</string>
@@ -146,7 +145,7 @@
         Edited
     </string>
     <string name="description_post_reblogged">
-        Reblogged
+        Boosted
     </string>
     <string name="description_post_favourited">
         Favorited


### PR DESCRIPTION
fe7bf1912a4521b28e58769b0aa280b0bcac2396 moved the Talkback location of an account handle's content description to the start of the status content description, with the account's name and roles.

User's have provided feedback that this was not necessary, so return it to the previous position.

While I'm here, refactor some of TimelineAccountExtensions for consistency.

Suggested by:
- Rene Ludwig @Clio09@digitalcourage.social
- Woochancho @muchanchoasado@tkz.one