### PR TITLE
build: Update precommit task to clean and update lint baseline

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,21 +66,24 @@ tasks.register<Delete>("clean") {
 
 // Create a "precommit" lifecycle task that depends on other tasks that
 // give reasonable confidence the change will pass CI. The tasks are
-// limited to the "orangeGoogleDebug" flavour/variant. While problems
+// (mostly) limited to the "orangeGoogleDebug" flavour/variant. While problems
 // might affect other combinations (and CI will check all of them), this
 // combination passing gives high confidence for the amount of time it
 // takes to run.
 //
+// - clean
 // - :app:lintOrangeGoogleDebug
 // - :app:assembleOrangeDebug
 // - *:pixel9api31orangegoogledebugAndroidTest
 // - *:testOrangeGoogleDebugUnitTest
 // - *:validateOrangeGoogleDebugScreenshotTest
+// - app:updateLintBaselineBlueFdroidDebug
 tasks.register("precommit") {
     group = "Verification"
     description = "Runs the precommit tests."
-    dependsOn(":app:lintOrangeGoogleDebug")
+    dependsOn("clean")
     dependsOn(":app:assembleOrangeGoogleDebug")
+    dependsOn(":app:updateLintBaselineBlueFdroidDebug")
     val perModuleDeps =
         listOf(
             "testOrangeGoogleDebugUnitTest",


### PR DESCRIPTION
Updating the lint baseline is a better way to catch errors locally than running lint.

If you run lint and it finds a problem you either:

1. Fix the issue.
2. Decide it needs to be in the baseline, and regenerate the baseline.

If you regenerate the baseline and it finds a new problem you either:

1. Fix the issue, delete the changes to the baseline
2. Commit the new baseline

So this saves a time consuming step if the baseline needs to be updated.