### PR TITLE
fix: Update tab contents when moved

### DIFF
--- a/app/src/main/java/app/pachli/pager/MainPagerAdapter.kt
+++ b/app/src/main/java/app/pachli/pager/MainPagerAdapter.kt
@@ -29,4 +29,16 @@ class MainPagerAdapter(var tabs: List<TabViewData>, activity: FragmentActivity) 
     }
 
     override fun getItemCount() = tabs.size
+
+    // Tabs can move, so the default implementation of getItem() won't work (it's
+    // based on item position, so can return the wrong fragment if items move).
+    override fun getItemId(position: Int): Long {
+        return tabs[position].fragment.hashCode().toLong()
+    }
+
+    // Tabs can move, so the default implementation of containsItem() won't work
+    // (it's based on item position, so can return the wrong result if items move).
+    override fun containsItem(itemId: Long): Boolean {
+        return tabs.map { it.fragment.hashCode().toLong() }.contains(itemId)
+    }
 }


### PR DESCRIPTION
The previous code was using the default implementation of `getItemId` and `containsItem` in the adapter for tabs. These are based on the tab's position and don't work correctly if tabs can move in the adapter after fragments are created.

The symptom is the viewpager shows a tab in its old position after moving.

Fix this by basing the item ID on each fragment's hashcode().

Fixes #2178