### PR TITLE
feat: Highlight followed tags in posts

### DIFF
--- a/app/src/main/java/app/pachli/adapter/StatusViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/StatusViewHolder.kt
@@ -17,21 +17,27 @@
 package app.pachli.adapter
 
 import android.graphics.Rect
+import android.graphics.Typeface
 import android.graphics.drawable.Drawable
+import android.text.style.StyleSpan
 import android.view.View
 import android.widget.TextView
 import androidx.annotation.DrawableRes
 import androidx.annotation.Px
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.text.HtmlCompat
+import androidx.core.text.buildSpannedString
 import androidx.core.text.htmlEncode
+import androidx.core.text.set
 import androidx.core.util.TypedValueCompat.dpToPx
+import app.pachli.R
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
 import app.pachli.core.common.string.unicodeWrap
 import app.pachli.core.data.model.IStatusViewData
 import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.model.FilterAction
+import app.pachli.core.model.Hashtag
 import app.pachli.core.model.TimelineAccount
 import app.pachli.core.ui.SetContent
 import app.pachli.core.ui.StatusActionListener
@@ -106,6 +112,11 @@ open class StatusViewHolder<T : IStatusViewData>(
 
         if (status.inReplyToAccountId != null) {
             setStatusInfoAsReply(statusInfo, viewData, statusDisplayOptions)
+            return
+        }
+
+        status.tags?.firstOrNull { it.following == true }?.let { hashtag ->
+            setStatusInfoAsHashtag(statusInfo, hashtag, listener)
             return
         }
 
@@ -190,6 +201,26 @@ open class StatusViewHolder<T : IStatusViewData>(
 
         setStatusInfoDrawableRes(app.pachli.core.ui.R.drawable.ic_reblog_24dp, statusInfo)
         statusInfo.setOnClickListener { listener.onOpenReblog(viewData.status) }
+        statusInfo.show()
+    }
+
+    /**
+     * Sets [statusInfo] icon to a hashtag mark, and the text to the name
+     * of [hashtag]. Clicks on the hashtag are sent to
+     * [listener.onViewTag][StatusActionListener.onViewTag].
+     */
+    private fun setStatusInfoAsHashtag(
+        statusInfo: TextView,
+        hashtag: Hashtag,
+        listener: StatusActionListener,
+    ) {
+        setStatusInfoDrawableRes(R.drawable.ic_hashtag, statusInfo)
+        val statusInfoText = buildSpannedString {
+            append(hashtag.name)
+            set(0, hashtag.name.length, StyleSpan(Typeface.BOLD))
+        }
+        statusInfo.text = statusInfoText
+        statusInfo.setOnClickListener { listener.onViewTag(hashtag.name) }
         statusInfo.show()
     }
 

--- a/app/src/test/java/app/pachli/components/compose/ComposeActivityTest.kt
+++ b/app/src/test/java/app/pachli/components/compose/ComposeActivityTest.kt
@@ -180,6 +180,7 @@ class ComposeActivityTest {
             on { listAnnouncements(any()) } doReturn success(emptyList())
             on { getContentFiltersV1() } doReturn success(emptyList())
             on { accountFollowing(any(), anyOrNull(), any()) } doReturn success(emptyList())
+            on { followedTags() } doReturn success(emptyList())
         }
 
         reset(nodeInfoApi)

--- a/app/src/test/java/app/pachli/components/notifications/NotificationsViewModelTestBase.kt
+++ b/app/src/test/java/app/pachli/components/notifications/NotificationsViewModelTestBase.kt
@@ -143,6 +143,7 @@ abstract class NotificationsViewModelTestBase {
             on { getContentFilters() } doReturn success(emptyList())
             on { listAnnouncements(anyOrNull()) } doReturn success(emptyList())
             on { accountFollowing(any(), anyOrNull(), any()) } doReturn success(emptyList())
+            on { followedTags() } doReturn success(emptyList())
         }
 
         reset(nodeInfoApi)

--- a/app/src/test/java/app/pachli/components/timeline/CachedTimelineRemoteMediatorTest.kt
+++ b/app/src/test/java/app/pachli/components/timeline/CachedTimelineRemoteMediatorTest.kt
@@ -120,6 +120,7 @@ class CachedTimelineRemoteMediatorTest {
             on { getContentFilters() } doReturn success(emptyList())
             on { listAnnouncements(anyOrNull()) } doReturn success(emptyList())
             on { accountFollowing(any(), anyOrNull(), any()) } doReturn success(emptyList())
+            on { followedTags() } doReturn success(emptyList())
         }
 
         reset(nodeInfoApi)

--- a/app/src/test/java/app/pachli/components/timeline/CachedTimelineViewModelTestBase.kt
+++ b/app/src/test/java/app/pachli/components/timeline/CachedTimelineViewModelTestBase.kt
@@ -124,6 +124,7 @@ abstract class CachedTimelineViewModelTestBase {
             on { listAnnouncements(any()) } doReturn success(emptyList())
             on { getContentFiltersV1() } doReturn success(emptyList())
             on { accountFollowing(any(), anyOrNull(), any()) } doReturn success(emptyList())
+            on { followedTags() } doReturn success(emptyList())
         }
 
         reset(nodeInfoApi)

--- a/app/src/test/java/app/pachli/components/timeline/NetworkTimelineRemoteMediatorTest.kt
+++ b/app/src/test/java/app/pachli/components/timeline/NetworkTimelineRemoteMediatorTest.kt
@@ -134,6 +134,7 @@ class NetworkTimelineRemoteMediatorTest {
             on { listAnnouncements(any()) } doReturn success(emptyList())
             on { getContentFiltersV1() } doReturn success(emptyList())
             on { accountFollowing(any(), anyOrNull(), any()) } doReturn success(emptyList())
+            on { followedTags() } doReturn success(emptyList())
         }
 
         reset(nodeInfoApi)

--- a/app/src/test/java/app/pachli/components/timeline/NetworkTimelineViewModelTestBase.kt
+++ b/app/src/test/java/app/pachli/components/timeline/NetworkTimelineViewModelTestBase.kt
@@ -116,6 +116,7 @@ abstract class NetworkTimelineViewModelTestBase {
             on { getContentFilters() } doReturn success(emptyList())
             on { listAnnouncements(anyOrNull()) } doReturn success(emptyList())
             on { accountFollowing(any(), anyOrNull(), any()) } doReturn success(emptyList())
+            on { followedTags() } doReturn success(emptyList())
         }
 
         reset(nodeInfoApi)

--- a/app/src/test/java/app/pachli/components/viewthread/ViewThreadViewModelTest.kt
+++ b/app/src/test/java/app/pachli/components/viewthread/ViewThreadViewModelTest.kt
@@ -126,6 +126,7 @@ class ViewThreadViewModelTest {
             on { getLists() } doReturn success(emptyList())
             on { getContentFilters() } doReturn success(emptyList())
             on { accountFollowing(any(), anyOrNull(), any()) } doReturn success(emptyList())
+            on { followedTags() } doReturn success(emptyList())
         }
 
         reset(nodeInfoApi)

--- a/app/src/test/java/app/pachli/util/StatusDisplayOptionsRepositoryTest.kt
+++ b/app/src/test/java/app/pachli/util/StatusDisplayOptionsRepositoryTest.kt
@@ -121,6 +121,7 @@ class StatusDisplayOptionsRepositoryTest {
             on { getContentFilters() } doReturn success(emptyList())
             on { listAnnouncements(anyOrNull()) } doReturn success(emptyList())
             on { accountFollowing(any(), anyOrNull(), any()) } doReturn success(emptyList())
+            on { followedTags() } doReturn success(emptyList())
         }
 
         reset(nodeInfoApi)

--- a/core/data/src/main/kotlin/app/pachli/core/data/extensions/NetworkHashtag.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/extensions/NetworkHashtag.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.core.data.extensions
+
+import app.pachli.core.database.model.HashtagEntity
+import app.pachli.core.network.model.HashTag
+import app.pachli.core.network.model.asModel
+
+fun HashTag.asEntity(pachliAccountId: Long) = HashtagEntity(
+    pachliAccountId = pachliAccountId,
+    name = name,
+    url = url,
+    history = history.asModel(),
+    following = following == true,
+)
+
+fun Iterable<HashTag>.asEntity(pachliAccountId: Long) = map { it.asEntity(pachliAccountId) }

--- a/core/data/src/main/kotlin/app/pachli/core/data/model/StatusViewData.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/model/StatusViewData.kt
@@ -329,7 +329,13 @@ data class StatusViewData(
 
             return StatusViewData(
                 pachliAccountId = pachliAccount.id,
-                status = status,
+                status = status.copy(
+                    // Ensure the tags have the `following` property set correctly,
+                    // the property is typically null/missing from the server.
+                    tags = status.tags?.map {
+                        it.copy(following = pachliAccount.followedHashtags.contains(it.name))
+                    },
+                ),
                 translation = translation,
                 isExpanded = isExpanded,
                 isCollapsed = isCollapsed,

--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/AccountManager.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/AccountManager.kt
@@ -21,6 +21,7 @@ import android.database.sqlite.SQLiteException
 import app.pachli.core.common.PachliError
 import app.pachli.core.common.di.ApplicationScope
 import app.pachli.core.data.R
+import app.pachli.core.data.extensions.asEntity
 import app.pachli.core.data.model.Server
 import app.pachli.core.data.repository.ServerRepository.Error.GetNodeInfo
 import app.pachli.core.data.repository.ServerRepository.Error.GetWellKnownNodeInfo
@@ -29,6 +30,7 @@ import app.pachli.core.data.repository.ServerRepository.Error.ValidateNodeInfo
 import app.pachli.core.database.dao.AccountDao
 import app.pachli.core.database.dao.AnnouncementsDao
 import app.pachli.core.database.dao.FollowingAccountDao
+import app.pachli.core.database.dao.HashtagsDao
 import app.pachli.core.database.dao.InstanceDao
 import app.pachli.core.database.di.TransactionProvider
 import app.pachli.core.database.model.AccountEntity
@@ -175,6 +177,7 @@ class AccountManager @Inject constructor(
     private val listsRepository: ListsRepository,
     private val announcementsDao: AnnouncementsDao,
     private val followingAccountDao: FollowingAccountDao,
+    private val hashtagsDao: HashtagsDao,
     private val instanceSwitchAuthInterceptor: InstanceSwitchAuthInterceptor,
     @ApplicationScope private val externalScope: CoroutineScope,
 ) {
@@ -491,6 +494,27 @@ class AccountManager @Inject constructor(
             return@async Ok(following)
         }
 
+        val deferHashtags = externalScope.async {
+            var maxId: String? = null
+            val hashtags = buildList {
+                do {
+                    val response = mastodonApi.followedTags()
+                        .getOrElse { return@async Err(RefreshAccountError.General(account, it)) }
+                    addAll(response.body.asEntity(account.id))
+                    val links = HttpHeaderLink.parse(response.headers["Link"])
+                    val next = HttpHeaderLink.findByRelationType(links, "next")
+                    maxId = next?.uri?.getQueryParameter("max_id")
+                } while (maxId != null)
+            }
+
+            transactionProvider {
+                hashtagsDao.deleteFollowedHashtagsForAccount(account.id)
+                hashtagsDao.upsert(hashtags)
+            }
+
+            return@async Ok(hashtags)
+        }
+
         val nodeInfo = deferNodeInfo.await().bind()
         val instanceInfo = deferInstanceInfo.await().bind()
 
@@ -521,6 +545,8 @@ class AccountManager @Inject constructor(
             }.bind()
 
         deferEmojis.await().bind()
+
+        deferHashtags.await().bind()
 
         externalScope.async { listsRepository.refresh(account.id) }.await()
             .mapError { RefreshAccountError.General(account, it) }.bind()

--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/PachliAccount.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/PachliAccount.kt
@@ -23,6 +23,7 @@ import app.pachli.core.database.model.FollowingAccountEntity
 import app.pachli.core.database.model.asModel
 import app.pachli.core.model.Announcement
 import app.pachli.core.model.Emoji
+import app.pachli.core.model.Hashtag
 import app.pachli.core.model.InstanceInfo
 import app.pachli.core.model.MastodonList
 import app.pachli.core.model.ServerKind
@@ -41,6 +42,8 @@ import io.github.z4kn4fein.semver.Version
  * @property contentFilters Account's content filters.
  * @property announcements Announcements from the account's server.
  * @property following Accounts this account is following.
+ * @property followedHashtags Map of hashtags this account is following. The
+ * key is the hashtag's name, without the leading `#`.
  */
 // TODO: Still not sure if it's better to have one class that contains everything,
 // or provide dedicated functions that return specific flows for the different
@@ -56,6 +59,7 @@ data class PachliAccount(
     val contentFilters: ContentFilters,
     val announcements: List<Announcement>,
     val following: List<FollowingAccountEntity>,
+    val followedHashtags: Map<String, Hashtag>,
 ) {
     companion object {
         fun make(
@@ -71,6 +75,7 @@ data class PachliAccount(
                 contentFilters = account.contentFilters?.let { ContentFilters.from(it) } ?: ContentFilters.EMPTY,
                 announcements = account.announcements.orEmpty().map { it.announcement },
                 following = account.following,
+                followedHashtags = account.followedHashtags.asModel().associateBy { it.name },
             )
         }
     }

--- a/core/data/src/test/kotlin/app/pachli/core/data/repository/ExportedPreferencesRepositoryTest.kt
+++ b/core/data/src/test/kotlin/app/pachli/core/data/repository/ExportedPreferencesRepositoryTest.kt
@@ -133,6 +133,7 @@ class ExportedPreferencesRepositoryTest {
             on { getContentFilters() } doReturn success(emptyList())
             on { getContentFiltersV1() } doReturn success(emptyList())
             on { accountFollowing(any(), anyOrNull(), any()) } doReturn success(emptyList())
+            on { followedTags() } doReturn success(emptyList())
         }
 
         reset(nodeInfoApi)

--- a/core/data/src/test/kotlin/app/pachli/core/data/repository/InstanceInfoRepositoryTest.kt
+++ b/core/data/src/test/kotlin/app/pachli/core/data/repository/InstanceInfoRepositoryTest.kt
@@ -19,7 +19,6 @@ package app.pachli.core.data.repository
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
-import app.pachli.core.database.AppDatabase
 import app.pachli.core.model.InstanceInfo.Companion.DEFAULT_CHARACTER_LIMIT
 import app.pachli.core.network.model.AccountSource
 import app.pachli.core.network.model.CredentialAccount
@@ -77,9 +76,6 @@ class InstanceInfoRepositoryTest {
     @Inject
     lateinit var instanceInfoRepository: InstanceInfoRepository
 
-    @Inject
-    lateinit var appDatabase: AppDatabase
-
     /**
      * Tests set this to return a customised fake [InstanceV1].
      *
@@ -118,6 +114,7 @@ class InstanceInfoRepositoryTest {
             on { getContentFilters() } doReturn success(emptyList())
             on { getContentFiltersV1() } doReturn success(emptyList())
             on { accountFollowing(any(), anyOrNull(), any()) } doReturn success(emptyList())
+            on { followedTags() } doReturn success(emptyList())
         }
 
         reset(nodeInfoApi)

--- a/core/data/src/test/kotlin/app/pachli/core/data/repository/StatusRepositoryTest.kt
+++ b/core/data/src/test/kotlin/app/pachli/core/data/repository/StatusRepositoryTest.kt
@@ -141,6 +141,7 @@ class StatusRepositoryTest {
             on { getContentFilters() } doReturn success(emptyList())
             on { getContentFiltersV1() } doReturn success(emptyList())
             on { accountFollowing(any(), anyOrNull(), any()) } doReturn success(emptyList())
+            on { followedTags() } doReturn success(emptyList())
         }
 
         reset(nodeInfoApi)

--- a/core/data/src/test/kotlin/app/pachli/core/data/repository/filtersRepository/BaseContentFiltersRepositoryTest.kt
+++ b/core/data/src/test/kotlin/app/pachli/core/data/repository/filtersRepository/BaseContentFiltersRepositoryTest.kt
@@ -141,6 +141,7 @@ abstract class V2Test : BaseContentFiltersRepositoryTest() {
             on { listAnnouncements(any()) } doReturn success(emptyList())
             on { getContentFilters() } doReturn success(networkFilters)
             on { accountFollowing(any(), anyOrNull(), any()) } doReturn success(emptyList())
+            on { followedTags() } doReturn success(emptyList())
         }
 
         networkFilters.clear()
@@ -205,6 +206,7 @@ abstract class V1Test : BaseContentFiltersRepositoryTest() {
             on { listAnnouncements(any()) } doReturn success(emptyList())
             on { getContentFiltersV1() } doReturn success(networkFiltersV1)
             on { accountFollowing(any(), anyOrNull(), any()) } doReturn success(emptyList())
+            on { followedTags() } doReturn success(emptyList())
         }
 
         reset(nodeInfoApi)

--- a/core/database/schemas/app.pachli.core.database.AppDatabase/39.json
+++ b/core/database/schemas/app.pachli.core.database.AppDatabase/39.json
@@ -1,0 +1,2156 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 39,
+    "identityHash": "b74dcdaa04be769e927a8301fd0f7b5e",
+    "entities": [
+      {
+        "tableName": "DraftEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `pachliAccountId` INTEGER NOT NULL, `inReplyToId` TEXT, `content` TEXT, `contentWarning` TEXT, `sensitive` INTEGER NOT NULL, `visibility` INTEGER NOT NULL, `attachments` TEXT NOT NULL, `poll` TEXT, `failureMessage` TEXT, `scheduledAt` INTEGER, `language` TEXT, `statusId` TEXT, `quotePolicy` TEXT, `quotedStatusId` TEXT, `cursorPosition` INTEGER NOT NULL DEFAULT 0, `state` TEXT NOT NULL DEFAULT 'DEFAULT', FOREIGN KEY(`pachliAccountId`) REFERENCES `AccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pachliAccountId",
+            "columnName": "pachliAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inReplyToId",
+            "columnName": "inReplyToId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "contentWarning",
+            "columnName": "contentWarning",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sensitive",
+            "columnName": "sensitive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "visibility",
+            "columnName": "visibility",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attachments",
+            "columnName": "attachments",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "poll",
+            "columnName": "poll",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "failureMessage",
+            "columnName": "failureMessage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "scheduledAt",
+            "columnName": "scheduledAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "statusId",
+            "columnName": "statusId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "quotePolicy",
+            "columnName": "quotePolicy",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "quotedStatusId",
+            "columnName": "quotedStatusId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "cursorPosition",
+            "columnName": "cursorPosition",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'DEFAULT'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_DraftEntity_pachliAccountId",
+            "unique": false,
+            "columnNames": [
+              "pachliAccountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_DraftEntity_pachliAccountId` ON `${TABLE_NAME}` (`pachliAccountId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "AccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "pachliAccountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "AccountEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `domain` TEXT NOT NULL, `accessToken` TEXT NOT NULL, `clientId` TEXT NOT NULL, `clientSecret` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `accountId` TEXT NOT NULL, `username` TEXT NOT NULL, `displayName` TEXT NOT NULL, `profilePictureUrl` TEXT NOT NULL, `profileHeaderPictureUrl` TEXT NOT NULL DEFAULT '', `notificationsEnabled` INTEGER NOT NULL, `notificationsMentioned` INTEGER NOT NULL, `notificationsFollowed` INTEGER NOT NULL, `notificationsFollowRequested` INTEGER NOT NULL, `notificationsReblogged` INTEGER NOT NULL, `notificationsFavorited` INTEGER NOT NULL, `notificationsPolls` INTEGER NOT NULL, `notificationsSubscriptions` INTEGER NOT NULL, `notificationsSignUps` INTEGER NOT NULL, `notificationsUpdates` INTEGER NOT NULL, `notificationsReports` INTEGER NOT NULL, `notificationsSeveredRelationships` INTEGER NOT NULL DEFAULT true, `notificationsModerationWarnings` INTEGER NOT NULL DEFAULT true, `notificationsQuotes` INTEGER NOT NULL DEFAULT true, `notificationsQuotedUpdates` INTEGER NOT NULL DEFAULT true, `notificationSound` INTEGER NOT NULL, `notificationVibration` INTEGER NOT NULL, `notificationLight` INTEGER NOT NULL, `defaultPostPrivacy` INTEGER NOT NULL, `defaultMediaSensitivity` INTEGER NOT NULL, `defaultPostLanguage` TEXT NOT NULL, `defaultQuotePolicy` TEXT NOT NULL DEFAULT 'NOBODY', `alwaysShowSensitiveMedia` INTEGER NOT NULL, `alwaysOpenSpoiler` INTEGER NOT NULL, `mediaPreviewEnabled` INTEGER NOT NULL, `notificationMarkerId` TEXT NOT NULL DEFAULT '0', `emojis` TEXT NOT NULL, `tabPreferences` TEXT NOT NULL, `notificationsFilter` TEXT NOT NULL, `oauthScopes` TEXT NOT NULL, `unifiedPushUrl` TEXT NOT NULL, `pushPubKey` TEXT NOT NULL, `pushPrivKey` TEXT NOT NULL, `pushAuth` TEXT NOT NULL, `pushServerKey` TEXT NOT NULL, `locked` INTEGER NOT NULL DEFAULT 0, `notificationAccountFilterNotFollowed` TEXT NOT NULL DEFAULT 'NONE', `notificationAccountFilterYounger30d` TEXT NOT NULL DEFAULT 'NONE', `notificationAccountFilterLimitedByServer` TEXT NOT NULL DEFAULT 'NONE', `conversationAccountFilterNotFollowed` TEXT NOT NULL DEFAULT 'NONE', `conversationAccountFilterYounger30d` TEXT NOT NULL DEFAULT 'NONE', `conversationAccountFilterLimitedByServer` TEXT NOT NULL DEFAULT 'NONE', `isBot` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "domain",
+            "columnName": "domain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessToken",
+            "columnName": "accessToken",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "clientId",
+            "columnName": "clientId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "clientSecret",
+            "columnName": "clientSecret",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profilePictureUrl",
+            "columnName": "profilePictureUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileHeaderPictureUrl",
+            "columnName": "profileHeaderPictureUrl",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "notificationsEnabled",
+            "columnName": "notificationsEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsMentioned",
+            "columnName": "notificationsMentioned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsFollowed",
+            "columnName": "notificationsFollowed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsFollowRequested",
+            "columnName": "notificationsFollowRequested",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsReblogged",
+            "columnName": "notificationsReblogged",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsFavorited",
+            "columnName": "notificationsFavorited",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsPolls",
+            "columnName": "notificationsPolls",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsSubscriptions",
+            "columnName": "notificationsSubscriptions",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsSignUps",
+            "columnName": "notificationsSignUps",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsUpdates",
+            "columnName": "notificationsUpdates",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsReports",
+            "columnName": "notificationsReports",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsSeveredRelationships",
+            "columnName": "notificationsSeveredRelationships",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "true"
+          },
+          {
+            "fieldPath": "notificationsModerationWarnings",
+            "columnName": "notificationsModerationWarnings",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "true"
+          },
+          {
+            "fieldPath": "notificationsQuotes",
+            "columnName": "notificationsQuotes",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "true"
+          },
+          {
+            "fieldPath": "notificationsQuotedUpdates",
+            "columnName": "notificationsQuotedUpdates",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "true"
+          },
+          {
+            "fieldPath": "notificationSound",
+            "columnName": "notificationSound",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationVibration",
+            "columnName": "notificationVibration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationLight",
+            "columnName": "notificationLight",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultPostPrivacy",
+            "columnName": "defaultPostPrivacy",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultMediaSensitivity",
+            "columnName": "defaultMediaSensitivity",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultPostLanguage",
+            "columnName": "defaultPostLanguage",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultQuotePolicy",
+            "columnName": "defaultQuotePolicy",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'NOBODY'"
+          },
+          {
+            "fieldPath": "alwaysShowSensitiveMedia",
+            "columnName": "alwaysShowSensitiveMedia",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alwaysOpenSpoiler",
+            "columnName": "alwaysOpenSpoiler",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaPreviewEnabled",
+            "columnName": "mediaPreviewEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationMarkerId",
+            "columnName": "notificationMarkerId",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'0'"
+          },
+          {
+            "fieldPath": "emojis",
+            "columnName": "emojis",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tabPreferences",
+            "columnName": "tabPreferences",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsFilter",
+            "columnName": "notificationsFilter",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "oauthScopes",
+            "columnName": "oauthScopes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unifiedPushUrl",
+            "columnName": "unifiedPushUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pushPubKey",
+            "columnName": "pushPubKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pushPrivKey",
+            "columnName": "pushPrivKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pushAuth",
+            "columnName": "pushAuth",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pushServerKey",
+            "columnName": "pushServerKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locked",
+            "columnName": "locked",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "notificationAccountFilterNotFollowed",
+            "columnName": "notificationAccountFilterNotFollowed",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'NONE'"
+          },
+          {
+            "fieldPath": "notificationAccountFilterYounger30d",
+            "columnName": "notificationAccountFilterYounger30d",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'NONE'"
+          },
+          {
+            "fieldPath": "notificationAccountFilterLimitedByServer",
+            "columnName": "notificationAccountFilterLimitedByServer",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'NONE'"
+          },
+          {
+            "fieldPath": "conversationAccountFilterNotFollowed",
+            "columnName": "conversationAccountFilterNotFollowed",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'NONE'"
+          },
+          {
+            "fieldPath": "conversationAccountFilterYounger30d",
+            "columnName": "conversationAccountFilterYounger30d",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'NONE'"
+          },
+          {
+            "fieldPath": "conversationAccountFilterLimitedByServer",
+            "columnName": "conversationAccountFilterLimitedByServer",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'NONE'"
+          },
+          {
+            "fieldPath": "isBot",
+            "columnName": "isBot",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_AccountEntity_domain_accountId",
+            "unique": true,
+            "columnNames": [
+              "domain",
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_AccountEntity_domain_accountId` ON `${TABLE_NAME}` (`domain`, `accountId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "InstanceInfoEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`instance` TEXT NOT NULL, `maxPostCharacters` INTEGER NOT NULL, `maxPollOptions` INTEGER NOT NULL, `maxPollOptionLength` INTEGER NOT NULL, `minPollDuration` INTEGER NOT NULL, `maxPollDuration` INTEGER NOT NULL, `charactersReservedPerUrl` INTEGER NOT NULL, `version` TEXT NOT NULL, `videoSizeLimit` INTEGER NOT NULL, `imageSizeLimit` INTEGER NOT NULL, `imageMatrixLimit` INTEGER NOT NULL, `maxMediaAttachments` INTEGER NOT NULL, `maxMediaDescriptionChars` INTEGER NOT NULL DEFAULT 1500, `maxFields` INTEGER NOT NULL, `maxFieldNameLength` INTEGER, `maxFieldValueLength` INTEGER, `enabledTranslation` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`instance`))",
+        "fields": [
+          {
+            "fieldPath": "instance",
+            "columnName": "instance",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxPostCharacters",
+            "columnName": "maxPostCharacters",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxPollOptions",
+            "columnName": "maxPollOptions",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxPollOptionLength",
+            "columnName": "maxPollOptionLength",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minPollDuration",
+            "columnName": "minPollDuration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxPollDuration",
+            "columnName": "maxPollDuration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "charactersReservedPerUrl",
+            "columnName": "charactersReservedPerUrl",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoSizeLimit",
+            "columnName": "videoSizeLimit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageSizeLimit",
+            "columnName": "imageSizeLimit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageMatrixLimit",
+            "columnName": "imageMatrixLimit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxMediaAttachments",
+            "columnName": "maxMediaAttachments",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxMediaDescriptionChars",
+            "columnName": "maxMediaDescriptionChars",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1500"
+          },
+          {
+            "fieldPath": "maxFields",
+            "columnName": "maxFields",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxFieldNameLength",
+            "columnName": "maxFieldNameLength",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "maxFieldValueLength",
+            "columnName": "maxFieldValueLength",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "enabledTranslation",
+            "columnName": "enabledTranslation",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "instance"
+          ]
+        }
+      },
+      {
+        "tableName": "EmojisEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountId` INTEGER NOT NULL, `emojiList` TEXT NOT NULL, PRIMARY KEY(`accountId`), FOREIGN KEY(`accountId`) REFERENCES `AccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "emojiList",
+            "columnName": "emojiList",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "accountId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "AccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "StatusEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `url` TEXT, `timelineUserId` INTEGER NOT NULL, `authorServerId` TEXT NOT NULL, `inReplyToId` TEXT, `inReplyToAccountId` TEXT, `content` TEXT, `createdAt` INTEGER NOT NULL, `editedAt` INTEGER, `emojis` TEXT, `reblogsCount` INTEGER NOT NULL, `favouritesCount` INTEGER NOT NULL, `repliesCount` INTEGER NOT NULL, `quotesCount` INTEGER NOT NULL DEFAULT 0, `reblogged` INTEGER NOT NULL, `bookmarked` INTEGER NOT NULL, `favourited` INTEGER NOT NULL, `sensitive` INTEGER NOT NULL, `spoilerText` TEXT NOT NULL, `visibility` INTEGER NOT NULL, `attachments` TEXT, `mentions` TEXT, `tags` TEXT, `application` TEXT, `reblogServerId` TEXT, `reblogAccountId` TEXT, `poll` TEXT, `muted` INTEGER, `pinned` INTEGER NOT NULL, `card` TEXT, `quoteState` TEXT, `quoteServerId` TEXT, `quoteApproval` TEXT NOT NULL DEFAULT '{\"automatic\":[], \"manual\":[], \"currentUser\":\"UNKNOWN\"}', `language` TEXT, `filtered` TEXT, PRIMARY KEY(`serverId`, `timelineUserId`), FOREIGN KEY(`timelineUserId`) REFERENCES `AccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED, FOREIGN KEY(`authorServerId`, `timelineUserId`) REFERENCES `TimelineAccountEntity`(`serverId`, `timelineUserId`) ON UPDATE NO ACTION ON DELETE NO ACTION DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timelineUserId",
+            "columnName": "timelineUserId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authorServerId",
+            "columnName": "authorServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inReplyToId",
+            "columnName": "inReplyToId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "inReplyToAccountId",
+            "columnName": "inReplyToAccountId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "editedAt",
+            "columnName": "editedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "emojis",
+            "columnName": "emojis",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "reblogsCount",
+            "columnName": "reblogsCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favouritesCount",
+            "columnName": "favouritesCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repliesCount",
+            "columnName": "repliesCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quotesCount",
+            "columnName": "quotesCount",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "reblogged",
+            "columnName": "reblogged",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarked",
+            "columnName": "bookmarked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favourited",
+            "columnName": "favourited",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sensitive",
+            "columnName": "sensitive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spoilerText",
+            "columnName": "spoilerText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "visibility",
+            "columnName": "visibility",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attachments",
+            "columnName": "attachments",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mentions",
+            "columnName": "mentions",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "application",
+            "columnName": "application",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "reblogServerId",
+            "columnName": "reblogServerId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "reblogAccountId",
+            "columnName": "reblogAccountId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "poll",
+            "columnName": "poll",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "muted",
+            "columnName": "muted",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pinned",
+            "columnName": "pinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "card",
+            "columnName": "card",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "quoteState",
+            "columnName": "quoteState",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "quoteServerId",
+            "columnName": "quoteServerId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "quoteApproval",
+            "columnName": "quoteApproval",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'{\"automatic\":[], \"manual\":[], \"currentUser\":\"UNKNOWN\"}'"
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "filtered",
+            "columnName": "filtered",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "timelineUserId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_StatusEntity_authorServerId_timelineUserId",
+            "unique": false,
+            "columnNames": [
+              "authorServerId",
+              "timelineUserId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_StatusEntity_authorServerId_timelineUserId` ON `${TABLE_NAME}` (`authorServerId`, `timelineUserId`)"
+          },
+          {
+            "name": "index_StatusEntity_timelineUserId",
+            "unique": false,
+            "columnNames": [
+              "timelineUserId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_StatusEntity_timelineUserId` ON `${TABLE_NAME}` (`timelineUserId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "AccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "timelineUserId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "TimelineAccountEntity",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "authorServerId",
+              "timelineUserId"
+            ],
+            "referencedColumns": [
+              "serverId",
+              "timelineUserId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "TimelineAccountEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `timelineUserId` INTEGER NOT NULL, `localUsername` TEXT NOT NULL, `username` TEXT NOT NULL, `displayName` TEXT NOT NULL, `url` TEXT NOT NULL, `avatar` TEXT NOT NULL, `emojis` TEXT NOT NULL, `bot` INTEGER NOT NULL, `createdAt` INTEGER, `limited` INTEGER NOT NULL DEFAULT false, `note` TEXT NOT NULL DEFAULT '', `roles` TEXT DEFAULT '', `pronouns` TEXT DEFAULT '', PRIMARY KEY(`serverId`, `timelineUserId`), FOREIGN KEY(`timelineUserId`) REFERENCES `AccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timelineUserId",
+            "columnName": "timelineUserId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUsername",
+            "columnName": "localUsername",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatar",
+            "columnName": "avatar",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "emojis",
+            "columnName": "emojis",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bot",
+            "columnName": "bot",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "limited",
+            "columnName": "limited",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "roles",
+            "columnName": "roles",
+            "affinity": "TEXT",
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "pronouns",
+            "columnName": "pronouns",
+            "affinity": "TEXT",
+            "defaultValue": "''"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "timelineUserId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_TimelineAccountEntity_timelineUserId",
+            "unique": false,
+            "columnNames": [
+              "timelineUserId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_TimelineAccountEntity_timelineUserId` ON `${TABLE_NAME}` (`timelineUserId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "AccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "timelineUserId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "ConversationEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`pachliAccountId` INTEGER NOT NULL, `id` TEXT NOT NULL, `accounts` TEXT NOT NULL, `unread` INTEGER NOT NULL, `lastStatusServerId` TEXT NOT NULL DEFAULT '', `isConversationStarter` INTEGER NOT NULL DEFAULT 1, PRIMARY KEY(`id`, `pachliAccountId`), FOREIGN KEY(`pachliAccountId`) REFERENCES `AccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "pachliAccountId",
+            "columnName": "pachliAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accounts",
+            "columnName": "accounts",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unread",
+            "columnName": "unread",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastStatusServerId",
+            "columnName": "lastStatusServerId",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "isConversationStarter",
+            "columnName": "isConversationStarter",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id",
+            "pachliAccountId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_ConversationEntity_pachliAccountId",
+            "unique": false,
+            "columnNames": [
+              "pachliAccountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ConversationEntity_pachliAccountId` ON `${TABLE_NAME}` (`pachliAccountId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "AccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "pachliAccountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "RemoteKeyEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountId` INTEGER NOT NULL, `timelineId` TEXT NOT NULL, `kind` TEXT NOT NULL, `key` TEXT, PRIMARY KEY(`accountId`, `timelineId`, `kind`), FOREIGN KEY(`accountId`) REFERENCES `AccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timelineId",
+            "columnName": "timelineId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "accountId",
+            "timelineId",
+            "kind"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "AccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "StatusViewDataEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`pachliAccountId` INTEGER NOT NULL, `serverId` TEXT NOT NULL, `expanded` INTEGER, `contentCollapsed` INTEGER, `translationState` TEXT NOT NULL DEFAULT 'SHOW_ORIGINAL', `attachmentDisplayAction` TEXT, PRIMARY KEY(`serverId`, `pachliAccountId`), FOREIGN KEY(`pachliAccountId`) REFERENCES `AccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "pachliAccountId",
+            "columnName": "pachliAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expanded",
+            "columnName": "expanded",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "contentCollapsed",
+            "columnName": "contentCollapsed",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "translationState",
+            "columnName": "translationState",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'SHOW_ORIGINAL'"
+          },
+          {
+            "fieldPath": "attachmentDisplayAction",
+            "columnName": "attachmentDisplayAction",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "pachliAccountId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_StatusViewDataEntity_pachliAccountId",
+            "unique": false,
+            "columnNames": [
+              "pachliAccountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_StatusViewDataEntity_pachliAccountId` ON `${TABLE_NAME}` (`pachliAccountId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "AccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "pachliAccountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "TranslatedStatusEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `timelineUserId` INTEGER NOT NULL, `content` TEXT NOT NULL, `spoilerText` TEXT NOT NULL, `poll` TEXT, `attachments` TEXT NOT NULL, `provider` TEXT NOT NULL, PRIMARY KEY(`serverId`, `timelineUserId`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timelineUserId",
+            "columnName": "timelineUserId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spoilerText",
+            "columnName": "spoilerText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "poll",
+            "columnName": "poll",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "attachments",
+            "columnName": "attachments",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "timelineUserId"
+          ]
+        }
+      },
+      {
+        "tableName": "LogEntryEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `instant` INTEGER NOT NULL, `priority` INTEGER, `tag` TEXT, `message` TEXT NOT NULL, `t` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instant",
+            "columnName": "instant",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "t",
+            "columnName": "t",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "MastodonListEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountId` INTEGER NOT NULL, `listId` TEXT NOT NULL, `title` TEXT NOT NULL, `repliesPolicy` TEXT NOT NULL, `exclusive` INTEGER NOT NULL, PRIMARY KEY(`accountId`, `listId`), FOREIGN KEY(`accountId`) REFERENCES `AccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listId",
+            "columnName": "listId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repliesPolicy",
+            "columnName": "repliesPolicy",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exclusive",
+            "columnName": "exclusive",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "accountId",
+            "listId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "AccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "ServerEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountId` INTEGER NOT NULL, `serverKind` TEXT NOT NULL, `version` TEXT NOT NULL, `capabilities` TEXT NOT NULL, PRIMARY KEY(`accountId`), FOREIGN KEY(`accountId`) REFERENCES `AccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverKind",
+            "columnName": "serverKind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "capabilities",
+            "columnName": "capabilities",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "accountId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "AccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "ContentFiltersEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountId` INTEGER NOT NULL, `version` TEXT NOT NULL, `contentFilters` TEXT NOT NULL, PRIMARY KEY(`accountId`), FOREIGN KEY(`accountId`) REFERENCES `AccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentFilters",
+            "columnName": "contentFilters",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "accountId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "AccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "AnnouncementEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountId` INTEGER NOT NULL, `announcementId` TEXT NOT NULL, `announcement` TEXT NOT NULL, PRIMARY KEY(`accountId`), FOREIGN KEY(`accountId`) REFERENCES `AccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "announcementId",
+            "columnName": "announcementId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "announcement",
+            "columnName": "announcement",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "accountId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "AccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "FollowingAccountEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`pachliAccountId` INTEGER NOT NULL, `serverId` TEXT NOT NULL, PRIMARY KEY(`pachliAccountId`, `serverId`), FOREIGN KEY(`pachliAccountId`) REFERENCES `AccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "pachliAccountId",
+            "columnName": "pachliAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "pachliAccountId",
+            "serverId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "AccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "pachliAccountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "NotificationEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`pachliAccountId` INTEGER NOT NULL, `serverId` TEXT NOT NULL, `type` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `accountServerId` TEXT NOT NULL, `statusServerId` TEXT, PRIMARY KEY(`pachliAccountId`, `serverId`), FOREIGN KEY(`pachliAccountId`) REFERENCES `AccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED, FOREIGN KEY(`accountServerId`, `pachliAccountId`) REFERENCES `TimelineAccountEntity`(`serverId`, `timelineUserId`) ON UPDATE NO ACTION ON DELETE NO ACTION DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "pachliAccountId",
+            "columnName": "pachliAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountServerId",
+            "columnName": "accountServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "statusServerId",
+            "columnName": "statusServerId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "pachliAccountId",
+            "serverId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_NotificationEntity_accountServerId_pachliAccountId",
+            "unique": false,
+            "columnNames": [
+              "accountServerId",
+              "pachliAccountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_NotificationEntity_accountServerId_pachliAccountId` ON `${TABLE_NAME}` (`accountServerId`, `pachliAccountId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "AccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "pachliAccountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "TimelineAccountEntity",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "accountServerId",
+              "pachliAccountId"
+            ],
+            "referencedColumns": [
+              "serverId",
+              "timelineUserId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "NotificationReportEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`pachliAccountId` INTEGER NOT NULL, `serverId` TEXT NOT NULL, `reportId` TEXT NOT NULL, `actionTaken` INTEGER NOT NULL, `actionTakenAt` INTEGER, `category` TEXT NOT NULL, `comment` TEXT NOT NULL, `forwarded` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `statusIds` TEXT, `ruleIds` TEXT, `target_serverId` TEXT NOT NULL, `target_timelineUserId` INTEGER NOT NULL, `target_localUsername` TEXT NOT NULL, `target_username` TEXT NOT NULL, `target_displayName` TEXT NOT NULL, `target_url` TEXT NOT NULL, `target_avatar` TEXT NOT NULL, `target_emojis` TEXT NOT NULL, `target_bot` INTEGER NOT NULL, `target_createdAt` INTEGER, `target_limited` INTEGER NOT NULL DEFAULT false, `target_note` TEXT NOT NULL DEFAULT '', `target_roles` TEXT DEFAULT '', `target_pronouns` TEXT DEFAULT '', PRIMARY KEY(`pachliAccountId`, `serverId`), FOREIGN KEY(`pachliAccountId`, `serverId`) REFERENCES `NotificationEntity`(`pachliAccountId`, `serverId`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "pachliAccountId",
+            "columnName": "pachliAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reportId",
+            "columnName": "reportId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actionTaken",
+            "columnName": "actionTaken",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actionTakenAt",
+            "columnName": "actionTakenAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "comment",
+            "columnName": "comment",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "forwarded",
+            "columnName": "forwarded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "statusIds",
+            "columnName": "statusIds",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ruleIds",
+            "columnName": "ruleIds",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "targetAccount.serverId",
+            "columnName": "target_serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetAccount.timelineUserId",
+            "columnName": "target_timelineUserId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetAccount.localUsername",
+            "columnName": "target_localUsername",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetAccount.username",
+            "columnName": "target_username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetAccount.displayName",
+            "columnName": "target_displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetAccount.url",
+            "columnName": "target_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetAccount.avatar",
+            "columnName": "target_avatar",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetAccount.emojis",
+            "columnName": "target_emojis",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetAccount.bot",
+            "columnName": "target_bot",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetAccount.createdAt",
+            "columnName": "target_createdAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "targetAccount.limited",
+            "columnName": "target_limited",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "targetAccount.note",
+            "columnName": "target_note",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "targetAccount.roles",
+            "columnName": "target_roles",
+            "affinity": "TEXT",
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "targetAccount.pronouns",
+            "columnName": "target_pronouns",
+            "affinity": "TEXT",
+            "defaultValue": "''"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "pachliAccountId",
+            "serverId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "NotificationEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "pachliAccountId",
+              "serverId"
+            ],
+            "referencedColumns": [
+              "pachliAccountId",
+              "serverId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "NotificationViewDataEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`pachliAccountId` INTEGER NOT NULL, `serverId` TEXT NOT NULL, `accountFilterDecision` TEXT, PRIMARY KEY(`pachliAccountId`, `serverId`), FOREIGN KEY(`pachliAccountId`) REFERENCES `AccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "pachliAccountId",
+            "columnName": "pachliAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountFilterDecision",
+            "columnName": "accountFilterDecision",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "pachliAccountId",
+            "serverId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "AccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "pachliAccountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "NotificationRelationshipSeveranceEventEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`pachliAccountId` INTEGER NOT NULL, `serverId` TEXT NOT NULL, `eventId` TEXT NOT NULL, `type` TEXT NOT NULL, `purged` INTEGER NOT NULL, `targetName` TEXT NOT NULL DEFAULT '', `followersCount` INTEGER NOT NULL, `followingCount` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`pachliAccountId`, `serverId`, `eventId`), FOREIGN KEY(`pachliAccountId`, `serverId`) REFERENCES `NotificationEntity`(`pachliAccountId`, `serverId`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "pachliAccountId",
+            "columnName": "pachliAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventId",
+            "columnName": "eventId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "purged",
+            "columnName": "purged",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetName",
+            "columnName": "targetName",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "followersCount",
+            "columnName": "followersCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "followingCount",
+            "columnName": "followingCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "pachliAccountId",
+            "serverId",
+            "eventId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "NotificationEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "pachliAccountId",
+              "serverId"
+            ],
+            "referencedColumns": [
+              "pachliAccountId",
+              "serverId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "NotificationAccountWarningEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`pachliAccountId` INTEGER NOT NULL, `serverId` TEXT NOT NULL, `accountWarningId` TEXT NOT NULL, `text` TEXT NOT NULL, `action` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`pachliAccountId`, `serverId`, `accountWarningId`), FOREIGN KEY(`pachliAccountId`, `serverId`) REFERENCES `NotificationEntity`(`pachliAccountId`, `serverId`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "pachliAccountId",
+            "columnName": "pachliAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountWarningId",
+            "columnName": "accountWarningId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "action",
+            "columnName": "action",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "pachliAccountId",
+            "serverId",
+            "accountWarningId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "NotificationEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "pachliAccountId",
+              "serverId"
+            ],
+            "referencedColumns": [
+              "pachliAccountId",
+              "serverId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "TimelineStatusEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`kind` TEXT NOT NULL, `pachliAccountId` INTEGER NOT NULL, `statusId` TEXT NOT NULL, PRIMARY KEY(`kind`, `pachliAccountId`, `statusId`))",
+        "fields": [
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pachliAccountId",
+            "columnName": "pachliAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "statusId",
+            "columnName": "statusId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "kind",
+            "pachliAccountId",
+            "statusId"
+          ]
+        }
+      },
+      {
+        "tableName": "ConversationViewDataEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`pachliAccountId` INTEGER NOT NULL, `serverId` TEXT NOT NULL, `contentFilterAction` TEXT, `accountFilterDecision` TEXT, PRIMARY KEY(`pachliAccountId`, `serverId`), FOREIGN KEY(`pachliAccountId`) REFERENCES `AccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "pachliAccountId",
+            "columnName": "pachliAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentFilterAction",
+            "columnName": "contentFilterAction",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountFilterDecision",
+            "columnName": "accountFilterDecision",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "pachliAccountId",
+            "serverId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "AccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "pachliAccountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "HashtagEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`pachliAccountId` INTEGER NOT NULL, `name` TEXT NOT NULL, `url` TEXT NOT NULL, `history` TEXT NOT NULL, `following` INTEGER NOT NULL, PRIMARY KEY(`pachliAccountId`, `name`), FOREIGN KEY(`pachliAccountId`) REFERENCES `AccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "pachliAccountId",
+            "columnName": "pachliAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "history",
+            "columnName": "history",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "following",
+            "columnName": "following",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "pachliAccountId",
+            "name"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "AccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "pachliAccountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "views": [
+      {
+        "viewName": "TimelineStatusWithAccount",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS SELECT\n    s.serverId,\n    s.url,\n    s.timelineUserId,\n    s.authorServerId,\n    s.inReplyToId,\n    s.inReplyToAccountId,\n    s.createdAt,\n    s.editedAt,\n    s.emojis,\n    s.reblogsCount,\n    s.favouritesCount,\n    s.repliesCount,\n    s.quotesCount,\n    s.reblogged,\n    s.favourited,\n    s.bookmarked,\n    s.sensitive,\n    s.spoilerText,\n    s.visibility,\n    s.mentions,\n    s.tags,\n    s.application,\n    s.reblogServerId,\n    s.reblogAccountId,\n    s.content,\n    s.attachments,\n    s.poll,\n    s.card,\n    s.muted,\n    s.pinned,\n    s.language,\n    s.filtered,\n    s.quoteState,\n    s.quoteServerId,\n    s.quoteApproval,\n    a.serverId AS 'a_serverId',\n    a.timelineUserId AS 'a_timelineUserId',\n    a.localUsername AS 'a_localUsername',\n    a.username AS 'a_username',\n    a.displayName AS 'a_displayName',\n    a.url AS 'a_url',\n    a.avatar AS 'a_avatar',\n    a.emojis AS 'a_emojis',\n    a.bot AS 'a_bot',\n    a.createdAt AS 'a_createdAt',\n    a.limited AS 'a_limited',\n    a.note AS 'a_note',\n    a.roles AS 'a_roles',\n    a.pronouns AS 'a_pronouns',\n    rb.serverId AS 'rb_serverId',\n    rb.timelineUserId AS 'rb_timelineUserId',\n    rb.localUsername AS 'rb_localUsername',\n    rb.username AS 'rb_username',\n    rb.displayName AS 'rb_displayName',\n    rb.url AS 'rb_url',\n    rb.avatar AS 'rb_avatar',\n    rb.emojis AS 'rb_emojis',\n    rb.bot AS 'rb_bot',\n    rb.createdAt AS 'rb_createdAt',\n    rb.limited AS 'rb_limited',\n    rb.note AS 'rb_note',\n    rb.roles AS 'rb_roles',\n    rb.pronouns AS 'rb_pronouns',\n    svd.serverId AS 'svd_serverId',\n    svd.pachliAccountId AS 'svd_pachliAccountId',\n    svd.expanded AS 'svd_expanded',\n    svd.contentCollapsed AS 'svd_contentCollapsed',\n    svd.translationState AS 'svd_translationState',\n    svd.attachmentDisplayAction AS 'svd_attachmentDisplayAction',\n    tr.serverId AS 't_serverId',\n    tr.timelineUserId AS 't_timelineUserId',\n    tr.content AS 't_content',\n    tr.spoilerText AS 't_spoilerText',\n    tr.poll AS 't_poll',\n    tr.attachments AS 't_attachments',\n    tr.provider AS 't_provider',\n    reply.serverId AS 'reply_serverId',\n    reply.timelineUserId AS 'reply_timelineUserId',\n    reply.localUsername AS 'reply_localUsername',\n    reply.username AS 'reply_username',\n    reply.displayName AS 'reply_displayName',\n    reply.url AS 'reply_url',\n    reply.avatar AS 'reply_avatar',\n    reply.emojis AS 'reply_emojis',\n    reply.bot AS 'reply_bot',\n    reply.createdAt AS 'reply_createdAt',\n    reply.limited AS 'reply_limited',\n    reply.note AS 'reply_note',\n    reply.roles AS 'reply_roles',\n    reply.pronouns AS 'reply_pronouns'\nFROM StatusEntity AS s\nLEFT JOIN TimelineAccountEntity AS a ON (s.timelineUserId = a.timelineUserId AND s.authorServerId = a.serverId)\nLEFT JOIN TimelineAccountEntity AS rb ON (s.timelineUserId = rb.timelineUserId AND s.reblogAccountId = rb.serverId)\nLEFT JOIN\n    StatusViewDataEntity AS svd\n    ON (s.timelineUserId = svd.pachliAccountId AND (s.serverId = svd.serverId OR s.reblogServerId = svd.serverId))\nLEFT JOIN\n    TranslatedStatusEntity AS tr\n    ON (s.timelineUserId = tr.timelineUserId AND (s.serverId = tr.serverId OR s.reblogServerId = tr.serverId))\nLEFT JOIN TimelineAccountEntity AS reply ON (s.timelineUserId = reply.timelineUserId AND s.inReplyToAccountId = reply.serverId)"
+      },
+      {
+        "viewName": "ReferencedStatusId",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS WITH RECURSIVE\n-- CTEs to normalise the column names and restrict to just rows with\n-- non-null references to status IDs, for use in the refId CTE.\ntimelineStatusId(pachliAccountId, statusId) AS (\n    SELECT\n        pachliAccountId,\n        statusId\n    FROM TimelineStatusEntity\n),\n\nnotificationStatusId(pachliAccountId, statusId) AS (\n    SELECT\n        pachliAccountId,\n        statusServerId AS statusId\n    FROM NotificationEntity\n    WHERE statusServerId IS NOT NULL\n),\n\nconversationStatusId(pachliAccountId, statusId) AS (\n    SELECT\n        pachliAccountId,\n        lastStatusServerId AS statusId\n    FROM ConversationEntity\n    WHERE lastStatusServerId IS NOT NULL\n),\n\ndraftStatusId(pachliAccountId, statusId) AS (\n    SELECT\n        pachliAccountId AS pachliAccountId,\n        inReplyToId AS statusId\n    FROM DraftEntity\n    WHERE inReplyToId IS NOT NULL\n),\n\n--\n-- refId is a table of all referenced statusIds. A statusId is referenced\n-- if it is either (a) directly referenced by one of the CTEs above, or\n-- (b) referenced by a reply, reblog, or quote in any of the statuses\n-- from \"a\".\n--\nrefId(pachliAccountId, statusId) AS (\n    --\n    -- Find all the \"root\" statusId. These are the IDs that\n    -- are referenced by tables containing \"live\" data.\n    --\n    SELECT\n        pachliAccountId,\n        statusId\n    FROM timelineStatusId\n    UNION\n    SELECT\n        pachliAccountId,\n        statusId\n    FROM notificationStatusId\n    UNION\n    SELECT\n        pachliAccountId,\n        statusId\n    FROM conversationStatusId\n    UNION\n    SELECT\n        pachliAccountId,\n        statusId\n    FROM draftStatusId\n\n    -- Recursively chase down all the references to replies, reblogs, and\n    -- quotes, emitting the `inReblogId`, `inReplyToId`, or `quoteServerId`\n    -- columns renamed to `statusId` as extra rows.\n    UNION\n    SELECT\n        s.timelineUserId AS pachliAccountId,\n        s.reblogServerId AS statusId\n    FROM StatusEntity AS s, refId AS r\n    WHERE\n        s.reblogServerId IS NOT NULL\n        AND s.timelineUserId = r.pachliAccountId\n        AND s.serverId = r.statusID\n\n    UNION\n    SELECT\n        s.timelineUserId AS pachliAccountId,\n        s.inReplyToId AS statusId\n    FROM StatusEntity AS s, refId AS r\n    WHERE\n        s.inReplyToId IS NOT NULL\n        AND s.timelineUserId = r.pachliAccountId\n        AND s.serverId = r.statusID\n\n    UNION\n    SELECT\n        s.timelineUserId AS pachliAccountId,\n        s.quoteServerId AS statusId\n    FROM StatusEntity AS s, refId AS r\n    WHERE\n        s.quoteServerId IS NOT NULL\n        AND s.timelineUserId = r.pachliAccountId\n        AND s.serverId = r.statusID\n)\n\nSELECT\n    pachliAccountId,\n    statusId\nFROM refId"
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'b74dcdaa04be769e927a8301fd0f7b5e')"
+    ]
+  }
+}

--- a/core/database/src/main/kotlin/app/pachli/core/database/AppDatabase.kt
+++ b/core/database/src/main/kotlin/app/pachli/core/database/AppDatabase.kt
@@ -36,6 +36,7 @@ import app.pachli.core.database.dao.ConversationsDao
 import app.pachli.core.database.dao.DebugDao
 import app.pachli.core.database.dao.DraftDao
 import app.pachli.core.database.dao.FollowingAccountDao
+import app.pachli.core.database.dao.HashtagsDao
 import app.pachli.core.database.dao.InstanceDao
 import app.pachli.core.database.dao.ListsDao
 import app.pachli.core.database.dao.LogEntryDao
@@ -53,6 +54,7 @@ import app.pachli.core.database.model.ConversationViewDataEntity
 import app.pachli.core.database.model.DraftEntity
 import app.pachli.core.database.model.EmojisEntity
 import app.pachli.core.database.model.FollowingAccountEntity
+import app.pachli.core.database.model.HashtagEntity
 import app.pachli.core.database.model.InstanceInfoEntity
 import app.pachli.core.database.model.LogEntryEntity
 import app.pachli.core.database.model.MastodonListEntity
@@ -100,12 +102,13 @@ import java.util.TimeZone
         NotificationAccountWarningEntity::class,
         TimelineStatusEntity::class,
         ConversationViewDataEntity::class,
+        HashtagEntity::class,
     ],
     views = [
         TimelineStatusWithAccount::class,
         ReferencedStatusId::class,
     ],
-    version = 38,
+    version = 39,
     autoMigrations = [
         AutoMigration(from = 1, to = 2, spec = AppDatabase.MIGRATE_1_2::class),
         AutoMigration(from = 2, to = 3),
@@ -159,6 +162,8 @@ import java.util.TimeZone
         AutoMigration(from = 36, to = 37, spec = AppDatabase.MIGRATE_36_37::class),
         // Record cursor position, failure message, etc in DraftEntity
         AutoMigration(from = 37, to = 38, spec = AppDatabase.MIGRATE_37_38::class),
+        // HashtagEntity, to show followed hashtags in timelines.
+        AutoMigration(from = 38, to = 39),
     ],
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -176,6 +181,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun followingAccountDao(): FollowingAccountDao
     abstract fun notificationDao(): NotificationDao
     abstract fun statusDao(): StatusDao
+    abstract fun hashtagsDao(): HashtagsDao
     abstract fun debugDao(): DebugDao
 
     @DeleteColumn("TimelineStatusEntity", "expanded")

--- a/core/database/src/main/kotlin/app/pachli/core/database/Converters.kt
+++ b/core/database/src/main/kotlin/app/pachli/core/database/Converters.kt
@@ -30,6 +30,7 @@ import app.pachli.core.model.DraftAttachment
 import app.pachli.core.model.Emoji
 import app.pachli.core.model.FilterResult
 import app.pachli.core.model.Hashtag
+import app.pachli.core.model.HashtagHistory
 import app.pachli.core.model.NewPoll
 import app.pachli.core.model.Poll
 import app.pachli.core.model.Role
@@ -310,4 +311,10 @@ class Converters @Inject constructor(
 
     @TypeConverter
     fun jsonToQuoteApproval(s: String?) = fromJson<Status.QuoteApproval>(s)
+
+    @TypeConverter
+    fun hashtagHistoryToJson(hashtagHistory: List<HashtagHistory>) = toJson(hashtagHistory)
+
+    @TypeConverter
+    fun jsonToHashtagHistory(s: String?) = fromJson<List<HashtagHistory>>(s)
 }

--- a/core/database/src/main/kotlin/app/pachli/core/database/dao/HashtagsDao.kt
+++ b/core/database/src/main/kotlin/app/pachli/core/database/dao/HashtagsDao.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.core.database.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.TypeConverters
+import androidx.room.Upsert
+import app.pachli.core.database.Converters
+import app.pachli.core.database.model.HashtagEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+@TypeConverters(Converters::class)
+interface HashtagsDao {
+    @Query(
+        """
+DELETE
+FROM HashtagEntity
+WHERE pachliAccountId = :pachliAccountId and `following` = 1
+""",
+    )
+    suspend fun deleteFollowedHashtagsForAccount(pachliAccountId: Long)
+
+    @Query(
+        """
+SELECT *
+FROM HashtagEntity
+WHERE pachliAccountId = :pachliAccountId AND `following` = 1
+""",
+    )
+    fun followingFlowByAccount(pachliAccountId: Long): Flow<List<HashtagEntity>>
+
+    @Query(
+        """
+SELECT *
+FROM HashtagEntity
+WHERE pachliAccountId = :pachliAccountId
+""",
+    )
+    suspend fun get(pachliAccountId: Long): List<HashtagEntity>
+
+    @Upsert
+    suspend fun upsert(hashtag: HashtagEntity)
+
+    @Upsert
+    suspend fun upsert(hashtags: List<HashtagEntity>)
+
+    @Query(
+        """
+DELETE
+FROM HashtagEntity
+WHERE pachliAccountId = :pachliAccountId AND name = :name
+""",
+    )
+    suspend fun deleteForAccount(pachliAccountId: Long, name: String)
+}

--- a/core/database/src/main/kotlin/app/pachli/core/database/di/DatabaseModule.kt
+++ b/core/database/src/main/kotlin/app/pachli/core/database/di/DatabaseModule.kt
@@ -113,6 +113,9 @@ object DatabaseModule {
     fun providesStatusDao(appDatabase: AppDatabase) = appDatabase.statusDao()
 
     @Provides
+    fun providesHashtagsDao(appDatabase: AppDatabase) = appDatabase.hashtagsDao()
+
+    @Provides
     fun providesDebugDao(appDatabase: AppDatabase) = appDatabase.debugDao()
 }
 

--- a/core/database/src/main/kotlin/app/pachli/core/database/model/HashtagEntity.kt
+++ b/core/database/src/main/kotlin/app/pachli/core/database/model/HashtagEntity.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.core.database.model
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.TypeConverters
+import app.pachli.core.database.Converters
+import app.pachli.core.model.Hashtag
+import app.pachli.core.model.HashtagHistory
+
+/**
+ * Represents a [Hashtag].
+ *
+ * @property name Hashtag name, without the leading '#'.
+ */
+@TypeConverters(Converters::class)
+@Entity(
+    primaryKeys = ["pachliAccountId", "name"],
+    foreignKeys = [
+        ForeignKey(
+            entity = AccountEntity::class,
+            parentColumns = arrayOf("id"),
+            childColumns = arrayOf("pachliAccountId"),
+            onDelete = ForeignKey.CASCADE,
+            deferred = true,
+        ),
+    ],
+)
+data class HashtagEntity(
+    val pachliAccountId: Long,
+    val name: String,
+    val url: String,
+    val history: List<HashtagHistory>,
+    val following: Boolean,
+) {
+    fun asModel() = Hashtag(
+        name = name,
+        url = url,
+        history = history,
+        following = following,
+    )
+}
+
+fun Iterable<HashtagEntity>.asModel() = map { it.asModel() }
+
+fun Hashtag.asEntity(pachliAccountId: Long) = HashtagEntity(
+    pachliAccountId = pachliAccountId,
+    name = name,
+    url = url,
+    history = history,
+    following = following == true,
+)
+
+fun Iterable<Hashtag>.asEntity(pachliAccountId: Long) = map { it.asEntity(pachliAccountId) }

--- a/core/database/src/main/kotlin/app/pachli/core/database/model/PachliAccount.kt
+++ b/core/database/src/main/kotlin/app/pachli/core/database/model/PachliAccount.kt
@@ -69,4 +69,10 @@ data class PachliAccount(
         entityColumn = "pachliAccountId",
     )
     val following: List<FollowingAccountEntity>,
+
+    @Relation(
+        parentColumn = "id",
+        entityColumn = "pachliAccountId",
+    )
+    val followedHashtags: List<HashtagEntity>,
 )

--- a/core/testing/src/main/kotlin/app/pachli/core/testing/di/FakeDatabaseModule.kt
+++ b/core/testing/src/main/kotlin/app/pachli/core/testing/di/FakeDatabaseModule.kt
@@ -105,5 +105,8 @@ object FakeDatabaseModule {
     fun providesStatusDao(appDatabase: AppDatabase) = appDatabase.statusDao()
 
     @Provides
+    fun providesHashtagsDao(appDatabase: AppDatabase) = appDatabase.hashtagsDao()
+
+    @Provides
     fun providesDebugDao(appDatabase: AppDatabase) = appDatabase.debugDao()
 }

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/LinkHelper.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/LinkHelper.kt
@@ -169,10 +169,21 @@ fun getTagName(text: CharSequence, tags: List<Hashtag>?): String? {
     }
 }
 
-private fun getCustomSpanForHashtag(underline: Boolean, text: CharSequence, tags: List<Hashtag>?, span: URLSpan, listener: LinkListener): ClickableSpan? {
-    return getTagName(text, tags)?.let { tagName ->
-        HashtagSpan(tagName, underline, span.url) { listener.onViewTag(tagName) }
+private fun getCustomSpanForHashtag(underline: Boolean, text: CharSequence, tags: List<Hashtag>?, span: URLSpan, listener: LinkListener): ClickableSpan {
+    val scrapedName = text.subSequence(1, text.length).replaceAccents()
+    val normalisedName = scrapedName.normaliseHashtag()
+
+    // Return the appropriate span type depending on whether or not the
+    // user is following the tag.
+    tags?.firstOrNull { it.name.normaliseHashtag() == normalisedName }?.let { hashtag ->
+        return if (hashtag.following == true) {
+            FollowedHashtagSpan(hashtag.name, underline, span.url) { listener.onViewTag(hashtag.name) }
+        } else {
+            HashtagSpan(hashtag.name, underline, span.url) { listener.onViewTag(hashtag.name) }
+        }
     }
+
+    return HashtagSpan(scrapedName, underline, span.url) { listener.onViewTag(scrapedName) }
 }
 
 private fun getCustomSpanForMention(underline: Boolean, mentions: List<Mention>?, span: URLSpan, listener: LinkListener): ClickableSpan? {

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/MaybeUnderlineURLSpan.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/MaybeUnderlineURLSpan.kt
@@ -17,6 +17,7 @@
 
 package app.pachli.core.ui
 
+import android.graphics.Typeface
 import android.text.TextPaint
 import android.text.style.URLSpan
 import android.view.View
@@ -67,4 +68,18 @@ open class MentionSpan(underline: Boolean, url: String, onClickListener: OnClick
  * @param hashtag Text of the tag, without the leading `#`.
  * @param onClickListener Listener for clicks on the tag.
  */
-class HashtagSpan(val hashtag: String, underline: Boolean, url: String, onClickListener: OnClickListener?) : MaybeUnderlineURLSpan(underline, url, onClickListener)
+open class HashtagSpan(val hashtag: String, underline: Boolean, url: String, onClickListener: OnClickListener?) : MaybeUnderlineURLSpan(underline, url, onClickListener)
+
+/**
+ * Hashtags the user is following (`#foo`). Displayed in bold.
+ *
+ * @param hashtag Text of the tag, without the leading `#`.
+ * @param onClickListener Listener for clicks on the tag.
+ */
+class FollowedHashtagSpan(hashtag: String, underline: Boolean, url: String, onClickListener: OnClickListener?) :
+    HashtagSpan(hashtag, underline, url, onClickListener) {
+    override fun updateDrawState(ds: TextPaint) {
+        super.updateDrawState(ds)
+        ds.setTypeface(Typeface.DEFAULT_BOLD)
+    }
+}


### PR DESCRIPTION
In the home timeline statuses might be present because the user follows one or more of the hashtags in the post. In other timelines the user might still want to see that a post contains one or more of their followed hashtags.

So

- Highlight hashtags the user follows in all posts, by making them bold.
- In the home timeline, show the first followed hashtag in the info bar. Tapping the hashtag in the bar opens the timeline for that hashtag.

To do this:

- Fetch the user's list of followed tags when switching accounts, and attach it to `PachliAccount`.
- Add the `following` property to the hashtags on statuses received from timeline queries.
- Use the new `FollowedHashtagSpan` to mark up hashtags the user is following.
- If the statusInfo is empty and the status contains a followed hashtag then show this in the statusInfo.

Fixes #1923