### PR TITLE
fix: Clear status ID when creating a draft from a deleted status

### DIFF
--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/DraftsRepository.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/DraftsRepository.kt
@@ -207,7 +207,11 @@ fun DeletedStatus.asDraft() = Draft(
     language = language,
     quotePolicy = quoteApproval?.asQuotePolicy() ?: AccountSource.QuotePolicy.NOBODY,
     scheduledAt = null,
-    statusId = id,
+    // Clear the status ID. Since this is a deleted status the draft can't
+    // refer back to it, otherwise SendStatusService tries to send it as an
+    // update to an existing status (which has been deleted, so doesn't
+    // exist).
+    statusId = null,
     inReplyToId = inReplyToId,
     quotedStatusId = (quote as? Status.Quote.WithStatusId)?.statusId,
     cursorPosition = text?.length ?: 0,


### PR DESCRIPTION
Otherwise SendStatusService sees the status ID is present and tries to send it as an update to an existing status. This doesn't work, because the status has been deleted by this point.

Fixes #2295