### PR TITLE
fix: Show polls attached to boosted posts

### DIFF
--- a/core/ui/src/main/kotlin/app/pachli/core/ui/StatusView.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/StatusView.kt
@@ -318,7 +318,7 @@ abstract class StatusView<T : IStatusViewData> @JvmOverloads constructor(
         statusDisplayOptions: StatusDisplayOptions,
         listener: StatusActionListener,
     ) {
-        val poll = viewData.poll
+        val poll = viewData.actionable.poll
 
         if (!viewData.isShowingContent || poll == null) {
             pollView.hide()


### PR DESCRIPTION
The refactoring in https://github.com/pachli/pachli-android/pull/2302 used `viewData.poll` instead of `viewData.actionable.poll`, so polls on boosts were not shown.

Fixes #2316