### PR TITLE
refactor: Mark ServerRepository as internal, and cleanup

### DIFF
--- a/app/src/main/java/app/pachli/components/compose/ComposeViewModel.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeViewModel.kt
@@ -39,7 +39,6 @@ import app.pachli.core.data.repository.DraftsRepository
 import app.pachli.core.data.repository.InstanceInfoRepository
 import app.pachli.core.data.repository.Loadable
 import app.pachli.core.data.repository.PachliAccount
-import app.pachli.core.data.repository.ServerRepository
 import app.pachli.core.data.repository.StatusDisplayOptionsRepository
 import app.pachli.core.database.model.AccountEntity
 import app.pachli.core.model.AccountSource
@@ -173,7 +172,6 @@ class ComposeViewModel @AssistedInject constructor(
     private val mediaUploader: MediaUploader,
     private val sendStatus: SendStatusUseCase,
     instanceInfoRepo: InstanceInfoRepository,
-    serverRepository: ServerRepository,
     statusDisplayOptionsRepository: StatusDisplayOptionsRepository,
     private val sharedPreferencesRepository: SharedPreferencesRepository,
     private val draftsRepository: DraftsRepository,
@@ -294,8 +292,8 @@ class ComposeViewModel @AssistedInject constructor(
     val statusLength = _statusLength.asStateFlow()
 
     /** Flow of whether or not the server can schedule posts. */
-    val serverCanSchedule = serverRepository.flow.map {
-        it.get()?.can(ServerOperation.ORG_JOINMASTODON_STATUSES_SCHEDULED, ">= 1.0.0".toConstraint()) == true
+    val serverCanSchedule = accountFlow.map {
+        it.server.can(ServerOperation.ORG_JOINMASTODON_STATUSES_SCHEDULED, ">= 1.0.0".toConstraint())
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
 
     /**

--- a/app/src/main/java/app/pachli/components/search/SearchActivity.kt
+++ b/app/src/main/java/app/pachli/components/search/SearchActivity.kt
@@ -78,6 +78,7 @@ import app.pachli.core.common.extensions.show
 import app.pachli.core.common.extensions.toggleVisibility
 import app.pachli.core.common.extensions.viewBinding
 import app.pachli.core.common.extensions.visible
+import app.pachli.core.common.util.unsafeLazy
 import app.pachli.core.data.model.Server
 import app.pachli.core.model.ServerOperation
 import app.pachli.core.model.ServerOperation.ORG_JOINMASTODON_SEARCH_QUERY_BY_DATE
@@ -108,7 +109,6 @@ import app.pachli.databinding.SearchOperatorAttachmentDialogBinding
 import app.pachli.databinding.SearchOperatorDateDialogBinding
 import app.pachli.databinding.SearchOperatorFromDialogBinding
 import app.pachli.databinding.SearchOperatorWhereLocationDialogBinding
-import com.github.michaelbull.result.get
 import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.badge.BadgeDrawable
 import com.google.android.material.badge.BadgeUtils
@@ -127,6 +127,7 @@ import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneOffset
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
@@ -143,6 +144,8 @@ class SearchActivity :
 
     private val showFilterIcon: Boolean
         get() = viewModel.availableOperators.value.isNotEmpty()
+
+    private val pachliAccountId by unsafeLazy { intent.pachliAccountId }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
@@ -171,6 +174,7 @@ class SearchActivity :
         addMenuProvider(this)
         setupPages()
         bindOperators()
+        viewModel.setPachliAccountId(pachliAccountId)
         handleIntent(intent)
     }
 
@@ -219,9 +223,7 @@ class SearchActivity :
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.RESUMED) {
                 launch {
-                    viewModel.server.collectLatest {
-                        // Ignore errors for the moment
-                        val server = it?.get() ?: return@collectLatest
+                    viewModel.server.filterNotNull().collectLatest { server ->
                         bindDateChip(server)
                         bindFromChip(server)
                         bindHasMediaChip(server)

--- a/app/src/main/java/app/pachli/components/search/SearchViewModel.kt
+++ b/app/src/main/java/app/pachli/components/search/SearchViewModel.kt
@@ -39,12 +39,9 @@ import app.pachli.core.data.model.IStatusViewData
 import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.data.model.StatusItemViewData
 import app.pachli.core.data.repository.AccountManager
-import app.pachli.core.data.repository.Loadable
 import app.pachli.core.data.repository.OfflineFirstStatusRepository
-import app.pachli.core.data.repository.ServerRepository
 import app.pachli.core.data.repository.StatusDisplayOptionsRepository
 import app.pachli.core.database.dao.TimelineStatusWithAccount
-import app.pachli.core.database.model.AccountEntity
 import app.pachli.core.database.model.TimelineStatusWithQuote
 import app.pachli.core.database.model.asEntity
 import app.pachli.core.model.AttachmentDisplayAction
@@ -84,11 +81,13 @@ import io.github.z4kn4fein.semver.constraints.toConstraint
 import javax.inject.Inject
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -99,19 +98,22 @@ import timber.log.Timber
 class SearchViewModel @Inject constructor(
     private val mastodonApi: MastodonApi,
     private val timelineCases: TimelineCases,
-    private val accountManager: AccountManager,
+    accountManager: AccountManager,
     private val statusRepository: OfflineFirstStatusRepository,
     statusDisplayOptionsRepository: StatusDisplayOptionsRepository,
-    serverRepository: ServerRepository,
 ) : ViewModel() {
+    private val pachliAccountId = MutableSharedFlow<Long>(replay = 1)
+
+    internal val pachliAccount = pachliAccountId.flatMapLatest {
+        accountManager.getPachliAccountFlow(it)
+    }.stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(5000),
+        null,
+    )
 
     var currentQuery: String = ""
     var currentSearchFieldContent: String? = null
-
-    val activeAccount: AccountEntity?
-        get() = accountManager.activeAccount
-
-    private val alwaysOpenSpoiler = activeAccount?.alwaysOpenSpoiler ?: false
 
     val statusDisplayOptions: StatusDisplayOptions = statusDisplayOptionsRepository.flow.value
 
@@ -142,82 +144,75 @@ class SearchViewModel @Inject constructor(
      */
     val operatorViewData = _operatorViewData.asStateFlow()
 
-    val locales = accountManager.activeAccountFlow
-        .filterIsInstance<Loadable.Loaded<AccountEntity?>>()
-        .map { getLocaleList(getInitialLanguages(activeAccount = it.data)) }
+    val locales = pachliAccount.filterNotNull()
+        .map { getLocaleList(getInitialLanguages(activeAccount = it.entity)) }
         .stateIn(
             viewModelScope,
             SharingStarted.WhileSubscribed(5000),
             getLocaleList(getInitialLanguages()),
         )
 
-    val server = serverRepository.flow.stateIn(
-        viewModelScope,
-        SharingStarted.WhileSubscribed(5000),
-        null,
-    )
+    val server = pachliAccount.filterNotNull().map { it.server }
+        .stateIn(
+            viewModelScope,
+            SharingStarted.WhileSubscribed(5000),
+            null,
+        )
 
     /**
      * Set of operators the server supports.
      *
      * Empty set if the server does not support any operators.
      */
-    val availableOperators = serverRepository.flow.map { result ->
-        result.mapBoth(
-            { server ->
-                buildSet {
-                    val constraint100 = ">=1.0.0".toConstraint()
-                    val canHasMedia = server.can(ORG_JOINMASTODON_SEARCH_QUERY_HAS_MEDIA, constraint100)
-                    val canHasImage = server.can(ORG_JOINMASTODON_SEARCH_QUERY_HAS_IMAGE, constraint100)
-                    val canHasVideo = server.can(ORG_JOINMASTODON_SEARCH_QUERY_HAS_VIDEO, constraint100)
-                    val canHasAudio = server.can(ORG_JOINMASTODON_SEARCH_QUERY_HAS_AUDIO, constraint100)
-                    if (canHasMedia || canHasImage || canHasVideo || canHasAudio) {
-                        add(HasMediaOperator())
-                    }
+    val availableOperators = server.filterNotNull().map { server ->
+        buildSet {
+            val constraint100 = ">=1.0.0".toConstraint()
+            val canHasMedia = server.can(ORG_JOINMASTODON_SEARCH_QUERY_HAS_MEDIA, constraint100)
+            val canHasImage = server.can(ORG_JOINMASTODON_SEARCH_QUERY_HAS_IMAGE, constraint100)
+            val canHasVideo = server.can(ORG_JOINMASTODON_SEARCH_QUERY_HAS_VIDEO, constraint100)
+            val canHasAudio = server.can(ORG_JOINMASTODON_SEARCH_QUERY_HAS_AUDIO, constraint100)
+            if (canHasMedia || canHasImage || canHasVideo || canHasAudio) {
+                add(HasMediaOperator())
+            }
 
-                    if (server.can(ORG_JOINMASTODON_SEARCH_QUERY_BY_DATE, constraint100)) {
-                        add(DateOperator())
-                    }
+            if (server.can(ORG_JOINMASTODON_SEARCH_QUERY_BY_DATE, constraint100)) {
+                add(DateOperator())
+            }
 
-                    if (server.can(ORG_JOINMASTODON_SEARCH_QUERY_FROM, constraint100)) {
-                        add(FromOperator())
-                    }
+            if (server.can(ORG_JOINMASTODON_SEARCH_QUERY_FROM, constraint100)) {
+                add(FromOperator())
+            }
 
-                    if (server.can(ORG_JOINMASTODON_SEARCH_QUERY_LANGUAGE, constraint100)) {
-                        add(LanguageOperator())
-                    }
+            if (server.can(ORG_JOINMASTODON_SEARCH_QUERY_LANGUAGE, constraint100)) {
+                add(LanguageOperator())
+            }
 
-                    if (server.can(ORG_JOINMASTODON_SEARCH_QUERY_HAS_LINK, constraint100)) {
-                        add(HasLinkOperator())
-                    }
-                    if (server.can(ORG_JOINMASTODON_SEARCH_QUERY_HAS_EMBED, constraint100)) {
-                        add(HasEmbedOperator())
-                    }
+            if (server.can(ORG_JOINMASTODON_SEARCH_QUERY_HAS_LINK, constraint100)) {
+                add(HasLinkOperator())
+            }
+            if (server.can(ORG_JOINMASTODON_SEARCH_QUERY_HAS_EMBED, constraint100)) {
+                add(HasEmbedOperator())
+            }
 
-                    if (server.can(ORG_JOINMASTODON_SEARCH_QUERY_HAS_POLL, constraint100)) {
-                        add(HasPollOperator())
-                    }
+            if (server.can(ORG_JOINMASTODON_SEARCH_QUERY_HAS_POLL, constraint100)) {
+                add(HasPollOperator())
+            }
 
-                    if (server.can(ORG_JOINMASTODON_SEARCH_QUERY_HAS_QUOTE, constraint100)) {
-                        add(HasQuoteOperator())
-                    }
+            if (server.can(ORG_JOINMASTODON_SEARCH_QUERY_HAS_QUOTE, constraint100)) {
+                add(HasQuoteOperator())
+            }
 
-                    if (server.can(ORG_JOINMASTODON_SEARCH_QUERY_IS_REPLY, constraint100)) {
-                        add(IsReplyOperator())
-                    }
-                    if (server.can(ORG_JOINMASTODON_SEARCH_QUERY_IS_SENSITIVE, constraint100)) {
-                        add(IsSensitiveOperator())
-                    }
+            if (server.can(ORG_JOINMASTODON_SEARCH_QUERY_IS_REPLY, constraint100)) {
+                add(IsReplyOperator())
+            }
+            if (server.can(ORG_JOINMASTODON_SEARCH_QUERY_IS_SENSITIVE, constraint100)) {
+                add(IsSensitiveOperator())
+            }
 
-                    val canInLibrary = server.can(ORG_JOINMASTODON_SEARCH_QUERY_IN_LIBRARY, constraint100)
-                    val canInPublic = server.can(ORG_JOINMASTODON_SEARCH_QUERY_IN_PUBLIC, constraint100)
-                    if (canInLibrary || canInPublic) add(WhereOperator())
-                }
-            },
-            {
-                emptySet()
-            },
-        )
+            val canInLibrary = server.can(ORG_JOINMASTODON_SEARCH_QUERY_IN_LIBRARY, constraint100)
+            val canInPublic = server.can(ORG_JOINMASTODON_SEARCH_QUERY_IN_PUBLIC, constraint100)
+            if (canInLibrary || canInPublic) add(WhereOperator())
+        }
     }.stateIn(
         viewModelScope,
         SharingStarted.WhileSubscribed(5000),
@@ -227,7 +222,7 @@ class SearchViewModel @Inject constructor(
     private val loadedStatuses: MutableList<StatusItemViewData> = mutableListOf()
 
     private val statusesPagingSourceFactory = SearchPagingSourceFactory(mastodonApi, SearchType.Status, loadedStatuses) {
-        val pachliAccount = accountManager.activePachliAccountFlow.first()
+        val pachliAccount = pachliAccount.filterNotNull().first()
 
         // Search uses the "PUBLIC" context, since https://github.com/mastodon/mastodon/pull/36346/
         val contentFilterModel = when (pachliAccount.contentFilters.version) {
@@ -262,7 +257,7 @@ class SearchViewModel @Inject constructor(
                 StatusItemViewData.from(
                     pachliAccount = pachliAccount,
                     status,
-                    isExpanded = alwaysOpenSpoiler,
+                    isExpanded = pachliAccount.entity.alwaysOpenSpoiler,
                     contentFilterAction = contentFilterAction,
                     quoteContentFilterAction = status.quotedStatus?.let { contentFilterModel.filterActionFor(it.status) },
                     filterContext = null,
@@ -272,9 +267,11 @@ class SearchViewModel @Inject constructor(
                 loadedStatuses.addAll(this)
             }
     }
+
     private val accountsPagingSourceFactory = SearchPagingSourceFactory(mastodonApi, SearchType.Account) {
         it.accounts
     }
+
     private val hashtagsPagingSourceFactory = SearchPagingSourceFactory(mastodonApi, SearchType.Hashtag) {
         it.hashtags
     }
@@ -293,6 +290,10 @@ class SearchViewModel @Inject constructor(
         config = PagingConfig(pageSize = DEFAULT_LOAD_SIZE, initialLoadSize = DEFAULT_LOAD_SIZE),
         pagingSourceFactory = hashtagsPagingSourceFactory,
     ).flow.cachedIn(viewModelScope)
+
+    internal fun setPachliAccountId(pachliAccountId: Long) {
+        viewModelScope.launch { this@SearchViewModel.pachliAccountId.emit(pachliAccountId) }
+    }
 
     /** @return The operator of type T. */
     inline fun <reified T : SearchOperator> getOperator() = operatorViewData.value.find { it.operator is T }?.operator as T?
@@ -391,9 +392,9 @@ class SearchViewModel @Inject constructor(
         }
     }
 
-    fun muteAccount(accountId: String, notifications: Boolean, duration: Int?) {
+    fun muteAccount(pachliAccountId: Long, accountId: String, notifications: Boolean, duration: Int?) {
         viewModelScope.launch {
-            timelineCases.muteAccount(activeAccount!!.id, accountId, notifications, duration)
+            timelineCases.muteAccount(pachliAccountId, accountId, notifications, duration)
         }
     }
 
@@ -403,9 +404,9 @@ class SearchViewModel @Inject constructor(
         }
     }
 
-    fun blockAccount(accountId: String) {
+    fun blockAccount(pachliAccountId: Long, accountId: String) {
         viewModelScope.launch {
-            timelineCases.blockAccount(activeAccount!!.id, accountId)
+            timelineCases.blockAccount(pachliAccountId, accountId)
         }
     }
 
@@ -418,7 +419,7 @@ class SearchViewModel @Inject constructor(
     fun muteConversation(statusViewData: IStatusViewData, mute: Boolean) {
         updateStatus(statusViewData.status.copy(muted = mute))
         viewModelScope.launch {
-            timelineCases.muteConversation(activeAccount!!.id, statusViewData.statusId, mute)
+            timelineCases.muteConversation(statusViewData.pachliAccountId, statusViewData.statusId, mute)
         }
     }
 

--- a/app/src/main/java/app/pachli/components/search/fragments/SearchFragment.kt
+++ b/app/src/main/java/app/pachli/components/search/fragments/SearchFragment.kt
@@ -22,6 +22,7 @@ import app.pachli.core.activity.ViewUrlActivity
 import app.pachli.core.activity.extensions.startActivityWithDefaultTransition
 import app.pachli.core.common.extensions.viewBinding
 import app.pachli.core.common.extensions.visible
+import app.pachli.core.common.util.unsafeLazy
 import app.pachli.core.navigation.AccountActivityIntent
 import app.pachli.core.navigation.TimelineActivityIntent
 import app.pachli.core.network.retrofit.MastodonApi
@@ -35,7 +36,6 @@ import com.mikepenz.iconics.typeface.library.googlematerial.GoogleMaterial
 import com.mikepenz.iconics.utils.colorInt
 import com.mikepenz.iconics.utils.sizeDp
 import javax.inject.Inject
-import kotlin.properties.Delegates
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -62,12 +62,7 @@ abstract class SearchFragment<T : Any> :
 
     private var currentQuery: String = ""
 
-    protected var pachliAccountId by Delegates.notNull<Long>()
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        pachliAccountId = requireArguments().getLong(ARG_PACHLI_ACCOUNT_ID)
-    }
+    protected val pachliAccountId by unsafeLazy { requireArguments().getLong(ARG_PACHLI_ACCOUNT_ID) }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         binding.searchRecyclerView.applyDefaultWindowInsets()

--- a/app/src/main/java/app/pachli/components/search/fragments/SearchStatusesFragment.kt
+++ b/app/src/main/java/app/pachli/components/search/fragments/SearchStatusesFragment.kt
@@ -240,23 +240,13 @@ class SearchStatusesFragment : SearchFragment<StatusItemViewData>(), StatusActio
     }
 
     private fun reply(status: IStatusViewData) {
-        val actionableStatus = status.actionable
-        val mentionedUsernames = actionableStatus.mentions.map { it.username }
-            .toMutableSet()
-            .apply {
-                add(actionableStatus.account.username)
-                remove(viewModel.activeAccount?.username)
-            }
-
-        val intent = ComposeActivityIntent(
-            requireContext(),
-            status.pachliAccountId,
-            ComposeOptions(
-                draft = Draft.createDraftReply(viewModel.activeAccount!!, status.actionable),
-                referencingStatus = ReferencingStatus.ReplyingTo.from(status.actionable),
-            ),
+        val draft = Draft.createDraftReply(viewModel.pachliAccount.value!!.entity, status.actionable)
+        val composeOptions = ComposeOptions(
+            draft = draft,
+            referencingStatus = ReferencingStatus.ReplyingTo.from(status.actionable),
         )
-        startActivityWithDefaultTransition(intent)
+        val intent = ComposeActivityIntent(requireContext(), pachliAccountId, composeOptions)
+        startActivityWithTransition(intent, TransitionKind.SLIDE_FROM_END)
     }
 
     /**
@@ -266,7 +256,7 @@ class SearchStatusesFragment : SearchFragment<StatusItemViewData>(), StatusActio
         val actionableStatus = status.actionableStatus
 
         val composeOptions = ComposeOptions(
-            draft = Draft.createDraftQuote(viewModel.activeAccount!!, status.actionableStatus),
+            draft = Draft.createDraftQuote(viewModel.pachliAccount.value!!.entity, status.actionableStatus),
             referencingStatus = ReferencingStatus.Quoting.from(actionableStatus),
         )
 
@@ -280,11 +270,11 @@ class SearchStatusesFragment : SearchFragment<StatusItemViewData>(), StatusActio
         val accountId = status.account.id
         val accountUsername = status.account.username
         val statusUrl = status.url
-        val loggedInAccountId = viewModel.activeAccount?.accountId
+        val loggedInAccountId = viewModel.pachliAccount.value!!.entity.accountId
 
         val popup = PopupMenu(view.context, view)
-        val statusIsByCurrentUser = loggedInAccountId?.equals(accountId) == true
-        // Give a different menu depending on whether this is the user's own toot or not.
+        val statusIsByCurrentUser = loggedInAccountId == accountId
+        // Give a different menu depending on whether this is the user's own status or not.
         if (statusIsByCurrentUser) {
             popup.inflate(R.menu.status_more_for_user)
             val menu = popup.menu
@@ -317,7 +307,7 @@ class SearchStatusesFragment : SearchFragment<StatusItemViewData>(), StatusActio
             openAsItem.title = openAsText
         }
 
-        val mutable = statusIsByCurrentUser || accountIsInMentions(viewModel.activeAccount, status.mentions)
+        val mutable = statusIsByCurrentUser || accountIsInMentions(viewModel.pachliAccount.value!!.entity, status.mentions)
         val muteConversationItem = popup.menu.findItem(R.id.status_mute_conversation).apply {
             isVisible = mutable
         }
@@ -416,7 +406,7 @@ class SearchStatusesFragment : SearchFragment<StatusItemViewData>(), StatusActio
     private fun onBlock(accountId: String, accountUsername: String) {
         AlertDialog.Builder(requireContext())
             .setMessage(getString(R.string.dialog_block_warning, accountUsername))
-            .setPositiveButton(android.R.string.ok) { _, _ -> viewModel.blockAccount(accountId) }
+            .setPositiveButton(android.R.string.ok) { _, _ -> viewModel.blockAccount(pachliAccountId, accountId) }
             .setNegativeButton(android.R.string.cancel, null)
             .show()
     }
@@ -426,7 +416,7 @@ class SearchStatusesFragment : SearchFragment<StatusItemViewData>(), StatusActio
             this.requireActivity(),
             accountUsername,
         ) { notifications, duration ->
-            viewModel.muteAccount(accountId, notifications, duration)
+            viewModel.muteAccount(pachliAccountId, accountId, notifications, duration)
         }
     }
 
@@ -448,7 +438,7 @@ class SearchStatusesFragment : SearchFragment<StatusItemViewData>(), StatusActio
         Toast.makeText(context, R.string.downloading_media, Toast.LENGTH_SHORT).show()
         for ((_, url) in status.attachments) {
             lifecycleScope.launch {
-                downloadUrlUseCase(url, viewModel.activeAccount!!.fullName, status.actionableStatus.account.username)
+                downloadUrlUseCase(url, viewModel.pachliAccount.value!!.entity.fullName, status.actionableStatus.account.username)
             }
         }
     }

--- a/app/src/main/java/app/pachli/fragment/SFragment.kt
+++ b/app/src/main/java/app/pachli/fragment/SFragment.kt
@@ -42,7 +42,6 @@ import app.pachli.core.data.model.IStatusViewData
 import app.pachli.core.data.model.StatusItemViewData
 import app.pachli.core.data.repository.AccountManager
 import app.pachli.core.data.repository.OfflineFirstStatusRepository
-import app.pachli.core.data.repository.ServerRepository
 import app.pachli.core.data.repository.asDraft
 import app.pachli.core.data.repository.createDraftQuote
 import app.pachli.core.data.repository.createDraftReply
@@ -90,9 +89,6 @@ abstract class SFragment<T : IStatusViewData> : Fragment(), StatusActionListener
 
     @Inject
     lateinit var timelineCases: TimelineCases
-
-    @Inject
-    lateinit var serverRepository: ServerRepository
 
     @Inject
     lateinit var downloadUrlUseCase: DownloadUrlUseCase

--- a/core/data/src/main/kotlin/app/pachli/core/data/model/Server.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/model/Server.kt
@@ -381,8 +381,6 @@ data class Server(
                 }
 
                 GOTOSOCIAL -> {
-                    // Can't do scheduled posts, https://github.com/superseriousbusiness/gotosocial/issues/1006
-
                     // Filters
                     when {
                         // Implemented in https://github.com/superseriousbusiness/gotosocial/pull/2936

--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/ContentFiltersRepository.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/ContentFiltersRepository.kt
@@ -28,11 +28,6 @@ import kotlinx.coroutines.flow.Flow
 
 /** Errors that can be returned from this repository. */
 sealed interface ContentFiltersError : PachliError {
-    /** Wraps errors from actions on the [ServerRepository]. */
-    @JvmInline
-    value class ServerRepositoryError(private val error: ServerRepository.Error) :
-        ContentFiltersError, PachliError by error
-
     /** The user's server does not support filters. */
     data object ServerDoesNotFilter : ContentFiltersError {
         override val resourceId: Int = R.string.error_filter_server_does_not_filter

--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/ServerRepository.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/ServerRepository.kt
@@ -63,7 +63,7 @@ val SCHEMAS = listOf(
 )
 
 @Singleton
-class ServerRepository @Inject constructor(
+internal class ServerRepository @Inject constructor(
     private val mastodonApi: MastodonApi,
     private val nodeInfoApi: NodeInfoApi,
     accountManager: AccountManager,


### PR DESCRIPTION
Code that needs server info (e.g., to make UI decisions based on server capabilities) should be going through the server info attached to the account, not querying `ServerRepository` directly.

Mark `ServerRepository` as internal, and clean up direct usage outside `core.data.repository`.