### PR TITLE
feat: Allow images to be zoomed 12x

### DIFF
--- a/app/src/main/java/app/pachli/fragment/ViewImageFragment.kt
+++ b/app/src/main/java/app/pachli/fragment/ViewImageFragment.kt
@@ -106,6 +106,9 @@ class ViewImageFragment : ViewMediaFragment() {
             },
         )
 
+        binding.photoView.doubleTapScale = 3f
+        binding.photoView.maxZoom = 12f
+
         binding.photoView.setOnTouchCoordinatesListener(
             object : OnTouchCoordinatesListener {
                 /** Y coordinate of the last single-finger drag */


### PR DESCRIPTION
Keep the existing behaviour of double-tapping to zoom in 3x. Then allow the user to use the expand gesture to continue zooming into the image to a total of 12x.

Fixes #2254