### PR TITLE
fix: Encode user content that looks like HTML for display

### DIFF
--- a/app/src/main/java/app/pachli/adapter/FilterableStatusViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/FilterableStatusViewHolder.kt
@@ -19,6 +19,7 @@ package app.pachli.adapter
 
 import android.view.View
 import androidx.core.text.HtmlCompat
+import androidx.core.text.htmlEncode
 import app.pachli.core.data.model.IStatusViewData
 import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.model.ContentFilter
@@ -63,7 +64,7 @@ open class FilterableStatusViewHolder<T : IStatusViewData>(
             val label = HtmlCompat.fromHtml(
                 context.getString(
                     app.pachli.core.ui.R.string.status_filter_placeholder_label_format,
-                    result.filter.title,
+                    result.filter.title.htmlEncode(),
                 ),
                 HtmlCompat.FROM_HTML_MODE_LEGACY,
             )

--- a/app/src/main/java/app/pachli/adapter/FollowRequestViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/FollowRequestViewHolder.kt
@@ -18,6 +18,7 @@
 package app.pachli.adapter
 
 import androidx.core.text.HtmlCompat
+import androidx.core.text.htmlEncode
 import androidx.recyclerview.widget.RecyclerView
 import app.pachli.R
 import app.pachli.components.notifications.NotificationsPagingAdapter
@@ -93,7 +94,7 @@ class FollowRequestViewHolder(
             val wholeMessage = HtmlCompat.fromHtml(
                 itemView.context.getString(
                     R.string.notification_follow_request_format,
-                    displayName,
+                    displayName.htmlEncode(),
                 ),
                 HtmlCompat.FROM_HTML_MODE_LEGACY,
             )

--- a/app/src/main/java/app/pachli/adapter/StatusViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/StatusViewHolder.kt
@@ -19,6 +19,7 @@ package app.pachli.adapter
 import android.view.View
 import android.widget.TextView
 import androidx.core.text.HtmlCompat
+import androidx.core.text.htmlEncode
 import app.pachli.R
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
@@ -116,7 +117,7 @@ open class StatusViewHolder<T : IStatusViewData>(
                 HtmlCompat.fromHtml(
                     context.getString(
                         app.pachli.core.ui.R.string.post_replied_to_fmt,
-                        viewData.replyToAccount?.name.unicodeWrap(),
+                        viewData.replyToAccount?.name?.htmlEncode().unicodeWrap(),
                     ),
                     HtmlCompat.FROM_HTML_MODE_LEGACY,
                 ).emojify(
@@ -153,7 +154,7 @@ open class StatusViewHolder<T : IStatusViewData>(
         statusInfo.text = HtmlCompat.fromHtml(
             context.getString(
                 app.pachli.core.ui.R.string.post_boosted_fmt,
-                rebloggingAccount.name.unicodeWrap(),
+                rebloggingAccount.name.htmlEncode().unicodeWrap(),
             ),
             HtmlCompat.FROM_HTML_MODE_LEGACY,
         ).emojify(

--- a/app/src/main/java/app/pachli/components/notifications/FollowViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/notifications/FollowViewHolder.kt
@@ -18,6 +18,7 @@
 package app.pachli.components.notifications
 
 import androidx.core.text.HtmlCompat
+import androidx.core.text.htmlEncode
 import androidx.recyclerview.widget.RecyclerView
 import app.pachli.R
 import app.pachli.core.common.extensions.visible
@@ -72,7 +73,7 @@ class FollowViewHolder(
         showPronouns: Boolean,
     ) {
         val context = binding.notificationText.context
-        val displayName = account.name.unicodeWrap()
+        val displayName = account.name.htmlEncode().unicodeWrap()
         val msg = context.getString(
             if (isSignUp) {
                 R.string.notification_sign_up_format

--- a/app/src/main/java/app/pachli/components/notifications/NotificationHelper.kt
+++ b/app/src/main/java/app/pachli/components/notifications/NotificationHelper.kt
@@ -34,6 +34,7 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.RemoteInput
 import androidx.core.app.TaskStackBuilder
 import androidx.core.text.HtmlCompat
+import androidx.core.text.htmlEncode
 import androidx.work.Constraints
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.NetworkType
@@ -760,7 +761,7 @@ private fun titleForType(
     notification: Notification,
     account: AccountEntity,
 ): Spanned {
-    val accountName = notification.account.name.unicodeWrap()
+    val accountName = notification.account.name.htmlEncode().unicodeWrap()
     val htmlTitle = when (notification.type) {
         Notification.Type.MENTION -> {
             context.getString(R.string.notification_mention_format, accountName)

--- a/app/src/main/java/app/pachli/components/notifications/StatusNotificationViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/notifications/StatusNotificationViewHolder.kt
@@ -19,6 +19,7 @@ package app.pachli.components.notifications
 
 import android.widget.TextView
 import androidx.core.text.HtmlCompat
+import androidx.core.text.htmlEncode
 import androidx.core.util.TypedValueCompat.dpToPx
 import app.pachli.R
 import app.pachli.adapter.StatusViewDataDiffCallback
@@ -95,7 +96,7 @@ internal class StatusNotificationViewHolder(
         statusDisplayOptions: StatusDisplayOptions,
         listener: StatusActionListener,
     ) {
-        val displayName = viewData.account.name.unicodeWrap()
+        val displayName = viewData.account.name.htmlEncode().unicodeWrap()
         val msg = when (viewData) {
             is FavouriteNotificationViewData -> context.getString(R.string.notification_favourite_format, displayName)
             is ReblogNotificationViewData -> context.getString(R.string.notification_reblog_format, displayName)

--- a/app/src/main/java/app/pachli/util/ListStatusAccessibilityDelegate.kt
+++ b/app/src/main/java/app/pachli/util/ListStatusAccessibilityDelegate.kt
@@ -7,6 +7,7 @@ import android.widget.Checkable
 import android.widget.Toast
 import androidx.core.text.HtmlCompat
 import androidx.core.text.HtmlCompat.FROM_HTML_MODE_LEGACY
+import androidx.core.text.htmlEncode
 import androidx.core.view.AccessibilityDelegateCompat
 import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
 import androidx.core.view.accessibility.AccessibilityNodeInfoCompat.AccessibilityActionCompat
@@ -292,7 +293,7 @@ class ListStatusAccessibilityDelegate<T : IStatusItemViewData>(
                 showPronounsAction.id -> {
                     val pronouns = status.actionable.account.pronouns?.trim()
                     if (pronouns.isNullOrBlank()) return true
-                    val formatted = HtmlCompat.fromHtml(pronouns, FROM_HTML_MODE_LEGACY)
+                    val formatted = HtmlCompat.fromHtml(pronouns.htmlEncode(), FROM_HTML_MODE_LEGACY)
                     Toast.makeText(context, formatted, Toast.LENGTH_LONG).show()
                 }
 

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/PreviewCardView.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/PreviewCardView.kt
@@ -24,6 +24,7 @@ import android.view.LayoutInflater
 import androidx.annotation.Px
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.text.HtmlCompat
+import androidx.core.text.htmlEncode
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
 import app.pachli.core.common.string.unicodeWrap
@@ -221,7 +222,7 @@ class PreviewCardView @JvmOverloads constructor(
         when {
             // Author has an account, link to that, with their avatar.
             author?.account != null -> {
-                val name = author.account?.name.unicodeWrap()
+                val name = author.account?.name?.htmlEncode().unicodeWrap()
                 authorInfo.text = HtmlCompat.fromHtml(
                     authorInfo.context.getString(R.string.preview_card_byline_fediverse_account_fmt, name),
                     HtmlCompat.FROM_HTML_MODE_LEGACY,
@@ -245,7 +246,7 @@ class PreviewCardView @JvmOverloads constructor(
             // https://github.com/mastodon/mastodon/issues/33139).
             !author?.name.isNullOrBlank() -> {
                 authorInfo.text = HtmlCompat.fromHtml(
-                    authorInfo.context.getString(R.string.preview_card_byline_name_only_fmt, author.name),
+                    authorInfo.context.getString(R.string.preview_card_byline_name_only_fmt, author.name.htmlEncode()),
                     HtmlCompat.FROM_HTML_MODE_LEGACY,
                 )
                 authorInfo.setCompoundDrawablesRelativeWithIntrinsicBounds(null, null, null, null)

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/PronounsChip.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/PronounsChip.kt
@@ -22,6 +22,7 @@ import android.util.AttributeSet
 import android.widget.Toast
 import androidx.core.text.HtmlCompat
 import androidx.core.text.HtmlCompat.FROM_HTML_MODE_LEGACY
+import androidx.core.text.htmlEncode
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
 import com.google.android.material.chip.Chip
@@ -45,7 +46,7 @@ open class PronounsChip @JvmOverloads constructor(
             hide()
             setOnClickListener(null)
         } else {
-            val formatted = HtmlCompat.fromHtml(text.toString().trim(), FROM_HTML_MODE_LEGACY)
+            val formatted = HtmlCompat.fromHtml(text.toString().trim().htmlEncode(), FROM_HTML_MODE_LEGACY)
             super.setText(formatted, type)
             setOnClickListener { Toast.makeText(context, formatted, Toast.LENGTH_LONG).show() }
             show()

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/QuotedStatusView.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/QuotedStatusView.kt
@@ -21,6 +21,7 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import androidx.core.text.HtmlCompat
+import androidx.core.text.htmlEncode
 import androidx.core.util.TypedValueCompat.dpToPx
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
@@ -136,7 +137,7 @@ class QuotedStatusView @JvmOverloads constructor(
                     val label = HtmlCompat.fromHtml(
                         context.getString(
                             R.string.status_filter_placeholder_label_format,
-                            filters.first().filter.title,
+                            filters.first().filter.title.htmlEncode(),
                         ),
                         HtmlCompat.FROM_HTML_MODE_LEGACY,
                     )


### PR DESCRIPTION
Some user content (e.g., display names, pronouns, filter titles) might contain HTML characters (e.g., "</Antir>"). If these are passed through `fromHtml` the content is corrupted, and in some cases disappears.

For example, in the string "</Antir> boosted" for boosted posts the `</Antir>` text disappears.

Fix this by calling `htmlEncode()` on user generated content before it is passed to `htmlHtml`.

Reported by https://github.com/anauta in #2180