### PR TITLE
feat: Add an option to underline links

### DIFF
--- a/app/src/main/java/app/pachli/adapter/FollowRequestViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/FollowRequestViewHolder.kt
@@ -31,6 +31,7 @@ import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.designsystem.R as DR
 import app.pachli.core.model.TimelineAccount
 import app.pachli.core.network.parseAsMastodonHtml
+import app.pachli.core.preferences.LinksToUnderline
 import app.pachli.core.preferences.PronounDisplay
 import app.pachli.core.ui.LinkListener
 import app.pachli.core.ui.SetContent
@@ -70,6 +71,7 @@ class FollowRequestViewHolder(
                 PronounDisplay.HIDE,
                 -> false
             },
+            statusDisplayOptions.linksToUnderline,
         )
 
         setupActionListener(accountActionListener, viewData.account.id)
@@ -81,6 +83,7 @@ class FollowRequestViewHolder(
         animateEmojis: Boolean,
         showBotOverlay: Boolean,
         showPronouns: Boolean,
+        linksToUnderline: Set<LinksToUnderline>,
     ) {
         val displayName = account.name.unicodeWrap()
         val emojifiedName: CharSequence = displayName.emojify(
@@ -128,6 +131,7 @@ class FollowRequestViewHolder(
                 emojis = account.emojis.orEmpty(),
                 animateEmojis = animateEmojis,
                 removeQuoteInline = false,
+                linksToUnderline = linksToUnderline,
                 linkListener = linkListener,
             )
 

--- a/app/src/main/java/app/pachli/components/account/AccountActivity.kt
+++ b/app/src/main/java/app/pachli/components/account/AccountActivity.kt
@@ -162,6 +162,7 @@ class AccountActivity :
 
     private val animateAvatar by unsafeLazy { sharedPreferencesRepository.animateAvatars }
     private val animateEmojis by unsafeLazy { sharedPreferencesRepository.animateEmojis }
+    private val linksToUnderline by unsafeLazy { sharedPreferencesRepository.linksToUnderline }
 
     // fields for scroll animation
     private var hideFab: Boolean = false
@@ -276,7 +277,13 @@ class AccountActivity :
         binding.accountFollowsYouChip.hide()
 
         // setup the RecyclerView for the account fields
-        accountFieldAdapter = AccountFieldAdapter(glide, setContent, this, animateEmojis)
+        accountFieldAdapter = AccountFieldAdapter(
+            glide,
+            setContent,
+            this,
+            animateEmojis,
+            linksToUnderline,
+        )
         binding.accountFieldList.isNestedScrollingEnabled = false
         binding.accountFieldList.layoutManager = LinearLayoutManager(this)
         binding.accountFieldList.adapter = accountFieldAdapter
@@ -558,6 +565,7 @@ class AccountActivity :
             emojis = account.emojis.orEmpty(),
             animateEmojis = viewModel.statusDisplayOptions.value.animateEmojis,
             removeQuoteInline = false,
+            linksToUnderline = viewModel.statusDisplayOptions.value.linksToUnderline,
             linkListener = this,
         )
 

--- a/app/src/main/java/app/pachli/components/account/AccountFieldAdapter.kt
+++ b/app/src/main/java/app/pachli/components/account/AccountFieldAdapter.kt
@@ -22,6 +22,7 @@ import androidx.recyclerview.widget.RecyclerView
 import app.pachli.R
 import app.pachli.core.model.Emoji
 import app.pachli.core.model.Field
+import app.pachli.core.preferences.LinksToUnderline
 import app.pachli.core.ui.BindingHolder
 import app.pachli.core.ui.LinkListener
 import app.pachli.core.ui.SetContent
@@ -34,6 +35,7 @@ class AccountFieldAdapter(
     private val setContent: SetContent,
     private val linkListener: LinkListener,
     private val animateEmojis: Boolean,
+    private val linksToUnderline: Set<LinksToUnderline>,
 ) : RecyclerView.Adapter<BindingHolder<ItemAccountFieldBinding>>() {
 
     var emojis: List<Emoji> = emptyList()
@@ -61,6 +63,7 @@ class AccountFieldAdapter(
             emojis = emojis,
             animateEmojis = animateEmojis,
             removeQuoteInline = false,
+            linksToUnderline = linksToUnderline,
             linkListener = linkListener,
         )
 

--- a/app/src/main/java/app/pachli/components/accountlist/AccountListFragment.kt
+++ b/app/src/main/java/app/pachli/components/accountlist/AccountListFragment.kt
@@ -145,6 +145,7 @@ class AccountListFragment :
             PronounDisplay.HIDE,
             -> false
         }
+        val linksToUnderline = sharedPreferencesRepository.linksToUnderline
 
         val activeAccount = accountManager.activeAccount!!
 
@@ -158,8 +159,8 @@ class AccountListFragment :
             }
 
             adapter = when (kind) {
-                BLOCKS -> BlocksAdapter(glide, this@AccountListFragment, animateAvatar, animateEmojis, showBotOverlay, showPronouns)
-                MUTES -> MutesAdapter(glide, this@AccountListFragment, animateAvatar, animateEmojis, showBotOverlay, showPronouns)
+                BLOCKS -> BlocksAdapter(glide, this@AccountListFragment, animateAvatar, animateEmojis, showBotOverlay, showPronouns, linksToUnderline)
+                MUTES -> MutesAdapter(glide, this@AccountListFragment, animateAvatar, animateEmojis, showBotOverlay, showPronouns, linksToUnderline)
                 FOLLOW_REQUESTS -> {
                     val headerAdapter = FollowRequestsHeaderAdapter(
                         instanceName = activeAccount.domain,
@@ -174,6 +175,7 @@ class AccountListFragment :
                         animateEmojis,
                         showBotOverlay,
                         showPronouns,
+                        linksToUnderline,
                     )
                     binding.recyclerView.adapter = ConcatAdapter(headerAdapter, followRequestsAdapter)
                     followRequestsAdapter
@@ -186,6 +188,7 @@ class AccountListFragment :
                     animateEmojis,
                     showBotOverlay,
                     showPronouns,
+                    linksToUnderline,
                 )
             }
             if (binding.recyclerView.adapter == null) {

--- a/app/src/main/java/app/pachli/components/accountlist/adapter/AccountAdapter.kt
+++ b/app/src/main/java/app/pachli/components/accountlist/adapter/AccountAdapter.kt
@@ -19,6 +19,7 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import app.pachli.core.model.TimelineAccount
+import app.pachli.core.preferences.LinksToUnderline
 import app.pachli.core.ui.BindingHolder
 import app.pachli.databinding.ItemFooterBinding
 import app.pachli.interfaces.AccountActionListener
@@ -31,6 +32,7 @@ abstract class AccountAdapter<AVH : RecyclerView.ViewHolder> internal constructo
     protected val animateEmojis: Boolean,
     protected val showBotOverlay: Boolean,
     protected val showPronouns: Boolean,
+    protected val linksToUnderline: Set<LinksToUnderline>,
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder?>() {
 
     protected var accountList: MutableList<TimelineAccount> = mutableListOf()

--- a/app/src/main/java/app/pachli/components/accountlist/adapter/BlocksAdapter.kt
+++ b/app/src/main/java/app/pachli/components/accountlist/adapter/BlocksAdapter.kt
@@ -20,6 +20,7 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import app.pachli.core.common.extensions.visible
 import app.pachli.core.designsystem.R as DR
+import app.pachli.core.preferences.LinksToUnderline
 import app.pachli.core.ui.BindingHolder
 import app.pachli.core.ui.emojify
 import app.pachli.core.ui.loadAvatar
@@ -35,12 +36,14 @@ class BlocksAdapter(
     animateEmojis: Boolean,
     showBotOverlay: Boolean,
     showPronouns: Boolean,
+    linksToUnderline: Set<LinksToUnderline>,
 ) : AccountAdapter<BindingHolder<ItemBlockedUserBinding>>(
     accountActionListener = accountActionListener,
     animateAvatar = animateAvatar,
     animateEmojis = animateEmojis,
     showBotOverlay = showBotOverlay,
     showPronouns = showPronouns,
+    linksToUnderline = linksToUnderline,
 ) {
 
     override fun createAccountViewHolder(parent: ViewGroup): BindingHolder<ItemBlockedUserBinding> {

--- a/app/src/main/java/app/pachli/components/accountlist/adapter/FollowAdapter.kt
+++ b/app/src/main/java/app/pachli/components/accountlist/adapter/FollowAdapter.kt
@@ -19,6 +19,7 @@ package app.pachli.components.accountlist.adapter
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import app.pachli.adapter.AccountViewHolder
+import app.pachli.core.preferences.LinksToUnderline
 import app.pachli.databinding.ItemAccountBinding
 import app.pachli.interfaces.AccountActionListener
 import com.bumptech.glide.RequestManager
@@ -31,12 +32,14 @@ class FollowAdapter(
     animateEmojis: Boolean,
     showBotOverlay: Boolean,
     showPronouns: Boolean,
+    linksToUnderline: Set<LinksToUnderline>,
 ) : AccountAdapter<AccountViewHolder>(
     accountActionListener = accountActionListener,
     animateAvatar = animateAvatar,
     animateEmojis = animateEmojis,
     showBotOverlay = showBotOverlay,
     showPronouns = showPronouns,
+    linksToUnderline = linksToUnderline,
 ) {
 
     override fun createAccountViewHolder(parent: ViewGroup): AccountViewHolder {

--- a/app/src/main/java/app/pachli/components/accountlist/adapter/FollowRequestsAdapter.kt
+++ b/app/src/main/java/app/pachli/components/accountlist/adapter/FollowRequestsAdapter.kt
@@ -19,6 +19,7 @@ package app.pachli.components.accountlist.adapter
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import app.pachli.adapter.FollowRequestViewHolder
+import app.pachli.core.preferences.LinksToUnderline
 import app.pachli.core.ui.LinkListener
 import app.pachli.core.ui.SetContent
 import app.pachli.databinding.ItemFollowRequestBinding
@@ -35,12 +36,14 @@ class FollowRequestsAdapter(
     animateEmojis: Boolean,
     showBotOverlay: Boolean,
     showPronouns: Boolean,
+    linksToUnderline: Set<LinksToUnderline>,
 ) : AccountAdapter<FollowRequestViewHolder>(
     accountActionListener = accountActionListener,
     animateAvatar = animateAvatar,
     animateEmojis = animateEmojis,
     showBotOverlay = showBotOverlay,
     showPronouns = showPronouns,
+    linksToUnderline = linksToUnderline,
 ) {
 
     override fun createAccountViewHolder(parent: ViewGroup): FollowRequestViewHolder {
@@ -66,6 +69,7 @@ class FollowRequestsAdapter(
             animateEmojis = animateEmojis,
             showBotOverlay = showBotOverlay,
             showPronouns = showPronouns,
+            linksToUnderline = linksToUnderline,
         )
         viewHolder.setupActionListener(accountActionListener, accountList[position].id)
     }

--- a/app/src/main/java/app/pachli/components/accountlist/adapter/MutesAdapter.kt
+++ b/app/src/main/java/app/pachli/components/accountlist/adapter/MutesAdapter.kt
@@ -22,6 +22,7 @@ import androidx.core.view.ViewCompat
 import app.pachli.R
 import app.pachli.core.common.extensions.visible
 import app.pachli.core.designsystem.R as DR
+import app.pachli.core.preferences.LinksToUnderline
 import app.pachli.core.ui.BindingHolder
 import app.pachli.core.ui.emojify
 import app.pachli.core.ui.loadAvatar
@@ -37,12 +38,14 @@ class MutesAdapter(
     animateEmojis: Boolean,
     showBotOverlay: Boolean,
     showPronouns: Boolean,
+    linksToUnderline: Set<LinksToUnderline>,
 ) : AccountAdapter<BindingHolder<ItemMutedUserBinding>>(
     accountActionListener = accountActionListener,
     animateAvatar = animateAvatar,
     animateEmojis = animateEmojis,
     showBotOverlay = showBotOverlay,
     showPronouns = showPronouns,
+    linksToUnderline = linksToUnderline,
 ) {
 
     private val mutingNotificationsMap = HashMap<String, Boolean>()

--- a/app/src/main/java/app/pachli/components/announcements/AnnouncementAdapter.kt
+++ b/app/src/main/java/app/pachli/components/announcements/AnnouncementAdapter.kt
@@ -29,6 +29,7 @@ import app.pachli.R
 import app.pachli.core.common.extensions.visible
 import app.pachli.core.common.util.AbsoluteTimeFormatter
 import app.pachli.core.model.Announcement
+import app.pachli.core.preferences.LinksToUnderline
 import app.pachli.core.ui.BindingHolder
 import app.pachli.core.ui.EmojiSpan
 import app.pachli.core.ui.LinkListener
@@ -41,7 +42,6 @@ import app.pachli.util.equalByMinute
 import com.bumptech.glide.RequestManager
 import com.bumptech.glide.request.target.Target
 import com.google.android.material.chip.Chip
-import kotlin.collections.emptyList
 
 interface AnnouncementActionListener : LinkListener {
     fun openReactionPicker(announcementId: String, target: View)
@@ -56,6 +56,7 @@ class AnnouncementAdapter(
     private val listener: AnnouncementActionListener,
     private val hideStatsInDetailedPosts: Boolean = false,
     private val animateEmojis: Boolean = false,
+    private val linksToUnderline: Set<LinksToUnderline>,
     private val useAbsoluteTime: Boolean = false,
 ) : RecyclerView.Adapter<BindingHolder<ItemAnnouncementBinding>>() {
     private val absoluteTimeFormatter = AbsoluteTimeFormatter()
@@ -102,6 +103,7 @@ class AnnouncementAdapter(
             emojis = item.emojis,
             animateEmojis = animateEmojis,
             removeQuoteInline = false,
+            linksToUnderline = linksToUnderline,
             linkListener = listener,
         )
 

--- a/app/src/main/java/app/pachli/components/announcements/AnnouncementsActivity.kt
+++ b/app/src/main/java/app/pachli/components/announcements/AnnouncementsActivity.kt
@@ -99,6 +99,7 @@ class AnnouncementsActivity :
         val hideStatsInDetailedPosts = sharedPreferencesRepository.hideStatsInDetailedView
         val animateEmojis = sharedPreferencesRepository.animateEmojis
         val useAbsoluteTime = sharedPreferencesRepository.useAbsoluteTime
+        val linksToUnderline = sharedPreferencesRepository.linksToUnderline
 
         val setContent = if (viewModel.statusDisplayOptions.value.renderMarkdown) {
             SetContentAsMarkdown(this)
@@ -113,6 +114,7 @@ class AnnouncementsActivity :
             this,
             hideStatsInDetailedPosts,
             animateEmojis,
+            linksToUnderline,
             useAbsoluteTime,
         )
 

--- a/app/src/main/java/app/pachli/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeActivity.kt
@@ -711,10 +711,9 @@ class ComposeActivity :
         )
         binding.composeEditField.setTokenizer(ComposeTokenizer())
 
-        val mentionColour = binding.composeEditField.linkTextColors.defaultColor
-        highlightSpans(binding.composeEditField.text, mentionColour)
+        highlightSpans(binding.composeEditField.text, sharedPreferencesRepository.linksToUnderline)
         binding.composeEditField.doAfterTextChanged { editable ->
-            highlightSpans(editable!!, mentionColour)
+            highlightSpans(editable!!, sharedPreferencesRepository.linksToUnderline)
             viewModel.onContentChanged(editable)
         }
 

--- a/app/src/main/java/app/pachli/components/compose/ComposeViewModel.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeViewModel.kt
@@ -64,6 +64,7 @@ import app.pachli.core.sendstatus.UploadState.Uploaded
 import app.pachli.core.sendstatus.model.MediaToSend
 import app.pachli.core.sendstatus.model.QueuedMedia
 import app.pachli.core.sendstatus.model.StatusToSend
+import app.pachli.core.ui.HashtagSpan
 import app.pachli.core.ui.MentionSpan
 import app.pachli.util.SaveUriError
 import app.pachli.util.isInDirectory
@@ -968,6 +969,7 @@ class ComposeViewModel @AssistedInject constructor(
                                     ?: span.url.length
                                 )
                         }
+                        is HashtagSpan -> 0
                         else -> {
                             // Expected to be negative if the URL length < maxUrlLength
                             span.url.mastodonLength() - urlLength

--- a/app/src/main/java/app/pachli/components/notifications/FollowViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/notifications/FollowViewHolder.kt
@@ -28,6 +28,7 @@ import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.designsystem.R as DR
 import app.pachli.core.model.TimelineAccount
 import app.pachli.core.network.parseAsMastodonHtml
+import app.pachli.core.preferences.LinksToUnderline
 import app.pachli.core.preferences.PronounDisplay
 import app.pachli.core.ui.LinkListener
 import app.pachli.core.ui.SetContent
@@ -62,6 +63,7 @@ class FollowViewHolder(
             statusDisplayOptions.animateAvatars,
             statusDisplayOptions.animateEmojis,
             statusDisplayOptions.pronounDisplay == PronounDisplay.EVERYWHERE,
+            statusDisplayOptions.linksToUnderline,
         )
     }
 
@@ -71,6 +73,7 @@ class FollowViewHolder(
         animateAvatars: Boolean,
         animateEmojis: Boolean,
         showPronouns: Boolean,
+        linksToUnderline: Set<LinksToUnderline>,
     ) {
         val context = binding.notificationText.context
         val displayName = account.name.htmlEncode().unicodeWrap()
@@ -112,6 +115,7 @@ class FollowViewHolder(
             emojis = account.emojis.orEmpty(),
             animateEmojis = animateEmojis,
             removeQuoteInline = false,
+            linksToUnderline = linksToUnderline,
             linkListener = linkListener,
         )
 

--- a/app/src/main/java/app/pachli/components/preference/PreferencesFragment.kt
+++ b/app/src/main/java/app/pachli/components/preference/PreferencesFragment.kt
@@ -55,6 +55,7 @@ import app.pachli.core.domain.notifications.notificationMethod
 import app.pachli.core.preferences.AppTheme
 import app.pachli.core.preferences.DefaultAudioPlayback
 import app.pachli.core.preferences.DownloadLocation
+import app.pachli.core.preferences.LinksToUnderline
 import app.pachli.core.preferences.MainNavigationPosition
 import app.pachli.core.preferences.PrefKeys
 import app.pachli.core.preferences.PronounDisplay
@@ -73,6 +74,7 @@ import app.pachli.core.ui.makeIcon
 import app.pachli.databinding.AccountNotificationDetailsListItemBinding
 import app.pachli.settings.emojiPreference
 import app.pachli.settings.enumListPreference
+import app.pachli.settings.enumMultiSelectListPreference
 import app.pachli.settings.listPreference
 import app.pachli.settings.makePreferenceScreen
 import app.pachli.settings.preference
@@ -324,6 +326,11 @@ class PreferencesFragment : PreferenceFragmentCompat() {
                     setDefaultValue(PronounDisplay.WHEN_COMPOSING)
                     setTitle(app.pachli.core.preferences.R.string.pref_title_pronoun_display)
                     key = PrefKeys.PRONOUN_DISPLAY
+                }
+
+                enumMultiSelectListPreference<LinksToUnderline> {
+                    setTitle(app.pachli.core.preferences.R.string.pref_title_underline_links)
+                    key = PrefKeys.LINKS_TO_UNDERLINE
                 }
             }
 

--- a/app/src/main/java/app/pachli/components/viewthread/edits/ViewEditsAdapter.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/edits/ViewEditsAdapter.kt
@@ -21,6 +21,7 @@ import app.pachli.core.model.AttachmentDisplayAction
 import app.pachli.core.model.StatusEdit
 import app.pachli.core.network.PachliTagHandler
 import app.pachli.core.network.parseAsMastodonHtml
+import app.pachli.core.preferences.LinksToUnderline
 import app.pachli.core.ui.BindingHolder
 import app.pachli.core.ui.LinkListener
 import app.pachli.core.ui.PollAdapter
@@ -41,6 +42,7 @@ class ViewEditsAdapter(
     private val edits: List<StatusEdit>,
     private val animateEmojis: Boolean,
     private val useBlurhash: Boolean,
+    private val linksToUnderline: Set<LinksToUnderline>,
     private val listener: LinkListener,
 ) : RecyclerView.Adapter<BindingHolder<ItemStatusEditBinding>>() {
 
@@ -124,6 +126,7 @@ class ViewEditsAdapter(
             emojis = edit.emojis,
             animateEmojis = animateEmojis,
             removeQuoteInline = false,
+            linksToUnderline = linksToUnderline,
             tagHandler = viewEditsTagHandler,
             linkListener = listener,
         )

--- a/app/src/main/java/app/pachli/components/viewthread/edits/ViewEditsFragment.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/edits/ViewEditsFragment.kt
@@ -104,6 +104,7 @@ class ViewEditsFragment :
         val animateAvatars = sharedPreferencesRepository.animateAvatars
         val animateEmojis = sharedPreferencesRepository.animateEmojis
         val useBlurhash = sharedPreferencesRepository.useBlurHash
+        val linksToUnderline = sharedPreferencesRepository.linksToUnderline
         val avatarRadius: Int = requireContext().resources.getDimensionPixelSize(DR.dimen.avatar_radius_48dp)
 
         viewLifecycleOwner.lifecycleScope.launch {
@@ -149,6 +150,7 @@ class ViewEditsFragment :
                             edits = uiState.edits,
                             animateEmojis = animateEmojis,
                             useBlurhash = useBlurhash,
+                            linksToUnderline = linksToUnderline,
                             listener = this@ViewEditsFragment,
                         )
 

--- a/app/src/main/java/app/pachli/settings/SettingsDSL.kt
+++ b/app/src/main/java/app/pachli/settings/SettingsDSL.kt
@@ -15,6 +15,7 @@ import androidx.preference.PreferenceScreen
 import androidx.preference.SwitchPreferenceCompat
 import app.pachli.core.preferences.PreferenceEnum
 import app.pachli.core.ui.EnumListPreference
+import app.pachli.core.ui.EnumMultiSelectListPreference
 import app.pachli.view.SliderPreference
 import de.c1710.filemojicompat_ui.views.picker.preference.EmojiPickerPreference
 
@@ -43,6 +44,17 @@ inline fun <reified T> PreferenceParent.enumListPreference(
     where T : Enum<T>,
           T : PreferenceEnum {
     val pref = EnumListPreference<T>(context)
+    builder(pref)
+    addPref(pref)
+    return pref
+}
+
+inline fun <reified T> PreferenceParent.enumMultiSelectListPreference(
+    builder: EnumMultiSelectListPreference<T>.() -> Unit,
+): EnumMultiSelectListPreference<T>
+    where T : Enum<T>,
+          T : PreferenceEnum {
+    val pref = EnumMultiSelectListPreference<T>(context)
     builder(pref)
     addPref(pref)
     return pref

--- a/app/src/main/java/app/pachli/util/SpanUtils.kt
+++ b/app/src/main/java/app/pachli/util/SpanUtils.kt
@@ -19,20 +19,21 @@ package app.pachli.util
 
 import android.text.Spannable
 import android.text.Spanned
-import android.text.style.ForegroundColorSpan
 import android.text.style.URLSpan
+import app.pachli.core.preferences.LinksToUnderline
+import app.pachli.core.ui.HashtagSpan
+import app.pachli.core.ui.MaybeUnderlineURLSpan
 import app.pachli.core.ui.MentionSpan
-import app.pachli.core.ui.NoUnderlineURLSpan
 import com.twitter.twittertext.Extractor
 
-private val spanClasses = listOf(ForegroundColorSpan::class.java, URLSpan::class.java)
+private val spanClasses = listOf(URLSpan::class.java)
 
 private val extractor = Extractor().apply { isExtractURLWithoutProtocol = false }
 
 /**
  * Takes text containing mentions and hashtags and urls and makes them the given colour.
  */
-fun highlightSpans(text: Spannable, colour: Int) {
+fun highlightSpans(text: Spannable, linksToUnderline: Set<LinksToUnderline>) {
     // Strip all existing colour spans.
     for (spanClass in spanClasses) {
         clearSpans(text, spanClass)
@@ -45,9 +46,24 @@ fun highlightSpans(text: Spannable, colour: Int) {
 
     for (entity in entities) {
         val span = when (entity.type) {
-            Extractor.Entity.Type.URL -> NoUnderlineURLSpan(string.substring(entity.start, entity.end), null)
-            Extractor.Entity.Type.HASHTAG -> ForegroundColorSpan(colour)
-            Extractor.Entity.Type.MENTION -> MentionSpan(string.substring(entity.start, entity.end), null)
+            Extractor.Entity.Type.URL -> MaybeUnderlineURLSpan(
+                linksToUnderline.contains(LinksToUnderline.LINKS),
+                string.substring(entity.start, entity.end),
+                null,
+            )
+
+            Extractor.Entity.Type.HASHTAG -> HashtagSpan(
+                entity.value,
+                linksToUnderline.contains(LinksToUnderline.HASHTAGS),
+                string.substring(entity.start, entity.end),
+                null,
+            )
+
+            Extractor.Entity.Type.MENTION -> MentionSpan(
+                linksToUnderline.contains(LinksToUnderline.MENTIONS),
+                string.substring(entity.start, entity.end),
+                null,
+            )
         }
         text.setSpan(span, entity.start, entity.end, Spanned.SPAN_INCLUSIVE_EXCLUSIVE)
     }

--- a/app/src/test/java/app/pachli/SpanUtilsTest.kt
+++ b/app/src/test/java/app/pachli/SpanUtilsTest.kt
@@ -14,7 +14,7 @@ class SpanUtilsTest {
     fun matchesMixedSpans() {
         val input = "one #one two: @two three : https://thr.ee/meh?foo=bar&wat=@at#hmm four #four five @five ろく#six"
         val inputSpannable = FakeSpannable(input)
-        highlightSpans(inputSpannable, 0xffffff)
+        highlightSpans(inputSpannable, emptySet())
         val spans = inputSpannable.spans
         Assert.assertEquals(6, spans.size)
     }
@@ -24,7 +24,7 @@ class SpanUtilsTest {
         val firstURL = "http://first.bar"
         val secondURL = "https://second.bar"
         val inputSpannable = FakeSpannable("$firstURL $secondURL")
-        highlightSpans(inputSpannable, 0xffffff)
+        highlightSpans(inputSpannable, emptySet())
         val spans = inputSpannable.spans
         Assert.assertEquals(2, spans.size)
         Assert.assertEquals(firstURL.length, spans[0].end - spans[0].start)
@@ -50,7 +50,7 @@ class SpanUtilsTest {
         @Test
         fun matchesSpanAtStart() {
             val inputSpannable = FakeSpannable(thingToHighlight)
-            highlightSpans(inputSpannable, 0xffffff)
+            highlightSpans(inputSpannable, emptySet())
             val spans = inputSpannable.spans
             Assert.assertEquals(1, spans.size)
             Assert.assertEquals(thingToHighlight.length, spans[0].end - spans[0].start)
@@ -59,7 +59,7 @@ class SpanUtilsTest {
         @Test
         fun matchesSpanNotAtStart() {
             val inputSpannable = FakeSpannable(" $thingToHighlight")
-            highlightSpans(inputSpannable, 0xffffff)
+            highlightSpans(inputSpannable, emptySet())
             val spans = inputSpannable.spans
             Assert.assertEquals(1, spans.size)
             Assert.assertEquals(thingToHighlight.length, spans[0].end - spans[0].start)
@@ -68,7 +68,7 @@ class SpanUtilsTest {
         @Test
         fun doesNotMatchSpanEmbeddedInText() {
             val inputSpannable = FakeSpannable("aa${thingToHighlight}aa")
-            highlightSpans(inputSpannable, 0xffffff)
+            highlightSpans(inputSpannable, emptySet())
             val spans = inputSpannable.spans
             Assert.assertTrue(spans.isEmpty())
         }
@@ -78,7 +78,7 @@ class SpanUtilsTest {
             val begin = "@begin"
             val end = "#end"
             val inputSpannable = FakeSpannable("$begin $thingToHighlight $end")
-            highlightSpans(inputSpannable, 0xffffff)
+            highlightSpans(inputSpannable, emptySet())
             val spans = inputSpannable.spans
             Assert.assertEquals(3, spans.size)
 
@@ -113,7 +113,7 @@ class SpanUtilsTest {
         @Test
         fun matchExpectations() {
             val inputSpannable = FakeSpannable(text)
-            highlightSpans(inputSpannable, 0xffffff)
+            highlightSpans(inputSpannable, emptySet())
             val spans = inputSpannable.spans
             Assert.assertEquals(1, spans.size)
             val span = spans.first()

--- a/app/src/test/java/app/pachli/components/compose/StatusLengthTest.kt
+++ b/app/src/test/java/app/pachli/components/compose/StatusLengthTest.kt
@@ -57,7 +57,7 @@ class StatusLengthTest(
     @Test
     fun statusLength_matchesExpectations() {
         val spannedText = FakeSpannable(text)
-        highlightSpans(spannedText, 0)
+        highlightSpans(spannedText, emptySet())
 
         assertEquals(
             expectedLength,
@@ -68,7 +68,7 @@ class StatusLengthTest(
     @Test
     fun statusLength_withCwText_matchesExpectations() {
         val spannedText = FakeSpannable(text)
-        highlightSpans(spannedText, 0)
+        highlightSpans(spannedText, emptySet())
 
         val cwText = FakeSpannable(
             "a @example@example.org #hashtagmention and http://example.org URL",

--- a/core/data/src/main/kotlin/app/pachli/core/data/model/StatusDisplayOptions.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/model/StatusDisplayOptions.kt
@@ -18,6 +18,7 @@
 package app.pachli.core.data.model
 
 import app.pachli.core.preferences.CardViewMode
+import app.pachli.core.preferences.LinksToUnderline
 import app.pachli.core.preferences.PronounDisplay
 
 /**
@@ -78,4 +79,6 @@ data class StatusDisplayOptions(
     val showStatusInfo: Boolean = true,
 
     val pronounDisplay: PronounDisplay = PronounDisplay.WHEN_COMPOSING,
+
+    val linksToUnderline: Set<LinksToUnderline> = emptySet(),
 )

--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/StatusDisplayOptionsRepository.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/StatusDisplayOptionsRepository.kt
@@ -76,6 +76,7 @@ class StatusDisplayOptionsRepository @Inject constructor(
         PrefKeys.SHOW_STATS_INLINE,
         PrefKeys.LAB_RENDER_MARKDOWN,
         PrefKeys.PRONOUN_DISPLAY,
+        PrefKeys.LINKS_TO_UNDERLINE,
     )
 
     init {
@@ -130,6 +131,9 @@ class StatusDisplayOptionsRepository @Inject constructor(
                         PrefKeys.PRONOUN_DISPLAY -> prev.copy(
                             pronounDisplay = sharedPreferencesRepository.pronounDisplay,
                         )
+                        PrefKeys.LINKS_TO_UNDERLINE -> prev.copy(
+                            linksToUnderline = sharedPreferencesRepository.linksToUnderline,
+                        )
                         else -> prev
                     }
                 }
@@ -183,6 +187,7 @@ class StatusDisplayOptionsRepository @Inject constructor(
             canQuote = account?.server?.can(ServerOperation.ORG_JOINMASTODON_STATUSES_QUOTE, ">=1.0.0".toConstraint()) ?: default.canQuote,
             renderMarkdown = sharedPreferencesRepository.renderMarkdown,
             pronounDisplay = sharedPreferencesRepository.pronounDisplay,
+            linksToUnderline = sharedPreferencesRepository.linksToUnderline,
         )
     }
 }

--- a/core/preferences/src/main/kotlin/app/pachli/core/preferences/LinksToUnderline.kt
+++ b/core/preferences/src/main/kotlin/app/pachli/core/preferences/LinksToUnderline.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.core.preferences
+
+/** Types of links that can be underlined in the UI. */
+enum class LinksToUnderline(override val displayResource: Int, override val value: String? = null) : PreferenceEnum {
+    /** Underline external links. */
+    LINKS(R.string.pref_underline_links_links),
+
+    /** Underline account mentions. */
+    MENTIONS(R.string.pref_underline_links_mentions),
+
+    /** Underline hashtags. */
+    HASHTAGS(R.string.pref_underline_links_hashtags),
+}

--- a/core/preferences/src/main/kotlin/app/pachli/core/preferences/SettingsConstants.kt
+++ b/core/preferences/src/main/kotlin/app/pachli/core/preferences/SettingsConstants.kt
@@ -197,6 +197,9 @@ object PrefKeys {
     /** Tab contents. See [TabContents]. */
     const val TAB_CONTENTS = "tabContents"
 
+    /** Which links (if any) should be underlined. See [LinksToUnderline]. */
+    const val LINKS_TO_UNDERLINE = "linksToUnderline"
+
     /** True if experimental support for rendering markdown is enabled. */
     const val LAB_RENDER_MARKDOWN = "labRenderMarkdown"
 

--- a/core/preferences/src/main/kotlin/app/pachli/core/preferences/SharedPreferencesExtensions.kt
+++ b/core/preferences/src/main/kotlin/app/pachli/core/preferences/SharedPreferencesExtensions.kt
@@ -21,11 +21,26 @@ inline fun <reified E> SharedPreferences.getEnum(
 }
 
 /**
+ * @return The enums for the preference at [key]. If there is no value for
+ * [key] in preferences, or the values can not be converted to [E], then
+ * [defValue] is returned.
+ */
+inline fun <reified E> SharedPreferences.getEnumSet(
+    key: String,
+    defValue: Set<E> = emptySet(),
+): Set<E>
+    where E : Enum<E>,
+          E : PreferenceEnum {
+    return getStringSet(key, null)
+        ?.mapNotNull { PreferenceEnum.from<E>(it) }?.toSet() ?: defValue
+}
+
+/**
  * Sets an enum value in the preferences editor, to be written back once
  * [commit][SharedPreferences.Editor.commit] or [apply][SharedPreferences.Editor.apply]
  * are called.
  *
- * The enum is persisted using it's [value][PreferenceEnum.value] property. If that
+ * The enum is persisted using its [value][PreferenceEnum.value] property. If that
  * is null the enum's [name][Enum.name] property is used.
  *
  * @param key The name of the preference to modify

--- a/core/preferences/src/main/kotlin/app/pachli/core/preferences/SharedPreferencesRepository.kt
+++ b/core/preferences/src/main/kotlin/app/pachli/core/preferences/SharedPreferencesRepository.kt
@@ -283,6 +283,12 @@ class SharedPreferencesRepository @Inject constructor(
     val pronounDisplay: PronounDisplay
         get() = getEnum(PrefKeys.PRONOUN_DISPLAY, PronounDisplay.WHEN_COMPOSING)
 
+    /**
+     * Link types that should be underlined. Empty set if no link types should be underlined.
+     */
+    val linksToUnderline: Set<LinksToUnderline>
+        get() = getEnumSet(PrefKeys.LINKS_TO_UNDERLINE, emptySet())
+
     // Ensure the listener is retained during minification. If you do not do this the
     // field is removed and eventually garbage collected (because registering it as a
     // change listener does not create a strong reference to it) and then no more

--- a/core/preferences/src/main/res/values/strings.xml
+++ b/core/preferences/src/main/res/values/strings.xml
@@ -82,4 +82,9 @@
     <string name="pref_quote_policy_followers">Only your followers</string>
     <string name="pref_quote_policy_nobody">Only you</string>
     <string name="pref_summary_quote_policy_disabled">Your server does not support quote policies</string>
+
+    <string name="pref_title_underline_links">Underlined links</string>
+    <string name="pref_underline_links_links">External links</string>
+    <string name="pref_underline_links_mentions">\@-mentions</string>
+    <string name="pref_underline_links_hashtags">#hashtags</string>
 </resources>

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/DetailedStatusView.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/DetailedStatusView.kt
@@ -33,6 +33,7 @@ import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.data.model.StatusItemViewData
 import app.pachli.core.data.model.StatusViewData
 import app.pachli.core.preferences.CardViewMode
+import app.pachli.core.preferences.LinksToUnderline
 import app.pachli.core.ui.databinding.StatusContentDetailedBinding
 import app.pachli.core.ui.extensions.description
 import app.pachli.core.ui.extensions.icon
@@ -199,14 +200,27 @@ class DetailedStatusView @JvmOverloads constructor(
             val spanEnd = spanStart + editedAtString.length
             sb.append(editedAtString)
             viewData.status.editedAt?.also {
-                val editedClickSpan = NoUnderlineURLSpan(viewData.actionableId, listener::onShowEdits)
+                val editedClickSpan = MaybeUnderlineURLSpan(
+                    statusDisplayOptions.linksToUnderline.contains(LinksToUnderline.LINKS),
+                    viewData.actionableId,
+                    listener::onShowEdits,
+                )
                 sb.setSpan(editedClickSpan, spanStart, spanEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
             }
         }
 
         app?.also { (name, website) ->
             sb.append(metadataJoiner)
-            website?.also { sb.append(createClickableText(name, it, listener::onViewUrl)) } ?: sb.append(name)
+            website?.also {
+                sb.append(
+                    createClickableText(
+                        statusDisplayOptions.linksToUnderline.contains(LinksToUnderline.LINKS),
+                        name,
+                        it,
+                        listener::onViewUrl,
+                    ),
+                )
+            } ?: sb.append(name)
         }
 
         binding.statusMetaInfo.movementMethod = LinkMovementMethod.getInstance()

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/EnumMultiSelectListPreference.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/EnumMultiSelectListPreference.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.core.ui
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.preference.MultiSelectListPreference
+import app.pachli.core.preferences.PreferenceEnum
+
+/**
+ * Displays the different enums in a [PreferenceEnum], allowing the user to
+ * choose multiple values.
+ *
+ * A [SummaryProvider][androidx.preference.Preference.SummaryProvider] is
+ * automatically set to show the chosen values.
+ */
+class EnumMultiSelectListPreference<T> @JvmOverloads constructor(
+    clazz: Class<T>,
+    private val context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = androidx.preference.R.attr.dialogPreferenceStyle,
+    defStyleRes: Int = android.R.attr.dialogPreferenceStyle,
+) : MultiSelectListPreference(context, attrs, defStyleAttr, defStyleRes)
+    where T : Enum<T>,
+          T : PreferenceEnum {
+    init {
+        entries = clazz.enumConstants?.map { context.getString(it.displayResource) }?.toTypedArray<CharSequence>()
+            ?: emptyArray()
+        entryValues = clazz.enumConstants?.map { it.value ?: it.name }?.toTypedArray<CharSequence>() ?: emptyArray()
+
+        val valueToLabel = entryValues.zip(entries).toMap()
+
+        setSummaryProvider {
+            if (values.isEmpty()) return@setSummaryProvider context.getString(R.string.pref_summary_none)
+
+            valueToLabel.filterKeys { values.contains(it) }.values.joinToString(", ")
+        }
+    }
+
+    override fun setTitle(title: CharSequence?) {
+        super.setTitle(title)
+        dialogTitle = title
+    }
+
+    companion object {
+        // Can't use reified types in a class constructor, but you can in inline
+        // functions, so this helper supplies the correct type for the constructor's
+        // first class parameter, making it more ergonomic to use this class.
+        inline operator fun <reified T> invoke(
+            context: Context,
+            attrs: AttributeSet? = null,
+            defStyleAttr: Int = androidx.preference.R.attr.dialogPreferenceStyle,
+            defStyleRes: Int = android.R.attr.dialogPreferenceStyle,
+        ): EnumMultiSelectListPreference<T>
+            where T : Enum<T>,
+                  T : PreferenceEnum = EnumMultiSelectListPreference(
+            T::class.java,
+            context,
+            attrs,
+            defStyleAttr,
+            defStyleRes,
+        )
+    }
+}

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/LinkHelper.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/LinkHelper.kt
@@ -26,6 +26,7 @@ import androidx.core.net.toUri
 import androidx.core.text.method.LinkMovementMethodCompat
 import app.pachli.core.model.HashTag
 import app.pachli.core.model.Status.Mention
+import app.pachli.core.preferences.LinksToUnderline
 import com.mikepenz.iconics.IconicsColor
 import com.mikepenz.iconics.IconicsDrawable
 import com.mikepenz.iconics.IconicsSize
@@ -125,6 +126,7 @@ internal fun markupHiddenUrls(textView: TextView, content: SpannableStringBuilde
  */
 internal fun convertUrlSpanToMoreSpecificType(
     span: URLSpan,
+    linksToUnderline: Set<LinksToUnderline>,
     builder: SpannableStringBuilder,
     mentions: List<Mention>?,
     tags: List<HashTag>?,
@@ -137,9 +139,9 @@ internal fun convertUrlSpanToMoreSpecificType(
     // Determine the new span from the text content.
     val text = subSequence(start, end)
     val newSpan = when (text[0]) {
-        '#' -> getCustomSpanForHashtag(text, tags, span, listener)
-        '@' -> getCustomSpanForMention(mentions, span, listener)
-        else -> NoUnderlineURLSpan(span.url, listener::onViewUrl)
+        '#' -> getCustomSpanForHashtag(linksToUnderline.contains(LinksToUnderline.HASHTAGS), text, tags, span, listener)
+        '@' -> getCustomSpanForMention(linksToUnderline.contains(LinksToUnderline.MENTIONS), mentions, span, listener)
+        else -> MaybeUnderlineURLSpan(linksToUnderline.contains(LinksToUnderline.LINKS), span.url, listener::onViewUrl)
     }
 
     // Replace the previous span with the more appropriate span.
@@ -167,16 +169,16 @@ fun getTagName(text: CharSequence, tags: List<HashTag>?): String? {
     }
 }
 
-private fun getCustomSpanForHashtag(text: CharSequence, tags: List<HashTag>?, span: URLSpan, listener: LinkListener): ClickableSpan? {
+private fun getCustomSpanForHashtag(underline: Boolean, text: CharSequence, tags: List<HashTag>?, span: URLSpan, listener: LinkListener): ClickableSpan? {
     return getTagName(text, tags)?.let { tagName ->
-        HashtagSpan(tagName, span.url) { listener.onViewTag(tagName) }
+        HashtagSpan(tagName, underline, span.url) { listener.onViewTag(tagName) }
     }
 }
 
-private fun getCustomSpanForMention(mentions: List<Mention>?, span: URLSpan, listener: LinkListener): ClickableSpan? {
+private fun getCustomSpanForMention(underline: Boolean, mentions: List<Mention>?, span: URLSpan, listener: LinkListener): ClickableSpan? {
     // https://github.com/tuskyapp/Tusky/pull/2339
     return mentions?.firstOrNull { it.url == span.url }?.let { mention ->
-        MentionSpan(mention.url) { listener.onViewAccount(mention.id) }
+        MentionSpan(underline, mention.url) { listener.onViewAccount(mention.id) }
     }
 }
 
@@ -186,9 +188,10 @@ private fun getCustomSpanForMention(mentions: List<Mention>?, span: URLSpan, lis
  *
  * @param view the returned text will be put in
  * @param mentions any '@' mentions which are known to be in the content
+ * @param underline True if the mentions should be underlined.
  * @param listener to notify about particular spans that are clicked
  */
-fun setClickableMentions(view: TextView, mentions: List<Mention>?, listener: LinkListener) {
+fun setClickableMentions(view: TextView, mentions: List<Mention>?, underline: Boolean, listener: LinkListener) {
     if (mentions?.isEmpty() != false) {
         view.text = null
         return
@@ -201,7 +204,7 @@ fun setClickableMentions(view: TextView, mentions: List<Mention>?, listener: Lin
         var firstMention = true
 
         for (mention in mentions) {
-            val customSpan = MentionSpan(mention.url) { listener.onViewAccount(mention.id) }
+            val customSpan = MentionSpan(underline, mention.url) { listener.onViewAccount(mention.id) }
             end += 1 + mention.localUsername.length // length of @ + username
             flags = getSpanFlags(customSpan)
             if (firstMention) {
@@ -221,10 +224,10 @@ fun setClickableMentions(view: TextView, mentions: List<Mention>?, listener: Lin
     view.movementMethod = LinkMovementMethodCompat.getInstance()
 }
 
-fun createClickableText(text: String, link: String, onClickListener: OnClickListener): CharSequence {
+fun createClickableText(underline: Boolean, text: String, link: String, onClickListener: OnClickListener): CharSequence {
     return SpannableStringBuilder(text).apply {
         setSpan(
-            NoUnderlineURLSpan(link, onClickListener),
+            MaybeUnderlineURLSpan(underline, link, onClickListener),
             0,
             text.length,
             Spanned.SPAN_INCLUSIVE_EXCLUSIVE,

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/MaybeUnderlineURLSpan.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/MaybeUnderlineURLSpan.kt
@@ -28,12 +28,13 @@ fun interface OnClickListener {
 /**
  * Span that highlights content and optionally makes it clickable.
  *
+ * @param underline True if the span's content should be underlined.
  * @param url Link destination. This can be anything the [onClickListener] can
  * resolve when clicked, not just a URL.
  * @param onClickListener Called when the span is clicked on. If null the span
- * highlights the text but it is not clickable.
+ * highlights the text, but is not clickable.
  */
-open class NoUnderlineURLSpan(val url: String, private val onClickListener: OnClickListener?) : URLSpan(url) {
+open class MaybeUnderlineURLSpan(private val underline: Boolean, val url: String, private val onClickListener: OnClickListener?) : URLSpan(url) {
 
     // This should not be necessary. But if you don't do this the [StatusLengthTest] tests
     // fail. Without this, accessing the `url` property, or calling `getUrl()` (which should
@@ -44,7 +45,7 @@ open class NoUnderlineURLSpan(val url: String, private val onClickListener: OnCl
 
     override fun updateDrawState(ds: TextPaint) {
         super.updateDrawState(ds)
-        ds.isUnderlineText = false
+        ds.isUnderlineText = underline
     }
 
     override fun onClick(view: View) {
@@ -58,7 +59,7 @@ open class NoUnderlineURLSpan(val url: String, private val onClickListener: OnCl
  * @param url
  * @param onClickListener
  */
-open class MentionSpan(url: String, onClickListener: OnClickListener?) : NoUnderlineURLSpan(url, onClickListener)
+open class MentionSpan(underline: Boolean, url: String, onClickListener: OnClickListener?) : MaybeUnderlineURLSpan(underline, url, onClickListener)
 
 /**
  * Hashtags (`#foo`)
@@ -66,4 +67,4 @@ open class MentionSpan(url: String, onClickListener: OnClickListener?) : NoUnder
  * @param hashtag Text of the tag, without the leading `#`.
  * @param onClickListener Listener for clicks on the tag.
  */
-class HashtagSpan(val hashtag: String, url: String, onClickListener: OnClickListener) : NoUnderlineURLSpan(url, onClickListener)
+class HashtagSpan(val hashtag: String, underline: Boolean, url: String, onClickListener: OnClickListener?) : MaybeUnderlineURLSpan(underline, url, onClickListener)

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/SetContent.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/SetContent.kt
@@ -33,6 +33,7 @@ import app.pachli.core.model.Status
 import app.pachli.core.network.PachliTagHandler
 import app.pachli.core.network.parseAsMastodonHtml
 import app.pachli.core.network.removeQuoteInline
+import app.pachli.core.preferences.LinksToUnderline
 import app.pachli.core.ui.PreProcessMastodonHtml.processMarkdown
 import app.pachli.core.ui.taghandler.MastodonTagHandler
 import com.bumptech.glide.RequestManager
@@ -76,6 +77,7 @@ interface SetContent {
      * @param emojis
      * @param animateEmojis True if emojis should be animated.
      * @param removeQuoteInline If true, remove `p` elements with a `quote-inline` class.
+     * @param linksToUnderline
      * @param mentions
      * @param hashtags
      * @param tagHandler
@@ -88,6 +90,7 @@ interface SetContent {
         emojis: List<Emoji>,
         animateEmojis: Boolean,
         removeQuoteInline: Boolean,
+        linksToUnderline: Set<LinksToUnderline>,
         mentions: List<Status.Mention>? = null,
         hashtags: List<HashTag>? = null,
         tagHandler: PachliTagHandler? = null,
@@ -97,7 +100,7 @@ interface SetContent {
             append(parseToSpanned(textView.context, content, removeQuoteInline, tagHandler))
 
             getSpans(0, length, URLSpan::class.java).forEach {
-                convertUrlSpanToMoreSpecificType(it, this, mentions, hashtags, linkListener)
+                convertUrlSpanToMoreSpecificType(it, linksToUnderline, this, mentions, hashtags, linkListener)
             }
 
             val hashtagsInContent = getSpans(0, length, HashtagSpan::class.java).map {
@@ -105,8 +108,9 @@ interface SetContent {
             }.toSet()
             val oobHashtags = hashtags.orEmpty().filterNot { hashtagsInContent.contains(it.name) }
 
+            val underlineHashtags = linksToUnderline.contains(LinksToUnderline.HASHTAGS)
             val oobSpans = oobHashtags.map { tag ->
-                HashtagSpan(tag.name, tag.url) { linkListener.onViewTag(tag.name) }
+                HashtagSpan(tag.name, underlineHashtags, tag.url) { linkListener.onViewTag(tag.name) }
             }
 
             if (oobSpans.isNotEmpty()) {

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/StatusView.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/StatusView.kt
@@ -47,6 +47,7 @@ import app.pachli.core.model.PreviewCardKind
 import app.pachli.core.network.parseAsMastodonHtml
 import app.pachli.core.network.removeQuoteInline
 import app.pachli.core.preferences.CardViewMode
+import app.pachli.core.preferences.LinksToUnderline
 import app.pachli.core.preferences.PronounDisplay
 import app.pachli.core.ui.PollViewData.Companion.from
 import app.pachli.core.ui.extensions.contentDescription
@@ -305,6 +306,7 @@ abstract class StatusView<T : IStatusViewData> @JvmOverloads constructor(
                 emojis = emojis,
                 animateEmojis = statusDisplayOptions.animateEmojis,
                 removeQuoteInline = viewData.status.quote != null,
+                linksToUnderline = statusDisplayOptions.linksToUnderline,
                 mentions = mentions,
                 hashtags = tags,
                 linkListener = listener,
@@ -333,7 +335,12 @@ abstract class StatusView<T : IStatusViewData> @JvmOverloads constructor(
             } ?: pollView.hide()
         } else {
             pollView.hide()
-            setClickableMentions(this.content, mentions, listener)
+            setClickableMentions(
+                this.content,
+                mentions,
+                statusDisplayOptions.linksToUnderline.contains(LinksToUnderline.MENTIONS),
+                listener,
+            )
         }
         if (TextUtils.isEmpty(this.content.text)) {
             this.content.visibility = GONE

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -205,4 +205,6 @@
     <string name="duration_90_days">90 days</string>
     <string name="duration_180_days">180 days</string>
     <string name="duration_365_days">365 days</string>
+
+    <string name="pref_summary_none">None</string>
 </resources>

--- a/core/ui/src/test/kotlin/app/pachli/core/ui/LinkHelperTest.kt
+++ b/core/ui/src/test/kotlin/app/pachli/core/ui/LinkHelperTest.kt
@@ -63,7 +63,7 @@ class LinkHelperTest {
 
         var urlSpans = builder.getSpans(0, builder.length, URLSpan::class.java)
         for (span in urlSpans) {
-            convertUrlSpanToMoreSpecificType(span, builder, mentions, null, listener)
+            convertUrlSpanToMoreSpecificType(span, emptySet(), builder, mentions, null, listener)
         }
 
         urlSpans = builder.getSpans(0, builder.length, URLSpan::class.java)
@@ -84,7 +84,7 @@ class LinkHelperTest {
 
         var urlSpans = builder.getSpans(0, builder.length, URLSpan::class.java)
         for (span in urlSpans) {
-            convertUrlSpanToMoreSpecificType(span, builder, mentions, null, listener)
+            convertUrlSpanToMoreSpecificType(span, emptySet(), builder, mentions, null, listener)
         }
 
         urlSpans = builder.getSpans(0, builder.length, URLSpan::class.java)

--- a/feature/about/src/main/kotlin/app/pachli/feature/about/AboutFragment.kt
+++ b/feature/about/src/main/kotlin/app/pachli/feature/about/AboutFragment.kt
@@ -19,14 +19,12 @@ package app.pachli.feature.about
 
 import android.os.Build
 import android.os.Bundle
-import android.text.SpannableString
 import android.text.SpannableStringBuilder
 import android.text.method.LinkMovementMethod
 import android.text.style.URLSpan
 import android.text.util.Linkify
 import android.view.View
 import android.widget.TextView
-import androidx.annotation.StringRes
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
@@ -35,8 +33,9 @@ import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
 import app.pachli.core.common.extensions.viewBinding
 import app.pachli.core.common.util.versionName
+import app.pachli.core.preferences.LinksToUnderline
 import app.pachli.core.ui.ClipboardUseCase
-import app.pachli.core.ui.NoUnderlineURLSpan
+import app.pachli.core.ui.MaybeUnderlineURLSpan
 import app.pachli.core.ui.extensions.InsetType
 import app.pachli.core.ui.extensions.applyWindowInsets
 import app.pachli.feature.about.databinding.FragmentAboutBinding
@@ -98,9 +97,15 @@ class AboutFragment : Fragment(R.layout.fragment_about) {
             binding.aboutPoweredBy.hide()
         }
 
-        binding.aboutLicenseInfoTextView.setClickableTextWithoutUnderlines(R.string.about_pachli_license, openUrl::invoke)
-        binding.aboutWebsiteInfoTextView.setClickableTextWithoutUnderlines(R.string.about_project_site, openUrl::invoke)
-        binding.aboutBugsFeaturesInfoTextView.setClickableTextWithoutUnderlines(R.string.about_bug_feature_request_site, openUrl::invoke)
+        val underlineUrls = viewModel.linksToUnderline.contains(LinksToUnderline.LINKS)
+
+        binding.aboutNivenlyFoundation.convertUrlSpanToMaybeUnderlineUrlSpan(underlineUrls, openUrl::invoke)
+        binding.aboutLicenseInfoTextView.addLinks(Linkify.WEB_URLS)
+        binding.aboutLicenseInfoTextView.convertUrlSpanToMaybeUnderlineUrlSpan(underlineUrls, openUrl::invoke)
+        binding.aboutWebsiteInfoTextView.addLinks(Linkify.WEB_URLS)
+        binding.aboutWebsiteInfoTextView.convertUrlSpanToMaybeUnderlineUrlSpan(underlineUrls, openUrl::invoke)
+        binding.aboutBugsFeaturesInfoTextView.addLinks(Linkify.WEB_URLS)
+        binding.aboutBugsFeaturesInfoTextView.convertUrlSpanToMaybeUnderlineUrlSpan(underlineUrls, openUrl::invoke)
 
         binding.appProfileButton.setOnClickListener {
             openUrl(BuildConfig.SUPPORT_ACCOUNT_URL)
@@ -117,25 +122,37 @@ class AboutFragment : Fragment(R.layout.fragment_about) {
     }
 }
 
-internal fun TextView.setClickableTextWithoutUnderlines(@StringRes textId: Int, openUrl: (String) -> Unit) {
-    val text = SpannableString(context.getText(textId))
-
-    Linkify.addLinks(text, Linkify.WEB_URLS)
-
-    val builder = SpannableStringBuilder(text)
-    val urlSpans = text.getSpans(0, text.length, URLSpan::class.java)
-    for (span in urlSpans) {
-        val start = builder.getSpanStart(span)
-        val end = builder.getSpanEnd(span)
-        val flags = builder.getSpanFlags(span)
-
-        val customSpan = NoUnderlineURLSpan(span.url, openUrl::invoke)
-
-        builder.removeSpan(span)
-        builder.setSpan(customSpan, start, end, flags)
+/**
+ * Calls [Linkify.addLinks] on [text][TextView.text], applying [mask][Linkify.addLinks].
+ *
+ * @param mask Mask to define which kinds of links will be searched.
+ */
+internal fun TextView.addLinks(mask: Int) {
+    SpannableStringBuilder(text).apply {
+        Linkify.addLinks(this, mask)
+        text = this
     }
+}
 
-    setText(builder)
+/**
+ * Converts [URLSpan] in [text][TextView.text] to [MaybeUnderlineURLSpan].
+ *
+ * @param underlineUrls True if the URLs should be underlined.
+ * @param openUrl Function to call when the URL is clicked.
+ */
+internal fun TextView.convertUrlSpanToMaybeUnderlineUrlSpan(underlineUrls: Boolean, openUrl: (String) -> Unit) {
+    SpannableStringBuilder(text).apply {
+        getSpans(0, this.length, URLSpan::class.java).forEach { span ->
+            val start = getSpanStart(span)
+            val end = getSpanEnd(span)
+            val flags = getSpanFlags(span)
+            val replacement = MaybeUnderlineURLSpan(underlineUrls, span.url, openUrl)
+            removeSpan(span)
+            setSpan(replacement, start, end, flags)
+        }
+
+        text = this
+    }
     linksClickable = true
     movementMethod = LinkMovementMethod.getInstance()
 }

--- a/feature/about/src/main/kotlin/app/pachli/feature/about/AboutFragmentViewModel.kt
+++ b/feature/about/src/main/kotlin/app/pachli/feature/about/AboutFragmentViewModel.kt
@@ -22,6 +22,8 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import app.pachli.core.data.repository.AccountManager
 import app.pachli.core.data.repository.InstanceInfoRepository
+import app.pachli.core.preferences.LinksToUnderline
+import app.pachli.core.preferences.SharedPreferencesRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -33,9 +35,13 @@ class AboutFragmentViewModel @Inject constructor(
     private val application: Application,
     private val accountManager: AccountManager,
     private val instanceInfoRepository: InstanceInfoRepository,
+    private val sharedPreferencesRepository: SharedPreferencesRepository,
 ) : AndroidViewModel(application) {
     private val _accountInfo = MutableSharedFlow<String?>()
     val accountInfo = _accountInfo.asSharedFlow()
+
+    val linksToUnderline: Set<LinksToUnderline>
+        get() = sharedPreferencesRepository.linksToUnderline
 
     init {
         viewModelScope.launch {

--- a/feature/about/src/main/res/layout/fragment_about.xml
+++ b/feature/about/src/main/res/layout/fragment_about.xml
@@ -128,13 +128,13 @@
             android:layout_marginTop="24dp"
             android:hyphenationFrequency="full"
             android:lineSpacingMultiplier="1.2"
+            android:text="@string/about_pachli_license"
             android:textIsSelectable="true"
             android:layout_marginStart="@dimen/text_content_margin"
             android:layout_marginEnd="@dimen/text_content_margin"
             app:layout_constraintEnd_toEndOf="@+id/copyDeviceInfo"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/aboutNivenlyFoundation"
-            tools:text="@string/about_pachli_license" />
+            app:layout_constraintTop_toBottomOf="@id/aboutNivenlyFoundation" />
 
         <app.pachli.core.ui.ClickableSpanTextView
             android:id="@+id/aboutWebsiteInfoTextView"
@@ -142,11 +142,11 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="24dp"
             android:lineSpacingMultiplier="1.2"
+            android:text="@string/about_project_site"
             android:textIsSelectable="true"
             app:layout_constraintEnd_toEndOf="@+id/aboutLicenseInfoTextView"
             app:layout_constraintStart_toStartOf="@+id/aboutLicenseInfoTextView"
-            app:layout_constraintTop_toBottomOf="@id/aboutLicenseInfoTextView"
-            tools:text="@string/about_project_site" />
+            app:layout_constraintTop_toBottomOf="@id/aboutLicenseInfoTextView" />
 
         <app.pachli.core.ui.ClickableSpanTextView
             android:id="@+id/aboutBugsFeaturesInfoTextView"

--- a/feature/suggestions/src/main/kotlin/app/pachli/feature/suggestions/SuggestionsAdapter.kt
+++ b/feature/suggestions/src/main/kotlin/app/pachli/feature/suggestions/SuggestionsAdapter.kt
@@ -33,6 +33,7 @@ import app.pachli.core.common.extensions.visible
 import app.pachli.core.common.string.unicodeWrap
 import app.pachli.core.common.util.formatNumber
 import app.pachli.core.model.Suggestion
+import app.pachli.core.preferences.LinksToUnderline
 import app.pachli.core.ui.LinkListener
 import app.pachli.core.ui.SetContent
 import app.pachli.core.ui.emojify
@@ -62,6 +63,7 @@ internal class SuggestionsAdapter(
     private var animateEmojis: Boolean,
     private var showBotOverlay: Boolean,
     private var showPronouns: Boolean,
+    private var linksToUnderline: Set<LinksToUnderline>,
     private val accept: (UiAction) -> Unit,
 ) : ListAdapter<SuggestionViewData, SuggestionViewHolder>(SuggestionDiffer) {
     override fun getItemViewType(position: Int) = R.layout.item_suggestion
@@ -81,6 +83,12 @@ internal class SuggestionsAdapter(
         if (this.animateEmojis == animateEmojis) return
         this.animateEmojis = animateEmojis
         notifyItemRangeChanged(0, currentList.size, ChangePayload.AnimateEmojis(animateEmojis))
+    }
+
+    fun setLinksToUnderline(linksToUnderline: Set<LinksToUnderline>) {
+        if (this.linksToUnderline == linksToUnderline) return
+        this.linksToUnderline = linksToUnderline
+        notifyItemRangeChanged(0, currentList.size, ChangePayload.LinksToUnderline(linksToUnderline))
     }
 
     fun setShowBotOverlay(showBotOverlay: Boolean) {
@@ -104,7 +112,12 @@ internal class SuggestionsAdapter(
                 when (payload) {
                     is ChangePayload.IsEnabled -> holder.bindIsEnabled(payload.isEnabled)
                     is ChangePayload.AnimateAvatars -> holder.bindAvatar(viewData, payload.animateAvatars)
-                    is ChangePayload.AnimateEmojis -> holder.bindAnimateEmojis(viewData, payload.animateEmojis)
+                    is ChangePayload.AnimateEmojis -> {
+                        holder.bindDisplayName(viewData, payload.animateEmojis)
+                        holder.bindNote(viewData, payload.animateEmojis, linksToUnderline)
+                    }
+
+                    is ChangePayload.LinksToUnderline -> holder.bindNote(viewData, animateEmojis, payload.linksToUnderline)
                     is ChangePayload.ShowBotOverlay -> holder.bindShowBotOverlay(viewData, payload.showBotOverlay)
                     is ChangePayload.ShowPronouns -> holder.bindShowPronouns(viewData, payload.showPronouns)
                 }
@@ -119,6 +132,7 @@ internal class SuggestionsAdapter(
             animateAvatars,
             showBotOverlay,
             showPronouns,
+            linksToUnderline,
         )
     }
 }
@@ -150,6 +164,9 @@ internal class SuggestionViewHolder(
 
         /** The [animateEmojis] state of the UI has changed. */
         data class AnimateEmojis(val animateEmojis: Boolean) : ChangePayload
+
+        /** The [linksToUnderline] state of the UI has changed. */
+        data class LinksToUnderline(val linksToUnderline: Set<app.pachli.core.preferences.LinksToUnderline>) : ChangePayload
 
         /** The [showBotOverlay] state of the UI has changed. */
         data class ShowBotOverlay(val showBotOverlay: Boolean) : ChangePayload
@@ -187,6 +204,7 @@ internal class SuggestionViewHolder(
         animateAvatars: Boolean,
         showBotOverlay: Boolean,
         showPronouns: Boolean,
+        linksToUnderline: Set<LinksToUnderline>,
     ) {
         this.viewData = viewData
         this.suggestion = viewData.suggestion
@@ -201,7 +219,8 @@ internal class SuggestionViewHolder(
             username.text = username.context.getString(app.pachli.core.designsystem.R.string.post_username_format, account.username)
 
             bindAvatar(viewData, animateAvatars)
-            bindAnimateEmojis(viewData, animateEmojis)
+            bindDisplayName(viewData, animateEmojis)
+            bindNote(viewData, animateEmojis, linksToUnderline)
             bindShowBotOverlay(viewData, showBotOverlay)
             bindShowPronouns(viewData, showPronouns)
             bindPostStatistics(viewData)
@@ -238,10 +257,10 @@ internal class SuggestionViewHolder(
     }
 
     /**
-     * Binds the account's [name][app.pachli.core.model.Account.name] and
-     * [note][app.pachli.core.model.Account.note] respecting [animateEmojis].
+     * Binds the account's [name][app.pachli.core.model.Account.name] respecting
+     * [animateEmojis].
      */
-    fun bindAnimateEmojis(viewData: SuggestionViewData, animateEmojis: Boolean) = with(binding) {
+    fun bindDisplayName(viewData: SuggestionViewData, animateEmojis: Boolean) = with(binding) {
         val account = viewData.suggestion.account
         displayName.text = account.name.unicodeWrap().emojify(
             glide,
@@ -249,6 +268,14 @@ internal class SuggestionViewHolder(
             itemView,
             animateEmojis,
         )
+    }
+
+    /**
+     * Binds the account's [note][app.pachli.core.model.Account.note] respecting
+     * [animateEmojis] and [linksToUnderline].
+     */
+    fun bindNote(viewData: SuggestionViewData, animateEmojis: Boolean, linksToUnderline: Set<LinksToUnderline>) = with(binding) {
+        val account = viewData.suggestion.account
 
         if (account.note.isBlank()) {
             @SuppressLint("SetTextI18n")
@@ -262,6 +289,7 @@ internal class SuggestionViewHolder(
                 emojis = account.emojis.orEmpty(),
                 animateEmojis = animateEmojis,
                 removeQuoteInline = false,
+                linksToUnderline = linksToUnderline,
                 linkListener = linkListener,
             )
 

--- a/feature/suggestions/src/main/kotlin/app/pachli/feature/suggestions/SuggestionsFragment.kt
+++ b/feature/suggestions/src/main/kotlin/app/pachli/feature/suggestions/SuggestionsFragment.kt
@@ -137,6 +137,7 @@ class SuggestionsFragment :
             animateEmojis = viewModel.uiState.value.animateEmojis,
             showBotOverlay = viewModel.uiState.value.showBotOverlay,
             showPronouns = viewModel.uiState.value.showPronouns,
+            linksToUnderline = viewModel.uiState.value.linksToUnderline,
             accept = accept,
         )
 
@@ -184,6 +185,7 @@ class SuggestionsFragment :
         suggestionsAdapter.setAnimateEmojis(uiState.animateEmojis)
         suggestionsAdapter.setAnimateAvatars(uiState.animateAvatars)
         suggestionsAdapter.setShowBotOverlay(uiState.showBotOverlay)
+        suggestionsAdapter.setLinksToUnderline(uiState.linksToUnderline)
         suggestionsAdapter.setShowPronouns(uiState.showPronouns)
     }
 

--- a/feature/suggestions/src/main/kotlin/app/pachli/feature/suggestions/SuggestionsViewModel.kt
+++ b/feature/suggestions/src/main/kotlin/app/pachli/feature/suggestions/SuggestionsViewModel.kt
@@ -28,6 +28,7 @@ import app.pachli.core.data.repository.SuggestionsError.DeleteSuggestionError
 import app.pachli.core.data.repository.SuggestionsError.FollowAccountError
 import app.pachli.core.data.repository.SuggestionsRepository
 import app.pachli.core.model.Suggestion
+import app.pachli.core.preferences.LinksToUnderline
 import app.pachli.core.preferences.PronounDisplay
 import app.pachli.core.ui.OperationCounter
 import app.pachli.feature.suggestions.UiAction.GetSuggestions
@@ -64,6 +65,7 @@ internal data class UiState(
     val animateAvatars: Boolean = false,
     val showBotOverlay: Boolean = false,
     val showPronouns: Boolean = false,
+    val linksToUnderline: Set<LinksToUnderline> = emptySet(),
     val renderMarkdown: Boolean = false,
 ) {
     companion object {
@@ -72,6 +74,7 @@ internal data class UiState(
             animateAvatars = statusDisplayOptions.animateAvatars,
             showBotOverlay = statusDisplayOptions.showBotOverlay,
             showPronouns = statusDisplayOptions.pronounDisplay == PronounDisplay.EVERYWHERE,
+            linksToUnderline = statusDisplayOptions.linksToUnderline,
             renderMarkdown = statusDisplayOptions.renderMarkdown,
         )
     }


### PR DESCRIPTION
Allow the user to choose to underline any/all/none of:

- Links
- Mentions
- Hashtags

`NoUnderlineURLSpan` becomes `MaybeUnderlineURLSpan` and takes a parameter to reflect this. Make the user's choice available throughout the UI so the correct option can be passed to the span.

Add `EnumMultiSelectListPreference` to display the preference as a multi-select dialog.

Fixes #2045