### PR TITLE
fix: Scale the "info" icon above each post to match the text size

### DIFF
--- a/app/src/main/java/app/pachli/adapter/StatusViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/StatusViewHolder.kt
@@ -16,11 +16,16 @@
 
 package app.pachli.adapter
 
+import android.graphics.Rect
+import android.graphics.drawable.Drawable
 import android.view.View
 import android.widget.TextView
+import androidx.annotation.DrawableRes
+import androidx.annotation.Px
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.text.HtmlCompat
 import androidx.core.text.htmlEncode
-import app.pachli.R
+import androidx.core.util.TypedValueCompat.dpToPx
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
 import app.pachli.core.common.string.unicodeWrap
@@ -33,6 +38,7 @@ import app.pachli.core.ui.StatusActionListener
 import app.pachli.core.ui.emojify
 import app.pachli.databinding.ItemStatusBinding
 import com.bumptech.glide.RequestManager
+import kotlin.math.roundToInt
 
 open class StatusViewHolder<T : IStatusViewData>(
     private val binding: ItemStatusBinding,
@@ -40,6 +46,24 @@ open class StatusViewHolder<T : IStatusViewData>(
     setContent: SetContent,
     root: View? = null,
 ) : StatusBaseViewHolder<T>(root ?: binding.root, glide, setContent) {
+
+    /**
+     * The start padding (pixels) necessary to align the start of text in
+     * statusInfo with the start of text in statusDisplayName.
+     *
+     * See [setStatusInfoDrawableRes].
+     */
+    @Px
+    private val defaultStatusInfoPaddingStart: Int = dpToPx(56f, binding.root.context.resources.displayMetrics).roundToInt()
+
+    /**
+     * The bounds (pixels) for the drawable to show in the "start" slot of
+     * statusInfo.
+     */
+    private val statusInfoStartCompoundDrawableBounds = run {
+        val size = (binding.statusInfo.lineHeight * 1.29).roundToInt()
+        Rect(0, 0, size, size)
+    }
 
     override fun setupWithStatus(
         viewData: T,
@@ -132,7 +156,7 @@ open class StatusViewHolder<T : IStatusViewData>(
             else -> context.getString(app.pachli.core.ui.R.string.post_replied)
         }
 
-        statusInfo.setCompoundDrawablesRelativeWithIntrinsicBounds(app.pachli.core.ui.R.drawable.ic_reply_18dp, 0, 0, 0)
+        setStatusInfoDrawableRes(app.pachli.core.ui.R.drawable.ic_reply_18dp, statusInfo)
         statusInfo.isClickable = false
         statusInfo.show()
     }
@@ -164,9 +188,39 @@ open class StatusViewHolder<T : IStatusViewData>(
             statusDisplayOptions.animateEmojis,
         )
 
-        statusInfo.setCompoundDrawablesRelativeWithIntrinsicBounds(R.drawable.ic_reblog_18dp, 0, 0, 0)
+        setStatusInfoDrawableRes(app.pachli.core.ui.R.drawable.ic_reblog_24dp, statusInfo)
         statusInfo.setOnClickListener { listener.onOpenReblog(viewData.status) }
         statusInfo.show()
+    }
+
+    protected fun setStatusInfoDrawable(drawable: Drawable?, textView: TextView) {
+        drawable?.apply {
+            bounds = statusInfoStartCompoundDrawableBounds
+        }
+        textView.setPaddingRelative(
+            defaultStatusInfoPaddingStart - statusInfoStartCompoundDrawableBounds.width(),
+            textView.paddingTop,
+            textView.paddingEnd,
+            textView.paddingBottom,
+        )
+        textView.setCompoundDrawablesRelative(drawable, null, null, null)
+    }
+
+    /**
+     * Sets [drawableRes] as the "start" drawable in the statusInfo [textView], and
+     * adjusts the textView's start padding as necessary.*
+     */
+    private fun setStatusInfoDrawableRes(@DrawableRes drawableRes: Int, textView: TextView) {
+        setStatusInfoDrawable(getStatusInfoDrawable(drawableRes, textView), textView)
+    }
+
+    /**
+     * Gets [drawableRes], scaled to 129% the line height of [textView].
+     */
+    private fun getStatusInfoDrawable(@DrawableRes drawableRes: Int, textView: TextView): Drawable? {
+        return AppCompatResources.getDrawable(textView.context, drawableRes)?.apply {
+            bounds = statusInfoStartCompoundDrawableBounds
+        }
     }
 
     protected fun hideStatusInfo() = with(binding) {

--- a/app/src/main/java/app/pachli/components/notifications/StatusNotificationViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/notifications/StatusNotificationViewHolder.kt
@@ -20,7 +20,6 @@ package app.pachli.components.notifications
 import android.widget.TextView
 import androidx.core.text.HtmlCompat
 import androidx.core.text.htmlEncode
-import androidx.core.util.TypedValueCompat.dpToPx
 import app.pachli.R
 import app.pachli.adapter.StatusViewDataDiffCallback
 import app.pachli.adapter.StatusViewHolder
@@ -56,9 +55,6 @@ internal class StatusNotificationViewHolder(
     setContent: SetContent,
     private val notificationActionListener: NotificationActionListener,
 ) : NotificationsPagingAdapter.ViewHolder<WithStatus>, StatusViewHolder<WithStatus>(binding, glide, setContent) {
-    private val compoundDrawablePadding = dpToPx(10f, context.resources.displayMetrics).toInt()
-    private val relativePadding = dpToPx(28f, context.resources.displayMetrics).toInt()
-
     override fun bind(
         viewData: WithStatus,
         payloads: List<List<Any?>>?,
@@ -108,9 +104,8 @@ internal class StatusNotificationViewHolder(
             is WithStatus.PollNotificationViewData -> if (viewData.isAboutSelf) context.getString(R.string.poll_ended_created) else context.getString(R.string.poll_ended_voted)
         }
 
-        statusInfo.setCompoundDrawablesRelativeWithIntrinsicBounds(viewData.icon(context), null, null, null)
-        statusInfo.compoundDrawablePadding = compoundDrawablePadding
-        statusInfo.setPaddingRelative(relativePadding, 0, 0, 0)
+        val drawable = viewData.icon(context)
+        setStatusInfoDrawable(drawable, statusInfo)
 
         val wholeMessage = HtmlCompat.fromHtml(msg, HtmlCompat.FROM_HTML_MODE_LEGACY)
         val emojifiedText = wholeMessage.emojify(


### PR DESCRIPTION
Previous code was always showing the "info" icon (reblog, reply) at its intrinsic size, 18dp. So if the user scaled the text in Preferences the icon wouldn't adjust.

Change this, so the icon size is 129% of the line height of the textview. 129% seems to approximate the current size when the status text size is set to "medium".

Adjust the drawable padding as necessary to compensate.