### PR TITLE
chore: Replace deprecated `onBlocking` call with `on`

### DIFF
--- a/app/src/test/java/app/pachli/MainActivityTest.kt
+++ b/app/src/test/java/app/pachli/MainActivityTest.kt
@@ -120,8 +120,8 @@ class MainActivityTest {
 
         reset(mastodonApi)
         mastodonApi.stub {
-            onBlocking { accountVerifyCredentials() } doReturn success(account)
-            onBlocking { listAnnouncements(false) } doReturn success(emptyList())
+            on { accountVerifyCredentials() } doReturn success(account)
+            on { listAnnouncements(false) } doReturn success(emptyList())
         }
 
         accountManager.verifyAndAddAccount(

--- a/app/src/test/java/app/pachli/components/compose/ComposeActivityTest.kt
+++ b/app/src/test/java/app/pachli/components/compose/ComposeActivityTest.kt
@@ -140,10 +140,10 @@ class ComposeActivityTest {
         getInstanceCallback = null
         reset(mastodonApi)
         mastodonApi.stub {
-            onBlocking { accountVerifyCredentials(anyOrNull(), anyOrNull()) } doReturn success(account)
-            onBlocking { getCustomEmojis() } doReturn success(emptyList())
-            onBlocking { getInstanceV2() } doReturn failure()
-            onBlocking { getInstanceV1() } doAnswer {
+            on { accountVerifyCredentials(anyOrNull(), anyOrNull()) } doReturn success(account)
+            on { getCustomEmojis() } doReturn success(emptyList())
+            on { getInstanceV2() } doReturn failure()
+            on { getInstanceV1() } doAnswer {
                 getInstanceCallback?.invoke().let { instance ->
                     if (instance == null) {
                         failure()
@@ -152,18 +152,18 @@ class ComposeActivityTest {
                     }
                 }
             }
-            onBlocking { search(any(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull()) } doReturn success(
+            on { search(any(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull()) } doReturn success(
                 SearchResult(emptyList(), emptyList(), emptyList()),
             )
-            onBlocking { getLists() } doReturn success(emptyList())
-            onBlocking { listAnnouncements(any()) } doReturn success(emptyList())
-            onBlocking { getContentFiltersV1() } doReturn success(emptyList())
-            onBlocking { accountFollowing(any(), anyOrNull(), any()) } doReturn success(emptyList())
+            on { getLists() } doReturn success(emptyList())
+            on { listAnnouncements(any()) } doReturn success(emptyList())
+            on { getContentFiltersV1() } doReturn success(emptyList())
+            on { accountFollowing(any(), anyOrNull(), any()) } doReturn success(emptyList())
         }
 
         reset(nodeInfoApi)
         nodeInfoApi.stub {
-            onBlocking { nodeInfoJrd() } doReturn success(
+            on { nodeInfoJrd() } doReturn success(
                 UnvalidatedJrd(
                     listOf(
                         UnvalidatedJrd.Link(
@@ -173,7 +173,7 @@ class ComposeActivityTest {
                     ),
                 ),
             )
-            onBlocking { nodeInfo(any()) } doReturn success(
+            on { nodeInfo(any()) } doReturn success(
                 UnvalidatedNodeInfo(UnvalidatedNodeInfo.Software("mastodon", "4.2.0")),
             )
         }

--- a/app/src/test/java/app/pachli/components/notifications/NotificationsViewModelTestBase.kt
+++ b/app/src/test/java/app/pachli/components/notifications/NotificationsViewModelTestBase.kt
@@ -136,18 +136,18 @@ abstract class NotificationsViewModelTestBase {
 
         reset(mastodonApi)
         mastodonApi.stub {
-            onBlocking { accountVerifyCredentials(anyOrNull(), anyOrNull()) } doReturn success(account)
-            onBlocking { getInstanceV2(anyOrNull()) } doReturn success(DEFAULT_INSTANCE_V2)
-            onBlocking { getLists() } doReturn success(emptyList())
-            onBlocking { getCustomEmojis() } doReturn failure()
-            onBlocking { getContentFilters() } doReturn success(emptyList())
-            onBlocking { listAnnouncements(anyOrNull()) } doReturn success(emptyList())
-            onBlocking { accountFollowing(any(), anyOrNull(), any()) } doReturn success(emptyList())
+            on { accountVerifyCredentials(anyOrNull(), anyOrNull()) } doReturn success(account)
+            on { getInstanceV2(anyOrNull()) } doReturn success(DEFAULT_INSTANCE_V2)
+            on { getLists() } doReturn success(emptyList())
+            on { getCustomEmojis() } doReturn failure()
+            on { getContentFilters() } doReturn success(emptyList())
+            on { listAnnouncements(anyOrNull()) } doReturn success(emptyList())
+            on { accountFollowing(any(), anyOrNull(), any()) } doReturn success(emptyList())
         }
 
         reset(nodeInfoApi)
         nodeInfoApi.stub {
-            onBlocking { nodeInfoJrd() } doReturn success(
+            on { nodeInfoJrd() } doReturn success(
                 UnvalidatedJrd(
                     listOf(
                         UnvalidatedJrd.Link(
@@ -157,7 +157,7 @@ abstract class NotificationsViewModelTestBase {
                     ),
                 ),
             )
-            onBlocking { nodeInfo(any()) } doReturn success(
+            on { nodeInfo(any()) } doReturn success(
                 UnvalidatedNodeInfo(UnvalidatedNodeInfo.Software("mastodon", "4.2.0")),
             )
         }

--- a/app/src/test/java/app/pachli/components/notifications/NotificationsViewModelTestClearNotifications.kt
+++ b/app/src/test/java/app/pachli/components/notifications/NotificationsViewModelTestClearNotifications.kt
@@ -42,7 +42,7 @@ class NotificationsViewModelTestClearNotifications : NotificationsViewModelTestB
     @Test
     fun `clearing notifications succeeds`() = runTest {
         // Given
-        mastodonApi.stub { onBlocking { clearNotifications() } doReturn success(Unit) }
+        mastodonApi.stub { on { clearNotifications() } doReturn success(Unit) }
 
         // When
         viewModel.accept(FallibleUiAction.ClearNotifications(pachliAccountId))
@@ -54,7 +54,7 @@ class NotificationsViewModelTestClearNotifications : NotificationsViewModelTestB
     @Test
     fun `clearing notifications fails && emits UiError`() = runTest {
         // Given
-        notificationsRepository.stub { onBlocking { clearNotifications(pachliAccountId) } doReturn failure() }
+        notificationsRepository.stub { on { clearNotifications(pachliAccountId) } doReturn failure() }
 
         viewModel.uiResult.test {
             // When

--- a/app/src/test/java/app/pachli/components/notifications/NotificationsViewModelTestNotificationFilterAction.kt
+++ b/app/src/test/java/app/pachli/components/notifications/NotificationsViewModelTestNotificationFilterAction.kt
@@ -70,7 +70,7 @@ class NotificationsViewModelTestNotificationFilterAction : NotificationsViewMode
     fun `accepting follow request succeeds && emits UiSuccess`() = runTest {
         // Given
         timelineCases.stub {
-            onBlocking { acceptFollowRequest(any()) } doReturn success(relationship)
+            on { acceptFollowRequest(any()) } doReturn success(relationship)
         }
 
         viewModel.uiResult.test {
@@ -92,7 +92,7 @@ class NotificationsViewModelTestNotificationFilterAction : NotificationsViewMode
     @Test
     fun `accepting follow request fails && emits UiError`() = runTest {
         // Given
-        timelineCases.stub { onBlocking { acceptFollowRequest(any()) } doReturn failure() }
+        timelineCases.stub { on { acceptFollowRequest(any()) } doReturn failure() }
 
         viewModel.uiResult.test {
             // When
@@ -107,7 +107,7 @@ class NotificationsViewModelTestNotificationFilterAction : NotificationsViewMode
     @Test
     fun `rejecting follow request succeeds && emits UiSuccess`() = runTest {
         // Given
-        timelineCases.stub { onBlocking { rejectFollowRequest(any()) } doReturn success(relationship) }
+        timelineCases.stub { on { rejectFollowRequest(any()) } doReturn success(relationship) }
 
         viewModel.uiResult.test {
             // When
@@ -128,7 +128,7 @@ class NotificationsViewModelTestNotificationFilterAction : NotificationsViewMode
     @Test
     fun `rejecting follow request fails && emits UiError`() = runTest {
         // Given
-        timelineCases.stub { onBlocking { rejectFollowRequest(any()) } doReturn failure() }
+        timelineCases.stub { on { rejectFollowRequest(any()) } doReturn failure() }
 
         viewModel.uiResult.test {
             // When

--- a/app/src/test/java/app/pachli/components/notifications/NotificationsViewModelTestStatusFilterAction.kt
+++ b/app/src/test/java/app/pachli/components/notifications/NotificationsViewModelTestStatusFilterAction.kt
@@ -88,7 +88,7 @@ class NotificationsViewModelTestStatusFilterAction : NotificationsViewModelTestB
     fun `bookmark succeeds && emits UiSuccess`() = runTest {
         // Given
         mastodonApi.stub {
-            onBlocking { bookmarkStatus(any()) } doReturn
+            on { bookmarkStatus(any()) } doReturn
                 success(this@NotificationsViewModelTestStatusFilterAction.fakeStatus)
         }
 
@@ -105,7 +105,7 @@ class NotificationsViewModelTestStatusFilterAction : NotificationsViewModelTestB
     @Test
     fun `bookmark fails && emits UiError`() = runTest {
         // Given
-        mastodonApi.stub { onBlocking { bookmarkStatus(any()) } doReturn failure() }
+        mastodonApi.stub { on { bookmarkStatus(any()) } doReturn failure() }
 
         viewModel.uiResult.test {
             // When
@@ -121,7 +121,7 @@ class NotificationsViewModelTestStatusFilterAction : NotificationsViewModelTestB
     fun `favourite succeeds && emits UiSuccess`() = runTest {
         // Given
         mastodonApi.stub {
-            onBlocking { favouriteStatus(any()) } doReturn
+            on { favouriteStatus(any()) } doReturn
                 success(this@NotificationsViewModelTestStatusFilterAction.fakeStatus)
         }
 
@@ -138,7 +138,7 @@ class NotificationsViewModelTestStatusFilterAction : NotificationsViewModelTestB
     @Test
     fun `favourite fails && emits UiError`() = runTest {
         // Given
-        mastodonApi.stub { onBlocking { favouriteStatus(any()) } doReturn failure() }
+        mastodonApi.stub { on { favouriteStatus(any()) } doReturn failure() }
 
         viewModel.uiResult.test {
             // When
@@ -153,7 +153,7 @@ class NotificationsViewModelTestStatusFilterAction : NotificationsViewModelTestB
     @Test
     fun `reblog succeeds && emits UiSuccess`() = runTest {
         // Given
-        mastodonApi.stub { onBlocking { reblogStatus(any()) } doReturn success(fakeStatus) }
+        mastodonApi.stub { on { reblogStatus(any()) } doReturn success(fakeStatus) }
 
         viewModel.uiResult.test {
             // When
@@ -168,7 +168,7 @@ class NotificationsViewModelTestStatusFilterAction : NotificationsViewModelTestB
     @Test
     fun `reblog fails && emits UiError`() = runTest {
         // Given
-        mastodonApi.stub { onBlocking { reblogStatus(any()) } doReturn failure() }
+        mastodonApi.stub { on { reblogStatus(any()) } doReturn failure() }
 
         viewModel.uiResult.test {
             // When
@@ -183,7 +183,7 @@ class NotificationsViewModelTestStatusFilterAction : NotificationsViewModelTestB
     @Test
     fun `voteinpoll succeeds && emits UiSuccess`() = runTest {
         // Given
-        mastodonApi.stub { onBlocking { voteInPoll(any(), any()) } doReturn success(fakeStatus.poll!!) }
+        mastodonApi.stub { on { voteInPoll(any(), any()) } doReturn success(fakeStatus.poll!!) }
 
         viewModel.uiResult.test {
             // When
@@ -198,7 +198,7 @@ class NotificationsViewModelTestStatusFilterAction : NotificationsViewModelTestB
     @Test
     fun `voteinpoll fails && emits UiError`() = runTest {
         // Given
-        mastodonApi.stub { onBlocking { voteInPoll(any(), any()) } doReturn failure() }
+        mastodonApi.stub { on { voteInPoll(any(), any()) } doReturn failure() }
 
         viewModel.uiResult.test {
             // When

--- a/app/src/test/java/app/pachli/components/timeline/CachedTimelineRemoteMediatorTest.kt
+++ b/app/src/test/java/app/pachli/components/timeline/CachedTimelineRemoteMediatorTest.kt
@@ -113,18 +113,18 @@ class CachedTimelineRemoteMediatorTest {
 
         reset(mastodonApi)
         mastodonApi.stub {
-            onBlocking { accountVerifyCredentials(anyOrNull(), anyOrNull()) } doReturn success(account)
-            onBlocking { getInstanceV2(anyOrNull()) } doReturn success(DEFAULT_INSTANCE_V2)
-            onBlocking { getLists() } doReturn success(emptyList())
-            onBlocking { getCustomEmojis() } doReturn failure()
-            onBlocking { getContentFilters() } doReturn success(emptyList())
-            onBlocking { listAnnouncements(anyOrNull()) } doReturn success(emptyList())
-            onBlocking { accountFollowing(any(), anyOrNull(), any()) } doReturn success(emptyList())
+            on { accountVerifyCredentials(anyOrNull(), anyOrNull()) } doReturn success(account)
+            on { getInstanceV2(anyOrNull()) } doReturn success(DEFAULT_INSTANCE_V2)
+            on { getLists() } doReturn success(emptyList())
+            on { getCustomEmojis() } doReturn failure()
+            on { getContentFilters() } doReturn success(emptyList())
+            on { listAnnouncements(anyOrNull()) } doReturn success(emptyList())
+            on { accountFollowing(any(), anyOrNull(), any()) } doReturn success(emptyList())
         }
 
         reset(nodeInfoApi)
         nodeInfoApi.stub {
-            onBlocking { nodeInfoJrd() } doReturn success(
+            on { nodeInfoJrd() } doReturn success(
                 UnvalidatedJrd(
                     listOf(
                         UnvalidatedJrd.Link(
@@ -134,7 +134,7 @@ class CachedTimelineRemoteMediatorTest {
                     ),
                 ),
             )
-            onBlocking { nodeInfo(any()) } doReturn success(
+            on { nodeInfo(any()) } doReturn success(
                 UnvalidatedNodeInfo(UnvalidatedNodeInfo.Software("mastodon", "4.2.0")),
             )
         }
@@ -161,7 +161,7 @@ class CachedTimelineRemoteMediatorTest {
         val remoteMediator = CachedTimelineRemoteMediator(
             context = context,
             mastodonApi = mock {
-                onBlocking { homeTimeline(anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull()) } doReturn failure(code = 500)
+                on { homeTimeline(anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull()) } doReturn failure(code = 500)
             },
             pachliAccountId = activeAccount.id,
             transactionProvider = transactionProvider,
@@ -187,7 +187,7 @@ class CachedTimelineRemoteMediatorTest {
         val remoteMediator = CachedTimelineRemoteMediator(
             context = context,
             mastodonApi = mock {
-                onBlocking { homeTimeline(anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull()) } doReturn failure()
+                on { homeTimeline(anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull()) } doReturn failure()
             },
             pachliAccountId = activeAccount.id,
             transactionProvider = transactionProvider,
@@ -241,7 +241,7 @@ class CachedTimelineRemoteMediatorTest {
     @ExperimentalPagingApi
     fun `should not try to refresh already cached statuses when db is empty`() {
         mastodonApi.stub {
-            onBlocking { homeTimeline(maxId = anyOrNull(), minId = anyOrNull(), sinceId = anyOrNull(), limit = any()) } doReturn success(
+            on { homeTimeline(maxId = anyOrNull(), minId = anyOrNull(), sinceId = anyOrNull(), limit = any()) } doReturn success(
                 listOf(
                     fakeStatus("5"),
                     fakeStatus("4"),
@@ -297,7 +297,7 @@ class CachedTimelineRemoteMediatorTest {
         db.insertTimelineStatusWithQuote(statusesAlreadyInDb)
 
         mastodonApi.stub {
-            onBlocking { homeTimeline(maxId = anyOrNull(), minId = anyOrNull(), sinceId = anyOrNull(), limit = any()) } doReturn success(
+            on { homeTimeline(maxId = anyOrNull(), minId = anyOrNull(), sinceId = anyOrNull(), limit = any()) } doReturn success(
                 listOf(
                     fakeStatus("3"),
                     fakeStatus("1"),
@@ -355,7 +355,7 @@ class CachedTimelineRemoteMediatorTest {
         db.remoteKeyDao().upsert(RemoteKeyEntity(1, Timeline.Home.remoteKeyTimelineId, RemoteKeyKind.NEXT, "5"))
 
         mastodonApi.stub {
-            onBlocking { homeTimeline(maxId = "5", limit = 20) } doReturn success(
+            on { homeTimeline(maxId = "5", limit = 20) } doReturn success(
                 listOf(
                     fakeStatus("3"),
                     fakeStatus("2"),

--- a/app/src/test/java/app/pachli/components/timeline/CachedTimelineViewModelTestBase.kt
+++ b/app/src/test/java/app/pachli/components/timeline/CachedTimelineViewModelTestBase.kt
@@ -116,19 +116,19 @@ abstract class CachedTimelineViewModelTestBase {
 
         reset(mastodonApi)
         mastodonApi.stub {
-            onBlocking { accountVerifyCredentials(anyOrNull(), anyOrNull()) } doReturn success(account)
-            onBlocking { getInstanceV2() } doReturn success(DEFAULT_INSTANCE_V2)
-            onBlocking { getLists() } doReturn success(emptyList())
-            onBlocking { getCustomEmojis() } doReturn failure()
-            onBlocking { getContentFilters() } doReturn success(emptyList())
-            onBlocking { listAnnouncements(any()) } doReturn success(emptyList())
-            onBlocking { getContentFiltersV1() } doReturn success(emptyList())
-            onBlocking { accountFollowing(any(), anyOrNull(), any()) } doReturn success(emptyList())
+            on { accountVerifyCredentials(anyOrNull(), anyOrNull()) } doReturn success(account)
+            on { getInstanceV2() } doReturn success(DEFAULT_INSTANCE_V2)
+            on { getLists() } doReturn success(emptyList())
+            on { getCustomEmojis() } doReturn failure()
+            on { getContentFilters() } doReturn success(emptyList())
+            on { listAnnouncements(any()) } doReturn success(emptyList())
+            on { getContentFiltersV1() } doReturn success(emptyList())
+            on { accountFollowing(any(), anyOrNull(), any()) } doReturn success(emptyList())
         }
 
         reset(nodeInfoApi)
         nodeInfoApi.stub {
-            onBlocking { nodeInfoJrd() } doReturn success(
+            on { nodeInfoJrd() } doReturn success(
                 UnvalidatedJrd(
                     listOf(
                         UnvalidatedJrd.Link(
@@ -138,7 +138,7 @@ abstract class CachedTimelineViewModelTestBase {
                     ),
                 ),
             )
-            onBlocking { nodeInfo(any()) } doReturn success(
+            on { nodeInfo(any()) } doReturn success(
                 UnvalidatedNodeInfo(UnvalidatedNodeInfo.Software("mastodon", "4.2.0")),
             )
         }

--- a/app/src/test/java/app/pachli/components/timeline/CachedTimelineViewModelTestStatusFilterAction.kt
+++ b/app/src/test/java/app/pachli/components/timeline/CachedTimelineViewModelTestStatusFilterAction.kt
@@ -92,7 +92,7 @@ class CachedTimelineViewModelTestStatusFilterAction : CachedTimelineViewModelTes
     @Test
     fun `bookmark succeeds && emits UiSuccess`() = runTest {
         // Given
-        mastodonApi.stub { onBlocking { bookmarkStatus(any()) } doReturn success(fakeStatus) }
+        mastodonApi.stub { on { bookmarkStatus(any()) } doReturn success(fakeStatus) }
 
         viewModel.uiResult.test {
             // When
@@ -107,7 +107,7 @@ class CachedTimelineViewModelTestStatusFilterAction : CachedTimelineViewModelTes
     @Test
     fun `bookmark fails && emits UiError`() = runTest {
         // Given
-        mastodonApi.stub { onBlocking { bookmarkStatus(any()) } doReturn failure() }
+        mastodonApi.stub { on { bookmarkStatus(any()) } doReturn failure() }
 
         viewModel.uiResult.test {
             // When
@@ -122,7 +122,7 @@ class CachedTimelineViewModelTestStatusFilterAction : CachedTimelineViewModelTes
     @Test
     fun `favourite succeeds && emits UiSuccess`() = runTest {
         // Given
-        mastodonApi.stub { onBlocking { favouriteStatus(any()) } doReturn success(fakeStatus) }
+        mastodonApi.stub { on { favouriteStatus(any()) } doReturn success(fakeStatus) }
 
         viewModel.uiResult.test {
             // When
@@ -137,7 +137,7 @@ class CachedTimelineViewModelTestStatusFilterAction : CachedTimelineViewModelTes
     @Test
     fun `favourite fails && emits UiError`() = runTest {
         // Given
-        mastodonApi.stub { onBlocking { favouriteStatus(any()) } doReturn failure() }
+        mastodonApi.stub { on { favouriteStatus(any()) } doReturn failure() }
 
         viewModel.uiResult.test {
             // When
@@ -152,7 +152,7 @@ class CachedTimelineViewModelTestStatusFilterAction : CachedTimelineViewModelTes
     @Test
     fun `reblog succeeds && emits UiSuccess`() = runTest {
         // Given
-        mastodonApi.stub { onBlocking { reblogStatus(any()) } doReturn success(fakeStatus) }
+        mastodonApi.stub { on { reblogStatus(any()) } doReturn success(fakeStatus) }
 
         viewModel.uiResult.test {
             // When
@@ -167,7 +167,7 @@ class CachedTimelineViewModelTestStatusFilterAction : CachedTimelineViewModelTes
     @Test
     fun `reblog fails && emits UiError`() = runTest {
         // Given
-        mastodonApi.stub { onBlocking { reblogStatus(any()) } doReturn failure() }
+        mastodonApi.stub { on { reblogStatus(any()) } doReturn failure() }
 
         viewModel.uiResult.test {
             // When
@@ -182,7 +182,7 @@ class CachedTimelineViewModelTestStatusFilterAction : CachedTimelineViewModelTes
     @Test
     fun `voteinpoll succeeds && emits UiSuccess`() = runTest {
         // Given
-        mastodonApi.stub { onBlocking { voteInPoll(any(), any()) } doReturn success(fakeStatus.poll!!) }
+        mastodonApi.stub { on { voteInPoll(any(), any()) } doReturn success(fakeStatus.poll!!) }
 
         viewModel.uiResult.test {
             // When
@@ -197,7 +197,7 @@ class CachedTimelineViewModelTestStatusFilterAction : CachedTimelineViewModelTes
     @Test
     fun `voteinpoll fails && emits UiError`() = runTest {
         // Given
-        mastodonApi.stub { onBlocking { voteInPoll(any(), any()) } doReturn failure() }
+        mastodonApi.stub { on { voteInPoll(any(), any()) } doReturn failure() }
 
         viewModel.uiResult.test {
             // When

--- a/app/src/test/java/app/pachli/components/timeline/NetworkTimelinePagingSourceTest.kt
+++ b/app/src/test/java/app/pachli/components/timeline/NetworkTimelinePagingSourceTest.kt
@@ -40,8 +40,8 @@ import org.mockito.kotlin.mock
 @RunWith(AndroidJUnit4::class)
 class NetworkTimelinePagingSourceTest {
     private val statusRepository: StatusRepository = mock {
-        onBlocking { getStatusViewData(any<Long>(), any<Collection<String>>()) } doReturn emptyMap()
-        onBlocking { getTranslations(any(), any()) } doReturn emptyMap()
+        on { getStatusViewData(any<Long>(), any<Collection<String>>()) } doReturn emptyMap()
+        on { getTranslations(any(), any()) } doReturn emptyMap()
     }
 
     @Test

--- a/app/src/test/java/app/pachli/components/timeline/NetworkTimelineRemoteMediatorTest.kt
+++ b/app/src/test/java/app/pachli/components/timeline/NetworkTimelineRemoteMediatorTest.kt
@@ -126,19 +126,19 @@ class NetworkTimelineRemoteMediatorTest {
 
         reset(mastodonApi)
         mastodonApi.stub {
-            onBlocking { accountVerifyCredentials(anyOrNull(), anyOrNull()) } doReturn success(account)
-            onBlocking { getInstanceV2() } doReturn success(DEFAULT_INSTANCE_V2)
-            onBlocking { getLists() } doReturn success(emptyList())
-            onBlocking { getCustomEmojis() } doReturn failure()
-            onBlocking { getContentFilters() } doReturn success(emptyList())
-            onBlocking { listAnnouncements(any()) } doReturn success(emptyList())
-            onBlocking { getContentFiltersV1() } doReturn success(emptyList())
-            onBlocking { accountFollowing(any(), anyOrNull(), any()) } doReturn success(emptyList())
+            on { accountVerifyCredentials(anyOrNull(), anyOrNull()) } doReturn success(account)
+            on { getInstanceV2() } doReturn success(DEFAULT_INSTANCE_V2)
+            on { getLists() } doReturn success(emptyList())
+            on { getCustomEmojis() } doReturn failure()
+            on { getContentFilters() } doReturn success(emptyList())
+            on { listAnnouncements(any()) } doReturn success(emptyList())
+            on { getContentFiltersV1() } doReturn success(emptyList())
+            on { accountFollowing(any(), anyOrNull(), any()) } doReturn success(emptyList())
         }
 
         reset(nodeInfoApi)
         nodeInfoApi.stub {
-            onBlocking { nodeInfoJrd() } doReturn success(
+            on { nodeInfoJrd() } doReturn success(
                 UnvalidatedJrd(
                     listOf(
                         UnvalidatedJrd.Link(
@@ -148,7 +148,7 @@ class NetworkTimelineRemoteMediatorTest {
                     ),
                 ),
             )
-            onBlocking { nodeInfo(any()) } doReturn success(
+            on { nodeInfo(any()) } doReturn success(
                 UnvalidatedNodeInfo(UnvalidatedNodeInfo.Software("mastodon", "4.2.0")),
             )
         }
@@ -204,7 +204,7 @@ class NetworkTimelineRemoteMediatorTest {
         val pages = PageCache()
 
         mastodonApi.stub {
-            onBlocking { homeTimeline(maxId = anyOrNull(), minId = anyOrNull(), limit = anyOrNull(), sinceId = anyOrNull()) } doReturn success(
+            on { homeTimeline(maxId = anyOrNull(), minId = anyOrNull(), limit = anyOrNull(), sinceId = anyOrNull()) } doReturn success(
                 listOf(fakeStatus("7"), fakeStatus("6"), fakeStatus("5")),
                 headers = arrayOf(
                     "Link",
@@ -274,7 +274,7 @@ class NetworkTimelineRemoteMediatorTest {
         }
 
         mastodonApi.stub {
-            onBlocking { homeTimeline(maxId = anyOrNull(), minId = anyOrNull(), limit = anyOrNull(), sinceId = anyOrNull()) } doReturn success(
+            on { homeTimeline(maxId = anyOrNull(), minId = anyOrNull(), limit = anyOrNull(), sinceId = anyOrNull()) } doReturn success(
                 listOf(fakeStatus("10"), fakeStatus("9"), fakeStatus("8")),
                 headers = arrayOf(
                     "Link",
@@ -352,7 +352,7 @@ class NetworkTimelineRemoteMediatorTest {
         }
 
         mastodonApi.stub {
-            onBlocking { homeTimeline(maxId = anyOrNull(), minId = anyOrNull(), limit = anyOrNull(), sinceId = anyOrNull()) } doReturn success(
+            on { homeTimeline(maxId = anyOrNull(), minId = anyOrNull(), limit = anyOrNull(), sinceId = anyOrNull()) } doReturn success(
                 listOf(fakeStatus("4"), fakeStatus("3"), fakeStatus("2")),
                 headers = arrayOf(
                     "Link",

--- a/app/src/test/java/app/pachli/components/timeline/NetworkTimelineViewModelTestBase.kt
+++ b/app/src/test/java/app/pachli/components/timeline/NetworkTimelineViewModelTestBase.kt
@@ -110,17 +110,17 @@ abstract class NetworkTimelineViewModelTestBase {
 
         reset(mastodonApi)
         mastodonApi.stub {
-            onBlocking { accountVerifyCredentials(anyOrNull(), anyOrNull()) } doReturn success(account)
-            onBlocking { getInstanceV2(anyOrNull()) } doReturn success(DEFAULT_INSTANCE_V2)
-            onBlocking { getCustomEmojis() } doReturn failure()
-            onBlocking { getContentFilters() } doReturn success(emptyList())
-            onBlocking { listAnnouncements(anyOrNull()) } doReturn success(emptyList())
-            onBlocking { accountFollowing(any(), anyOrNull(), any()) } doReturn success(emptyList())
+            on { accountVerifyCredentials(anyOrNull(), anyOrNull()) } doReturn success(account)
+            on { getInstanceV2(anyOrNull()) } doReturn success(DEFAULT_INSTANCE_V2)
+            on { getCustomEmojis() } doReturn failure()
+            on { getContentFilters() } doReturn success(emptyList())
+            on { listAnnouncements(anyOrNull()) } doReturn success(emptyList())
+            on { accountFollowing(any(), anyOrNull(), any()) } doReturn success(emptyList())
         }
 
         reset(nodeInfoApi)
         nodeInfoApi.stub {
-            onBlocking { nodeInfoJrd() } doReturn success(
+            on { nodeInfoJrd() } doReturn success(
                 UnvalidatedJrd(
                     listOf(
                         UnvalidatedJrd.Link(
@@ -130,7 +130,7 @@ abstract class NetworkTimelineViewModelTestBase {
                     ),
                 ),
             )
-            onBlocking { nodeInfo(any()) } doReturn success(
+            on { nodeInfo(any()) } doReturn success(
                 UnvalidatedNodeInfo(UnvalidatedNodeInfo.Software("mastodon", "4.2.0")),
             )
         }

--- a/app/src/test/java/app/pachli/components/timeline/NetworkTimelineViewModelTestStatusFilterAction.kt
+++ b/app/src/test/java/app/pachli/components/timeline/NetworkTimelineViewModelTestStatusFilterAction.kt
@@ -93,7 +93,7 @@ class NetworkTimelineViewModelTestStatusFilterAction : NetworkTimelineViewModelT
     @Test
     fun `bookmark succeeds && emits Ok uiResult`() = runTest {
         // Given
-        mastodonApi.stub { onBlocking { bookmarkStatus(any()) } doReturn success(fakeStatus) }
+        mastodonApi.stub { on { bookmarkStatus(any()) } doReturn success(fakeStatus) }
 
         viewModel.uiResult.test {
             // When
@@ -108,7 +108,7 @@ class NetworkTimelineViewModelTestStatusFilterAction : NetworkTimelineViewModelT
     @Test
     fun `bookmark fails && emits Err uiResult`() = runTest {
         // Given
-        mastodonApi.stub { onBlocking { bookmarkStatus(any()) } doReturn failure() }
+        mastodonApi.stub { on { bookmarkStatus(any()) } doReturn failure() }
 
         viewModel.uiResult.test {
             // When
@@ -123,7 +123,7 @@ class NetworkTimelineViewModelTestStatusFilterAction : NetworkTimelineViewModelT
     @Test
     fun `favourite succeeds && emits Ok uiResult`() = runTest {
         // Given
-        mastodonApi.stub { onBlocking { favouriteStatus(any()) } doReturn success(fakeStatus) }
+        mastodonApi.stub { on { favouriteStatus(any()) } doReturn success(fakeStatus) }
 
         viewModel.uiResult.test {
             // When
@@ -138,7 +138,7 @@ class NetworkTimelineViewModelTestStatusFilterAction : NetworkTimelineViewModelT
     @Test
     fun `favourite fails && emits Err uiResult`() = runTest {
         // Given
-        mastodonApi.stub { onBlocking { favouriteStatus(any()) } doReturn failure() }
+        mastodonApi.stub { on { favouriteStatus(any()) } doReturn failure() }
 
         viewModel.uiResult.test {
             // When
@@ -153,7 +153,7 @@ class NetworkTimelineViewModelTestStatusFilterAction : NetworkTimelineViewModelT
     @Test
     fun `reblog succeeds && emits Ok uiResult`() = runTest {
         // Given
-        mastodonApi.stub { onBlocking { reblogStatus(any()) } doReturn success(fakeStatus) }
+        mastodonApi.stub { on { reblogStatus(any()) } doReturn success(fakeStatus) }
 
         viewModel.uiResult.test {
             // When
@@ -168,7 +168,7 @@ class NetworkTimelineViewModelTestStatusFilterAction : NetworkTimelineViewModelT
     @Test
     fun `reblog fails && emits Err uiResult`() = runTest {
         // Given
-        mastodonApi.stub { onBlocking { reblogStatus(any()) } doReturn failure() }
+        mastodonApi.stub { on { reblogStatus(any()) } doReturn failure() }
 
         viewModel.uiResult.test {
             // When
@@ -183,7 +183,7 @@ class NetworkTimelineViewModelTestStatusFilterAction : NetworkTimelineViewModelT
     @Test
     fun `voteinpoll succeeds && emits Ok uiResult`() = runTest {
         // Given
-        mastodonApi.stub { onBlocking { voteInPoll(any(), any()) } doReturn success(fakeStatus.poll!!) }
+        mastodonApi.stub { on { voteInPoll(any(), any()) } doReturn success(fakeStatus.poll!!) }
 
         viewModel.uiResult.test {
             // When
@@ -198,7 +198,7 @@ class NetworkTimelineViewModelTestStatusFilterAction : NetworkTimelineViewModelT
     @Test
     fun `voteinpoll fails && emits Err uiResult`() = runTest {
         // Given
-        mastodonApi.stub { onBlocking { voteInPoll(any(), any()) } doReturn failure() }
+        mastodonApi.stub { on { voteInPoll(any(), any()) } doReturn failure() }
 
         viewModel.uiResult.test {
             // When

--- a/app/src/test/java/app/pachli/components/viewthread/ViewThreadViewModelTest.kt
+++ b/app/src/test/java/app/pachli/components/viewthread/ViewThreadViewModelTest.kt
@@ -119,18 +119,18 @@ class ViewThreadViewModelTest {
 
         reset(mastodonApi)
         mastodonApi.stub {
-            onBlocking { accountVerifyCredentials(anyOrNull(), anyOrNull()) } doReturn success(account)
-            onBlocking { getInstanceV2(anyOrNull()) } doReturn success(DEFAULT_INSTANCE_V2)
-            onBlocking { getCustomEmojis() } doReturn failure()
-            onBlocking { listAnnouncements(any()) } doReturn success(emptyList())
-            onBlocking { getLists() } doReturn success(emptyList())
-            onBlocking { getContentFilters() } doReturn success(emptyList())
-            onBlocking { accountFollowing(any(), anyOrNull(), any()) } doReturn success(emptyList())
+            on { accountVerifyCredentials(anyOrNull(), anyOrNull()) } doReturn success(account)
+            on { getInstanceV2(anyOrNull()) } doReturn success(DEFAULT_INSTANCE_V2)
+            on { getCustomEmojis() } doReturn failure()
+            on { listAnnouncements(any()) } doReturn success(emptyList())
+            on { getLists() } doReturn success(emptyList())
+            on { getContentFilters() } doReturn success(emptyList())
+            on { accountFollowing(any(), anyOrNull(), any()) } doReturn success(emptyList())
         }
 
         reset(nodeInfoApi)
         nodeInfoApi.stub {
-            onBlocking { nodeInfoJrd() } doReturn success(
+            on { nodeInfoJrd() } doReturn success(
                 UnvalidatedJrd(
                     listOf(
                         UnvalidatedJrd.Link(
@@ -140,7 +140,7 @@ class ViewThreadViewModelTest {
                     ),
                 ),
             )
-            onBlocking { nodeInfo(any()) } doReturn success(
+            on { nodeInfo(any()) } doReturn success(
                 UnvalidatedNodeInfo(UnvalidatedNodeInfo.Software("mastodon", "4.2.0")),
             )
         }
@@ -156,8 +156,8 @@ class ViewThreadViewModelTest {
             .onSuccess { accountManager.refresh(it) }
 
         val cachedTimelineRepository: CachedTimelineRepository = mock {
-            onBlocking { getStatusViewData(anyLong(), any<List<String>>()) } doReturn emptyMap()
-            onBlocking { getStatusTranslations(anyLong(), any()) } doReturn emptyMap()
+            on { getStatusViewData(anyLong(), any<List<String>>()) } doReturn emptyMap()
+            on { getStatusTranslations(anyLong(), any()) } doReturn emptyMap()
         }
 
         viewModel = ViewThreadViewModel(
@@ -212,8 +212,8 @@ class ViewThreadViewModelTest {
     @Test
     fun `should emit status even if context fails to load`() = runTest {
         mastodonApi.stub {
-            onBlocking { status(threadId) } doReturn success(fakeStatus(id = "2", inReplyToId = "1", inReplyToAccountId = "1"))
-            onBlocking { statusContext(threadId) } doReturn failure()
+            on { status(threadId) } doReturn success(fakeStatus(id = "2", inReplyToId = "1", inReplyToAccountId = "1"))
+            on { statusContext(threadId) } doReturn failure()
         }
 
         viewModel.uiResult.test {
@@ -245,8 +245,8 @@ class ViewThreadViewModelTest {
     @Test
     fun `should emit error when status and context fail to load`() = runTest {
         mastodonApi.stub {
-            onBlocking { status(threadId) } doReturn failure()
-            onBlocking { statusContext(threadId) } doReturn failure()
+            on { status(threadId) } doReturn failure()
+            on { statusContext(threadId) } doReturn failure()
         }
 
         viewModel.uiResult.test {
@@ -267,8 +267,8 @@ class ViewThreadViewModelTest {
     @Test
     fun `should emit error when status fails to load`() = runTest {
         mastodonApi.stub {
-            onBlocking { status(threadId) } doReturn failure()
-            onBlocking { statusContext(threadId) } doReturn success(
+            on { status(threadId) } doReturn failure()
+            on { statusContext(threadId) } doReturn success(
                 StatusContext(
                     ancestors = listOf(fakeStatus(id = "1")),
                     descendants = listOf(fakeStatus(id = "3", inReplyToId = "2", inReplyToAccountId = "1")),
@@ -591,8 +591,8 @@ class ViewThreadViewModelTest {
 
     private fun mockSuccessResponses() {
         mastodonApi.stub {
-            onBlocking { status(threadId) } doReturn success(fakeStatus(id = "2", inReplyToId = "1", inReplyToAccountId = "1", spoilerText = "Test"))
-            onBlocking { statusContext(threadId) } doReturn success(
+            on { status(threadId) } doReturn success(fakeStatus(id = "2", inReplyToId = "1", inReplyToAccountId = "1", spoilerText = "Test"))
+            on { statusContext(threadId) } doReturn success(
                 StatusContext(
                     ancestors = listOf(fakeStatus(id = "1", spoilerText = "Test")),
                     descendants = listOf(fakeStatus(id = "3", inReplyToId = "2", inReplyToAccountId = "1", spoilerText = "Test")),

--- a/app/src/test/java/app/pachli/util/StatusDisplayOptionsRepositoryTest.kt
+++ b/app/src/test/java/app/pachli/util/StatusDisplayOptionsRepositoryTest.kt
@@ -114,18 +114,18 @@ class StatusDisplayOptionsRepositoryTest {
 
         reset(mastodonApi)
         mastodonApi.stub {
-            onBlocking { accountVerifyCredentials(anyOrNull(), anyOrNull()) } doReturn success(account)
-            onBlocking { getInstanceV2(anyOrNull()) } doReturn success(DEFAULT_INSTANCE_V2)
-            onBlocking { getLists() } doReturn success(emptyList())
-            onBlocking { getCustomEmojis() } doReturn failure()
-            onBlocking { getContentFilters() } doReturn success(emptyList())
-            onBlocking { listAnnouncements(anyOrNull()) } doReturn success(emptyList())
-            onBlocking { accountFollowing(any(), anyOrNull(), any()) } doReturn success(emptyList())
+            on { accountVerifyCredentials(anyOrNull(), anyOrNull()) } doReturn success(account)
+            on { getInstanceV2(anyOrNull()) } doReturn success(DEFAULT_INSTANCE_V2)
+            on { getLists() } doReturn success(emptyList())
+            on { getCustomEmojis() } doReturn failure()
+            on { getContentFilters() } doReturn success(emptyList())
+            on { listAnnouncements(anyOrNull()) } doReturn success(emptyList())
+            on { accountFollowing(any(), anyOrNull(), any()) } doReturn success(emptyList())
         }
 
         reset(nodeInfoApi)
         nodeInfoApi.stub {
-            onBlocking { nodeInfoJrd() } doReturn success(
+            on { nodeInfoJrd() } doReturn success(
                 UnvalidatedJrd(
                     listOf(
                         UnvalidatedJrd.Link(
@@ -135,7 +135,7 @@ class StatusDisplayOptionsRepositoryTest {
                     ),
                 ),
             )
-            onBlocking { nodeInfo(any()) } doReturn success(
+            on { nodeInfo(any()) } doReturn success(
                 UnvalidatedNodeInfo(UnvalidatedNodeInfo.Software("mastodon", "4.2.0")),
             )
         }
@@ -208,7 +208,7 @@ class StatusDisplayOptionsRepositoryTest {
         )
 
         mastodonApi.stub {
-            onBlocking { accountVerifyCredentials() } doReturn success(account)
+            on { accountVerifyCredentials() } doReturn success(account)
         }
 
         // When -- addAccount changes the active account

--- a/app/src/testFdroid/kotlin/app/pachli/updatecheck/UpdateCheckTest.kt
+++ b/app/src/testFdroid/kotlin/app/pachli/updatecheck/UpdateCheckTest.kt
@@ -51,7 +51,7 @@ class UpdateCheckTest {
     @Test
     fun `remoteFetchLatestVersionCode returns null on network error`() = runTest {
         fdroidService.stub {
-            onBlocking { getPackage(any()) } doReturn failure()
+            on { getPackage(any()) } doReturn failure()
         }
 
         assertThat(updateCheck.remoteFetchLatestVersionCode()).isNull()
@@ -60,7 +60,7 @@ class UpdateCheckTest {
     @Test
     fun `remoteFetchLatestVersionCode returns suggestedVersionCode if in packages`() = runTest {
         fdroidService.stub {
-            onBlocking { getPackage(any()) } doReturn success(
+            on { getPackage(any()) } doReturn success(
                 FdroidPackage(
                     packageName = "app.pachli",
                     suggestedVersionCode = 3,
@@ -80,7 +80,7 @@ class UpdateCheckTest {
     @Test
     fun `remoteFetchLatestVersionCode returns greatest code if suggestedVersionCode is missing`() = runTest {
         fdroidService.stub {
-            onBlocking { getPackage(any()) } doReturn success(
+            on { getPackage(any()) } doReturn success(
                 FdroidPackage(
                     packageName = "app.pachli",
                     suggestedVersionCode = 3,

--- a/core/activity/src/test/kotlin/app/pachli/core/activity/ViewUrlActivityTest.kt
+++ b/core/activity/src/test/kotlin/app/pachli/core/activity/ViewUrlActivityTest.kt
@@ -116,10 +116,10 @@ class ViewUrlActivityTest {
     @Before
     fun setup() {
         apiMock = mock {
-            onBlocking { search(eq(accountQuery), eq(null), anyBoolean(), eq(null), eq(null), eq(null)) } doReturn accountResponse
-            onBlocking { search(eq(statusQuery), eq(null), anyBoolean(), eq(null), eq(null), eq(null)) } doReturn statusResponse
-            onBlocking { search(eq(nonexistentStatusQuery), eq(null), anyBoolean(), eq(null), eq(null), eq(null)) } doReturn accountResponse
-            onBlocking { search(eq(nonMastodonQuery), eq(null), anyBoolean(), eq(null), eq(null), eq(null)) } doReturn emptyResponse
+            on { search(eq(accountQuery), eq(null), anyBoolean(), eq(null), eq(null), eq(null)) } doReturn accountResponse
+            on { search(eq(statusQuery), eq(null), anyBoolean(), eq(null), eq(null), eq(null)) } doReturn statusResponse
+            on { search(eq(nonexistentStatusQuery), eq(null), anyBoolean(), eq(null), eq(null), eq(null)) } doReturn accountResponse
+            on { search(eq(nonMastodonQuery), eq(null), anyBoolean(), eq(null), eq(null), eq(null)) } doReturn emptyResponse
         }
 
         activity = FakeViewUrlActivity(apiMock)

--- a/core/data/src/test/kotlin/app/pachli/core/data/repository/ExportedPreferencesRepositoryTest.kt
+++ b/core/data/src/test/kotlin/app/pachli/core/data/repository/ExportedPreferencesRepositoryTest.kt
@@ -113,10 +113,10 @@ class ExportedPreferencesRepositoryTest {
 
         reset(mastodonApi)
         mastodonApi.stub {
-            onBlocking { accountVerifyCredentials(anyOrNull(), anyOrNull()) } doReturn success(account)
-            onBlocking { getCustomEmojis() } doReturn success(emptyList())
-            onBlocking { getInstanceV2() } doReturn failure()
-            onBlocking { getInstanceV1(anyOrNull()) } doReturn success(
+            on { accountVerifyCredentials(anyOrNull(), anyOrNull()) } doReturn success(account)
+            on { getCustomEmojis() } doReturn success(emptyList())
+            on { getInstanceV2() } doReturn failure()
+            on { getInstanceV1(anyOrNull()) } doReturn success(
                 InstanceV1(
                     uri = "https://example.token",
                     version = "2.6.3",
@@ -128,16 +128,16 @@ class ExportedPreferencesRepositoryTest {
                     rules = emptyList(),
                 ),
             )
-            onBlocking { getLists() } doReturn success(emptyList())
-            onBlocking { listAnnouncements(any()) } doReturn success(emptyList())
-            onBlocking { getContentFilters() } doReturn success(emptyList())
-            onBlocking { getContentFiltersV1() } doReturn success(emptyList())
-            onBlocking { accountFollowing(any(), anyOrNull(), any()) } doReturn success(emptyList())
+            on { getLists() } doReturn success(emptyList())
+            on { listAnnouncements(any()) } doReturn success(emptyList())
+            on { getContentFilters() } doReturn success(emptyList())
+            on { getContentFiltersV1() } doReturn success(emptyList())
+            on { accountFollowing(any(), anyOrNull(), any()) } doReturn success(emptyList())
         }
 
         reset(nodeInfoApi)
         nodeInfoApi.stub {
-            onBlocking { nodeInfoJrd() } doReturn success(
+            on { nodeInfoJrd() } doReturn success(
                 UnvalidatedJrd(
                     listOf(
                         UnvalidatedJrd.Link(
@@ -147,7 +147,7 @@ class ExportedPreferencesRepositoryTest {
                     ),
                 ),
             )
-            onBlocking { nodeInfo(any()) } doReturn success(
+            on { nodeInfo(any()) } doReturn success(
                 UnvalidatedNodeInfo(UnvalidatedNodeInfo.Software("mastodon", "4.2.0")),
             )
         }

--- a/core/data/src/test/kotlin/app/pachli/core/data/repository/InstanceInfoRepositoryTest.kt
+++ b/core/data/src/test/kotlin/app/pachli/core/data/repository/InstanceInfoRepositoryTest.kt
@@ -107,22 +107,22 @@ class InstanceInfoRepositoryTest {
 
         reset(mastodonApi)
         mastodonApi.stub {
-            onBlocking { accountVerifyCredentials(anyOrNull(), anyOrNull()) } doReturn success(account)
-            onBlocking { getCustomEmojis() } doReturn success(emptyList())
-            onBlocking { getInstanceV2() } doReturn failure()
-            onBlocking { getInstanceV1(anyOrNull()) } doAnswer {
+            on { accountVerifyCredentials(anyOrNull(), anyOrNull()) } doReturn success(account)
+            on { getCustomEmojis() } doReturn success(emptyList())
+            on { getInstanceV2() } doReturn failure()
+            on { getInstanceV1(anyOrNull()) } doAnswer {
                 instanceResponseCallback.invoke().let { success(it) }
             }
-            onBlocking { getLists() } doReturn success(emptyList())
-            onBlocking { listAnnouncements(any()) } doReturn success(emptyList())
-            onBlocking { getContentFilters() } doReturn success(emptyList())
-            onBlocking { getContentFiltersV1() } doReturn success(emptyList())
-            onBlocking { accountFollowing(any(), anyOrNull(), any()) } doReturn success(emptyList())
+            on { getLists() } doReturn success(emptyList())
+            on { listAnnouncements(any()) } doReturn success(emptyList())
+            on { getContentFilters() } doReturn success(emptyList())
+            on { getContentFiltersV1() } doReturn success(emptyList())
+            on { accountFollowing(any(), anyOrNull(), any()) } doReturn success(emptyList())
         }
 
         reset(nodeInfoApi)
         nodeInfoApi.stub {
-            onBlocking { nodeInfoJrd() } doReturn success(
+            on { nodeInfoJrd() } doReturn success(
                 UnvalidatedJrd(
                     listOf(
                         UnvalidatedJrd.Link(
@@ -132,7 +132,7 @@ class InstanceInfoRepositoryTest {
                     ),
                 ),
             )
-            onBlocking { nodeInfo(any()) } doReturn success(
+            on { nodeInfo(any()) } doReturn success(
                 UnvalidatedNodeInfo(UnvalidatedNodeInfo.Software("mastodon", "4.2.0")),
             )
         }

--- a/core/data/src/test/kotlin/app/pachli/core/data/repository/StatusRepositoryTest.kt
+++ b/core/data/src/test/kotlin/app/pachli/core/data/repository/StatusRepositoryTest.kt
@@ -121,10 +121,10 @@ class StatusRepositoryTest {
 
         reset(mastodonApi)
         mastodonApi.stub {
-            onBlocking { accountVerifyCredentials(anyOrNull(), anyOrNull()) } doReturn success(account)
-            onBlocking { getCustomEmojis() } doReturn success(emptyList())
-            onBlocking { getInstanceV2() } doReturn failure()
-            onBlocking { getInstanceV1(anyOrNull()) } doReturn success(
+            on { accountVerifyCredentials(anyOrNull(), anyOrNull()) } doReturn success(account)
+            on { getCustomEmojis() } doReturn success(emptyList())
+            on { getInstanceV2() } doReturn failure()
+            on { getInstanceV1(anyOrNull()) } doReturn success(
                 InstanceV1(
                     uri = "https://example.token",
                     version = "2.6.3",
@@ -136,16 +136,16 @@ class StatusRepositoryTest {
                     rules = emptyList(),
                 ),
             )
-            onBlocking { getLists() } doReturn success(emptyList())
-            onBlocking { listAnnouncements(any()) } doReturn success(emptyList())
-            onBlocking { getContentFilters() } doReturn success(emptyList())
-            onBlocking { getContentFiltersV1() } doReturn success(emptyList())
-            onBlocking { accountFollowing(any(), anyOrNull(), any()) } doReturn success(emptyList())
+            on { getLists() } doReturn success(emptyList())
+            on { listAnnouncements(any()) } doReturn success(emptyList())
+            on { getContentFilters() } doReturn success(emptyList())
+            on { getContentFiltersV1() } doReturn success(emptyList())
+            on { accountFollowing(any(), anyOrNull(), any()) } doReturn success(emptyList())
         }
 
         reset(nodeInfoApi)
         nodeInfoApi.stub {
-            onBlocking { nodeInfoJrd() } doReturn success(
+            on { nodeInfoJrd() } doReturn success(
                 UnvalidatedJrd(
                     listOf(
                         UnvalidatedJrd.Link(
@@ -155,7 +155,7 @@ class StatusRepositoryTest {
                     ),
                 ),
             )
-            onBlocking { nodeInfo(any()) } doReturn success(
+            on { nodeInfo(any()) } doReturn success(
                 UnvalidatedNodeInfo(UnvalidatedNodeInfo.Software("mastodon", "4.2.0")),
             )
         }
@@ -188,7 +188,7 @@ class StatusRepositoryTest {
         appDatabase.insertTimelineStatusWithQuote(listOf(fakeStatusEntityWithAccount))
 
         mastodonApi.stub {
-            onBlocking { pinStatus(statusId) } doReturn success(fakeStatus)
+            on { pinStatus(statusId) } doReturn success(fakeStatus)
         }
 
         eventHub.events.test {
@@ -207,7 +207,7 @@ class StatusRepositoryTest {
         )
 
         mastodonApi.stub {
-            onBlocking { pinStatus(statusId) } doReturn apiResult
+            on { pinStatus(statusId) } doReturn apiResult
         }
 
         runBlocking {

--- a/core/data/src/test/kotlin/app/pachli/core/data/repository/filtersRepository/BaseContentFiltersRepositoryTest.kt
+++ b/core/data/src/test/kotlin/app/pachli/core/data/repository/filtersRepository/BaseContentFiltersRepositoryTest.kt
@@ -134,20 +134,20 @@ abstract class V2Test : BaseContentFiltersRepositoryTest() {
         reset(mastodonApi)
         mastodonApi.stub {
             // API calls when registering an account
-            onBlocking { accountVerifyCredentials(anyOrNull(), anyOrNull()) } doReturn success(account)
-            onBlocking { getInstanceV2() } doReturn success(DEFAULT_INSTANCE_V2)
-            onBlocking { getLists() } doReturn success(emptyList())
-            onBlocking { getCustomEmojis() } doReturn success(emptyList())
-            onBlocking { listAnnouncements(any()) } doReturn success(emptyList())
-            onBlocking { getContentFilters() } doReturn success(networkFilters)
-            onBlocking { accountFollowing(any(), anyOrNull(), any()) } doReturn success(emptyList())
+            on { accountVerifyCredentials(anyOrNull(), anyOrNull()) } doReturn success(account)
+            on { getInstanceV2() } doReturn success(DEFAULT_INSTANCE_V2)
+            on { getLists() } doReturn success(emptyList())
+            on { getCustomEmojis() } doReturn success(emptyList())
+            on { listAnnouncements(any()) } doReturn success(emptyList())
+            on { getContentFilters() } doReturn success(networkFilters)
+            on { accountFollowing(any(), anyOrNull(), any()) } doReturn success(emptyList())
         }
 
         networkFilters.clear()
 
         reset(nodeInfoApi)
         nodeInfoApi.stub {
-            onBlocking { nodeInfoJrd() } doReturn success(
+            on { nodeInfoJrd() } doReturn success(
                 UnvalidatedJrd(
                     listOf(
                         UnvalidatedJrd.Link(
@@ -157,7 +157,7 @@ abstract class V2Test : BaseContentFiltersRepositoryTest() {
                     ),
                 ),
             )
-            onBlocking { nodeInfo(any()) } doReturn success(
+            on { nodeInfo(any()) } doReturn success(
                 UnvalidatedNodeInfo(UnvalidatedNodeInfo.Software("mastodon", "4.2.0")),
             )
         }
@@ -197,19 +197,19 @@ abstract class V1Test : BaseContentFiltersRepositoryTest() {
         reset(mastodonApi)
         mastodonApi.stub {
             // API calls when registering an account
-            onBlocking { accountVerifyCredentials(anyOrNull(), anyOrNull()) } doReturn success(account)
-            onBlocking { getInstanceV2() } doReturn failure()
-            onBlocking { getInstanceV1() } doReturn success(instanceV1)
-            onBlocking { getLists() } doReturn success(emptyList())
-            onBlocking { getCustomEmojis() } doReturn success(emptyList())
-            onBlocking { listAnnouncements(any()) } doReturn success(emptyList())
-            onBlocking { getContentFiltersV1() } doReturn success(networkFiltersV1)
-            onBlocking { accountFollowing(any(), anyOrNull(), any()) } doReturn success(emptyList())
+            on { accountVerifyCredentials(anyOrNull(), anyOrNull()) } doReturn success(account)
+            on { getInstanceV2() } doReturn failure()
+            on { getInstanceV1() } doReturn success(instanceV1)
+            on { getLists() } doReturn success(emptyList())
+            on { getCustomEmojis() } doReturn success(emptyList())
+            on { listAnnouncements(any()) } doReturn success(emptyList())
+            on { getContentFiltersV1() } doReturn success(networkFiltersV1)
+            on { accountFollowing(any(), anyOrNull(), any()) } doReturn success(emptyList())
         }
 
         reset(nodeInfoApi)
         nodeInfoApi.stub {
-            onBlocking { nodeInfoJrd() } doReturn success(
+            on { nodeInfoJrd() } doReturn success(
                 UnvalidatedJrd(
                     listOf(
                         UnvalidatedJrd.Link(
@@ -219,7 +219,7 @@ abstract class V1Test : BaseContentFiltersRepositoryTest() {
                     ),
                 ),
             )
-            onBlocking { nodeInfo(any()) } doReturn success(
+            on { nodeInfo(any()) } doReturn success(
                 UnvalidatedNodeInfo(UnvalidatedNodeInfo.Software("mastodon", "3.9.0")),
             )
         }

--- a/core/data/src/test/kotlin/app/pachli/core/data/repository/filtersRepository/ContentFiltersRepositoryTestCreate.kt
+++ b/core/data/src/test/kotlin/app/pachli/core/data/repository/filtersRepository/ContentFiltersRepositoryTestCreate.kt
@@ -70,7 +70,7 @@ class ContentFiltersRepositoryTestCreate : V2Test() {
         var expiresAt = Date()
 
         mastodonApi.stub {
-            onBlocking { createFilter(any<NewContentFilter>()) } doAnswer { call ->
+            on { createFilter(any<NewContentFilter>()) } doAnswer { call ->
                 val newContentFilter = call.getArgument<NewContentFilter>(0)
                 val expiresIn = newContentFilter.expiresIn
                 expiresAt = Date(System.currentTimeMillis() + (expiresIn * 1000))
@@ -164,7 +164,7 @@ class ContentFiltersRepositoryTestCreateV1 : V1Test() {
 
         // Initialise with no existing filters, and API stubs for creating V1 filters.
         mastodonApi.stub {
-            onBlocking { createFilterV1(any(), any(), any(), any(), any()) } doAnswer { call ->
+            on { createFilterV1(any(), any(), any(), any(), any()) } doAnswer { call ->
                 val expiresIn = call.getArgument<String>(4).toInt()
                 expiresAt = Date(System.currentTimeMillis() + (expiresIn * 1000))
 

--- a/core/data/src/test/kotlin/app/pachli/core/data/repository/filtersRepository/ContentFiltersRepositoryTestDelete.kt
+++ b/core/data/src/test/kotlin/app/pachli/core/data/repository/filtersRepository/ContentFiltersRepositoryTestDelete.kt
@@ -38,7 +38,7 @@ class ContentFiltersRepositoryTestV2Delete : V2Test() {
     @Test
     fun `delete on v2 server should call delete`() = runTest {
         mastodonApi.stub {
-            onBlocking { deleteFilter(anyString()) } doReturn success(Unit)
+            on { deleteFilter(anyString()) } doReturn success(Unit)
         }
 
         // Configure API with a single filter.
@@ -76,7 +76,7 @@ class ContentFiltersRepositoryTestV1Delete : V1Test() {
     @Test
     fun `delete on v1 server should call deleteFilterV1`() = runTest {
         mastodonApi.stub {
-            onBlocking { deleteFilterV1(anyString()) } doReturn success(Unit)
+            on { deleteFilterV1(anyString()) } doReturn success(Unit)
         }
 
         // Configure API with a single filter.

--- a/core/data/src/test/kotlin/app/pachli/core/data/repository/filtersRepository/ContentFiltersRepositoryTestUpdate.kt
+++ b/core/data/src/test/kotlin/app/pachli/core/data/repository/filtersRepository/ContentFiltersRepositoryTestUpdate.kt
@@ -60,7 +60,7 @@ class ContentFiltersRepositoryTestUpdate : V2Test() {
         mastodonApi.stub {
             // Takes the original network filter and applies the update, returning the updated
             // filter.
-            onBlocking { updateFilter(any(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull()) } doAnswer { call ->
+            on { updateFilter(any(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull()) } doAnswer { call ->
                 val id = call.getArgument<String>(0)
                 val originalNetworkFilter = networkFilters.find { it.id == id }!!
 
@@ -79,7 +79,7 @@ class ContentFiltersRepositoryTestUpdate : V2Test() {
                 )
             }
             // Returns a copy of the filter with the modified title.
-            onBlocking { getFilter(anyString()) } doAnswer { call ->
+            on { getFilter(anyString()) } doAnswer { call ->
                 val id = call.getArgument<String>(0)
                 success(networkFilters.first { it.id == id }.copy(title = updatedTitle))
             }
@@ -136,16 +136,16 @@ class ContentFiltersRepositoryTestUpdate : V2Test() {
         contentFiltersRepository.refresh(pachliAccountId)
 
         mastodonApi.stub {
-            onBlocking { deleteFilterKeyword(any()) } doReturn success(Unit)
-            onBlocking { updateFilterKeyword(any(), any(), any()) } doAnswer { call ->
+            on { deleteFilterKeyword(any()) } doReturn success(Unit)
+            on { updateFilterKeyword(any(), any(), any()) } doAnswer { call ->
                 success(NetworkFilterKeyword(call.getArgument(0), call.getArgument(1), call.getArgument(2)))
             }
-            onBlocking { addFilterKeyword(any(), any(), any()) } doAnswer { call ->
+            on { addFilterKeyword(any(), any(), any()) } doAnswer { call ->
                 success(NetworkFilterKeyword("x", call.getArgument(1), call.getArgument(2)))
             }
             // Return the unmodified filter. The actual network calls are checked, so this
             // simplifies the test by not needing to recreate the modified filter.
-            onBlocking { getFilter(any()) } doReturn success(networkFilters.first())
+            on { getFilter(any()) } doReturn success(networkFilters.first())
         }
 
         contentFiltersRepository.getContentFiltersFlow(pachliAccountId).test {

--- a/core/network-test/src/main/kotlin/app/pachli/core/network/di/test/FakeMastodonApiModule.kt
+++ b/core/network-test/src/main/kotlin/app/pachli/core/network/di/test/FakeMastodonApiModule.kt
@@ -53,7 +53,7 @@ import org.mockito.stubbing.Answer
  *
  *     reset(mastodonApi)
  *     mastodonApi.stub {
- *         onBlocking { someFunction() } doReturn SomeValue
+ *         on { someFunction() } doReturn SomeValue
  *         // ...
  *     }
  *
@@ -89,7 +89,7 @@ object ThrowingAnswer : Answer<Any> {
         // like:
         //
         // mastodonApi.stub {
-        //   onBlocking { someFunction() } doReturn success(emptyList())
+        //   on { someFunction() } doReturn success(emptyList())
         // }
         //
         // then `someFunction()` will be called.
@@ -98,12 +98,15 @@ object ThrowingAnswer : Answer<Any> {
         // as part of the stubbing process.
         //
         // To determine whether this call is during the stubbing process get the
-        // current call stack and look for a call to org.mockito.kotlin.KStubbing.onBlocking.
+        // current call stack and look for a call to org.mockito.kotlin.KStubbing.onBlocking
+        // or org.mockito.kotlin.KStubbing.on.
+        //
         // If that's somewhere in the call stack then this is a call during the stubbing
         // process and Unit should be returned.
         val callstack = Thread.currentThread().getStackTrace()
         val isDuringStubbing = callstack.firstOrNull {
-            it.className == "org.mockito.kotlin.KStubbing" && it.methodName == "onBlocking"
+            it.className == "org.mockito.kotlin.KStubbing" &&
+                (it.methodName == "onBlocking" || it.methodName == "on")
         } != null
         if (isDuringStubbing) return Unit
 

--- a/core/network-test/src/main/kotlin/app/pachli/core/network/di/test/FakeNodeInfoApiModule.kt
+++ b/core/network-test/src/main/kotlin/app/pachli/core/network/di/test/FakeNodeInfoApiModule.kt
@@ -41,7 +41,7 @@ import org.mockito.kotlin.mock
  *
  *     reset(nodeInfoApi)
  *     nodeInfoApi.stub {
- *         onBlocking { someFunction() } doReturn SomeValue
+ *         on { someFunction() } doReturn SomeValue
  *         // ...
  *     }
  *


### PR DESCRIPTION
Clears test logs of lines like:

```
w: pachli-android/app/src/test/java/app/pachli/components/viewthread/ViewThreadViewModelTest.kt:133:13 'fun <T : Any, R> KStubbing<T>.onBlocking(methodCall: suspend T.() -> R): OngoingStubbing<R>' is deprecated. Use on { methodCall } instead.
```