### PR TITLE
fix: Hide preview cards on all posts with content warnings

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -337,22 +337,11 @@
     <issue
         id="MemberExtensionConflict"
         message="`hide` is defined both as a member in class `app.pachli.core.ui.PollView` and an extension in package `app.pachli.core.common.extensions`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
-        errorLine1="            } ?: pollView.hide()"
-        errorLine2="                 ~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/app/pachli/core/ui/StatusView.kt"
-            line="336"
-            column="18"/>
-    </issue>
-
-    <issue
-        id="MemberExtensionConflict"
-        message="`hide` is defined both as a member in class `app.pachli.core.ui.PollView` and an extension in package `app.pachli.core.common.extensions`. The defined behavior for this is to use the member, but since the extension is explicitly imported into this file, there&apos;s a chance that this was not expected. (One common way this happens is for members to be added to a class after code was already written to use an extension)."
         errorLine1="            pollView.hide()"
         errorLine2="            ~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/app/pachli/core/ui/StatusView.kt"
-            line="338"
+            line="324"
             column="13"/>
     </issue>
 
@@ -440,7 +429,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/components/trending/TrendingLinksFragment.kt"
-            line="123"
+            line="127"
             column="13"/>
     </issue>
 
@@ -473,7 +462,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/components/viewthread/ViewThreadFragment.kt"
-            line="192"
+            line="194"
             column="13"/>
     </issue>
 
@@ -484,7 +473,7 @@
         errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/components/viewthread/ViewThreadFragment.kt"
-            line="222"
+            line="224"
             column="21"/>
     </issue>
 
@@ -495,7 +484,7 @@
         errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/components/viewthread/ViewThreadFragment.kt"
-            line="244"
+            line="246"
             column="21"/>
     </issue>
 
@@ -506,7 +495,7 @@
         errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/components/viewthread/ViewThreadFragment.kt"
-            line="266"
+            line="268"
             column="21"/>
     </issue>
 

--- a/core/data/src/main/kotlin/app/pachli/core/data/model/StatusViewData.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/model/StatusViewData.kt
@@ -145,7 +145,7 @@ sealed interface IStatusViewData : IStatus {
      * True if this status' content is being shown (either because the status has no
      * spoiler warning, or because the user has clicked through the spoiler warning).
      * False if the content is not shown because the status has a warning and the user
-     * has clicked through.
+     * has not clicked through.
      */
     val isShowingContent: Boolean
 }
