### PR TITLE
fix: Support ol, pre, and code elements in content

### DIFF
--- a/app/src/main/java/app/pachli/components/viewthread/edits/ViewEditsAdapter.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/edits/ViewEditsAdapter.kt
@@ -3,10 +3,6 @@ package app.pachli.components.viewthread.edits
 import android.content.Context
 import android.graphics.Typeface
 import android.text.Editable
-import android.text.Html
-import android.text.Spannable
-import android.text.SpannableStringBuilder
-import android.text.Spanned
 import android.text.TextPaint
 import android.text.style.CharacterStyle
 import android.text.style.MetricAffectingSpan
@@ -23,6 +19,7 @@ import app.pachli.core.common.util.AbsoluteTimeFormatter
 import app.pachli.core.designsystem.R as DR
 import app.pachli.core.model.AttachmentDisplayAction
 import app.pachli.core.model.StatusEdit
+import app.pachli.core.network.PachliTagHandler
 import app.pachli.core.network.parseAsMastodonHtml
 import app.pachli.core.ui.BindingHolder
 import app.pachli.core.ui.LinkListener
@@ -31,6 +28,9 @@ import app.pachli.core.ui.PollAdapter.DisplayMode
 import app.pachli.core.ui.PollOptionViewData
 import app.pachli.core.ui.SetContentAsMastodonHtml
 import app.pachli.core.ui.emojify
+import app.pachli.core.ui.taghandler.Mark
+import app.pachli.core.ui.taghandler.appendMark
+import app.pachli.core.ui.taghandler.setSpansFromMark
 import app.pachli.databinding.ItemStatusEditBinding
 import com.bumptech.glide.RequestManager
 import org.xml.sax.XMLReader
