### PR TITLE
change: Use a tab's hashcode as the MainPagerAdapter itemId

### DIFF
--- a/app/src/main/java/app/pachli/pager/MainPagerAdapter.kt
+++ b/app/src/main/java/app/pachli/pager/MainPagerAdapter.kt
@@ -30,15 +30,21 @@ class MainPagerAdapter(var tabs: List<TabViewData>, activity: FragmentActivity) 
 
     override fun getItemCount() = tabs.size
 
-    // Tabs can move, so the default implementation of getItem() won't work (it's
-    // based on item position, so can return the wrong fragment if items move).
     override fun getItemId(position: Int): Long {
-        return tabs[position].fragment.hashCode().toLong()
+        // Tabs can move, so the default implementation of getItem() won't work (it's
+        // based on item position, so can return the wrong fragment if items move).
+        return tabs[position].itemId()
     }
 
-    // Tabs can move, so the default implementation of containsItem() won't work
-    // (it's based on item position, so can return the wrong result if items move).
     override fun containsItem(itemId: Long): Boolean {
-        return tabs.map { it.fragment.hashCode().toLong() }.contains(itemId)
+        // Tabs can move, so the default implementation of containsItem() won't work
+        // (it's based on item position, so can return the wrong result if items move).
+        return tabs.map { it.itemId() }.contains(itemId)
     }
 }
+
+/**
+ * @return A unique ID for this tab, for use as a [MainPagerAdapter]
+ * item ID.
+ */
+private fun TabViewData.itemId(): Long = hashCode().toLong()


### PR DESCRIPTION
Previous change to this file used the fragment's hashcode. Use the hashcode for the tab instead, to future proof against being able to host the same fragment in multiple tabs.