### PR TITLE
fix: Display quote markers and list indicators without artifacts

### DIFF
--- a/core/ui/src/androidTest/kotlin/app/pachli/core/ui/taghandler/MastodonTagHandlerTest.kt
+++ b/core/ui/src/androidTest/kotlin/app/pachli/core/ui/taghandler/MastodonTagHandlerTest.kt
@@ -22,6 +22,7 @@ import android.graphics.Typeface
 import android.text.Spanned
 import android.text.style.StyleSpan
 import android.text.style.TypefaceSpan
+import android.widget.TextView
 import androidx.core.text.getSpans
 import androidx.core.text.parseAsHtml
 import androidx.test.core.app.ApplicationProvider
@@ -42,7 +43,7 @@ class MastodonTagHandlerTest(private val testData: TestData) {
 
     private val context: Context = ApplicationProvider.getApplicationContext()
 
-    private val tagHandler = MastodonTagHandler(context)
+    private val tagHandler = MastodonTagHandler(TextView(context))
 
     data class TestData(val src: String, val want: String)
 

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/SetContent.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/SetContent.kt
@@ -98,7 +98,7 @@ interface SetContent {
         linkListener: LinkListener,
     ) {
         val spannableStringBuilder = SpannableStringBuilder().apply {
-            append(parseToSpanned(textView.context, content, removeQuoteInline, tagHandler))
+            append(parseToSpanned(textView, content, removeQuoteInline, tagHandler))
 
             getSpans(0, length, URLSpan::class.java).forEach {
                 convertUrlSpanToMoreSpecificType(it, linksToUnderline, this, mentions, hashtags, linkListener)
@@ -141,6 +141,7 @@ interface SetContent {
      * Implementations of [SetContent] should override this to perform the
      * actual parsing. Post-processing is handled in [invoke].
      *
+     * @param textView [TextView] to load the final content in to.
      * @param content The content to parse, expected to be HTML.
      * @param removeQuoteInline If true, remove any `p` elements with a `quote-inline`
      * class as part of parsing.
@@ -148,7 +149,7 @@ interface SetContent {
      *
      * @return [content] converted to a [Spanned] string.
      */
-    fun parseToSpanned(context: Context, content: CharSequence, removeQuoteInline: Boolean, tagHandler: PachliTagHandler? = null): Spanned
+    fun parseToSpanned(textView: TextView, content: CharSequence, removeQuoteInline: Boolean, tagHandler: PachliTagHandler? = null): Spanned
 
     /** Sets the content of [textView] to [text]. */
     fun setText(textView: TextView, text: Spannable)
@@ -159,15 +160,15 @@ interface SetContent {
  */
 object SetContentAsMastodonHtml : SetContent {
     override fun parseToSpanned(
-        context: Context,
+        textView: TextView,
         content: CharSequence,
         removeQuoteInline: Boolean,
         tagHandler: PachliTagHandler?,
     ): Spanned {
         return if (removeQuoteInline) {
-            content.removeQuoteInline().parseAsMastodonHtml(tagHandler = tagHandler ?: MastodonTagHandler(context))
+            content.removeQuoteInline().parseAsMastodonHtml(tagHandler = tagHandler ?: MastodonTagHandler(textView))
         } else {
-            content.parseAsMastodonHtml(tagHandler = tagHandler ?: MastodonTagHandler(context))
+            content.parseAsMastodonHtml(tagHandler = tagHandler ?: MastodonTagHandler(textView))
         }
     }
 
@@ -212,7 +213,7 @@ class SetContentAsMarkdown(context: Context) : SetContent {
         .usePlugin(PachliMarkwonTheme(context))
         .build()
 
-    override fun parseToSpanned(context: Context, content: CharSequence, removeQuoteInline: Boolean, tagHandler: PachliTagHandler?): Spanned {
+    override fun parseToSpanned(textView: TextView, content: CharSequence, removeQuoteInline: Boolean, tagHandler: PachliTagHandler?): Spanned {
         return markwon.toMarkdown(if (removeQuoteInline) content.removeQuoteInline() else content.toString())
     }
 

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/taghandler/BlockQuoteSpan.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/taghandler/BlockQuoteSpan.kt
@@ -17,37 +17,30 @@
 
 package app.pachli.core.ui.taghandler
 
-import android.content.Context
 import android.graphics.Canvas
-import android.graphics.Color
 import android.graphics.Paint
 import android.text.Layout
 import android.text.style.LeadingMarginSpan
-import androidx.appcompat.R
-import com.google.android.material.color.MaterialColors
-import kotlin.math.roundToInt
+import androidx.annotation.ColorInt
+import androidx.annotation.Px
 
 /**
  * A [LeadingMarginSpan] that draws a vertical line in the leading margin of
  * the text, suitable for displaying an HTML `blockquote`.
  *
- * The margin is sized to the width of an "m" in the text's font.
- *
- * The stripe is set to one-third of the margin width, and drawn in
- * `colorPrimary`.
- *
  * [android.text.style.QuoteSpan] is not suitable for this as the basic
- * implementation does not allow you to set the colour or stripe width.
+ * implementation does not allow you to set the colour or stripe width,
+ * that's only possible in API 28+.
+ *
+ * @param marginWidth Width of the margin, in pixels.
+ * @param stripeWidth Width of the stripe, in pixels.
+ * @param stripeColour Colour to use for the stripe.
  */
-internal class BlockQuoteSpan(context: Context) : LeadingMarginSpan {
-    private var marginWidth = 0
-
-    private val stripeColour = MaterialColors.getColor(
-        context,
-        R.attr.colorPrimary,
-        Color.WHITE,
-    )
-
+internal class BlockQuoteSpan(
+    @Px private val marginWidth: Int,
+    @Px private val stripeWidth: Int,
+    @ColorInt private val stripeColour: Int,
+) : LeadingMarginSpan {
     override fun drawLeadingMargin(
         c: Canvas,
         p: Paint,
@@ -62,13 +55,11 @@ internal class BlockQuoteSpan(context: Context) : LeadingMarginSpan {
         first: Boolean,
         layout: Layout?,
     ) {
-        marginWidth = p.measureText("m").roundToInt()
-        val stripeWidth = (marginWidth / 3f)
         val style = p.style
         val color = p.color
         p.style = Paint.Style.FILL
         p.color = stripeColour
-        c.drawRect(x.toFloat(), top.toFloat(), x + dir * stripeWidth, bottom.toFloat(), p)
+        c.drawRect(x.toFloat(), top.toFloat(), (x + dir * stripeWidth).toFloat(), bottom.toFloat(), p)
         p.style = style
         p.color = color
     }

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/taghandler/LeadingMarginWithTextSpan.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/taghandler/LeadingMarginWithTextSpan.kt
@@ -19,9 +19,10 @@ package app.pachli.core.ui.taghandler
 
 import android.graphics.Canvas
 import android.graphics.Paint
+import android.os.Build
 import android.text.Layout
-import android.text.Spanned
 import android.text.style.LeadingMarginSpan
+import androidx.annotation.Px
 import androidx.annotation.VisibleForTesting
 import kotlin.math.roundToInt
 
@@ -39,25 +40,23 @@ fun interface ComputeLeadingMarginWithTextSpanText {
  * A [LeadingMarginSpan][android.text.style.LeadingMarginSpan] that shows text
  * inside the margin.
  *
- * The leading margin is sized to provide enough room to show the text `99. `,
- * so this can be used for lists of up to 99 items.
- *
  * The text to display in the margin should be provided by [computeMarginText].
  *
  * Within the margin the text is aligned according to [alignment].
  *
+ * @param marginWidth Width of the margin, in pixels
  * @param indentation 0-based indentation level of this item.
  * @param alignment See [Alignment].
  * @param computeMarginText See [ComputeLeadingMarginWithTextSpanText.invoke]
  */
 internal class LeadingMarginWithTextSpan(
+    @Px private val marginWidth: Int,
     private val indentation: Int,
     private val alignment: Alignment = Alignment.END,
     @get:VisibleForTesting
     val computeMarginText: ComputeLeadingMarginWithTextSpanText,
 ) : LeadingMarginSpan {
-    private var marginWidth: Int = 0
-
+    /** Text to display in the margin. */
     private var marginText: String? = null
 
     /** How text in the leading margin should be aligned. */
@@ -86,13 +85,26 @@ internal class LeadingMarginWithTextSpan(
         first: Boolean,
         l: Layout,
     ) {
-        // Margin is sized to allow enough space for "99. " in the active font.
-        marginWidth = p.measureText("99. ").roundToInt()
+        if (!first) return
 
-        val startCharOfSpan = (text as Spanned).getSpanStart(this)
-        val isFirstChar = startCharOfSpan == start
-
-        if (!isFirstChar) return
+        // On newer Android versions the paint may be flagged to include hyphens
+        // at the start or end (this seems to occur if the first line of the
+        // paragraph this span is attached to will be hyphenated). This:
+        //
+        // 1. Miscalculates the text measurements.
+        // 2. Causes the text drawn in the leading margin to have a leading or
+        // trailing hyphen.
+        //
+        // Fix this by using a new paint, constructed from the first, with the
+        // hyphenation flags disabled.
+        val finalPaint = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            Paint(p).apply {
+                startHyphenEdit = Paint.START_HYPHEN_EDIT_NO_EDIT
+                endHyphenEdit = Paint.END_HYPHEN_EDIT_NO_EDIT
+            }
+        } else {
+            p
+        }
 
         val computedMarginText = if (marginText == null) {
             marginText = computeMarginText(dir)
@@ -100,7 +112,7 @@ internal class LeadingMarginWithTextSpan(
         } else {
             marginText!!
         }
-        val marginTextWidth = p.measureText(computedMarginText)
+        val marginTextWidth = finalPaint.measureText(computedMarginText)
 
         val xOffset = when (alignment) {
             Alignment.START -> 0f
@@ -119,7 +131,31 @@ internal class LeadingMarginWithTextSpan(
                 marginWidth * indentation
             }
         }
-        c.drawText(computedMarginText, trueX + xOffset, baseline.toFloat(), p)
+
+        // Alternative code for fixing the "Hyphenated text draws a hyphen
+        // after a bullet" problem, in case changing the paint doesn't work
+        // on all devices. Requires the span be passed the target TextView
+        // as a constructor parameter.
+//        val builder = StaticLayout.Builder.obtain(
+//            computedMarginText,
+//            0,
+//            computedMarginText.length,
+//            textView.paint,
+//            marginWidth,
+//        )
+//
+//        val staticLayout = builder
+//            .setAlignment(Layout.Alignment.ALIGN_NORMAL)
+//            .setLineSpacing(textView.lineSpacingExtra, textView.lineSpacingMultiplier)
+//            .setIncludePad(false)
+//            .setHyphenationFrequency(Layout.HYPHENATION_FREQUENCY_NONE)
+//            .build()
+//
+//        c.withTranslation(trueX + xOffset, top.toFloat()) {
+//            staticLayout.draw(this)
+//        }
+
+        c.drawText(computedMarginText, trueX + xOffset, baseline.toFloat(), finalPaint)
     }
 
     override fun getLeadingMargin(first: Boolean): Int = marginWidth

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/taghandler/MastodonTagHandler.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/taghandler/MastodonTagHandler.kt
@@ -18,8 +18,12 @@
 package app.pachli.core.ui.taghandler
 
 import android.content.Context
+import android.graphics.Color
 import android.text.Editable
 import android.text.style.TypefaceSpan
+import android.widget.TextView
+import androidx.annotation.ColorInt
+import androidx.annotation.Px
 import app.pachli.core.network.PachliTagHandler
 import app.pachli.core.ui.taghandler.LeadingMarginWithTextSpan.Alignment
 import app.pachli.core.ui.taghandler.Mark.BlockQuote
@@ -27,7 +31,9 @@ import app.pachli.core.ui.taghandler.Mark.Code
 import app.pachli.core.ui.taghandler.Mark.OrderedListItem
 import app.pachli.core.ui.taghandler.Mark.Pre
 import app.pachli.core.ui.taghandler.Mark.UnorderedListItem
+import com.google.android.material.color.MaterialColors
 import java.util.Stack
+import kotlin.math.roundToInt
 import org.xml.sax.XMLReader
 
 /**
@@ -57,14 +63,18 @@ private val rxPre = """(?is)<pre>(.*?)</pre>""".toRegex()
  * - `pre` (not supported by HtmlCompat).
  * - `ol / li` (not supported by HtmlCompat, rewritten to `pachli-ol`).
  * - `ul / li` (supported by HtmlCompat, but badly, rewritten to `pachli-ul`).
+ *
+ * @param textView The [TextView] the content will be displayed in.
  */
-class MastodonTagHandler(context: Context) : PachliTagHandler {
+class MastodonTagHandler(textView: TextView) : PachliTagHandler {
     /** Stack of currently open `ol` and `ul` lists. */
     private val lists = Stack<ListElementHandler>()
 
-    private val codeHandler = CodeHandler(context)
-    private val blockQuoteHandler = BlockQuoteHandler(context)
+    private val codeHandler = CodeHandler(textView.context)
+    private val blockQuoteHandler = BlockQuoteHandler(textView)
     private val preHandler = PreHandler()
+    private val orderedListElementHandler = OrderedListElementHandler(textView)
+    private val unorderedListElementHandler = UnorderedListElementHandler(textView)
 
     override fun rewriteHtml(html: CharSequence): String {
         // Work around an Android bug. If a custom tag handler exists, and the
@@ -140,13 +150,13 @@ class MastodonTagHandler(context: Context) : PachliTagHandler {
             }
 
             "pachli-ul" -> if (opening) {
-                lists.push(UnorderedListElementHandler())
+                lists.push(unorderedListElementHandler)
             } else {
                 if (lists.isNotEmpty()) lists.pop().endElement(output)
             }
 
             "pachli-ol" -> if (opening) {
-                lists.push(OrderedListElementHandler())
+                lists.push(orderedListElementHandler)
             } else {
                 if (lists.isNotEmpty()) lists.pop().endElement(output)
             }
@@ -203,8 +213,23 @@ private interface ListElementHandler : ElementHandler {
  *
  * Marks the `<blockquote>` tag. `</blockquote>` inserts [BlockQuoteSpan]
  * between the start and end tags.
+ *
+ * @param textView [TextView] the content will be set in to.
  */
-private class BlockQuoteHandler(private val context: Context) : ElementHandler {
+private class BlockQuoteHandler(textView: TextView) : ElementHandler {
+    @Px
+    private val marginWidth = textView.lineHeight / 2
+
+    @Px
+    private val stripeWidth = marginWidth / 3
+
+    @ColorInt
+    private val stripeColour = MaterialColors.getColor(
+        textView.context,
+        androidx.appcompat.R.attr.colorPrimary,
+        Color.WHITE,
+    )
+
     override fun startElement(text: Editable) {
         text.ensureEndsWithNewline()
         text.appendMark(BlockQuote)
@@ -213,7 +238,7 @@ private class BlockQuoteHandler(private val context: Context) : ElementHandler {
     override fun endElement(text: Editable) {
         text.ensureEndsWithNewline()
         text.getLastSpanOrNull<BlockQuote>()?.let { mark ->
-            text.setSpansFromMark(mark, BlockQuoteSpan(context))
+            text.setSpansFromMark(mark, BlockQuoteSpan(marginWidth, stripeWidth, stripeColour))
         }
     }
 }
@@ -262,8 +287,13 @@ private class PreHandler : ElementHandler {
  *
  * Marks the `<li>` tag. `</li>` tags insert a [LeadingMarginWithTextSpan]
  * between the start and end tag with a bullet character in the margin.
+ *
+ * @param textView [TextView] the content will be set in to.
  */
-private class UnorderedListElementHandler : ListElementHandler {
+private class UnorderedListElementHandler(textView: TextView) : ListElementHandler {
+    @Px
+    private val marginWidth = textView.paint.measureText("99. ").roundToInt()
+
     override fun startListItem(text: Editable) {
         text.ensureEndsWithNewline()
         text.appendMark(UnorderedListItem)
@@ -275,7 +305,7 @@ private class UnorderedListElementHandler : ListElementHandler {
         text.getLastSpanOrNull<UnorderedListItem>()?.let { mark ->
             text.setSpansFromMark(
                 mark,
-                LeadingMarginWithTextSpan(indentation, Alignment.CENTER) { "•" },
+                LeadingMarginWithTextSpan(marginWidth, indentation, Alignment.CENTER) { "•" },
             )
         }
     }
@@ -292,8 +322,12 @@ private class UnorderedListElementHandler : ListElementHandler {
  * Marks the `<li>` tag. `</li>` tags insert a [LeadingMarginWithTextSpan]
  * between the start and end tag, with the 1-based numbered index of the
  * `li` element in the list.
+ *
+ * @param textView [TextView] the content will be set in to.
  */
-private class OrderedListElementHandler : ListElementHandler {
+private class OrderedListElementHandler(textView: TextView) : ListElementHandler {
+    private val marginWidth = textView.paint.measureText("99. ").roundToInt()
+
     /** Count of total `li` tags seen in this ordered list. */
     private var count = 1
 
@@ -308,7 +342,7 @@ private class OrderedListElementHandler : ListElementHandler {
         text.getLastSpanOrNull<OrderedListItem>()?.let { mark ->
             text.setSpansFromMark(
                 mark,
-                LeadingMarginWithTextSpan(indentation) {
+                LeadingMarginWithTextSpan(marginWidth, indentation) {
                     if (it > 0) {
                         "${mark.number}. "
                     } else {


### PR DESCRIPTION
Previous code might have visual artifacts when displaying quote markers and list indicators (bullets or numbers).

The problems were:

- The stripe next to blockquotes consisting of multiple paragraphs could change width.
- List indicators might have a `-` drawn after them.

Both of them are the same problem -- on some Android devices, if the first line in the paragraph is hyphenated then the paint passed to `drawLeadingMargin` will want to append/prepend a hyphen to anything it draws.

This causes the inconsistent text measurement, leading to the stripe width changing if the paragraph was hyphenated. And draws the `-` after the list indicators.

Fix these by:

1. Passing a consistent width measurement into the spans, instead of computing it every time.
2. Modifying the paint used to draw the list indicators and explicitly removing the hyphenation flags.

Fixes #2265