### PR TITLE
fix: Ensure first load of "with replies" tab starts from the top

### DIFF
--- a/app/src/main/java/app/pachli/components/timeline/TimelineFragment.kt
+++ b/app/src/main/java/app/pachli/components/timeline/TimelineFragment.kt
@@ -256,8 +256,9 @@ class TimelineFragment :
                             // Logging shows that some initial updated pages may be empty or may not
                             // contain the ID we expect (no idea how that can happen). Filter those
                             // out.
+                            .filter { (_, snapshot) -> snapshot.isNotEmpty() }
                             .onEach { (statusId, _) -> Timber.d("timeline: $timeline, Checking contains $statusId") }
-                            .map { (statusId, snapshot) -> Triple(statusId, snapshot, snapshot.indexOfFirst { it?.statusId == statusId }) }
+                            .map { (statusId, snapshot) -> Triple(statusId, snapshot, if (statusId == null) 0 else snapshot.indexOfFirst { it?.statusId == statusId }) }
                             .filter { (_, _, index) -> index != -1 }
                             // Only going to restore the position manually once over the lifetime of this
                             // fragment. Other position restoration is handled by the RecyclerView.


### PR DESCRIPTION
Previous code didn't attempt position restoration unless the loaded page snapshot contained the status ID to restore to.

This doesn't work if there is no position (i.e., the status ID to restore to is null).

Practically, this meant the account screen's "with replies" tab was loading somewhere in the middle of the first page of statuses.

Fix this, by:

1. Explicitly filtering out updates where the snapshot is empty (can't restore position in an empty snapshot).
2. Explicitly set the position to restore to 0 if the status ID is null.

Fixes #2236