### PR TITLE
fix: Prevent race deleting drafts and scheduled posts

### DIFF
--- a/app/src/main/java/app/pachli/components/scheduled/ScheduledStatusFragment.kt
+++ b/app/src/main/java/app/pachli/components/scheduled/ScheduledStatusFragment.kt
@@ -125,7 +125,6 @@ class ScheduledStatusFragment :
 
         override fun onDestroyActionMode(actionMode: ActionMode) {
             selectScheduledStatusActionMode = null
-            viewModel.clearChecked()
         }
     }
 

--- a/app/src/main/java/app/pachli/components/scheduled/ScheduledStatusViewModel.kt
+++ b/app/src/main/java/app/pachli/components/scheduled/ScheduledStatusViewModel.kt
@@ -167,19 +167,15 @@ internal class ScheduledStatusViewModel @Inject constructor(
     /** @return The number of checked scheduled statuses. */
     fun countChecked() = states.value.values.filter { it == State.CHECKED }.size
 
-    /** Unchecks all scheduled statuses. */
-    fun clearChecked() {
-        states.update {
-            it.filterValues { it != State.CHECKED }
-        }
-    }
-
     /** Deletes all checked scheduled statuses. */
     fun deleteCheckedScheduledStatuses() {
         viewModelScope.launch {
             states.value.filter { it.value == State.CHECKED }.keys.forEach { scheduledStatusId ->
                 mastodonApi.deleteScheduledStatus(scheduledStatusId)
-                    .onSuccess { pagingSourceFactory.remove(scheduledStatusId) }
+                    .onSuccess {
+                        pagingSourceFactory.remove(scheduledStatusId)
+                        states.update { it - scheduledStatusId }
+                    }
                     .onFailure { Timber.w("Error deleting scheduled status: %s", it) }
             }
         }

--- a/feature/drafts/src/main/kotlin/app/pachli/feature/drafts/DraftsFragment.kt
+++ b/feature/drafts/src/main/kotlin/app/pachli/feature/drafts/DraftsFragment.kt
@@ -122,7 +122,6 @@ class DraftsFragment :
 
         override fun onDestroyActionMode(actionMode: ActionMode) {
             selectDraftsActionMode = null
-            viewModel.clearChecked()
         }
     }
 

--- a/feature/drafts/src/main/kotlin/app/pachli/feature/drafts/DraftsViewModel.kt
+++ b/feature/drafts/src/main/kotlin/app/pachli/feature/drafts/DraftsViewModel.kt
@@ -91,18 +91,13 @@ internal class DraftsViewModel @Inject constructor(
     /** @return The number of checked drafts. */
     fun countChecked() = checkedDrafts.value.size
 
-    /** Unchecks all drafts. */
-    fun clearChecked() {
-        checkedDrafts.value = emptySet()
-    }
-
     /** Deletes all checked drafts. */
     fun deleteCheckedDrafts() {
         viewModelScope.launch {
             checkedDrafts.value.forEach { draftId ->
                 draftsRepository.deleteDraftAndAttachments(draftId)
             }
-            checkedDrafts.update { emptySet() }
+            checkedDrafts.value = emptySet()
         }
     }
 


### PR DESCRIPTION
Previous code could race between the drafts/scheduled posts being deleted and the "checked" state of the post being cleared, resulting in some/all of the posts not being deleted.

Fix by clearing as the viewmodel deletes the posts, instead of in response to the action mode being cleared.

Reported by @lufertec@mastodon.uy.