### PR TITLE
fix: Don't crash checking user's sensitive media preference

### DIFF
--- a/app/src/main/java/app/pachli/components/account/media/AccountMediaFragment.kt
+++ b/app/src/main/java/app/pachli/components/account/media/AccountMediaFragment.kt
@@ -26,6 +26,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.paging.LoadState
 import androidx.recyclerview.widget.StaggeredGridLayoutManager
 import androidx.recyclerview.widget.StaggeredGridLayoutManager.VERTICAL
@@ -37,6 +38,7 @@ import app.pachli.core.activity.extensions.startActivityWithDefaultTransition
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
 import app.pachli.core.common.extensions.viewBinding
+import app.pachli.core.common.util.unsafeLazy
 import app.pachli.core.designsystem.R as DR
 import app.pachli.core.model.Attachment
 import app.pachli.core.navigation.AttachmentViewData
@@ -52,7 +54,6 @@ import com.mikepenz.iconics.utils.colorInt
 import com.mikepenz.iconics.utils.sizeDp
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
-import kotlin.properties.Delegates
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
@@ -75,13 +76,9 @@ class AccountMediaFragment :
 
     private lateinit var adapter: AccountMediaGridAdapter
 
-    private var pachliAccountId by Delegates.notNull<Long>()
+    private val pachliAccountId by unsafeLazy { requireArguments().getLong(ARG_PACHLI_ACCOUNT_ID) }
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        pachliAccountId = requireArguments().getLong(ARG_PACHLI_ACCOUNT_ID)
-        viewModel.accountId = arguments?.getString(ARG_ACCOUNT_ID)!!
-    }
+    private val accountId by unsafeLazy { requireArguments().getString(ARG_ACCOUNT_ID)!! }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         binding.recyclerView.applyDefaultWindowInsets()
@@ -108,8 +105,10 @@ class AccountMediaFragment :
         binding.statusView.visibility = View.GONE
 
         viewLifecycleOwner.lifecycleScope.launch {
-            viewModel.media.collectLatest { pagingData ->
-                adapter.submitData(pagingData)
+            repeatOnLifecycle(Lifecycle.State.RESUMED) {
+                viewModel.getMedia(pachliAccountId, accountId).collectLatest { pagingData ->
+                    adapter.submitData(pagingData)
+                }
             }
         }
 

--- a/app/src/main/java/app/pachli/components/account/media/AccountMediaRemoteMediator.kt
+++ b/app/src/main/java/app/pachli/components/account/media/AccountMediaRemoteMediator.kt
@@ -21,16 +21,24 @@ import androidx.paging.ExperimentalPagingApi
 import androidx.paging.LoadType
 import androidx.paging.PagingState
 import androidx.paging.RemoteMediator
-import app.pachli.core.database.model.AccountEntity
 import app.pachli.core.navigation.AttachmentViewData
 import app.pachli.core.network.retrofit.MastodonApi
 import com.github.michaelbull.result.getOrElse
 
+/**
+ * @param context
+ * @param api
+ * @param alwaysShowSensitiveMedia The user's preference for showing
+ * sensitive media.
+ * @param accountId Server ID of the account we're fetching media from.
+ * @param viewModel
+ */
 @OptIn(ExperimentalPagingApi::class)
 class AccountMediaRemoteMediator(
     private val context: Context,
     private val api: MastodonApi,
-    private val activeAccount: AccountEntity,
+    private val alwaysShowSensitiveMedia: Boolean,
+    private val accountId: String,
     private val viewModel: AccountMediaViewModel,
 ) : RemoteMediator<String, AttachmentViewData>() {
     override suspend fun load(
@@ -39,7 +47,7 @@ class AccountMediaRemoteMediator(
     ): MediatorResult {
         val statusResponse = when (loadType) {
             LoadType.REFRESH -> {
-                api.accountStatuses(viewModel.accountId, onlyMedia = true)
+                api.accountStatuses(accountId, onlyMedia = true)
             }
 
             LoadType.PREPEND -> {
@@ -49,7 +57,7 @@ class AccountMediaRemoteMediator(
             LoadType.APPEND -> {
                 val maxId = state.lastItemOrNull()?.statusId
                 if (maxId != null) {
-                    api.accountStatuses(viewModel.accountId, maxId = maxId, onlyMedia = true)
+                    api.accountStatuses(accountId, maxId = maxId, onlyMedia = true)
                 } else {
                     return MediatorResult.Success(endOfPaginationReached = false)
                 }
@@ -58,7 +66,7 @@ class AccountMediaRemoteMediator(
 
         val statuses = statusResponse.body
         val attachments = statuses.flatMap { status ->
-            AttachmentViewData.list(status.asModel(), activeAccount.alwaysShowSensitiveMedia)
+            AttachmentViewData.list(status.asModel(), alwaysShowSensitiveMedia)
         }
 
         if (loadType == LoadType.REFRESH) {

--- a/app/src/main/java/app/pachli/components/account/media/AccountMediaViewModel.kt
+++ b/app/src/main/java/app/pachli/components/account/media/AccountMediaViewModel.kt
@@ -22,6 +22,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.paging.ExperimentalPagingApi
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
+import androidx.paging.PagingData
 import androidx.paging.cachedIn
 import app.pachli.core.data.repository.AccountManager
 import app.pachli.core.data.repository.StatusDisplayOptionsRepository
@@ -30,46 +31,48 @@ import app.pachli.core.network.retrofit.MastodonApi
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.flatMapLatest
 
 @HiltViewModel
 class AccountMediaViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
-    accountManager: AccountManager,
-    api: MastodonApi,
+    private val accountManager: AccountManager,
+    private val api: MastodonApi,
     statusDisplayOptionsRepository: StatusDisplayOptionsRepository,
 ) : ViewModel() {
-
-    lateinit var accountId: String
-
     val attachmentData: MutableList<AttachmentViewData> = mutableListOf()
 
     var currentSource: AccountMediaPagingSource? = null
 
-    val activeAccount = accountManager.activeAccount!!
-
     val statusDisplayOptions = statusDisplayOptionsRepository.flow
 
     @OptIn(ExperimentalPagingApi::class)
-    val media = Pager(
-        config = PagingConfig(
-            pageSize = LOAD_AT_ONCE,
-            prefetchDistance = LOAD_AT_ONCE * 2,
-        ),
-        pagingSourceFactory = {
-            AccountMediaPagingSource(
-                viewModel = this,
-            ).also { source ->
-                currentSource = source
-            }
-        },
-        remoteMediator = AccountMediaRemoteMediator(
-            context,
-            api,
-            activeAccount,
-            this,
-        ),
-    ).flow
-        .cachedIn(viewModelScope)
+    fun getMedia(pachliAccountId: Long, accountId: String): Flow<PagingData<AttachmentViewData>> {
+        return accountManager.getPachliAccountFlow(pachliAccountId).filterNotNull().flatMapLatest { activeAccount ->
+            Pager(
+                config = PagingConfig(
+                    pageSize = LOAD_AT_ONCE,
+                    prefetchDistance = LOAD_AT_ONCE * 2,
+                ),
+                pagingSourceFactory = {
+                    AccountMediaPagingSource(
+                        viewModel = this,
+                    ).also { source ->
+                        currentSource = source
+                    }
+                },
+                remoteMediator = AccountMediaRemoteMediator(
+                    context,
+                    api,
+                    activeAccount.entity.alwaysShowSensitiveMedia,
+                    accountId,
+                    this,
+                ),
+            ).flow
+        }.cachedIn(viewModelScope)
+    }
 
     fun revealAttachment(viewData: AttachmentViewData) {
         val position = attachmentData.indexOfFirst { oldViewData -> oldViewData.id == viewData.id }


### PR DESCRIPTION
Previous code used `accountManager.activeAccount!!`, which might be null at the point `activeAccount.alwaysShowSensitiveMedia` is checked, causing an NPE.

Re-write the offending code to collect the correct flow from `accountManager` and use that data (guaranteed to be non-null at that point)