### PR TITLE
fix: Displays mentions as links when the mention URL doesn't match

### DIFF
--- a/core/ui/src/main/kotlin/app/pachli/core/ui/LinkHelper.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/LinkHelper.kt
@@ -141,8 +141,8 @@ internal fun convertUrlSpanToMoreSpecificType(
     val newSpan = when (text[0]) {
         '#' -> getCustomSpanForHashtag(linksToUnderline.contains(LinksToUnderline.HASHTAGS), text, tags, span, listener)
         '@' -> getCustomSpanForMention(linksToUnderline.contains(LinksToUnderline.MENTIONS), mentions, span, listener)
-        else -> MaybeUnderlineURLSpan(linksToUnderline.contains(LinksToUnderline.LINKS), span.url, listener::onViewUrl)
-    }
+        else -> null
+    } ?: MaybeUnderlineURLSpan(linksToUnderline.contains(LinksToUnderline.LINKS), span.url, listener::onViewUrl)
 
     // Replace the previous span with the more appropriate span.
     removeSpan(span)


### PR DESCRIPTION
To resolve mentions Pachli compares the `a.href` of the link to the `mention.url` properties in the status.

If it doesn't match the previous code was returning null from `getCustomSpanForMention`. This removed the `URLSpan` from the mention, rendering it unlinked.

Fallback to `MaybeUnderlineURLSpan` in this case, so the mention is still clickable. It will almost certainly open the account in the user's browser (because the search to lookup the account will probably fail) but this is better than it not being clickable, and matches the behaviour of the web UI.

Reported by @badnetmask@hachyderm.io, @ozoned@btfree.social