### PR TITLE
refactor: Improve notification channel type safety

### DIFF
--- a/app/src/main/java/app/pachli/components/notifications/NotificationHelper.kt
+++ b/app/src/main/java/app/pachli/components/notifications/NotificationHelper.kt
@@ -26,10 +26,12 @@ import android.content.Intent
 import android.graphics.BitmapFactory
 import android.os.Build
 import android.os.Bundle
+import android.os.Parcelable
 import android.provider.Settings
 import android.service.notification.StatusBarNotification
 import android.text.Spanned
 import android.text.TextUtils
+import androidx.annotation.StringRes
 import androidx.core.app.NotificationCompat
 import androidx.core.app.RemoteInput
 import androidx.core.app.TaskStackBuilder
@@ -50,6 +52,7 @@ import app.pachli.core.common.string.unicodeWrap
 import app.pachli.core.data.repository.PachliAccount
 import app.pachli.core.data.repository.createDraftReply
 import app.pachli.core.database.model.AccountEntity
+import app.pachli.core.database.model.AccountIdentifier
 import app.pachli.core.database.model.NotificationData
 import app.pachli.core.database.model.NotificationEntity
 import app.pachli.core.designsystem.R as DR
@@ -95,21 +98,44 @@ const val KEY_SERVER_NOTOFICATION_ID = "KEY_SERVER_NOTIFICATION_ID"
 /** Key to return the [Draft]. */
 const val KEY_DRAFT = "KEY_DRAFT"
 
-/** notification channels used on Android O+ */
-const val CHANNEL_MENTION = "CHANNEL_MENTION"
-private const val CHANNEL_FOLLOW = "CHANNEL_FOLLOW"
-private const val CHANNEL_FOLLOW_REQUEST = "CHANNEL_FOLLOW_REQUEST"
-private const val CHANNEL_BOOST = "CHANNEL_BOOST"
-private const val CHANNEL_FAVOURITE = "CHANNEL_FAVOURITE"
-private const val CHANNEL_POLL = "CHANNEL_POLL"
-private const val CHANNEL_SUBSCRIPTIONS = "CHANNEL_SUBSCRIPTIONS"
-private const val CHANNEL_SIGN_UP = "CHANNEL_SIGN_UP"
-private const val CHANNEL_UPDATES = "CHANNEL_UPDATES"
-private const val CHANNEL_REPORT = "CHANNEL_REPORT"
-private const val CHANNEL_SEVERED_RELATIONSHIPS = "CHANNEL_SEVERED_RELATIONSHIPS"
-private const val CHANNEL_MODERATION_WARNINGS = "CHANNEL_MODERATION_WARNING"
-private const val CHANNEL_QUOTE = "CHANNEL_QUOTE"
-private const val CHANNEL_QUOTED_UPDATE = "CHANNEL_QUOTED_UPDATE"
+/**
+ * Notification channels for per-account Mastodon notifications, used on
+ * Android O+
+ *
+ * @property baseId Base ID for the channel. Notification channels are created
+ * per account, use [channelId] to get the full channel ID.
+ * @property nameRes Resource identifier for the notification channel name
+ * @property descriptionRes Resource identifier for the notification
+ * channel description
+ */
+enum class PachliNotificationChannels(
+    private val baseId: String,
+    @StringRes val nameRes: Int,
+    @StringRes val descriptionRes: Int,
+) {
+    MENTION("CHANNEL_MENTION", R.string.notification_mention_name, R.string.notification_mention_descriptions),
+    FOLLOW("CHANNEL_FOLLOW", R.string.notification_follow_name, R.string.notification_follow_description),
+    FOLLOW_REQUEST("CHANNEL_FOLLOW_REQUEST", R.string.notification_follow_request_name, R.string.notification_follow_request_description),
+    REBLOG("CHANNEL_BOOST", R.string.notification_boost_name, R.string.notification_boost_description),
+    FAVOURITE("CHANNEL_FAVOURITE", R.string.notification_favourite_name, R.string.notification_favourite_description),
+    POLL("CHANNEL_POLL", R.string.notification_poll_name, R.string.notification_poll_description),
+    SUBSCRIPTIONS("CHANNEL_SUBSCRIPTIONS", R.string.notification_subscription_name, R.string.notification_subscription_description),
+    SIGN_UP("CHANNEL_SIGN_UP", R.string.notification_sign_up_name, R.string.notification_sign_up_description),
+    UPDATES("CHANNEL_UPDATES", R.string.notification_update_name, R.string.notification_update_description),
+    REPORT("CHANNEL_REPORT", R.string.notification_report_name, R.string.notification_report_description),
+    SEVERED_RELATIONSHIPS("CHANNEL_SEVERED_RELATIONSHIPS", R.string.notification_severed_relationships_name, R.string.notification_severed_relationships_description),
+    MODERATION_WARNINGS("CHANNEL_MODERATION_WARNING", R.string.notification_moderation_warnings_name, R.string.notification_moderation_warnings_description),
+    QUOTE("CHANNEL_QUOTE", R.string.notification_quote_name, R.string.notification_quote_description),
+    QUOTED_UPDATE("CHANNEL_QUOTED_UPDATE", R.string.notification_quoted_update_name, R.string.notification_quoted_update_description),
+
+    ;
+
+    /**
+     * @return The full ID for this channel for the account identified
+     * by [accountIdentifier].
+     */
+    fun channelId(accountIdentifier: AccountIdentifier) = baseId + accountIdentifier
+}
 
 /** WorkManager Tag */
 private const val NOTIFICATION_PULL_TAG = "pullNotifications"
