### PR TITLE
refactor: Implement HashtagsRepository

### DIFF
--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/CachedTimelineViewModel.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/CachedTimelineViewModel.kt
@@ -42,7 +42,7 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.distinctUntilChangedBy
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
@@ -69,7 +69,9 @@ class CachedTimelineViewModel @AssistedInject constructor(
     statusDisplayOptionsRepository = statusDisplayOptionsRepository,
     sharedPreferencesRepository = sharedPreferencesRepository,
 ) {
-    override val statuses = pachliAccountFlow.distinctUntilChangedBy { it.id }.flatMapLatest { pachliAccount ->
+    override val statuses = pachliAccountFlow.distinctUntilChanged { old, new ->
+        old.id == new.id && old.followedHashtags == new.followedHashtags
+    }.flatMapLatest { pachliAccount ->
         repository.getStatusStream(pachliAccount.id, timeline).map { pagingData ->
             pagingData
                 .map { Pair(it, shouldFilterStatus(it.timelineStatus)) }

--- a/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelineViewModel.kt
+++ b/app/src/main/java/app/pachli/components/timeline/viewmodel/NetworkTimelineViewModel.kt
@@ -50,7 +50,7 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.distinctUntilChangedBy
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
@@ -77,7 +77,9 @@ open class NetworkTimelineViewModel @AssistedInject constructor(
     statusDisplayOptionsRepository,
     sharedPreferencesRepository,
 ) {
-    override val statuses = pachliAccountFlow.distinctUntilChangedBy { it.id }.flatMapLatest { pachliAccount ->
+    override val statuses = pachliAccountFlow.distinctUntilChanged { old, new ->
+        old.id == new.id && old.followedHashtags == new.followedHashtags
+    }.flatMapLatest { pachliAccount ->
         repository.getStatusStream(pachliAccount.id, timeline = timeline).map { pagingData ->
             pagingData
                 .map { Pair(it, shouldFilterStatus(it.timelineStatus)) }

--- a/core/data/src/main/kotlin/app/pachli/core/data/di/DataModule.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/di/DataModule.kt
@@ -25,6 +25,8 @@ import app.pachli.core.data.repository.NetworkSuggestionsRepository
 import app.pachli.core.data.repository.OfflineFirstContentFiltersRepository
 import app.pachli.core.data.repository.OfflineFirstListRepository
 import app.pachli.core.data.repository.SuggestionsRepository
+import app.pachli.core.data.repository.hashtags.HashtagsRepository
+import app.pachli.core.data.repository.hashtags.OfflineFirstHashtagsRepository
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -52,4 +54,9 @@ abstract class DataModule {
     internal abstract fun bindsSuggestionsRepository(
         suggestionsRepository: NetworkSuggestionsRepository,
     ): SuggestionsRepository
+
+    @Binds
+    internal abstract fun bindsHashtagsRepository(
+        hashtagsRepository: OfflineFirstHashtagsRepository,
+    ): HashtagsRepository
 }

--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/AccountManager.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/AccountManager.kt
@@ -21,16 +21,15 @@ import android.database.sqlite.SQLiteException
 import app.pachli.core.common.PachliError
 import app.pachli.core.common.di.ApplicationScope
 import app.pachli.core.data.R
-import app.pachli.core.data.extensions.asEntity
 import app.pachli.core.data.model.Server
 import app.pachli.core.data.repository.ServerRepository.Error.GetNodeInfo
 import app.pachli.core.data.repository.ServerRepository.Error.GetWellKnownNodeInfo
 import app.pachli.core.data.repository.ServerRepository.Error.UnsupportedSchema
 import app.pachli.core.data.repository.ServerRepository.Error.ValidateNodeInfo
+import app.pachli.core.data.repository.hashtags.HashtagsRepository
 import app.pachli.core.database.dao.AccountDao
 import app.pachli.core.database.dao.AnnouncementsDao
 import app.pachli.core.database.dao.FollowingAccountDao
-import app.pachli.core.database.dao.HashtagsDao
 import app.pachli.core.database.dao.InstanceDao
 import app.pachli.core.database.di.TransactionProvider
 import app.pachli.core.database.model.AccountEntity
@@ -177,7 +176,7 @@ class AccountManager @Inject constructor(
     private val listsRepository: ListsRepository,
     private val announcementsDao: AnnouncementsDao,
     private val followingAccountDao: FollowingAccountDao,
-    private val hashtagsDao: HashtagsDao,
+    private val hashtagsRepository: HashtagsRepository,
     private val instanceSwitchAuthInterceptor: InstanceSwitchAuthInterceptor,
     @ApplicationScope private val externalScope: CoroutineScope,
 ) {
@@ -494,26 +493,11 @@ class AccountManager @Inject constructor(
             return@async Ok(following)
         }
 
-        val deferHashtags = externalScope.async {
-            var maxId: String? = null
-            val hashtags = buildList {
-                do {
-                    val response = mastodonApi.followedTags()
-                        .getOrElse { return@async Err(RefreshAccountError.General(account, it)) }
-                    addAll(response.body.asEntity(account.id))
-                    val links = HttpHeaderLink.parse(response.headers["Link"])
-                    val next = HttpHeaderLink.findByRelationType(links, "next")
-                    maxId = next?.uri?.getQueryParameter("max_id")
-                } while (maxId != null)
-            }
-
-            transactionProvider {
-                hashtagsDao.deleteFollowedHashtagsForAccount(account.id)
-                hashtagsDao.upsert(hashtags)
-            }
-
-            return@async Ok(hashtags)
-        }
+        // Refreshing the hashtags can run in the background without waiting for
+        // success/failure. Worst thing that can happen is the UI is out of date
+        // for followed hashtags for a few seconds if the user followed/unfollowed
+        // hashtags outside Pachli.
+        externalScope.launch { hashtagsRepository.refreshFollowedHashtags(account.id) }
 
         val nodeInfo = deferNodeInfo.await().bind()
         val instanceInfo = deferInstanceInfo.await().bind()
@@ -545,8 +529,6 @@ class AccountManager @Inject constructor(
             }.bind()
 
         deferEmojis.await().bind()
-
-        deferHashtags.await().bind()
 
         externalScope.async { listsRepository.refresh(account.id) }.await()
             .mapError { RefreshAccountError.General(account, it) }.bind()

--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/hashtags/HashtagsRepository.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/hashtags/HashtagsRepository.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.core.data.repository.hashtags
+
+import app.pachli.core.common.PachliError
+import app.pachli.core.model.Hashtag
+import app.pachli.core.network.retrofit.apiresult.ApiError
+import com.github.michaelbull.result.Result
+import kotlinx.coroutines.flow.Flow
+
+interface HashtagsError : PachliError {
+    @JvmInline
+    value class Retrieve(private val error: ApiError) : HashtagsError, PachliError by error
+
+    @JvmInline
+    value class Follow(private val error: ApiError) : HashtagsError, PachliError by error
+
+    @JvmInline
+    value class Unfollow(private val error: ApiError) : HashtagsError, PachliError by error
+}
+
+interface HashtagsRepository {
+    /** @return Known followed hashtags for [pachliAccountId]. */
+    fun getFollowedHashtags(pachliAccountId: Long): Flow<List<Hashtag>>
+
+    /**
+     * Refresh followed hashtags for [pachliAccountId].
+     *
+     * @return Latest followed hashtags, or an error.
+     */
+    suspend fun refreshFollowedHashtags(pachliAccountId: Long): Result<List<Hashtag>, HashtagsError.Retrieve>
+
+    /**
+     * Follow [hashtag].
+     *
+     * @return The server's latest view of [hashtag], or an error.
+     */
+    suspend fun followHashtag(pachliAccountId: Long, hashtag: String): Result<Hashtag, HashtagsError.Follow>
+
+    /**
+     * Unfollow [hashtag].
+     *
+     * @return The server's latest view of [hashtag], or an error.
+     */
+    suspend fun unfollowHashtag(pachliAccountId: Long, hashtag: String): Result<Hashtag, HashtagsError.Unfollow>
+}

--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/hashtags/OfflineFirstHashtagsRepository.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/hashtags/OfflineFirstHashtagsRepository.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.core.data.repository.hashtags
+
+import app.pachli.core.common.di.ApplicationScope
+import app.pachli.core.database.dao.HashtagsDao
+import app.pachli.core.database.di.TransactionProvider
+import app.pachli.core.database.model.HashtagEntity
+import app.pachli.core.database.model.asEntity
+import app.pachli.core.database.model.asModel
+import app.pachli.core.model.Hashtag
+import app.pachli.core.network.model.HttpHeaderLink
+import app.pachli.core.network.model.asModel
+import app.pachli.core.network.retrofit.MastodonApi
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getOrElse
+import com.github.michaelbull.result.map
+import com.github.michaelbull.result.mapEither
+import com.github.michaelbull.result.onSuccess
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+/**
+ * Repository for hashtags that caches information locally.
+ *
+ * - Methods that query data always return from the cache.
+ * - Methods that update data update the remote server first, and cache
+ * successful responses.
+ * - Call [refreshFollowedHashtags] to update the local cache of followed
+ * hashtags.
+ */
+@Singleton
+internal class OfflineFirstHashtagsRepository @Inject constructor(
+    @ApplicationScope private val externalScope: CoroutineScope,
+    private val localDataSource: HashtagsLocalDataSource,
+    private val remoteDataSource: HashtagsRemoteDataSource,
+) : HashtagsRepository {
+    override suspend fun refreshFollowedHashtags(pachliAccountId: Long): Result<List<Hashtag>, HashtagsError.Retrieve> = externalScope.async {
+        remoteDataSource.getFollowedHashtags(pachliAccountId).map { it.asModel() }
+            .onSuccess { localDataSource.replace(pachliAccountId, it.asEntity(pachliAccountId)) }
+    }.await()
+
+    override fun getFollowedHashtags(pachliAccountId: Long): Flow<List<Hashtag>> =
+        localDataSource.getFollowedHashtags(pachliAccountId).map { it.asModel() }
+
+    override suspend fun followHashtag(pachliAccountId: Long, hashtag: String): Result<Hashtag, HashtagsError.Follow> = externalScope.async {
+        remoteDataSource.followHashtag(hashtag)
+            .map { it.asModel() }
+            .onSuccess { localDataSource.followHashtag(it.asEntity(pachliAccountId)) }
+    }.await()
+
+    override suspend fun unfollowHashtag(pachliAccountId: Long, hashtag: String): Result<Hashtag, HashtagsError.Unfollow> = externalScope.async {
+        remoteDataSource.unfollowHashtag(hashtag)
+            .map { it.asModel() }
+            .onSuccess { localDataSource.unfollowHashtag(it.asEntity(pachliAccountId)) }
+    }.await()
+}
+
+@Singleton
+internal class HashtagsLocalDataSource @Inject constructor(
+    private val transactionProvider: TransactionProvider,
+    private val hashtagsDao: HashtagsDao,
+) {
+    suspend fun replace(pachliAccountId: Long, hashtags: List<HashtagEntity>) {
+        transactionProvider {
+            hashtagsDao.deleteFollowedHashtagsForAccount(pachliAccountId)
+            hashtagsDao.upsert(hashtags)
+        }
+    }
+
+    fun getFollowedHashtags(pachliAccountId: Long) = hashtagsDao.followingFlowByAccount(pachliAccountId)
+
+    suspend fun followHashtag(hashtag: HashtagEntity) = hashtagsDao.upsert(hashtag)
+
+    suspend fun unfollowHashtag(hashtag: HashtagEntity) = hashtagsDao.deleteForAccount(hashtag.pachliAccountId, hashtag.name)
+}
+
+@Singleton
+internal class HashtagsRemoteDataSource @Inject constructor(
+    private val mastodonApi: MastodonApi,
+) {
+    suspend fun getFollowedHashtags(pachliAccountId: Long): Result<List<app.pachli.core.network.model.HashTag>, HashtagsError.Retrieve> {
+        var maxId: String? = null
+        val hashtags = buildList {
+            do {
+                val response = mastodonApi.followedTags(maxId = maxId)
+                    .getOrElse { return Err(HashtagsError.Retrieve(it)) }
+                addAll(response.body)
+                val links = HttpHeaderLink.parse(response.headers["Link"])
+                val next = HttpHeaderLink.findByRelationType(links, "next")
+                maxId = next?.uri?.getQueryParameter("max_id")
+            } while (maxId != null)
+        }
+
+        return Ok(hashtags)
+    }
+
+    suspend fun followHashtag(hashtag: String) = mastodonApi.followTag(hashtag)
+        .mapEither({ it.body }, { HashtagsError.Follow(it) })
+
+    suspend fun unfollowHashtag(hashtag: String) = mastodonApi.unfollowTag(hashtag)
+        .mapEither({ it.body }, { HashtagsError.Unfollow(it) })
+}


### PR DESCRIPTION
Create a repository for hashtags with local and remote datasources and access the followed hashtags through that.

Don't wait for the hashtags to load when switching accounts, so it doesn't introduce extra delay. Include changes to the hashtags when deciding whether the status flow has changed in `*TimelineViewModel` so if a modified list of followed hashtags is loaded the UI will update.