@@ -52,7 +52,7 @@ class ViewEditsAdapter(
     /** Size of medium text in this theme, in px */
     private var mediumTextSizePx: Float = 0f
 
-    private val pachliTagHandler = PachliTagHandler(context)
+    private val viewEditsTagHandler = ViewEditsTagHandler(context)
 
     override fun onCreateViewHolder(
         parent: ViewGroup,
@@ -108,7 +108,7 @@ class ViewEditsAdapter(
             binding.statusEditContentWarningDescription.show()
             binding.statusEditContentWarningSeparator.show()
             binding.statusEditContentWarningDescription.text = edit.spoilerText
-                .parseAsMastodonHtml(pachliTagHandler)
+                .parseAsMastodonHtml(viewEditsTagHandler)
                 .emojify(
                     glide,
                     edit.emojis,
@@ -124,7 +124,7 @@ class ViewEditsAdapter(
             emojis = edit.emojis,
             animateEmojis = animateEmojis,
             removeQuoteInline = false,
-            tagHandler = pachliTagHandler,
+            tagHandler = viewEditsTagHandler,
             linkListener = listener,
         )
 
@@ -182,65 +182,29 @@ class ViewEditsAdapter(
  * Handle XML tags created by [ViewEditsViewModel] and create custom spans to display inserted or
  * deleted text.
  */
-class PachliTagHandler(val context: Context) : Html.TagHandler {
-    /** Class to mark the start of a span of deleted text */
-    class Del
+class ViewEditsTagHandler(val context: Context) : PachliTagHandler {
+    /** Object to mark the start of a span of deleted text */
+    object Del : Mark
 
-    /** Class to mark the start of a span of inserted text */
-    class Ins
+    /** Object to mark the start of a span of inserted text */
+    object Ins : Mark
 
     override fun handleTag(opening: Boolean, tag: String, output: Editable, xmlReader: XMLReader) {
         when (tag) {
             DELETED_TEXT_EL -> {
                 if (opening) {
-                    start(output as SpannableStringBuilder, Del())
+                    output.appendMark(Del)
                 } else {
-                    end(
-                        output as SpannableStringBuilder,
-                        Del::class.java,
-                        DeletedTextSpan(context),
-                    )
+                    output.setSpansFromMark(Del, DeletedTextSpan(context))
                 }
             }
             INSERTED_TEXT_EL -> {
                 if (opening) {
-                    start(output as SpannableStringBuilder, Ins())
+                    output.appendMark(Ins)
                 } else {
-                    end(
-                        output as SpannableStringBuilder,
-                        Ins::class.java,
-                        InsertedTextSpan(context),
-                    )
+                    output.setSpansFromMark(Ins, InsertedTextSpan(context))
                 }
             }
-        }
-    }
-
-    /** @return the last span in [text] of type [kind], or null if that kind is not in text */
-    private fun <T> getLast(text: Spanned, kind: Class<T>): Any? {
-        val spans = text.getSpans(0, text.length, kind)
-        return spans?.get(spans.size - 1)
-    }
-
-    /**
-     * Mark the start of a span of [text] with [mark] so it can be discovered later by [end].
-     */
-    private fun start(text: SpannableStringBuilder, mark: Any) {
-        val len = text.length
-        text.setSpan(mark, len, len, Spannable.SPAN_MARK_MARK)
-    }
-
-    /**
-     * Set a [span] over the [text] most from the point recently marked with [mark] to the end
-     * of the text.
-     */
-    private fun <T> end(text: SpannableStringBuilder, mark: Class<T>, span: Any) {
-        val len = text.length
-        val obj = getLast(text, mark)
-        val where = text.getSpanStart(obj)
-        text.removeSpan(obj)
-        if (where != len) {
-            text.setSpan(span, where, len, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
         }
     }
 

--- a/app/src/main/java/app/pachli/components/viewthread/edits/ViewEditsViewModel.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/edits/ViewEditsViewModel.kt
@@ -19,8 +19,8 @@ package app.pachli.components.viewthread.edits
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import app.pachli.components.viewthread.edits.PachliTagHandler.Companion.DELETED_TEXT_EL
-import app.pachli.components.viewthread.edits.PachliTagHandler.Companion.INSERTED_TEXT_EL
+import app.pachli.components.viewthread.edits.ViewEditsTagHandler.Companion.DELETED_TEXT_EL
+import app.pachli.components.viewthread.edits.ViewEditsTagHandler.Companion.INSERTED_TEXT_EL
 import app.pachli.core.model.StatusEdit
 import app.pachli.core.network.model.asModel
 import app.pachli.core.network.retrofit.MastodonApi

--- a/core/network/src/main/kotlin/app/pachli/core/network/StatusParsingHelper.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/StatusParsingHelper.kt
@@ -17,16 +17,14 @@
 
 package app.pachli.core.network
 
-import android.text.Html.TagHandler
+import android.text.Html
 import android.text.SpannableStringBuilder
 import android.text.Spanned
 import androidx.core.text.parseAsHtml
 import app.pachli.core.common.string.trimTrailingWhitespace
 
-private val rxBR = "<br> ".toRegex()
-
 /**
- * Matches the fallback "<X class="quote-inline">...</X>" added to statuses
+ * Matches the fallback `<X class="quote-inline">...</X>` added to statuses
  * with an embedded quote for clients that don't display quotes (X may be any
  * element, not just `p`. For example, Akkoma inserts a `span` element).
  */
@@ -39,17 +37,23 @@ fun CharSequence.removeQuoteInline(): String {
     return this.replace(rxQuoteInline, "")
 }
 
+interface PachliTagHandler : Html.TagHandler {
+    /**
+     * Called before parsing the HTML, allowing the tag handler to
+     * rewrite any of the HTML (e.g., renaming tags) before it is
+     * processed by the [Html.TagHandler].
+     */
+    fun rewriteHtml(html: CharSequence): String = html.toString()
+}
+
 /**
- * parse a String containing html from the Mastodon api to Spanned
+ * Parses a String containing HTML from the Mastodon API to Spanned
  */
 @JvmOverloads
-fun CharSequence.parseAsMastodonHtml(tagHandler: TagHandler? = null): Spanned {
-    return this.replace(rxBR, "<br>&nbsp;")
-        .replace("<br /> ", "<br />&nbsp;")
-        .replace("<br/> ", "<br/>&nbsp;")
-        .replace("  ", "&nbsp;&nbsp;")
+fun CharSequence.parseAsMastodonHtml(tagHandler: PachliTagHandler? = null): Spanned {
+    return (tagHandler?.rewriteHtml(this) ?: this.toString())
         .parseAsHtml(tagHandler = tagHandler)
-        // Html.fromHtml returns trailing whitespace if the html ends in a </p> tag, which
+        // Html.fromHtml returns trailing whitespace if the HTML ends in a </p> tag, which
         // most status contents do, so it should be trimmed.
         .trimTrailingWhitespace()
 }

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/SetContent.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/SetContent.kt
@@ -19,7 +19,6 @@ package app.pachli.core.ui
 
 import android.content.Context
 import android.graphics.Color
-import android.text.Html
 import android.text.SpannableStringBuilder
 import android.text.Spanned
 import android.text.style.URLSpan
@@ -31,9 +30,11 @@ import app.pachli.core.designsystem.R
 import app.pachli.core.model.Emoji
 import app.pachli.core.model.HashTag
 import app.pachli.core.model.Status
+import app.pachli.core.network.PachliTagHandler
 import app.pachli.core.network.parseAsMastodonHtml
 import app.pachli.core.network.removeQuoteInline
 import app.pachli.core.ui.PreProcessMastodonHtml.processMarkdown
+import app.pachli.core.ui.taghandler.MastodonTagHandler
 import com.bumptech.glide.RequestManager
 import com.google.android.material.color.MaterialColors
 import com.mohamedrejeb.ksoup.entities.KsoupEntities
@@ -89,11 +90,11 @@ interface SetContent {
         removeQuoteInline: Boolean,
         mentions: List<Status.Mention>? = null,
         hashtags: List<HashTag>? = null,
-        tagHandler: Html.TagHandler? = null,
+        tagHandler: PachliTagHandler? = null,
         linkListener: LinkListener,
     ) {
         val spannableStringBuilder = SpannableStringBuilder().apply {
-            append(parseToSpanned(content, removeQuoteInline, tagHandler))
+            append(parseToSpanned(textView.context, content, removeQuoteInline, tagHandler))
 
             getSpans(0, length, URLSpan::class.java).forEach {
                 convertUrlSpanToMoreSpecificType(it, this, mentions, hashtags, linkListener)
@@ -138,11 +139,11 @@ interface SetContent {
      * @param content The content to parse, expected to be HTML.
      * @param removeQuoteInline If true, remove any `p` elements with a `quote-inline`
      * class as part of parsing.
-     * @param tagHandler Optional [Html.TagHandler] to use when parsing HTML.
+     * @param tagHandler Optional [PachliTagHandler] to use when parsing HTML.
      *
      * @return [content] converted to a [Spanned] string.
      */
-    fun parseToSpanned(content: CharSequence, removeQuoteInline: Boolean, tagHandler: Html.TagHandler? = null): Spanned
+    fun parseToSpanned(context: Context, content: CharSequence, removeQuoteInline: Boolean, tagHandler: PachliTagHandler? = null): Spanned
 }
 
 /**
@@ -150,14 +151,15 @@ interface SetContent {
  */
 object SetContentAsMastodonHtml : SetContent {
     override fun parseToSpanned(
+        context: Context,
         content: CharSequence,
         removeQuoteInline: Boolean,
-        tagHandler: Html.TagHandler?,
+        tagHandler: PachliTagHandler?,
     ): Spanned {
         return if (removeQuoteInline) {
-            content.removeQuoteInline().parseAsMastodonHtml(tagHandler = tagHandler)
+            content.removeQuoteInline().parseAsMastodonHtml(tagHandler = tagHandler ?: MastodonTagHandler(context))
         } else {
-            content.parseAsMastodonHtml(tagHandler = tagHandler)
+            content.parseAsMastodonHtml(tagHandler = tagHandler ?: MastodonTagHandler(context))
         }
     }
 }
@@ -198,7 +200,7 @@ class SetContentAsMarkdown(context: Context) : SetContent {
         .usePlugin(PachliMarkwonTheme(context))
         .build()
 
-    override fun parseToSpanned(content: CharSequence, removeQuoteInline: Boolean, tagHandler: Html.TagHandler?): Spanned {
+    override fun parseToSpanned(context: Context, content: CharSequence, removeQuoteInline: Boolean, tagHandler: PachliTagHandler?): Spanned {
         return markwon.toMarkdown(if (removeQuoteInline) content.removeQuoteInline() else content.toString())
     }
 }

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/taghandler/LeadingMarginWithTextSpan.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/taghandler/LeadingMarginWithTextSpan.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.core.ui.taghandler
+
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.text.Layout
+import android.text.Spanned
+import android.text.style.LeadingMarginSpan
+import kotlin.math.roundToInt
+
+fun interface ComputeLeadingMarginWithTextSpanText {
+    /**
+     * Returns the text to display.
+     *
+     * @param dir Positive if the text will be displayed LTR, negative
+     * if the text will be displayed RTL.
+     */
+    operator fun invoke(dir: Int): String
+}
+
+/**
+ * A [LeadingMarginSpan][android.text.style.LeadingMarginSpan] that shows text
+ * inside the margin.
+ *
+ * The leading margin is sized to provide enough room to show the text `99. `,
+ * so this can be used for lists of up to 99 items.
+ *
+ * The text to display in the margin should be provided by [computeMarginText].
+ *
+ * Within the margin the text is aligned according to [alignment].
+ *
+ * @param indentation 0-based indentation level of this item.
+ * @param alignment See [Alignment].
+ * @param computeMarginText See [ComputeLeadingMarginWithTextSpanText.invoke]
+ */
+class LeadingMarginWithTextSpan(
+    private val indentation: Int,
+    private val alignment: Alignment = Alignment.END,
+    private val computeMarginText: ComputeLeadingMarginWithTextSpanText,
+) : LeadingMarginSpan {
+    private var marginWidth: Int = 0
+
+    private var marginText: String? = null
+
+    /** How text in the leading margin should be aligned. */
+    enum class Alignment {
+        /** Text aligned to the start of the margin. */
+        START,
+
+        /** Text centered between the start and end of the margin. */
+        CENTER,
+
+        /** Text aligned to the end of the margin. */
+        END,
+    }
+
+    override fun drawLeadingMargin(
+        c: Canvas,
+        p: Paint,
+        x: Int,
+        dir: Int,
+        top: Int,
+        baseline: Int,
+        bottom: Int,
+        text: CharSequence,
+        start: Int,
+        end: Int,
+        first: Boolean,
+        l: Layout,
+    ) {
+        // Margin is sized to allow enough space for "99. " in the active font.
+        marginWidth = p.measureText("99. ").roundToInt()
+
+        val startCharOfSpan = (text as Spanned).getSpanStart(this)
+        val isFirstChar = startCharOfSpan == start
+
+        if (!isFirstChar) return
+
+        val computedMarginText = if (marginText == null) {
+            marginText = computeMarginText(dir)
+            marginText!!
+        } else {
+            marginText!!
+        }
+        val marginTextWidth = p.measureText(computedMarginText)
+
+        val xOffset = when (alignment) {
+            Alignment.START -> 0f
+            Alignment.CENTER -> (marginWidth - marginTextWidth) / 2
+            Alignment.END -> if (dir > 0) marginWidth - marginTextWidth else -(marginWidth - marginTextWidth)
+        }
+
+        // Some Android versions have a bug where `x` is always 0 (e.g., API 28).
+        // Calculate the correct value.
+        val trueX: Int = if (dir > 0) {
+            marginWidth * indentation
+        } else {
+            c.width - if (marginWidth * indentation == 0) {
+                marginTextWidth.roundToInt()
+            } else {
+                marginWidth * indentation
+            }
+        }
+        c.drawText(computedMarginText, trueX + xOffset, baseline.toFloat(), p)
+    }
+
+    override fun getLeadingMargin(first: Boolean): Int = marginWidth
+}

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/taghandler/Mark.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/taghandler/Mark.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.core.ui.taghandler
+
+/** Spans used to mark the start of HTML tags. */
+interface Mark {
+    /** Marks the opening tag location of a `code` element. */
+    object Code : Mark
+
+    /**
+     * Marks the opening tag location of a list item in an <ol> element.
+     *
+     * @property number The list item's 1-based position in the list.
+     */
+    class OrderedListItem(val number: Int) : Mark
+
+    /** Marks the opening tag location of a list item in an <ul> element. */
+    object UnorderedListItem : Mark
+}

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/taghandler/MastodonTagHandler.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/taghandler/MastodonTagHandler.kt
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2026 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.core.ui.taghandler
+
+import android.content.Context
+import android.graphics.Color
+import android.text.Editable
+import android.text.style.BackgroundColorSpan
+import android.text.style.ForegroundColorSpan
+import android.text.style.TypefaceSpan
+import app.pachli.core.network.PachliTagHandler
+import app.pachli.core.ui.taghandler.LeadingMarginWithTextSpan.Alignment
+import app.pachli.core.ui.taghandler.Mark.Code
+import app.pachli.core.ui.taghandler.Mark.OrderedListItem
+import app.pachli.core.ui.taghandler.Mark.UnorderedListItem
+import com.google.android.material.color.MaterialColors
+import java.util.Stack
+import org.xml.sax.XMLReader
+
+/**
+ * Matches `<br> ` and variants with an internal space or self-closing
+ * `/` character.
+ *
+ * - `<br> `
+ * - `<br > `
+ * - `<br/> `
+ * - `<br /> `
+ *
+ * etc.
+ */
+private val rxBR = """(?i)<br(?<inner>\s*/)?> """.toRegex()
+
+/**
+ * Matches opening and closing `ul`, `ol`, and `li` tags.
+ *
+ * The `/` in a (possible) closing tag is saved in `$bl`. The tag name is
+ * saved in `$tag`.
+ */
+private val rxListTags = """(?i)<(?<bl>/)?(?<tag>li|ol|ul)[^>]*>""".toRegex()
+
+/**
+ * Handles HTML elements that may appear in Mastodon content and are not handled
+ * by [HtmlCompat.fromHtml][androidx.core.text.HtmlCompat.fromHtml].
+ *
+ * The elements Mastodon may use are described at
+ * https://docs.joinmastodon.org/spec/activitypub/#sanitization
+ *
+ * Of those, the elements that require custom handling are:
+ *
+ * - `code` (not supported by HtmlCompat)
+ * - `pre` (not supported by HtmlCompat)
+ * - `ol / li` (not supported by HtmlCompat, rewritten to pachli-ol)
+ * - `ul / li` (supported by HtmlCompat, but badly, rewritten to pachli-ul)
+ */
+class MastodonTagHandler(context: Context) : PachliTagHandler {
+    /** Stack of currently open `ol` and `ul` lists. */
+    private val lists = Stack<ListElementHandler>()
+
+    private val codeHandler = CodeHandler(context)
+
+    override fun rewriteHtml(html: CharSequence): String {
+        // Can't use named match groups here (e.g., code like
+        // `.replace(rxListTags, $$"<${bl}pachli-${tag}>")` because named
+        // match groups aren't supported on Android < API 26.
+        //
+        // Can't use numbered match groups either (e.g., code like
+        // `.replace(rxListTags, $$"<$1pachli-$2>")` because if the numbered
+        // match group didn't match anything it interpolates into the string
+        // as the literal text `null`.
+        //
+        // So use a transform function that can handle both of these cases.
+        return html
+            .replace(rxBR, { "<br${it.groups[1]?.value ?: ""}>&nbsp;" })
+            .replace("  ", "&nbsp;&nbsp;")
+            .replace(
+                rxListTags,
+                { "<${it.groups[1]?.value ?: ""}pachli-${it.groups[2]?.value}>" },
+            )
+    }
+
+    override fun handleTag(opening: Boolean, tag: String, output: Editable, xmlReader: XMLReader) {
+        // `ul`, `ol`, and `li` were re-written to have a `pachli-` prefix in
+        // `rewriteHtml`.
+        //
+        // `code` and `pre` aren't handled by the default tag handler, so can
+        // be used as is.
+        when (tag.lowercase()) {
+            "pachli-ul" -> if (opening) {
+                lists.push(UnorderedListElementHandler())
+            } else {
+                if (lists.isNotEmpty()) lists.pop()
+            }
+
+            "pachli-ol" -> if (opening) {
+                lists.push(OrderedListElementHandler())
+            } else {
+                if (lists.isNotEmpty()) lists.pop()
+            }
+
+            "pachli-li" -> if (opening) {
+                if (lists.isNotEmpty()) lists.peek().startListItem(output)
+            } else {
+                if (lists.isNotEmpty()) lists.peek().endListItem(output, indentation = lists.size - 1)
+            }
+
+            "code", "pre" -> if (opening) {
+                codeHandler.startElement(output)
+            } else {
+                codeHandler.endElement(output)
+            }
+        }
+    }
+}
+
+private interface ElementHandler {
+    /**
+     * Called when the element's start tag is encountered.
+     *
+     * @param text The current content, up to, but not including, the start
+     * tag.
+     */
+    fun startElement(text: Editable) = Unit
+
+    /**
+     * Called when the element's end tag is encountered.
+     *
+     * @param text The current content, up to, but not including, the end
+     * tag.
+     */
+    fun endElement(text: Editable) = Unit
+}
+
+private interface ListElementHandler : ElementHandler {
+    /** Called when an opening <li> tag is encountered. */
+    fun startListItem(text: Editable) = Unit
+
+    /** Called when a closing </li> tag is encountered. */
+    fun endListItem(text: Editable, indentation: Int) = Unit
+}
+
+/**
+ * Processes inline `code` elements.
+ *
+ * Marks the `<code>` tag. `</code>` inserts spans between the start
+ * and end tags setting the font family and foreground/background colours.
+ */
+private class CodeHandler(context: Context) : ElementHandler {
+    private val bgColor = MaterialColors.getColor(
+        context,
+        com.google.android.material.R.attr.colorSurfaceContainerLow,
+        Color.WHITE,
+    )
+    private val fgColor = MaterialColors.getColor(
+        context,
+        com.google.android.material.R.attr.colorOnSurfaceVariant,
+        Color.BLACK,
+    )
+
+    private val typefaceSpan = TypefaceSpan("monospace")
+    private val fgColorSpan = ForegroundColorSpan(fgColor)
+    private val bgColorSpan = BackgroundColorSpan(bgColor)
+
+    override fun startElement(text: Editable) {
+        text.appendMark(Code)
+    }
+
+    override fun endElement(text: Editable) {
+        text.getLastSpanOrNull<Code>()?.let { mark ->
+            text.setSpansFromMark(mark, typefaceSpan, fgColorSpan, bgColorSpan)
+        }
+    }
+}
+
+/**
+ * Processes unordered lists and their `li` contents.
+ *
+ * Marks the `<li>` tag. `</li>` tags insert a [LeadingMarginWithTextSpan]
+ * between the start and end tag with a bullet character in the margin.
+ */
+private class UnorderedListElementHandler : ListElementHandler {
+    override fun startListItem(text: Editable) {
+        text.ensureEndsWithNewline()
+        text.appendMark(UnorderedListItem)
+    }
+
+    override fun endListItem(text: Editable, indentation: Int) {
+        text.ensureEndsWithNewline()
+
+        text.getLastSpanOrNull<UnorderedListItem>()?.let { mark ->
+            text.setSpansFromMark(
+                mark,
+                LeadingMarginWithTextSpan(indentation, Alignment.CENTER) { "•" },
+            )
+        }
+    }
+}
+
+/**
+ * Processes ordered lists and their `li` contents.
+ *
+ * Marks the `<li>` tag. `</li>` tags insert a [LeadingMarginWithTextSpan]
+ * between the start and end tag, with the 1-based numbered index of the
+ * `li` element in the list.
+ */
+private class OrderedListElementHandler : ListElementHandler {
+    /** Count of total `li` tags seen in this ordered list. */
+    private var count = 1
+
+    override fun startListItem(text: Editable) {
+        text.ensureEndsWithNewline()
+        text.appendMark(OrderedListItem(count++))
+    }
+
+    override fun endListItem(text: Editable, indentation: Int) {
+        text.ensureEndsWithNewline()
+
+        text.getLastSpanOrNull<OrderedListItem>()?.let { mark ->
+            text.setSpansFromMark(
+                mark,
+                LeadingMarginWithTextSpan(indentation) {
+                    if (it > 0) {
+                        "${mark.number}. "
+                    } else {
+                        " .${mark.number}"
+                    }
+                },
+            )
+        }
+    }
+}

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/taghandler/SpannedExtensions.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/taghandler/SpannedExtensions.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.core.ui.taghandler
+
+import android.text.Editable
+import android.text.Spannable
+import android.text.Spanned
+import android.text.Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+import android.text.Spanned.SPAN_MARK_MARK
+
+/**
+ * @return The last span of type [T] in [Spanned], null if no such
+ * span exists.
+ */
+inline fun <reified T : Mark> Spanned.getLastSpanOrNull() =
+    getSpans(0, length, T::class.java).lastOrNull()
+
+/** Inserts a [mark] at the end of [Spannable]. */
+fun Spannable.appendMark(mark: Mark) {
+    val len = length
+    setSpan(mark, len, len, SPAN_MARK_MARK)
+}
+
+/**
+ * Finds [mark], and sets [spans] over [Spannable] from [mark] to the
+ * end of [Spannable].
+ */
+fun Spannable.setSpansFromMark(mark: Mark, vararg spans: Any) {
+    val start = getSpanStart(mark)
+    removeSpan(mark)
+
+    val end = length
+    if (start != end) {
+        spans.forEach {
+            setSpan(it, start, end, SPAN_EXCLUSIVE_EXCLUSIVE)
+        }
+    }
+}
+
+/** Ensures [Editable] ends with a new line. */
+fun Editable.ensureEndsWithNewline() {
+    if (isNotEmpty() && last() != '\n') append("\n")
+}


### PR DESCRIPTION
Mastodon extended the list of supported HTML elements in 4.2.0, but didn't mention it in the release notes.

https://docs.joinmastodon.org/spec/activitypub/#sanitization has the list of supported elements.

Most of them are handled by Android, but a few are not, or are handled badly. They are:

- `code`
- `pre`
- `ol` / `li`
- `ul` / `li`

Provide a `MastodonTagHandler` that handles these, by creating appropriate spans in the content.

In particular, a new `LeadingMarginWithTextSpan` is used to create spans with a leading margin that can contain text -- typically either bullets for `ul` or numbers for `ol`.

The margin is sized to allow space for an `li` labeled `99. `, which should hopefully be enough for use on Mastodon and similar servers. The labels respect LTR and RTL locales, but do not allow setting custom labels (e.g., through the `type` or `start` attributes on the content) because Android's tag handler system does not pass the attributes down.

This duplicates some of the code in the pre-existing `PachliTagHandler`, so move that code to `core.ui.taghandler` and adjust as necessary.

Fixes #2217