@@ -271,8 +271,14 @@ data class StatusViewData(
 
     override val username: String
 
+    /**
+     * True if the status content is showing (either there is no spoiler text, or
+     * the user has clicked through the spoiler warning).
+     */
+    // Use the original spoiler text, not the translated spoiler text, in case the
+    // translation erroneously returned empty spoiler text.
     override val isShowingContent: Boolean
-        get() = (_spoilerText.isEmpty() || isExpanded)
+        get() = (_spoilerText.isBlank() || isExpanded)
 
     override val rebloggedAvatar: String?
         get() = if (status.reblog != null) {

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/StatusView.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/StatusView.kt
@@ -187,52 +187,34 @@ abstract class StatusView<T : IStatusViewData> @JvmOverloads constructor(
         statusDisplayOptions: StatusDisplayOptions,
         listener: StatusActionListener,
     ) {
-        val spoilerText = when (viewData.translationState) {
-            TranslationState.SHOW_ORIGINAL -> viewData.actionable.spoilerText
-            TranslationState.TRANSLATING -> viewData.actionable.spoilerText
-            TranslationState.SHOW_TRANSLATION -> viewData.translation?.spoilerText.orEmpty()
-        }
+        val hasContentWarning = viewData.actionable.spoilerText.isNotBlank()
 
-        // Determine sensitive state from the original spoiler text, not the translated
-        // text, in case the translation erroneously returns empty spoiler text.
-        val sensitive = !TextUtils.isEmpty(viewData.actionable.spoilerText)
-        val expanded = viewData.isExpanded
-        if (sensitive) {
-            val emojiSpoiler = spoilerText.emojify(
+        contentWarningButton.visible(hasContentWarning)
+        contentWarningDescription.visible(hasContentWarning)
+
+        if (hasContentWarning) {
+            val emojiSpoiler = viewData.spoilerText.emojify(
                 glide,
                 viewData.actionable.emojis,
                 contentWarningDescription,
                 statusDisplayOptions.animateEmojis,
             )
             contentWarningDescription.text = emojiSpoiler
-            contentWarningDescription.visibility = VISIBLE
-            contentWarningButton.visibility = VISIBLE
             setContentWarningButtonText(viewData.isExpanded)
             contentWarningButton.setOnClickListener {
                 toggleExpandedState(
                     setContent,
                     glide,
                     viewData,
-                    true,
-                    !expanded,
+                    !viewData.isExpanded,
                     statusDisplayOptions,
                     listener,
                 )
             }
-            setTextVisible(setContent, glide, true, viewData, statusDisplayOptions, listener)
-            return
         }
 
-        contentWarningDescription.visibility = GONE
-        contentWarningButton.visibility = GONE
-        setTextVisible(
-            setContent,
-            glide,
-            sensitive = false,
-            viewData = viewData,
-            statusDisplayOptions = statusDisplayOptions,
-            listener = listener,
-        )
+        setTextVisible(setContent, glide, viewData, statusDisplayOptions, listener)
+        setupPoll(glide, viewData, statusDisplayOptions, listener)
     }
 
     private fun setContentWarningButtonText(expanded: Boolean) {
@@ -247,7 +229,6 @@ abstract class StatusView<T : IStatusViewData> @JvmOverloads constructor(
         setContent: SetContent,
         glide: RequestManager,
         viewData: T,
-        sensitive: Boolean,
         expanded: Boolean,
         statusDisplayOptions: StatusDisplayOptions,
         listener: StatusActionListener,
@@ -255,7 +236,8 @@ abstract class StatusView<T : IStatusViewData> @JvmOverloads constructor(
         contentWarningDescription.invalidate()
         listener.onExpandedChange(viewData, expanded)
         setContentWarningButtonText(expanded)
-        setTextVisible(setContent, glide, sensitive, viewData, statusDisplayOptions, listener)
+        setTextVisible(setContent, glide, viewData, statusDisplayOptions, listener)
+        setupPoll(glide, viewData, statusDisplayOptions, listener)
         setupCard(
             glide,
             viewData,
@@ -269,7 +251,6 @@ abstract class StatusView<T : IStatusViewData> @JvmOverloads constructor(
     private fun setTextVisible(
         setContent: SetContent,
         glide: RequestManager,
-        sensitive: Boolean,
         viewData: T,
         statusDisplayOptions: StatusDisplayOptions,
         listener: StatusActionListener,
@@ -277,7 +258,6 @@ abstract class StatusView<T : IStatusViewData> @JvmOverloads constructor(
         val emojis = viewData.actionable.emojis
         val mentions = viewData.actionable.mentions
         val tags = viewData.actionable.tags
-        val poll = viewData.actionable.poll
 
         when (viewData.translationState) {
             TranslationState.SHOW_ORIGINAL -> translationProvider.hide()
@@ -299,7 +279,7 @@ abstract class StatusView<T : IStatusViewData> @JvmOverloads constructor(
             }
         }
 
-        if (!sensitive || viewData.isExpanded) {
+        if (viewData.isShowingContent) {
             setContent(
                 glide = glide,
                 textView = this.content,
@@ -312,30 +292,7 @@ abstract class StatusView<T : IStatusViewData> @JvmOverloads constructor(
                 hashtags = tags,
                 linkListener = listener,
             )
-
-            poll?.let {
-                val pollViewData = if (viewData.translationState == TranslationState.SHOW_TRANSLATION) {
-                    from(poll).copy(translatedPoll = viewData.translation?.poll)
-                } else {
-                    from(poll)
-                }
-
-                pollView.bind(
-                    glide,
-                    pollViewData,
-                    emojis,
-                    statusDisplayOptions,
-                    NUMBER_FORMATTER,
-                    TIME_FORMATTER,
-                ) { choices ->
-                    choices?.let {
-                        listener.onVoteInPoll(viewData, poll, it)
-                    } ?: listener.onViewThread(viewData.actionable)
-                }
-                pollView.show()
-            } ?: pollView.hide()
         } else {
-            pollView.hide()
             setClickableMentions(
                 this.content,
                 mentions,
@@ -343,11 +300,50 @@ abstract class StatusView<T : IStatusViewData> @JvmOverloads constructor(
                 listener,
             )
         }
-        if (TextUtils.isEmpty(this.content.text)) {
+        if (this.content.text.isBlank()) {
             this.content.visibility = GONE
         } else {
             this.content.visibility = VISIBLE
         }
+    }
+
+    /**
+     * Displays any poll in [viewData], if
+     * [isShowingContent][StatusViewData.isShowingContent] (otherwise
+     * the poll is hidden).
+     */
+    private fun setupPoll(
+        glide: RequestManager,
+        viewData: T,
+        statusDisplayOptions: StatusDisplayOptions,
+        listener: StatusActionListener,
+    ) {
+        val poll = viewData.poll
+
+        if (!viewData.isShowingContent || poll == null) {
+            pollView.hide()
+            return
+        }
+
+        val pollViewData = if (viewData.translationState == TranslationState.SHOW_TRANSLATION) {
+            from(poll).copy(translatedPoll = viewData.translation?.poll)
+        } else {
+            from(poll)
+        }
+
+        pollView.bind(
+            glide,
+            pollViewData,
+            viewData.actionable.emojis,
+            statusDisplayOptions,
+            NUMBER_FORMATTER,
+            TIME_FORMATTER,
+        ) { choices ->
+            choices?.let {
+                listener.onVoteInPoll(viewData, poll, it)
+            } ?: listener.onViewThread(viewData.actionable)
+        }
+        pollView.show()
     }
 
     private fun setAvatar(
@@ -489,6 +485,11 @@ abstract class StatusView<T : IStatusViewData> @JvmOverloads constructor(
         listener: StatusActionListener,
         useBlurhash: Boolean,
     ) {
+        if (!viewData.isShowingContent) {
+            attachmentsView.hide()
+            return
+        }
+
         // Get the attachments -- this might be the translated version (with any
         // translated descriptions).
         val actionable = viewData.actionable
@@ -656,9 +657,8 @@ abstract class StatusView<T : IStatusViewData> @JvmOverloads constructor(
 
             append("; ")
 
-            // Content is optional, and hidden if there are spoilers or the status is
-            // marked sensitive, and it has not been expanded.
-            if (TextUtils.isEmpty(spoilerText) || !sensitive || viewData.isExpanded) {
+            // Content is only included if it's visible.
+            if (viewData.isShowingContent) {
                 val removeQuoteInline = viewData.actionable.quote != null
                 val content = if (removeQuoteInline) {
                     viewData.content.removeQuoteInline().parseAsMastodonHtml()
@@ -761,36 +761,35 @@ abstract class StatusView<T : IStatusViewData> @JvmOverloads constructor(
         statusDisplayOptions: StatusDisplayOptions,
         listener: StatusActionListener,
     ) {
-        val sensitive = viewData.actionable.sensitive
-        val attachments = viewData.actionable.attachments
-        val poll = viewData.actionable.poll
-        val card = viewData.actionable.card
+        val actionable = viewData.actionable
+        val sensitive = actionable.sensitive
+        val card = actionable.card
 
-        if (cardViewMode !== CardViewMode.NONE &&
-            attachments.isEmpty() &&
-            poll == null &&
-            card != null &&
-            !TextUtils.isEmpty(card.url) &&
-            (!sensitive || expanded) &&
-            (!viewData.isCollapsible || !viewData.isCollapsed)
-        ) {
-            cardView.visibility = VISIBLE
-            cardView.bind(glide, card, viewData.actionable.sensitive, statusDisplayOptions, false) { card, target ->
-                if (target == PreviewCardView.Target.BYLINE) {
-                    card.authors?.firstOrNull()?.account?.id?.let { listener.onViewAccount(it) }
-                    return@bind
-                }
+        val hasAttachments = actionable.attachments.isNotEmpty()
+        val hasPoll = actionable.poll != null
+        val hasCard = card != null && card.url.isNotBlank()
 
-                if (card.kind == PreviewCardKind.PHOTO && card.embedUrl.isNotEmpty() && target == PreviewCardView.Target.IMAGE) {
-                    listener.onViewMedia(viewData.pachliAccountId, viewData.actionable.account.username, card.embedUrl)
-                    return@bind
-                }
+        val showCard = hasCard && !hasAttachments && !hasPoll && cardViewMode != CardViewMode.NONE && viewData.isShowingContent
 
-                listener.onViewUrl(card.url)
-            }
-        } else {
-            cardView.visibility = GONE
+        if (!showCard) {
+            cardView.hide()
+            return
         }
+
+        cardView.bind(glide, card, sensitive, statusDisplayOptions, false) { card, target ->
+            if (target == PreviewCardView.Target.BYLINE) {
+                card.authors?.firstOrNull()?.account?.id?.let { listener.onViewAccount(it) }
+                return@bind
+            }
+
+            if (card.kind == PreviewCardKind.PHOTO && card.embedUrl.isNotBlank() && target == PreviewCardView.Target.IMAGE) {
+                listener.onViewMedia(viewData.pachliAccountId, actionable.account.username, card.embedUrl)
+                return@bind
+            }
+
+            listener.onViewUrl(card.url)
+        }
+        cardView.show()
     }
 
     companion object {


### PR DESCRIPTION
A `Status` has a `spoiler_text` property and a `sensitive` property.

On the web UI Mastodon, if you create a `Status` with spoiler text the `sensitive` property is set to `true`. This is front end behaviour, not something enforced by the API.

The previous code was assuming that `sensitive` being `true` also meant there was spoiler text, and vice-versa, but this is not the case, all four possible options are possible (empty/non-empty spoiler text x true/false sensitive property).

This meant that a preview card on a `Status` with `spoiler_text` but not marked `sensitive` would still be displayed.

Re-write the code to control whether the `Status` body is displayed to use the `spoiler_text` property exclusively.

The `sensitive` property is still used to determine how to display images in preview cards.

Fixes #2280