### PR TITLE
build: Don't run lint when creating release builds

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -80,6 +80,9 @@ android {
 
     lint {
         checkDependencies = true
+        // Disable lint for release builds, it's already checked as part of
+        // CI, and checking again unnecessarily slows down release builds.
+        checkReleaseBuilds = false
     }
 
     testOptions {


### PR DESCRIPTION
Lint is already run as part of CI, so this just slows down the build and release process.