### PR TITLE
change: Use "app.pachli." when checking if an intent is for us

### DIFF
--- a/core/activity/src/main/kotlin/app/pachli/core/activity/extensions/IntentExtensions.kt
+++ b/core/activity/src/main/kotlin/app/pachli/core/activity/extensions/IntentExtensions.kt
@@ -72,4 +72,4 @@ fun Intent.getTransitionKind(): TransitionKind? {
 
 /** True if [Intent] is for a Pachli component, false otherwise. */
 val Intent.forPachliComponent: Boolean
-    get() = this.component?.className?.startsWith("app.pachli") == true
+    get() = this.component?.className?.startsWith("app.pachli.") == true


### PR DESCRIPTION
Previous code used "app.pachli", introducing a theoretical risk of trying to process an intent intended for "app.pachlinotreally...".