@@ -406,7 +432,8 @@ private fun getStatusReplyIntent(
         .setAction(REPLY_ACTION)
         .putExtra(KEY_DRAFT, draft)
         .putExtra(KEY_SENDER_ACCOUNT_ID, account.id)
-        .putExtra(KEY_SENDER_ACCOUNT_IDENTIFIER, account.identifier)
+        // Required
+        .putExtra(KEY_SENDER_ACCOUNT_IDENTIFIER, account.identifier as Parcelable)
         .putExtra(KEY_SENDER_ACCOUNT_FULL_NAME, account.fullName)
         .putExtra(KEY_SERVER_NOTOFICATION_ID, body.id)
     return PendingIntent.getBroadcast(
@@ -448,61 +475,14 @@ fun createNotificationChannelsForAccount(account: AccountEntity, context: Contex
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
         val notificationManager =
             context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        val channelIds = arrayOf(
-            CHANNEL_MENTION + account.identifier,
-            CHANNEL_FOLLOW + account.identifier,
-            CHANNEL_FOLLOW_REQUEST + account.identifier,
-            CHANNEL_BOOST + account.identifier,
-            CHANNEL_FAVOURITE + account.identifier,
-            CHANNEL_POLL + account.identifier,
-            CHANNEL_SUBSCRIPTIONS + account.identifier,
-            CHANNEL_SIGN_UP + account.identifier,
-            CHANNEL_UPDATES + account.identifier,
-            CHANNEL_REPORT + account.identifier,
-            CHANNEL_SEVERED_RELATIONSHIPS + account.identifier,
-            CHANNEL_MODERATION_WARNINGS + account.identifier,
-            CHANNEL_QUOTE + account.identifier,
-            CHANNEL_QUOTED_UPDATE + account.identifier,
-        )
-        val channelNames = intArrayOf(
-            R.string.notification_mention_name,
-            R.string.notification_follow_name,
-            R.string.notification_follow_request_name,
-            R.string.notification_boost_name,
-            R.string.notification_favourite_name,
-            R.string.notification_poll_name,
-            R.string.notification_subscription_name,
-            R.string.notification_sign_up_name,
-            R.string.notification_update_name,
-            R.string.notification_report_name,
-            R.string.notification_severed_relationships_name,
-            R.string.notification_moderation_warnings_name,
-            R.string.notification_quote_name,
-            R.string.notification_quoted_update_name,
-        )
-        val channelDescriptions = intArrayOf(
-            R.string.notification_mention_descriptions,
-            R.string.notification_follow_description,
-            R.string.notification_follow_request_description,
-            R.string.notification_boost_description,
-            R.string.notification_favourite_description,
-            R.string.notification_poll_description,
-            R.string.notification_subscription_description,
-            R.string.notification_sign_up_description,
-            R.string.notification_update_description,
-            R.string.notification_report_description,
-            R.string.notification_severed_relationships_description,
-            R.string.notification_moderation_warnings_description,
-            R.string.notification_quote_description,
-            R.string.notification_quoted_update_description,
-        )
-        val channels: MutableList<NotificationChannel> = ArrayList(6)
-        val channelGroup = NotificationChannelGroup(account.identifier, account.fullName)
+
+        val channelGroup = NotificationChannelGroup(account.identifier.value, account.fullName)
         notificationManager.createNotificationChannelGroup(channelGroup)
-        for (i in channelIds.indices) {
-            val id = channelIds[i]
-            val name = context.getString(channelNames[i])
-            val description = context.getString(channelDescriptions[i])
+
+        val channels = PachliNotificationChannels.entries.map {
+            val id = it.channelId(account.identifier)
+            val name = context.getString(it.nameRes)
+            val description = context.getString(it.descriptionRes)
             val importance = NotificationManager.IMPORTANCE_DEFAULT
             val channel = NotificationChannel(id, name, importance)
             channel.description = description
@@ -510,8 +490,8 @@ fun createNotificationChannelsForAccount(account: AccountEntity, context: Contex
             channel.lightColor = -0xd46f27
             channel.enableVibration(true)
             channel.setShowBadge(true)
-            channel.group = account.identifier
-            channels.add(channel)
+            channel.group = account.identifier.value
+            channel
         }
         notificationManager.createNotificationChannels(channels)
     }
@@ -688,20 +668,20 @@ private fun getChannelId(account: AccountEntity, notification: Notification): St
 
 private fun getChannelId(account: AccountEntity, type: Notification.Type): String? {
     return when (type) {
-        Notification.Type.MENTION -> CHANNEL_MENTION + account.identifier
-        Notification.Type.STATUS -> CHANNEL_SUBSCRIPTIONS + account.identifier
-        Notification.Type.FOLLOW -> CHANNEL_FOLLOW + account.identifier
-        Notification.Type.FOLLOW_REQUEST -> CHANNEL_FOLLOW_REQUEST + account.identifier
-        Notification.Type.REBLOG -> CHANNEL_BOOST + account.identifier
-        Notification.Type.FAVOURITE -> CHANNEL_FAVOURITE + account.identifier
-        Notification.Type.POLL -> CHANNEL_POLL + account.identifier
-        Notification.Type.SIGN_UP -> CHANNEL_SIGN_UP + account.identifier
-        Notification.Type.UPDATE -> CHANNEL_UPDATES + account.identifier
-        Notification.Type.REPORT -> CHANNEL_REPORT + account.identifier
-        Notification.Type.SEVERED_RELATIONSHIPS -> CHANNEL_SEVERED_RELATIONSHIPS + account.identifier
-        Notification.Type.MODERATION_WARNING -> CHANNEL_MODERATION_WARNINGS + account.identifier
-        Notification.Type.QUOTE -> CHANNEL_QUOTE + account.identifier
-        Notification.Type.QUOTED_UPDATE -> CHANNEL_QUOTED_UPDATE + account.identifier
+        Notification.Type.MENTION -> PachliNotificationChannels.MENTION.channelId(account.identifier)
+        Notification.Type.STATUS -> PachliNotificationChannels.SUBSCRIPTIONS.channelId(account.identifier)
+        Notification.Type.FOLLOW -> PachliNotificationChannels.FOLLOW.channelId(account.identifier)
+        Notification.Type.FOLLOW_REQUEST -> PachliNotificationChannels.FOLLOW_REQUEST.channelId(account.identifier)
+        Notification.Type.REBLOG -> PachliNotificationChannels.REBLOG.channelId(account.identifier)
+        Notification.Type.FAVOURITE -> PachliNotificationChannels.FAVOURITE.channelId(account.identifier)
+        Notification.Type.POLL -> PachliNotificationChannels.POLL.channelId(account.identifier)
+        Notification.Type.SIGN_UP -> PachliNotificationChannels.SIGN_UP.channelId(account.identifier)
+        Notification.Type.UPDATE -> PachliNotificationChannels.UPDATES.channelId(account.identifier)
+        Notification.Type.REPORT -> PachliNotificationChannels.REPORT.channelId(account.identifier)
+        Notification.Type.SEVERED_RELATIONSHIPS -> PachliNotificationChannels.SEVERED_RELATIONSHIPS.channelId(account.identifier)
+        Notification.Type.MODERATION_WARNING -> PachliNotificationChannels.MODERATION_WARNINGS.channelId(account.identifier)
+        Notification.Type.QUOTE -> PachliNotificationChannels.QUOTE.channelId(account.identifier)
+        Notification.Type.QUOTED_UPDATE -> PachliNotificationChannels.QUOTED_UPDATE.channelId(account.identifier)
         Notification.Type.UNKNOWN -> null
     }
 }

--- a/app/src/main/java/app/pachli/receiver/SendStatusBroadcastReceiver.kt
+++ b/app/src/main/java/app/pachli/receiver/SendStatusBroadcastReceiver.kt
@@ -25,19 +25,21 @@ import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.app.RemoteInput
+import androidx.core.content.IntentCompat
 import app.pachli.R
-import app.pachli.components.notifications.CHANNEL_MENTION
 import app.pachli.components.notifications.KEY_DRAFT
 import app.pachli.components.notifications.KEY_REPLY
 import app.pachli.components.notifications.KEY_SENDER_ACCOUNT_FULL_NAME
 import app.pachli.components.notifications.KEY_SENDER_ACCOUNT_ID
 import app.pachli.components.notifications.KEY_SENDER_ACCOUNT_IDENTIFIER
 import app.pachli.components.notifications.KEY_SERVER_NOTOFICATION_ID
+import app.pachli.components.notifications.PachliNotificationChannels
 import app.pachli.components.notifications.REPLY_ACTION
 import app.pachli.core.common.di.ApplicationScope
 import app.pachli.core.common.string.randomAlphanumericString
 import app.pachli.core.data.repository.AccountManager
 import app.pachli.core.data.repository.DraftsRepository
+import app.pachli.core.database.model.AccountIdentifier
 import app.pachli.core.designsystem.R as DR
 import app.pachli.core.model.Draft
 import app.pachli.core.sendstatus.SendStatusUseCase
@@ -70,13 +72,19 @@ class SendStatusBroadcastReceiver : BroadcastReceiver() {
 
         val serverNotificationId = intent.getStringExtra(KEY_SERVER_NOTOFICATION_ID)
         val senderId = intent.getLongExtra(KEY_SENDER_ACCOUNT_ID, -1)
-        val senderIdentifier = intent.getStringExtra(KEY_SENDER_ACCOUNT_IDENTIFIER)
+        val senderIdentifier = IntentCompat.getParcelableExtra(intent, KEY_SENDER_ACCOUNT_IDENTIFIER, AccountIdentifier::class.java)
         val senderFullName = intent.getStringExtra(KEY_SENDER_ACCOUNT_FULL_NAME)
         val draft = intent.getParcelableExtra<Draft>(KEY_DRAFT)
 
         val account = accountManager.getAccountById(senderId)
 
         val notificationManager = NotificationManagerCompat.from(context)
+
+        if (senderIdentifier == null) {
+            Timber.w("KEY_SENDER_ACCOUNT_IDENTIFIER value was null")
+            showQuickReplyErrorNotification(senderId, context, senderIdentifier, senderFullName, notificationManager, serverNotificationId)
+            return
+        }
 
         if (account == null) {
             Timber.w("Account \"$senderId\" not found in database. Aborting quick reply!")
@@ -115,7 +123,7 @@ class SendStatusBroadcastReceiver : BroadcastReceiver() {
 
             // Can't cancel the QuickReply notification, replace it with one that
             // auto-cancels.
-            val notification = NotificationCompat.Builder(context, CHANNEL_MENTION + senderIdentifier)
+            val notification = NotificationCompat.Builder(context, PachliNotificationChannels.MENTION.channelId(senderIdentifier))
                 .setSmallIcon(app.pachli.core.common.R.drawable.ic_notify)
                 .setColor(context.getColor(DR.color.notification_color))
                 .setGroup(senderFullName)
@@ -135,7 +143,7 @@ class SendStatusBroadcastReceiver : BroadcastReceiver() {
     private fun showQuickReplyErrorNotification(
         senderId: Long,
         context: Context,
-        senderIdentifier: String?,
+        senderIdentifier: AccountIdentifier?,
         senderFullName: String?,
         notificationManager: NotificationManagerCompat,
         serverNotificationId: String?,
@@ -144,7 +152,15 @@ class SendStatusBroadcastReceiver : BroadcastReceiver() {
             return
         }
 
-        val notification = NotificationCompat.Builder(context, CHANNEL_MENTION + senderIdentifier)
+        val channelId = if (senderIdentifier == null) {
+            // Need a channel ID that's not tied to a particular account. This is
+            // SendStatusService.CHANNEL_ID
+            "send_toots"
+        } else {
+            PachliNotificationChannels.MENTION.channelId(senderIdentifier)
+        }
+
+        val notification = NotificationCompat.Builder(context, channelId)
             .setSmallIcon(app.pachli.core.common.R.drawable.ic_notify)
             .setColor(context.getColor(DR.color.notification_color))
             .setGroup(senderFullName)

--- a/app/src/main/java/app/pachli/util/UpdateShortCutsUseCase.kt
+++ b/app/src/main/java/app/pachli/util/UpdateShortCutsUseCase.kt
@@ -86,7 +86,7 @@ class UpdateShortCutsUseCase @Inject constructor(
                 val person = Person.Builder()
                     .setIcon(icon)
                     .setName(account.displayName)
-                    .setKey(account.identifier)
+                    .setKey(account.identifier.value)
                     .build()
 
                 // This intent will be sent when the user clicks on one of the launcher shortcuts.

--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/ExportedPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/ExportedPreferencesRepository.kt
@@ -26,6 +26,7 @@ import app.pachli.core.data.R
 import app.pachli.core.data.repository.Error.ExportError
 import app.pachli.core.data.repository.Error.ImportError
 import app.pachli.core.database.model.AccountEntity
+import app.pachli.core.database.model.AccountIdentifier
 import app.pachli.core.model.FilterAction
 import app.pachli.core.model.Timeline
 import app.pachli.core.preferences.PrefKeys
@@ -349,8 +350,10 @@ data class RedactedAccount(
     val conversationAccountFilterYounger30d: FilterAction,
     val conversationAccountFilterLimitedByServer: FilterAction,
 ) {
-    val identifier: String
-        get() = "$domain:$accountId"
+    // Caution! This has to behave identically to the `AccountEntity` constructor
+    // for `AccountIdentifier`.
+    val identifier: AccountIdentifier
+        get() = AccountIdentifier.unsafe("$domain:$accountId")
 }
 
 /** Converts [AccountEntity] to [RedactedAccount]. */

--- a/core/database/src/main/kotlin/app/pachli/core/database/model/AccountEntity.kt
+++ b/core/database/src/main/kotlin/app/pachli/core/database/model/AccountEntity.kt
@@ -17,6 +17,7 @@
 
 package app.pachli.core.database.model
 
+import android.os.Parcelable
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Index
@@ -28,7 +29,51 @@ import app.pachli.core.model.Emoji
 import app.pachli.core.model.FilterAction
 import app.pachli.core.model.Status
 import app.pachli.core.model.Timeline
+import java.util.stream.IntStream
+import kotlinx.parcelize.Parcelize
 
+/**
+ * Unique identifier for the user's account. Guaranteed unique irrespective of
+ * the order the user logs in to their accounts.
+ *
+ * @property value Underlying string value for the identifier.
+ * @constructor Creates a new [AccountIdentifier] from a string. Should not
+ * normally be used, use the constructor that takes an [AccountEntity].
+ */
+// @Parcelize so this can be passed directly in an intent, instead of round
+// tripping as a String.
+@JvmInline
+@Parcelize
+value class AccountIdentifier internal constructor(val value: String) : CharSequence by value, Parcelable {
+    /**
+     * Creates a new [AccountIdentifier] from an [AccountEntity]. The
+     * preferred way to construct an [AccountIdentifier], as it ensures the
+     * value is constructed correctly.
+     */
+    constructor(account: AccountEntity) : this("${account.domain}:${account.accountId}")
+
+    override fun chars(): IntStream {
+        return super.chars()
+    }
+
+    override fun codePoints(): IntStream {
+        return super.codePoints()
+    }
+
+    override fun toString() = value
+
+    companion object {
+        /**
+         * Unsafe way to construct an [AccountIdentifier]. It is the caller's
+         * responsibility to ensure [value] is in the expected format.
+         */
+        fun unsafe(value: String) = AccountIdentifier(value)
+    }
+}
+
+/**
+ * @property identifier A unique identifier for the account.
+ */
 @Entity(
     indices = [
         Index(
@@ -150,8 +195,8 @@ data class AccountEntity(
     @ColumnInfo(defaultValue = "0")
     val isBot: Boolean = false,
 ) {
-    val identifier: String
-        get() = "$domain:$accountId"
+    val identifier: AccountIdentifier
+        get() = AccountIdentifier(this)
 
     /** Full account name, of the form `@username@domain` */
     val fullName: String

--- a/core/domain/src/main/kotlin/app/pachli/core/domain/LogoutUseCase.kt
+++ b/core/domain/src/main/kotlin/app/pachli/core/domain/LogoutUseCase.kt
@@ -78,7 +78,7 @@ class LogoutUseCase @Inject constructor(
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val notificationManager =
                 context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-            notificationManager.deleteNotificationChannelGroup(account.identifier)
+            notificationManager.deleteNotificationChannelGroup(account.identifier.value)
         }
     }
 }

--- a/core/sendstatus/src/main/kotlin/app/pachli/core/sendstatus/SendStatusService.kt
+++ b/core/sendstatus/src/main/kotlin/app/pachli/core/sendstatus/SendStatusService.kt
@@ -429,6 +429,8 @@ internal class SendStatusService : Service() {
     companion object {
         private const val KEY_STATUS = "status"
         private const val KEY_CANCEL = "cancel_id"
+
+        // TODO: Also used in SendStatusBroadcastReceiver.showQuickReplyErrorNotification
         private const val CHANNEL_ID = "send_toots"
 
         private val MAX_RETRY_INTERVAL = TimeUnit.MINUTES.toMillis(1)


### PR DESCRIPTION
Notifications channels were being created my iterating over constants for channel names and string resources, with channel IDs consisting of a per-channel constant and an identifier for each account.

Improve this:

- Convert the channel list to an enum with associated properties.
- Create a value class for `AccountIdentifier`, and use that class where appropriate, to improve type safety.