### PR TITLE
fix: Don't crash when cropping account avatar or header images

### DIFF
--- a/app/src/main/java/app/pachli/viewmodel/EditProfileViewModel.kt
+++ b/app/src/main/java/app/pachli/viewmodel/EditProfileViewModel.kt
@@ -18,10 +18,11 @@ package app.pachli.viewmodel
 
 import android.app.Application
 import android.net.Uri
-import androidx.core.net.toUri
+import androidx.core.content.FileProvider
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import app.pachli.BuildConfig
 import app.pachli.core.common.string.randomAlphanumericString
 import app.pachli.core.data.repository.AccountManager
 import app.pachli.core.data.repository.InstanceInfoRepository
@@ -100,9 +101,17 @@ class EditProfileViewModel @Inject constructor(
         }
     }
 
-    fun getAvatarUri() = getCacheFileForName(AVATAR_FILE_NAME).toUri()
+    fun getAvatarUri(): Uri = FileProvider.getUriForFile(
+        application,
+        "${BuildConfig.APPLICATION_ID}.fileprovider",
+        getCacheFileForName(AVATAR_FILE_NAME),
+    )
 
-    fun getHeaderUri() = getCacheFileForName(HEADER_FILE_NAME).toUri()
+    fun getHeaderUri(): Uri = FileProvider.getUriForFile(
+        application,
+        "${BuildConfig.APPLICATION_ID}.fileprovider",
+        getCacheFileForName(HEADER_FILE_NAME),
+    )
 
     fun newAvatarPicked() {
         avatarData.value = getAvatarUri()


### PR DESCRIPTION
The functions to return the URI for the local file for the avatar and header images weren't going through `FileProvider.getUriForFile` (e.g., as is done in `ComposeActivity`) causing a `SecurityException` on newer Android devices.

```
java.lang.SecurityException: Only content:// URIs are allowed for security reasons. Received: file://
  at com.canhub.cropper.BitmapUtils.validateOutputUri$cropper_release(BitmapUtils.kt:437)
  at com.canhub.cropper.BitmapUtils.writeBitmapToUri(BitmapUtils.kt:476)
  at com.canhub.cropper.BitmapCroppingWorkerJob$start$1$1.invokeSuspend(BitmapCroppingWorkerJob.kt:96)
  ...
```