### PR TITLE
fix: Crash with "PARAGRAPH span must end at paragraph boundary"

### DIFF
--- a/core/ui/src/main/kotlin/app/pachli/core/ui/StatusView.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/StatusView.kt
@@ -59,6 +59,7 @@ import com.bumptech.glide.RequestManager
 import com.google.android.material.color.MaterialColors
 import java.text.NumberFormat
 import java.util.Date
+import timber.log.Timber
 
 /** Array of [InputFilter] to collapse status content. */
 private val COLLAPSE_INPUT_FILTER = arrayOf<InputFilter>(SmartLengthInputFilter)
@@ -572,6 +573,7 @@ abstract class StatusView<T : IStatusViewData> @JvmOverloads constructor(
         statusDisplayOptions: StatusDisplayOptions,
     ) {
         val actionable = viewData.actionable
+        Timber.d("setupWithStatus for status ID and URL: ${actionable.statusId}, ${actionable.url}")
         setDisplayName(glide, actionable.account.name, actionable.account.emojis, statusDisplayOptions)
         setUsername(actionable.account.username)
         setMetaData(viewData, statusDisplayOptions, listener)

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/taghandler/MastodonTagHandler.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/taghandler/MastodonTagHandler.kt
@@ -22,6 +22,7 @@ import android.text.Editable
 import android.text.style.TypefaceSpan
 import app.pachli.core.network.PachliTagHandler
 import app.pachli.core.ui.taghandler.LeadingMarginWithTextSpan.Alignment
+import app.pachli.core.ui.taghandler.Mark.BlockQuote
 import app.pachli.core.ui.taghandler.Mark.Code
 import app.pachli.core.ui.taghandler.Mark.OrderedListItem
 import app.pachli.core.ui.taghandler.Mark.Pre
@@ -190,11 +191,12 @@ private interface ListElementHandler : ElementHandler {
  */
 private class BlockQuoteHandler(private val context: Context) : ElementHandler {
     override fun startElement(text: Editable) {
-        text.appendMark(Mark.BlockQuote)
+        text.ensureEndsWithNewline()
+        text.appendMark(BlockQuote)
     }
 
     override fun endElement(text: Editable) {
-        text.getLastSpanOrNull<Mark.BlockQuote>()?.let { mark ->
+        text.getLastSpanOrNull<BlockQuote>()?.let { mark ->
             text.setSpansFromMark(mark, BlockQuoteSpan(context))
         }
         text.ensureEndsWithNewline()
@@ -228,6 +230,7 @@ private class CodeHandler(private val context: Context) : ElementHandler {
  */
 private class PreHandler : ElementHandler {
     override fun startElement(text: Editable) {
+        text.ensureEndsWithNewline()
         text.appendMark(Pre)
     }
 


### PR DESCRIPTION
Maybe. Just in case this doesn't fix the problem, log the ID and URL of the status being processed, to make it easier to reproduce future crashes.