### PR TITLE
fix: Don't crash when removing tabs

### DIFF
--- a/app/src/main/java/app/pachli/MainActivity.kt
+++ b/app/src/main/java/app/pachli/MainActivity.kt
@@ -1029,7 +1029,9 @@ class MainActivity : ViewUrlActivity(), ActionButtonActivity, MenuProvider {
         tabLayoutMediator?.detach()
 
         tabAdapter.tabs = tabs
-        tabAdapter.notifyItemRangeChanged(0, tabs.size)
+        // Tabs may have been removed, so notifyDataSetChanged is OK here.
+        @SuppressLint("NotifyDataSetChanged")
+        tabAdapter.notifyDataSetChanged()
 
         tabLayoutMediator = TabLayoutMediator(
             activeTabLayout,
@@ -1080,9 +1082,10 @@ class MainActivity : ViewUrlActivity(), ActionButtonActivity, MenuProvider {
             override fun onTabSelected(tab: TabLayout.Tab) {
                 onBackPressedCallback.isEnabled = tab.position > 0 || binding.mainDrawerLayout.isOpen
 
-                supportActionBar?.title = tabs[tab.position].title(this@MainActivity)
-
-                refreshComposeButtonState(tabs[tab.position])
+                tabAdapter.tabs.getOrNull(tab.position)?.let {
+                    supportActionBar?.title = it.title(this@MainActivity)
+                    refreshComposeButtonState(it)
+                }
             }
 
             override fun onTabUnselected(tab: TabLayout.Tab) {}
@@ -1091,7 +1094,9 @@ class MainActivity : ViewUrlActivity(), ActionButtonActivity, MenuProvider {
                 val fragment = tabAdapter.getFragment(tab.position)
                 (fragment as? ReselectableFragment)?.onReselect()
 
-                refreshComposeButtonState(tabs[tab.position])
+                tabAdapter.tabs.getOrNull(tab.position)?.let {
+                    refreshComposeButtonState(it)
+                }
             }
         }.also {
             activeTabLayout.addOnTabSelectedListener(it)


### PR DESCRIPTION
Removing a tab notified the adapter that tabs 0..tabs.size had changed, but tabs.size was the new size, not the old size. So deleting a tab from the end could cause the adapter to assume the previous end tab was still present. Fix that by calling `notifyDataSetChanged()`.

To guard against the tab selection listener being called with a tab position that no longer exists, use `getOrNull` to fetch the tab data, ignoring the case when the tab does not exist.