### PR TITLE
feat: Add a setting to hide attachments by default

### DIFF
--- a/app/src/main/java/app/pachli/components/preference/PreferencesFragment.kt
+++ b/app/src/main/java/app/pachli/components/preference/PreferencesFragment.kt
@@ -310,6 +310,13 @@ class PreferencesFragment : PreferenceFragmentCompat() {
                     isSingleLineTitle = false
                 }
 
+                switchPreference {
+                    setDefaultValue(false)
+                    key = PrefKeys.HIDE_ATTACHMENTS
+                    setTitle(R.string.pref_title_hide_attachments)
+                    isSingleLineTitle = false
+                }
+
                 enumListPreference<DefaultAudioPlayback> {
                     setDefaultValue(DefaultAudioPlayback.UNMUTED)
                     setTitle(R.string.pref_default_audio_playback)

--- a/app/src/main/java/app/pachli/components/search/SearchViewModel.kt
+++ b/app/src/main/java/app/pachli/components/search/SearchViewModel.kt
@@ -267,6 +267,7 @@ class SearchViewModel @Inject constructor(
                     quoteContentFilterAction = status.quotedStatus?.let { contentFilterModel.filterActionFor(it.status) },
                     filterContext = null,
                     showSensitiveMedia = pachliAccount.entity.alwaysShowSensitiveMedia,
+                    hideAttachments = statusDisplayOptions.hideAttachments,
                 )
             }.apply {
                 loadedStatuses.addAll(this)

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/CachedTimelineViewModel.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/CachedTimelineViewModel.kt
@@ -83,6 +83,7 @@ class CachedTimelineViewModel @AssistedInject constructor(
                         quoteContentFilterAction = timelineStatusWithQuote.quotedStatus?.let { contentFilterModel?.filterActionFor(it.status) },
                         showSensitiveMedia = pachliAccount.entity.alwaysShowSensitiveMedia,
                         filterContext = filterContext,
+                        hideAttachments = statusDisplayOptions.value.hideAttachments,
                     )
                 }
         }

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelineViewModel.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelineViewModel.kt
@@ -93,6 +93,7 @@ open class NetworkTimelineViewModel @AssistedInject constructor(
                         quoteContentFilterAction = timelineStatusWithQuote.quotedStatus?.let { contentFilterModel?.filterActionFor(it.status) },
                         showSensitiveMedia = pachliAccount.entity.alwaysShowSensitiveMedia,
                         filterContext = filterContext,
+                        hideAttachments = statusDisplayOptions.value.hideAttachments,
                     )
                 }
         }

