### PR TITLE
change: Use colorControlNormal as AppImageButton tint

### DIFF
--- a/core/designsystem/src/main/res/values/styles.xml
+++ b/core/designsystem/src/main/res/values/styles.xml
@@ -136,7 +136,7 @@
     </style>
 
     <style name="AppImageButton" parent="@style/Widget.MaterialComponents.Button.UnelevatedButton">
-        <item name="android:tint">?android:attr/textColorTertiary</item>
+        <item name="android:tint">?attr/colorControlNormal</item>
         <item name="android:background">?attr/selectableItemBackgroundBorderless</item>
     </style>
 


### PR DESCRIPTION
This is the same colour as textColorTertiary, but is semantically more appropriate.