### PR TITLE
fix: Don't crash when updating media on an existing status

### DIFF
--- a/app/src/main/java/app/pachli/util/UriExtensions.kt
+++ b/app/src/main/java/app/pachli/util/UriExtensions.kt
@@ -109,7 +109,7 @@ suspend fun Uri.saveToDirectory(context: Context, callFactory: Call.Factory, dir
     return@withContext try {
         // saving redrafted media
         if (scheme == "https") {
-            val request = Request.Builder().url(toString()).build()
+            val request = Request.Builder().url(this@saveToDirectory.toString()).build()
             callFactory.newCall(request).execute().use { response ->
                 response.body.source().buffer.use { input ->
                     file.sink().buffer().use { it.writeAll(input) }


### PR DESCRIPTION
Previous code crashed because (simplified):

```kotlin
suspend fun URI.foo() = withContext(Dispatchers.IO) {
    println(scheme)
    println(toString())
}
```

resolves `scheme` from the `URI` but `toString()` from the coroutine context. So the wrong string was passed to `Request.Builder().url()`.