--- a/app/src/main/java/app/pachli/components/viewthread/ViewThreadViewModel.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/ViewThreadViewModel.kt
@@ -160,6 +160,7 @@ class ViewThreadViewModel @Inject constructor(
                     quoteContentFilterAction = timelineStatusWithQuote.quotedStatus?.status?.let { contentFilterModel?.filterActionFor(it) },
                     translationState = TranslationState.SHOW_ORIGINAL,
                     filterContext = FilterContext.CONVERSATIONS,
+                    hideAttachments = statusDisplayOptions.value.hideAttachments,
                 )
             } else {
                 Timber.d("Loading status from network")
@@ -502,6 +503,7 @@ class ViewThreadViewModel @Inject constructor(
             quoteContentFilterAction = quote?.let { contentFilterModel?.filterActionFor(it) },
             translationState = TranslationState.SHOW_ORIGINAL,
             filterContext = FilterContext.CONVERSATIONS,
+            hideAttachments = statusDisplayOptions.value.hideAttachments,
         )
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -480,6 +480,7 @@
     <string name="pref_title_confirm_reblogs">Show confirmation before boosting</string>
     <string name="pref_title_confirm_favourites">Show confirmation before favoriting</string>
     <string name="pref_title_confirm_status_language">Check post\'s language setting before posting</string>
+    <string name="pref_title_hide_attachments">Hide attachments by default</string>
     <string name="pref_title_hide_top_toolbar">Hide the title of the top toolbar</string>
     <string name="pref_title_wellbeing_mode">Wellbeing</string>
     <string name="account_note_hint">Your private note about this account</string>

--- a/core/data/src/main/kotlin/app/pachli/core/data/extensions/StatusExtensions.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/extensions/StatusExtensions.kt
@@ -42,6 +42,7 @@ fun Status.getAttachmentDisplayAction(filterContext: FilterContext?, showSensiti
     sensitive,
     showSensitiveMedia = showSensitiveMedia,
     cachedAction = cachedAction,
+    hideAttachments = false,
 )
 
 /**
@@ -52,17 +53,19 @@ fun Status.getAttachmentDisplayAction(filterContext: FilterContext?, showSensiti
  * not filtered (e.g., private messages).
  * @param showSensitiveMedia True if the user's preference is to show attachments
  * marked sensitive.
- * @param cachedAction
+ * @param hideAttachments True if attachments should be hidden by default
  */
 fun TimelineStatusWithAccount.getAttachmentDisplayAction(
     filterContext: FilterContext?,
     showSensitiveMedia: Boolean,
+    hideAttachments: Boolean,
 ) = getAttachmentDisplayAction(
     filterContext,
     status.filtered,
     status.sensitive,
     showSensitiveMedia = showSensitiveMedia,
     cachedAction = viewData?.attachmentDisplayAction,
+    hideAttachments = hideAttachments,
 )
 
 /**
@@ -73,9 +76,10 @@ fun TimelineStatusWithAccount.getAttachmentDisplayAction(
  * @param filterContext Applicable filter context. May be null for timelines that are
  * not filtered (e.g., private messages).
  * @param matchingFilters List of filters that matched the status.
- * @param sensitive True if the status was marked senstive.
+ * @param sensitive True if the status was marked sensitive.
  * @param showSensitiveMedia True if the user's preference is to show attachments
  * marked sensitive.
+ * @param hideAttachments True if attachments should be hidde by default
  * @param cachedAction
  */
 private fun getAttachmentDisplayAction(
@@ -83,6 +87,7 @@ private fun getAttachmentDisplayAction(
     matchingFilters: List<FilterResult>?,
     sensitive: Boolean,
     showSensitiveMedia: Boolean,
+    hideAttachments: Boolean,
     cachedAction: AttachmentDisplayAction?,
 ): AttachmentDisplayAction {
     // Hide attachments if there is any matching "blur" filter.
@@ -123,6 +128,11 @@ private fun getAttachmentDisplayAction(
     // see them.
     if (sensitive && !showSensitiveMedia) {
         return AttachmentDisplayAction.Hide(reason = AttachmentDisplayReason.Sensitive)
+    }
+
+    // Hide attachments if the user's preferences are to hide them by default
+    if (hideAttachments) {
+        return AttachmentDisplayAction.Hide(reason = AttachmentDisplayReason.Preferences)
     }
 
     // Attachment is OK, and can be shown.

--- a/core/data/src/main/kotlin/app/pachli/core/data/model/ConversationViewData.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/model/ConversationViewData.kt
@@ -83,6 +83,7 @@ data class ConversationViewData(
                 quoteContentFilterAction = quoteContentFilterAction,
                 showSensitiveMedia = showSensitiveMedia,
                 filterContext = FilterContext.from(Timeline.Conversations),
+                hideAttachments = false,
             ),
             isConversationStarter = conversationData.isConversationStarter,
             accountFilterDecision = accountFilterDecision,

--- a/core/data/src/main/kotlin/app/pachli/core/data/model/StatusDisplayOptions.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/model/StatusDisplayOptions.kt
@@ -78,4 +78,9 @@ data class StatusDisplayOptions(
     val showStatusInfo: Boolean = true,
 
     val pronounDisplay: PronounDisplay = PronounDisplay.WHEN_COMPOSING,
+
+    /**
+     * True if attachments should be hidden by default
+     */
+    val hideAttachments: Boolean = false,
 )

--- a/core/data/src/main/kotlin/app/pachli/core/data/model/StatusViewData.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/model/StatusViewData.kt
@@ -189,6 +189,7 @@ data class StatusItemViewData(
             quoteContentFilterAction: FilterAction?,
             translationState: TranslationState = TranslationState.SHOW_ORIGINAL,
             showSensitiveMedia: Boolean,
+            hideAttachments: Boolean,
             filterContext: FilterContext?,
         ): StatusItemViewData {
             return StatusItemViewData(
@@ -203,6 +204,7 @@ data class StatusItemViewData(
                     attachmentDisplayAction = timelineStatusWithQuote.timelineStatus.getAttachmentDisplayAction(
                         filterContext,
                         showSensitiveMedia,
+                        hideAttachments = hideAttachments,
                     ),
                     translationState = timelineStatusWithQuote.timelineStatus.viewData?.translationState ?: translationState,
                     replyToAccount = timelineStatusWithQuote.timelineStatus.replyAccount?.asModel(),
@@ -219,6 +221,7 @@ data class StatusItemViewData(
                         attachmentDisplayAction = status.getAttachmentDisplayAction(
                             filterContext,
                             showSensitiveMedia,
+                            hideAttachments = hideAttachments,
                         ),
                         translationState = status.viewData?.translationState ?: translationState,
                         replyToAccount = status.replyAccount?.asModel(),

--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/StatusDisplayOptionsRepository.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/StatusDisplayOptionsRepository.kt
@@ -76,6 +76,7 @@ class StatusDisplayOptionsRepository @Inject constructor(
         PrefKeys.SHOW_STATS_INLINE,
         PrefKeys.LAB_RENDER_MARKDOWN,
         PrefKeys.PRONOUN_DISPLAY,
+        PrefKeys.HIDE_ATTACHMENTS,
     )
 
     init {
@@ -130,6 +131,9 @@ class StatusDisplayOptionsRepository @Inject constructor(
                         PrefKeys.PRONOUN_DISPLAY -> prev.copy(
                             pronounDisplay = sharedPreferencesRepository.pronounDisplay,
                         )
+                        PrefKeys.HIDE_ATTACHMENTS -> prev.copy(
+                            hideAttachments = sharedPreferencesRepository.hideAttachments,
+                        )
                         else -> prev
                     }
                 }
@@ -183,6 +187,7 @@ class StatusDisplayOptionsRepository @Inject constructor(
             canQuote = account?.server?.can(ServerOperation.ORG_JOINMASTODON_STATUSES_QUOTE, ">=1.0.0".toConstraint()) ?: default.canQuote,
             renderMarkdown = sharedPreferencesRepository.renderMarkdown,
             pronounDisplay = sharedPreferencesRepository.pronounDisplay,
+            hideAttachments = sharedPreferencesRepository.hideAttachments,
         )
     }
 }

--- a/core/model/src/main/kotlin/app/pachli/core/model/AttachmentDisplayAction.kt
+++ b/core/model/src/main/kotlin/app/pachli/core/model/AttachmentDisplayAction.kt
@@ -51,6 +51,10 @@ sealed class AttachmentDisplayReason(val type: String) {
     /** The user hid the attachment using the UI. */
     @TypeLabel("userAction")
     data object UserAction : AttachmentDisplayReason("userAction")
+
+    /** The attachment was hidden due to user preference */
+    @TypeLabel("Preferences")
+    data object Preferences : AttachmentDisplayReason("preferences")
 }
 
 /** How to display attachments, with the reason for the action. */

--- a/core/preferences/src/main/kotlin/app/pachli/core/preferences/SettingsConstants.kt
+++ b/core/preferences/src/main/kotlin/app/pachli/core/preferences/SettingsConstants.kt
@@ -191,6 +191,11 @@ object PrefKeys {
      */
     const val CONFIRM_STATUS_LANGUAGE = "confirmStatusLanguage"
 
+    /**
+     * True if attachments should be hidden by default.
+     */
+    const val HIDE_ATTACHMENTS = "hideAttachments"
+
     /** Tab alignment. See [TabAlignment]. */
     const val TAB_ALIGNMENT = "tabAlignment"
 

--- a/core/preferences/src/main/kotlin/app/pachli/core/preferences/SharedPreferencesRepository.kt
+++ b/core/preferences/src/main/kotlin/app/pachli/core/preferences/SharedPreferencesRepository.kt
@@ -80,6 +80,13 @@ class SharedPreferencesRepository @Inject constructor(
             edit { putBoolean(PrefKeys.CONFIRM_STATUS_LANGUAGE, value) }
         }
 
+    /** True if attachments should be hidden by default. */
+    var hideAttachments: Boolean
+        get() = getBoolean(PrefKeys.HIDE_ATTACHMENTS, false)
+        set(value) {
+            edit { putBoolean(PrefKeys.HIDE_ATTACHMENTS, value) }
+        }
+
     /** How statuses should be translated. */
     var translationBackend: TranslationBackend
         get() = if (BuildConfig.FLAVOR_store != "google") {

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/extensions/AttachmentDisplayReasonExtensions.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/extensions/AttachmentDisplayReasonExtensions.kt
@@ -33,4 +33,5 @@ fun AttachmentDisplayReason.getFormattedDescription(context: Context) = when (th
     }
     is AttachmentDisplayReason.Sensitive -> context.getText(R.string.post_sensitive_media_title)
     is AttachmentDisplayReason.UserAction -> context.getText(R.string.attachment_hidden_user_action)
+    is AttachmentDisplayReason.Preferences -> context.getText(R.string.attachment_hidden_preferences)
 }

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/extensions/NotificationViewDataExtensions.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/extensions/NotificationViewDataExtensions.kt
@@ -87,6 +87,7 @@ fun NotificationViewData.Companion.make(
                 quoteContentFilterAction = quoteContentFilterAction,
                 showSensitiveMedia = showSensitiveMedia,
                 filterContext = FilterContext.NOTIFICATIONS,
+                hideAttachments = false,
             )
         },
     )
@@ -108,6 +109,7 @@ fun NotificationViewData.Companion.make(
                 quoteContentFilterAction = quoteContentFilterAction,
                 showSensitiveMedia = showSensitiveMedia,
                 filterContext = FilterContext.NOTIFICATIONS,
+                hideAttachments = false,
             )
         },
     )
@@ -129,6 +131,7 @@ fun NotificationViewData.Companion.make(
                 quoteContentFilterAction = quoteContentFilterAction,
                 showSensitiveMedia = showSensitiveMedia,
                 filterContext = FilterContext.NOTIFICATIONS,
+                hideAttachments = false,
             )
         },
     )
@@ -168,6 +171,7 @@ fun NotificationViewData.Companion.make(
                 quoteContentFilterAction = quoteContentFilterAction,
                 showSensitiveMedia = showSensitiveMedia,
                 filterContext = FilterContext.NOTIFICATIONS,
+                hideAttachments = false,
             )
         },
     )
