### PR TITLE
fix: Improve display of nested blockquotes and lists

### DIFF
--- a/core/ui/src/androidTest/kotlin/app/pachli/core/ui/taghandler/MastodonTagHandlerTest.kt
+++ b/core/ui/src/androidTest/kotlin/app/pachli/core/ui/taghandler/MastodonTagHandlerTest.kt
@@ -130,6 +130,61 @@ quote
 block</s:BlockQuoteSpan>
                     """.trimIndent(),
                 ),
+                // Ensure nested blockquotes work.
+                TestData(
+                    """
+<blockquote>
+<p>Para 1 that runs on several lines to make sure it wraps and is visible</p>
+<p>Para 2 that runs on several lines to make sure it wraps and is visible</p>
+<blockquote>
+<p>Nested 1 that runs on several lines to make sure it wraps and is visible</p>
+<p>Nested 2 that runs on several lines to make sure it wraps and is visible</p>
+<ul>
+  <li>list item 1</li>
+  <li>list item 2</li>
+  <li><ul><li>a</li><li>b</li><li>c</li></ul></li>
+</ul>
+</blockquote>
+<p>Para 3 that runs on several lines to make sure it wraps and is visible</p>
+</blockquote>
+                    """.trimIndent(),
+                    """
+<s:BlockQuoteSpan>Para 1 that runs on several lines to make sure it wraps and is visible
+
+Para 2 that runs on several lines to make sure it wraps and is visible
+
+<s:BlockQuoteSpan>Nested 1 that runs on several lines to make sure it wraps and is visible
+
+Nested 2 that runs on several lines to make sure it wraps and is visible
+
+<s:LeadingMarginWithTextSpan text="•">list item 1
+</s:LeadingMarginWithTextSpan><s:LeadingMarginWithTextSpan text="•">list item 2
+</s:LeadingMarginWithTextSpan><s:LeadingMarginWithTextSpan text="•"><s:LeadingMarginWithTextSpan text="•">a
+</s:LeadingMarginWithTextSpan><s:LeadingMarginWithTextSpan text="•">b
+</s:LeadingMarginWithTextSpan><s:LeadingMarginWithTextSpan text="•">c
+</s:LeadingMarginWithTextSpan></s:LeadingMarginWithTextSpan></s:BlockQuoteSpan>
+Para 3 that runs on several lines to make sure it wraps and is visible</s:BlockQuoteSpan>
+                    """.trimIndent(),
+                ),
+                // Check nested lists.
+                TestData(
+                    """
+<ul>
+  <li>item 1</li>
+  <li>item 2</li>
+  <li><ul><li>nest 1</li><li>nest 2</li><li>nest 3</li></ul></li>
+  <li>item 4</li>
+</ul>
+                    """.trimIndent(),
+                    """
+<s:LeadingMarginWithTextSpan text="•">item 1
+</s:LeadingMarginWithTextSpan><s:LeadingMarginWithTextSpan text="•">item 2
+</s:LeadingMarginWithTextSpan><s:LeadingMarginWithTextSpan text="•"><s:LeadingMarginWithTextSpan text="•">nest 1
+</s:LeadingMarginWithTextSpan><s:LeadingMarginWithTextSpan text="•">nest 2
+</s:LeadingMarginWithTextSpan><s:LeadingMarginWithTextSpan text="•">nest 3
+</s:LeadingMarginWithTextSpan></s:LeadingMarginWithTextSpan><s:LeadingMarginWithTextSpan text="•">item 4</s:LeadingMarginWithTextSpan>
+                    """.trimIndent(),
+                ),
             )
         }
     }

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/SetContent.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/SetContent.kt
@@ -25,6 +25,7 @@ import android.text.Spanned
 import android.text.style.URLSpan
 import android.util.TypedValue
 import android.widget.TextView
+import androidx.core.text.getSpans
 import androidx.core.text.method.LinkMovementMethodCompat
 import app.pachli.core.common.string.unicodeWrap
 import app.pachli.core.designsystem.R
@@ -36,6 +37,7 @@ import app.pachli.core.network.parseAsMastodonHtml
 import app.pachli.core.network.removeQuoteInline
 import app.pachli.core.preferences.LinksToUnderline
 import app.pachli.core.ui.PreProcessMastodonHtml.processMarkdown
+import app.pachli.core.ui.taghandler.LeadingMarginWithTextSpan
 import app.pachli.core.ui.taghandler.MastodonTagHandler
 import com.bumptech.glide.RequestManager
 import com.google.android.material.color.MaterialColors
@@ -182,6 +184,45 @@ object SetContentAsMastodonHtml : SetContent {
     }
 
     override fun setText(textView: TextView, text: Spannable) {
+        // HTML like this:
+        //
+        // <ul>
+        //   <li>one</li>
+        //   <li>two</li>
+        //   <li><ul><li>a</li><li>b</li></ul></li>
+        // </ul>
+        //
+        // will have created nested LeadingMarginWithTextSpans for the third item, the
+        // nested list.
+        //
+        // This is a problem, because the nested LeadingMarginWithTextSpans will each
+        // draw their own marker. So the output for the above looks like:
+        //
+        // ```
+        //  * one
+        //  * two
+        //  *  * a
+        //  *  * b
+        // ```
+        //
+        // To fix this (hack) update `computeMarginText` in the outermost spans to return
+        // the empty string.
+
+        // First, find all spans that share a start index.
+        //
+        // key: Index of the start of the span in `text`.
+        // value: List<Span>, a list of all spans starting at `key`, sorted, shortest span
+        // first.
+        val spansSharingStartIndex = text.getSpans<LeadingMarginWithTextSpan>(0, text.length)
+            .groupBy { text.getSpanStart(it) }
+            .filter { it.value.size != 1 }
+            .mapValues { it.value.sortedBy { text.getSpanEnd(it) } }
+
+        // Then update the margin text of all spans except the first (which is the shortest).
+        spansSharingStartIndex.values.forEach { spans ->
+            spans.drop(1).forEach { span -> span.computeMarginText = { "" } }
+        }
+
         textView.text = text
     }
 }

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/taghandler/BlockQuoteSpan.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/taghandler/BlockQuoteSpan.kt
@@ -35,11 +35,14 @@ import androidx.annotation.Px
  * @param marginWidth Width of the margin, in pixels.
  * @param stripeWidth Width of the stripe, in pixels.
  * @param stripeColour Colour to use for the stripe.
+ * @param indentation Count of the number of open `blockquote` elements
+ * before this one.
  */
 internal class BlockQuoteSpan(
     @Px private val marginWidth: Int,
     @Px private val stripeWidth: Int,
     @ColorInt private val stripeColour: Int,
+    private val indentation: Int,
 ) : LeadingMarginSpan {
     override fun drawLeadingMargin(
         c: Canvas,
@@ -59,7 +62,18 @@ internal class BlockQuoteSpan(
         val color = p.color
         p.style = Paint.Style.FILL
         p.color = stripeColour
-        c.drawRect(x.toFloat(), top.toFloat(), (x + dir * stripeWidth).toFloat(), bottom.toFloat(), p)
+
+        // Draw N stripes in the margin, one for this quote, and one for
+        // every other open blockquote to here.
+        for (level in 0..indentation) {
+            val trueX = if (dir > 0) {
+                marginWidth * level
+            } else {
+                c.width - (marginWidth * level)
+            }
+            c.drawRect(trueX.toFloat(), top.toFloat(), (trueX + dir * stripeWidth).toFloat(), bottom.toFloat(), p)
+        }
+
         p.style = style
         p.color = color
     }

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/taghandler/LeadingMarginWithTextSpan.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/taghandler/LeadingMarginWithTextSpan.kt
@@ -23,8 +23,6 @@ import android.os.Build
 import android.text.Layout
 import android.text.style.LeadingMarginSpan
 import androidx.annotation.Px
-import androidx.annotation.VisibleForTesting
-import kotlin.math.roundToInt
 
 fun interface ComputeLeadingMarginWithTextSpanText {
     /**
@@ -44,17 +42,26 @@ fun interface ComputeLeadingMarginWithTextSpanText {
  *
  * Within the margin the text is aligned according to [alignment].
  *
- * @param marginWidth Width of the margin, in pixels
- * @param indentation 0-based indentation level of this item.
+ * The content is laid out with space reserved for [additionalMargin]
+ * first, then [marginWidth]. The contents (from [computeMarginText])
+ * are aligned within the space defined by [marginWidth].
+ *
+ * ```
+ * |<-- additional margin -->||<-- marginWidth -->|
+ *                                 ^-- margin text inserted/aligned here
+ * ```
+ *
+ * @param marginWidth Width of the margin this span should create, in pixels
+ * @param additionalMargin Extra margin to include before [marginWidth]
+ * when laying out the content.
  * @param alignment See [Alignment].
  * @param computeMarginText See [ComputeLeadingMarginWithTextSpanText.invoke]
  */
 internal class LeadingMarginWithTextSpan(
-    @Px private val marginWidth: Int,
-    private val indentation: Int,
+    @Px val marginWidth: Int,
+    @Px val additionalMargin: Int,
     private val alignment: Alignment = Alignment.END,
-    @get:VisibleForTesting
-    val computeMarginText: ComputeLeadingMarginWithTextSpanText,
+    var computeMarginText: ComputeLeadingMarginWithTextSpanText,
 ) : LeadingMarginSpan {
     /** Text to display in the margin. */
     private var marginText: String? = null
@@ -87,6 +94,14 @@ internal class LeadingMarginWithTextSpan(
     ) {
         if (!first) return
 
+        val computedMarginText = if (marginText == null) {
+            marginText = computeMarginText(dir)
+            marginText!!
+        } else {
+            marginText!!
+        }
+        if (computedMarginText.isBlank()) return
+
         // On newer Android versions the paint may be flagged to include hyphens
         // at the start or end (this seems to occur if the first line of the
         // paragraph this span is attached to will be hyphenated). This:
@@ -106,12 +121,6 @@ internal class LeadingMarginWithTextSpan(
             p
         }
 
-        val computedMarginText = if (marginText == null) {
-            marginText = computeMarginText(dir)
-            marginText!!
-        } else {
-            marginText!!
-        }
         val marginTextWidth = finalPaint.measureText(computedMarginText)
 
         val xOffset = when (alignment) {
@@ -120,17 +129,11 @@ internal class LeadingMarginWithTextSpan(
             Alignment.END -> if (dir > 0) marginWidth - marginTextWidth else -(marginWidth - marginTextWidth)
         }
 
-        // Some Android versions have a bug where `x` is always 0 (e.g., API 28).
-        // Calculate the correct value.
-        val trueX: Int = if (dir > 0) {
-            marginWidth * indentation
+        val trueX = if (dir > 0) {
+            additionalMargin
         } else {
-            c.width - if (marginWidth * indentation == 0) {
-                marginTextWidth.roundToInt()
-            } else {
-                marginWidth * indentation
-            }
-        }
+            c.width - additionalMargin
+        } + xOffset
 
         // Alternative code for fixing the "Hyphenated text draws a hyphen
         // after a bullet" problem, in case changing the paint doesn't work
@@ -155,7 +158,7 @@ internal class LeadingMarginWithTextSpan(
 //            staticLayout.draw(this)
 //        }
 
-        c.drawText(computedMarginText, trueX + xOffset, baseline.toFloat(), finalPaint)
+        c.drawText(computedMarginText, trueX, baseline.toFloat(), finalPaint)
     }
 
     override fun getLeadingMargin(first: Boolean): Int = marginWidth

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/taghandler/Mark.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/taghandler/Mark.kt
@@ -23,18 +23,23 @@ interface Mark {
     object Code : Mark
 
     /** Marks the opening tag location of a `blockquote` element. */
-    object BlockQuote : Mark
+    // `class` instead of `object`, as these can be nested, as repeatedly
+    // setting an `object` span just moves it around.
+    class BlockQuote : Mark
 
     /** Marks the opening tag location of a `pre` element. */
     object Pre : Mark
 
-    /**
-     * Marks the opening tag location of a list item in an <ol> element.
-     *
-     * @property number The list item's 1-based position in the list.
-     */
-    class OrderedListItem(val number: Int) : Mark
+    /** Marks the opening tag location of an `li` element. */
+    interface ListItem : Mark {
+        /**
+         * Marks the opening tag location of an `li` element in a `ol` element.
+         *
+         * @property number The list item's 1-based position in the list.
+         */
+        class OrderedListItem(val number: Int) : ListItem
 
-    /** Marks the opening tag location of a list item in an <ul> element. */
-    object UnorderedListItem : Mark
+        /** Marks the opening tag location of an `li` element in a `ul` element. */
+        class UnorderedListItem : ListItem
+    }
 }

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/taghandler/MastodonTagHandler.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/taghandler/MastodonTagHandler.kt
@@ -28,11 +28,10 @@ import app.pachli.core.network.PachliTagHandler
 import app.pachli.core.ui.taghandler.LeadingMarginWithTextSpan.Alignment
 import app.pachli.core.ui.taghandler.Mark.BlockQuote
 import app.pachli.core.ui.taghandler.Mark.Code
-import app.pachli.core.ui.taghandler.Mark.OrderedListItem
+import app.pachli.core.ui.taghandler.Mark.ListItem.OrderedListItem
+import app.pachli.core.ui.taghandler.Mark.ListItem.UnorderedListItem
 import app.pachli.core.ui.taghandler.Mark.Pre
-import app.pachli.core.ui.taghandler.Mark.UnorderedListItem
 import com.google.android.material.color.MaterialColors
-import java.util.Stack
 import kotlin.math.roundToInt
 import org.xml.sax.XMLReader
 
@@ -66,9 +65,12 @@ private val rxPre = """(?is)<pre>(.*?)</pre>""".toRegex()
  *
  * @param textView The [TextView] the content will be displayed in.
  */
-class MastodonTagHandler(textView: TextView) : PachliTagHandler {
+class MastodonTagHandler(private val textView: TextView) : PachliTagHandler {
     /** Stack of currently open `ol` and `ul` lists. */
-    private val lists = Stack<ListElementHandler>()
+    private val lists = mutableListOf<ListElementHandler>()
+
+    /** Count of currently open `blockquote` elements. */
+    private var blockquotes = 0
 
     private val codeHandler = CodeHandler(textView.context)
     private val blockQuoteHandler = BlockQuoteHandler(textView)
@@ -112,27 +114,22 @@ class MastodonTagHandler(textView: TextView) : PachliTagHandler {
         val rewritten = html
             // The XML reader doesn't treat whitespace as significant in `pre`
             // so replace some content within the element.
-            .replace(
-                rxPre,
-                { preBody ->
-                    val newBody = preBody.groups[1]?.value
-                        // Whitespace at the start of internal paras is significant.
-                        ?.replace("\n ", "<br />&nbsp;")
-                        // Convert internal paras to `br`.
-                        ?.replace("\n", "<br />")
-                        // Runs of two or more spaces are significant.
-                        ?.replace("  ", "&nbsp;&nbsp;")
-                    "<pre>$newBody</pre>"
-                },
-            )
-            .replace(
-                rxPachliTags,
-                {
-                    wrapInHtmlElement = wrapInHtmlElement || it.groups[0]?.range?.start == 0
+            .replace(rxPre) { preBody ->
+                val newBody = preBody.groups[1]?.value
+                    // Whitespace at the start of internal paras is significant.
+                    ?.replace("\n ", "<br />&nbsp;")
+                    // Convert internal paras to `br`.
+                    ?.replace("\n", "<br />")
+                    // Runs of two or more spaces are significant.
+                    ?.replace("  ", "&nbsp;&nbsp;")
+                "<pre>$newBody</pre>"
+            }
+            .replace(rxPachliTags) {
+                wrapInHtmlElement = wrapInHtmlElement || it.groups[0]?.range?.start == 0
 
-                    "<${it.groups[1]?.value ?: ""}pachli-${it.groups[2]?.value}>"
-                },
-            )
+                "<${it.groups[1]?.value ?: ""}pachli-${it.groups[2]?.value}>"
+            }
+
         return if (wrapInHtmlElement) "<html>$rewritten</html>" else rewritten
     }
 
@@ -145,26 +142,33 @@ class MastodonTagHandler(textView: TextView) : PachliTagHandler {
         when (tag.lowercase()) {
             "pachli-blockquote" -> if (opening) {
                 blockQuoteHandler.startElement(output)
+                blockquotes++
             } else {
-                blockQuoteHandler.endElement(output)
+                blockquotes--
+                blockQuoteHandler.endElement(output, blockquotes)
             }
 
             "pachli-ul" -> if (opening) {
-                lists.push(unorderedListElementHandler)
+                lists.add(unorderedListElementHandler)
             } else {
-                if (lists.isNotEmpty()) lists.pop().endElement(output)
+                lists.removeLastOrNull()?.endElement(output)
             }
 
             "pachli-ol" -> if (opening) {
-                lists.push(orderedListElementHandler)
+                lists.add(orderedListElementHandler)
             } else {
-                if (lists.isNotEmpty()) lists.pop().endElement(output)
+                lists.removeLastOrNull()?.endElement(output)
             }
 
             "pachli-li" -> if (opening) {
-                if (lists.isNotEmpty()) lists.peek().startListItem(output)
+                lists.lastOrNull()?.startListItem(output)
             } else {
-                if (lists.isNotEmpty()) lists.peek().endListItem(output, indentation = lists.size - 1)
+                lists.lastOrNull()?.endListItem(
+                    output,
+                    // Add additional margin for all open blockquotes and lists.
+                    additionalMargin = (blockquotes * blockQuoteHandler.marginWidth) +
+                        lists.dropLast(1).sumOf { it.marginWidth },
+                )
             }
 
             "code" -> if (opening) {
@@ -201,11 +205,15 @@ private interface ElementHandler {
 }
 
 private interface ListElementHandler : ElementHandler {
+    /** The width of the space reserved for each list marker. */
+    @get:Px
+    val marginWidth: Int
+
     /** Called when an opening <li> tag is encountered. */
     fun startListItem(text: Editable) = Unit
 
     /** Called when a closing </li> tag is encountered. */
-    fun endListItem(text: Editable, indentation: Int) = Unit
+    fun endListItem(text: Editable, additionalMargin: Int) = Unit
 }
 
 /**
@@ -217,9 +225,11 @@ private interface ListElementHandler : ElementHandler {
  * @param textView [TextView] the content will be set in to.
  */
 private class BlockQuoteHandler(textView: TextView) : ElementHandler {
+    /** The total width of the space reserved for the blockquote margin. */
     @Px
-    private val marginWidth = textView.lineHeight / 2
+    val marginWidth = textView.lineHeight / 2
 
+    /** The width of the stripe drawn inside the margin. */
     @Px
     private val stripeWidth = marginWidth / 3
 
@@ -232,13 +242,13 @@ private class BlockQuoteHandler(textView: TextView) : ElementHandler {
 
     override fun startElement(text: Editable) {
         text.ensureEndsWithNewline()
-        text.appendMark(BlockQuote)
+        text.appendMark(BlockQuote())
     }
 
-    override fun endElement(text: Editable) {
+    fun endElement(text: Editable, indentation: Int) {
         text.ensureEndsWithNewline()
         text.getLastSpanOrNull<BlockQuote>()?.let { mark ->
-            text.setSpansFromMark(mark, BlockQuoteSpan(marginWidth, stripeWidth, stripeColour))
+            text.setSpansFromMark(mark, BlockQuoteSpan(marginWidth, stripeWidth, stripeColour, indentation))
         }
     }
 }
@@ -285,34 +295,36 @@ private class PreHandler : ElementHandler {
 /**
  * Processes unordered lists and their `li` contents.
  *
- * Marks the `<li>` tag. `</li>` tags insert a [LeadingMarginWithTextSpan]
+ * Marks the `<li>` tag. `</li>` tags, inserts a [LeadingMarginWithTextSpan]
  * between the start and end tag with a bullet character in the margin.
  *
  * @param textView [TextView] the content will be set in to.
  */
 private class UnorderedListElementHandler(textView: TextView) : ListElementHandler {
     @Px
-    private val marginWidth = textView.paint.measureText("99. ").roundToInt()
+    override val marginWidth = textView.paint.measureText("99. ").roundToInt()
 
     override fun startListItem(text: Editable) {
         text.ensureEndsWithNewline()
-        text.appendMark(UnorderedListItem)
+        text.appendMark(UnorderedListItem())
     }
 
-    override fun endListItem(text: Editable, indentation: Int) {
+    override fun endListItem(text: Editable, additionalMargin: Int) {
         text.ensureEndsWithNewline()
 
         text.getLastSpanOrNull<UnorderedListItem>()?.let { mark ->
             text.setSpansFromMark(
                 mark,
-                LeadingMarginWithTextSpan(marginWidth, indentation, Alignment.CENTER) { "•" },
+                LeadingMarginWithTextSpan(marginWidth, additionalMargin, Alignment.CENTER) { "•" },
             )
         }
     }
 
     override fun endElement(text: Editable) {
         text.ensureEndsWithNewline()
-        text.append("\n")
+        // Add another new line after the list, unless this list is nested inside
+        // another list.
+        if (text.getLastSpanOrNull<Mark.ListItem>() == null) text.append("\n")
     }
 }
 
@@ -326,7 +338,8 @@ private class UnorderedListElementHandler(textView: TextView) : ListElementHandl
  * @param textView [TextView] the content will be set in to.
  */
 private class OrderedListElementHandler(textView: TextView) : ListElementHandler {
-    private val marginWidth = textView.paint.measureText("99. ").roundToInt()
+    @Px
+    override val marginWidth = textView.paint.measureText("99. ").roundToInt()
 
     /** Count of total `li` tags seen in this ordered list. */
     private var count = 1
@@ -336,13 +349,13 @@ private class OrderedListElementHandler(textView: TextView) : ListElementHandler
         text.appendMark(OrderedListItem(count++))
     }
 
-    override fun endListItem(text: Editable, indentation: Int) {
+    override fun endListItem(text: Editable, additionalMargin: Int) {
         text.ensureEndsWithNewline()
 
         text.getLastSpanOrNull<OrderedListItem>()?.let { mark ->
             text.setSpansFromMark(
                 mark,
-                LeadingMarginWithTextSpan(marginWidth, indentation) {
+                LeadingMarginWithTextSpan(marginWidth, additionalMargin) {
                     if (it > 0) {
                         "${mark.number}. "
                     } else {
@@ -355,6 +368,8 @@ private class OrderedListElementHandler(textView: TextView) : ListElementHandler
 
     override fun endElement(text: Editable) {
         text.ensureEndsWithNewline()
-        text.append("\n")
+        // Add another new line after the list, unless this list is nested inside
+        // another list.
+        if (text.getLastSpanOrNull<Mark.ListItem>() == null) text.append("\n")
     }
 }


### PR DESCRIPTION
A list inside a blockquote, like this:

```
<blockquote><ul><li>item 1</li><li>item 2</li></ul></blockquote>
```

was rendering a bit like this:

```
  * | item 1
  * | item 2
```

I.e., the blockquote stripe was inside the list item marker (bullet), instead of being drawn on the outer margin.

In addition, nested blockquotes were only rendering one stripe, instead of N stripes, one for each level of nesting.

While digging into this I noticed nested lists were not being displayed correctly either, with duplicate list markers appearing for nested list items, and additional space after the last item in a nested list, looking a bit like this:

```
  * item 1
  * item 2
  *  * item 2.1
  *  * item 2.2

  * item 3
```

Fix this by:

- For lists, compute an additional leading margin to reserve before the list marker, taking into account any open lists and blockquotes.
- For blockquotes, compute an additional leading margin to reserve before content, and draw N stripes at appropriate distances.
- Clear the list item marker if it's a list item that contains a nested list.
- Only insert an additional newline at the end of lists if it's not a nested list

Reported by @reuterbal@mast.hpc.social