@@ -189,6 +193,7 @@ fun NotificationViewData.Companion.make(
                 quoteContentFilterAction = quoteContentFilterAction,
                 showSensitiveMedia = showSensitiveMedia,
                 filterContext = FilterContext.NOTIFICATIONS,
+                hideAttachments = false,
             )
         },
     )
@@ -219,6 +224,7 @@ fun NotificationViewData.Companion.make(
                 quoteContentFilterAction = quoteContentFilterAction,
                 showSensitiveMedia = showSensitiveMedia,
                 filterContext = FilterContext.NOTIFICATIONS,
+                hideAttachments = false,
             )
         },
     )
@@ -270,6 +276,7 @@ fun NotificationViewData.Companion.make(
                 quoteContentFilterAction = quoteContentFilterAction,
                 showSensitiveMedia = showSensitiveMedia,
                 filterContext = FilterContext.NOTIFICATIONS,
+                hideAttachments = false,
             )
         },
     )
@@ -291,6 +298,7 @@ fun NotificationViewData.Companion.make(
                 quoteContentFilterAction = quoteContentFilterAction,
                 showSensitiveMedia = showSensitiveMedia,
                 filterContext = FilterContext.NOTIFICATIONS,
+                hideAttachments = false,
             )
         },
     )

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -109,6 +109,7 @@
     <string name="attachment_matches_filter_other_fmt">Matches filters: \"%1$s\", \"%2$s\", and more. Tap to show.</string>
     <string name="post_sensitive_media_title">Sensitive content. Tap to show.</string>
     <string name="attachment_hidden_user_action">You hid this. Tap to show.</string>
+    <string name="attachment_hidden_preferences">Hidden due to settings. Tap to show.</string>
     <string name="post_media_images">Images</string>
     <string name="post_media_audio">Audio</string>
     <string name="post_media_video">Video</string>


### PR DESCRIPTION
By default, scrolling through your timeline can be wrought with peril (especially in public). Adds a new setting that when enabled will hide all attachments default, behaving as if *everything* was marked sensitive.
Consider this the direct opposite to "Always show sensitive content". 

Looks like so when enabled:
<img width="803" height="580" alt="image" src="https://github.com/user-attachments/assets/194b207a-0a4c-492f-b666-d7a0c3b851b5" />
