### PR TITLE
chore: Move account info string resources to core.ui

### DIFF
--- a/core/ui/src/main/res/values-de/strings.xml
+++ b/core/ui/src/main/res/values-de/strings.xml
@@ -180,4 +180,9 @@
     <string name="pref_summary_none">Keine</string>
     <string name="action_add_to_tab">Zum Tab hinzufügen</string>
     <string name="action_add_to_tab_success">\'%1$s\' zu Tabs hinzugefügt</string>
+    <string name="follower_count_fmt">&lt;b>%1$s&lt;/b> Follower</string>
+    <string name="follows_count_fmt">&lt;b>%1$s&lt;/b> folgen</string>
+    <string name="statuses_count_fmt">&lt;b>%1$s&lt;/b> Beiträge</string>
+    <string name="statuses_count_per_week_fmt">&lt;b>%1$s&lt;/b> Beiträge (&lt;b>%2$d&lt;/b> pro Woche)</string>
+    <string name="statuses_count_per_week_last_fmt">&lt;b>%1$s&lt;/b> Beiträge (&lt;b>%2$d&lt;/b> pro Woche, letzter am &lt;b>%3$s&lt;/b>)</string>
 </resources>

--- a/core/ui/src/main/res/values-es/strings.xml
+++ b/core/ui/src/main/res/values-es/strings.xml
@@ -190,4 +190,9 @@
     <string name="action_add_to_tab">Añadir a pestaña</string>
     <string name="action_add_to_tab_success">Se ha añadido \'%1$s\' a pestañas</string>
     <string name="pref_summary_none">Ninguno</string>
+    <string name="follower_count_fmt">&lt;b>%1$s&lt;/b> seguidores</string>
+    <string name="follows_count_fmt">&lt;b>%1$s&lt;/b> siguiendo</string>
+    <string name="statuses_count_fmt">&lt;b>%1$s&lt;/b> publicaciones</string>
+    <string name="statuses_count_per_week_fmt">&lt;b>%1$s&lt;/b> publicaciones (&lt;b>%2$d&lt;/b> por semana)</string>
+    <string name="statuses_count_per_week_last_fmt">&lt;b>%1$s&lt;/b> publicaciones (&lt;b>%2$d&lt;/b> por semana; última: &lt;b>%3$s&lt;/b>)</string>
 </resources>

--- a/core/ui/src/main/res/values-et/strings.xml
+++ b/core/ui/src/main/res/values-et/strings.xml
@@ -180,4 +180,9 @@
     <string name="pref_summary_none">Määratlemata</string>
     <string name="action_add_to_tab">Lisa vahekaardiks</string>
     <string name="action_add_to_tab_success">„%1$s“ on lisatud vahekaartide sekka</string>
+    <string name="follower_count_fmt">&lt;b>%1$s&lt;/b> jälgijat</string>
+    <string name="follows_count_fmt">&lt;b>%1$s&lt;/b> jälgimas</string>
+    <string name="statuses_count_fmt">&lt;b>%1$s&lt;/b> postitust</string>
+    <string name="statuses_count_per_week_fmt">&lt;b>%1$s&lt;/b> postitust (&lt;b>%2$d&lt;/b> nädalas)</string>
+    <string name="statuses_count_per_week_last_fmt">&lt;b>%1$s&lt;/b> postitust (&lt;b>%2$d&lt;/b> nädalas, viimati &lt;b>%3$s&lt;/b>)</string>
 </resources>

--- a/core/ui/src/main/res/values-fi/strings.xml
+++ b/core/ui/src/main/res/values-fi/strings.xml
@@ -179,4 +179,9 @@
     <string name="action_add_to_tab">Lisää välilehteen</string>
     <string name="action_add_to_tab_success">\'%1$s\' lisätty välilehtiin</string>
     <string name="pref_summary_none">Ei mitään</string>
+    <string name="follower_count_fmt">&lt;b>%1$s&lt;/b> seuraajaa</string>
+    <string name="follows_count_fmt">&lt;b>%1$s&lt;/b> seuraa</string>
+    <string name="statuses_count_fmt">&lt;b>%1$s&lt;/b> julkaisua</string>
+    <string name="statuses_count_per_week_fmt">&lt;b>%1$s&lt;/b> julkaisua (&lt;b>%2$d&lt;/b> viikossa)</string>
+    <string name="statuses_count_per_week_last_fmt">&lt;b>%1$s&lt;/b> julkaisua &lt;b>%2$d&lt;/b> viikossa, uusin &lt;b>%3$s&lt;/b>)</string>
 </resources>

--- a/core/ui/src/main/res/values-fr/strings.xml
+++ b/core/ui/src/main/res/values-fr/strings.xml
@@ -191,4 +191,9 @@
     <string name="action_add_to_tab">Ajouter à l\'onglet</string>
     <string name="action_add_to_tab_success">« %1$s » ajouté aux onglets</string>
     <string name="pref_summary_none">Aucun(e)</string>
+    <string name="follower_count_fmt">&lt;b&gt;%1$s&lt;/b&gt; suivi·e·s</string>
+    <string name="follows_count_fmt">&lt;b&gt;%1$s&lt;/b&gt; abonné·e·s</string>
+    <string name="statuses_count_fmt">&lt;b&gt;%1$s&lt;/b&gt; messages</string>
+    <string name="statuses_count_per_week_fmt">&lt;b&gt;%1$s&lt;/b&gt; messages (&lt;b&gt;%2$d&lt;/b&gt; par semaine)</string>
+    <string name="statuses_count_per_week_last_fmt">&lt;b&gt;%1$s&lt;/b&gt; messages (&lt;b&gt;%2$d&lt;/b&gt; par semaine, depuis &lt;b&gt;%3$s&lt;/b&gt;)</string>
 </resources>

--- a/core/ui/src/main/res/values-ga/strings.xml
+++ b/core/ui/src/main/res/values-ga/strings.xml
@@ -210,4 +210,9 @@
     <string name="action_add_to_tab">Cuir leis an táb</string>
     <string name="action_add_to_tab_success">Cuireadh \'%1$s\' leis na cluaisíní</string>
     <string name="pref_summary_none">Dada</string>
+    <string name="follower_count_fmt">&lt;b>%1$s&lt;/b> leantóir</string>
+    <string name="follows_count_fmt">&lt;b>%1$s&lt;/b> ina dhiaidh</string>
+    <string name="statuses_count_fmt">&lt;b>%1$s&lt;/b> postáil</string>
+    <string name="statuses_count_per_week_fmt">&lt;b>%1$s&lt;/b> postáil (&lt;b>%2$d&lt;/b> in aghaidh na seachtaine)</string>
+    <string name="statuses_count_per_week_last_fmt">&lt;b>%1$s&lt;/b> postáil (&lt;b>%2$d&lt;/b> sa tseachtain, an &lt;b>%3$s&lt;/b> deireanach)</string>
 </resources>

--- a/core/ui/src/main/res/values-gl/strings.xml
+++ b/core/ui/src/main/res/values-gl/strings.xml
@@ -127,4 +127,9 @@
     <string name="duration_365_days">365 días</string>
     <string name="action_add_to_tab">Engadir á pestana</string>
     <string name="action_add_to_tab_success">Engadíuse «%1$s» ás pestanas</string>
+    <string name="follower_count_fmt">&lt;b>%1$s&lt;/b> seguidoras</string>
+    <string name="follows_count_fmt">&lt;b>%1$s&lt;/b> seguimentos</string>
+    <string name="statuses_count_fmt">&lt;b>%1$s&lt;/b> publicacións</string>
+    <string name="statuses_count_per_week_fmt">&lt;b>%1$s&lt;/b> publicacións (&lt;b>%2$d&lt;/b> por semana)</string>
+    <string name="statuses_count_per_week_last_fmt">&lt;b>%1$s&lt;/b> publicacións (&lt;b>%2$d&lt;/b> por semana, última o &lt;b>%3$s&lt;/b>)</string>
 </resources>

--- a/core/ui/src/main/res/values-in/strings.xml
+++ b/core/ui/src/main/res/values-in/strings.xml
@@ -170,4 +170,9 @@
     <string name="pref_summary_none">Tidak ada</string>
     <string name="action_add_to_tab">Tambahkan ke tab</string>
     <string name="action_add_to_tab_success">Ditambahkan \'%1$s\' ke tab</string>
+    <string name="follower_count_fmt">&lt;b>%1$s&lt;/b> pengikut</string>
+    <string name="follows_count_fmt">&lt;b>%1$s&lt;/b> mengikuti</string>
+    <string name="statuses_count_fmt">&lt;b>%1$s&lt;/b> postingan</string>
+    <string name="statuses_count_per_week_fmt">&lt;b>%1$s&lt;/b> postingan (&lt;b>%2$d&lt;/b> per minggu)</string>
+    <string name="statuses_count_per_week_last_fmt">&lt;b>%1$s&lt;/b> postingan (&lt;b>%2$d&lt;/b> per minggu, terakhir &lt;b>%3$s&lt;/b>)</string>
 </resources>

--- a/core/ui/src/main/res/values-it/strings.xml
+++ b/core/ui/src/main/res/values-it/strings.xml
@@ -140,4 +140,9 @@
     <string name="duration_180_days">180 giorni</string>
     <string name="duration_365_days">365 giorni</string>
     <string name="action_add_to_tab">Aggiungi a scheda</string>
+    <string name="follower_count_fmt">&lt;b>%1$s&lt;/b> seguaci</string>
+    <string name="follows_count_fmt">&lt;b>%1$s&lt;/b> seguiti</string>
+    <string name="statuses_count_fmt">&lt;b>%1$s&lt;/b> post</string>
+    <string name="statuses_count_per_week_fmt">&lt;b>%1$s&lt;/b> posta (&lt;b>%2$d&lt;/b> alla settimana)</string>
+    <string name="statuses_count_per_week_last_fmt">&lt;b>%1$s&lt;/b> post (&lt;b>%2$d&lt;/b> per settimana, ultimo &lt;b>%3$s&lt;/b>)</string>
 </resources>

--- a/core/ui/src/main/res/values-lt/strings.xml
+++ b/core/ui/src/main/res/values-lt/strings.xml
@@ -14,4 +14,9 @@
     <string name="action_mentions">Paminėjimai</string>
     <string name="action_more">Daugiau</string>
     <string name="action_hashtags">Saitažodžiai</string>
+    <string name="follower_count_fmt">&lt;b>%1$s&lt;/b> sekėjai</string>
+    <string name="follows_count_fmt">&lt;b>%1$s&lt;/b> sekimai</string>
+    <string name="statuses_count_fmt">&lt;b>%1$s&lt;/b> įrašai</string>
+    <string name="statuses_count_per_week_fmt">&lt;b>%1$s&lt;/b> įrašai (&lt;b>%2$d&lt;/b> per savaitę)</string>
+    <string name="statuses_count_per_week_last_fmt">&lt;b>%1$s&lt;/b> įrašai (&lt;b>%2$d&lt;/b> per savaitę, paskutinis &lt;b>%3$s&lt;/b>)</string>
 </resources>

--- a/core/ui/src/main/res/values-lv/strings.xml
+++ b/core/ui/src/main/res/values-lv/strings.xml
@@ -190,4 +190,9 @@
     <string name="action_add_to_tab">Pievienot cilnei</string>
     <string name="action_add_to_tab_success">\"%1$s\" pievienots cilnēm</string>
     <string name="pref_summary_none">Nekas</string>
+    <string name="follower_count_fmt">&lt;b>%1$s&lt;/b> sekotājs/i/u</string>
+    <string name="follows_count_fmt">Seko &lt;b>%1$s&lt;/b></string>
+    <string name="statuses_count_fmt">&lt;b>%1$s&lt;/b> ieraksts/i/u</string>
+    <string name="statuses_count_per_week_fmt">&lt;b>%1$s&lt;/b> ieraksts/i/u (&lt;b>%2$d&lt;/b> nedēļā)</string>
+    <string name="statuses_count_per_week_last_fmt">&lt;b>%1$s&lt;/b> ieraksts/i/u (&lt;b>%2$d&lt;/b> nedēļā, pēdējais &lt;b>%3$s&lt;/b>)</string>
 </resources>

--- a/core/ui/src/main/res/values-nb-rNO/strings.xml
+++ b/core/ui/src/main/res/values-nb-rNO/strings.xml
@@ -129,4 +129,9 @@
     <string name="duration_365_days">365 dager</string>
     <string name="action_add_to_tab">Legg til til fane</string>
     <string name="action_add_to_tab_success">La til «%1$s» til fanene</string>
+    <string name="follower_count_fmt">&lt;b>%1$s&lt;/b> følgere</string>
+    <string name="follows_count_fmt">Følger &lt;b>%1$s&lt;/b></string>
+    <string name="statuses_count_fmt">&lt;b>%1$s&lt;/b> innlegg</string>
+    <string name="statuses_count_per_week_fmt">&lt;b>%1$s&lt;/b> innlegg (&lt;b>%2$d&lt;/b> om uken)</string>
+    <string name="statuses_count_per_week_last_fmt">&lt;b>%1$s&lt;/b> innlegg (&lt;b>%2$d&lt;/b> om uken, siste uke &lt;b>%3$s&lt;/b>)</string>
 </resources>

--- a/core/ui/src/main/res/values-nn/strings.xml
+++ b/core/ui/src/main/res/values-nn/strings.xml
@@ -173,4 +173,9 @@
     <string name="duration_365_days">365 dagar</string>
     <string name="action_add_to_tab">Legg til i fane</string>
     <string name="action_add_to_tab_success">La til «%1$s» i fanene</string>
+    <string name="follower_count_fmt">&lt;b&gt;%1$s&lt;/b&gt; fylgjarar</string>
+    <string name="follows_count_fmt">Fylgjer &lt;b&gt;%1$s&lt;/b&gt;</string>
+    <string name="statuses_count_fmt">&lt;b&gt;%1$s&lt;/b&gt; innlegg</string>
+    <string name="statuses_count_per_week_fmt">&lt;b&gt;%1$s&lt;/b&gt; innlegg (&lt;b&gt;%2$d&lt;/b&gt; om veka)</string>
+    <string name="statuses_count_per_week_last_fmt">&lt;b&gt;%1$s&lt;/b&gt; innlegg (&lt;b&gt;%2$d&lt;/b&gt; om veka, førre veke &lt;b&gt;%3$s&lt;/b&gt;)</string>
 </resources>

--- a/core/ui/src/main/res/values-pl/strings.xml
+++ b/core/ui/src/main/res/values-pl/strings.xml
@@ -199,4 +199,9 @@
     <string name="action_add_to_tab">Dodaj do kart</string>
     <string name="action_add_to_tab_success">Dodano \'%1$s\' do kart</string>
     <string name="pref_summary_none">Brak</string>
+    <string name="follower_count_fmt">&lt;b>%1$s&lt;/b> obserwujących</string>
+    <string name="follows_count_fmt">&lt;b>%1$s&lt;/b> obserwowanych</string>
+    <string name="statuses_count_fmt">&lt;b>%1$s&lt;/b> wpisów</string>
+    <string name="statuses_count_per_week_fmt">&lt;b>%1$s&lt;/b> wpisów (&lt;b>%2$d&lt;/b> na tydzień)</string>
+    <string name="statuses_count_per_week_last_fmt">&lt;b>%1$s&lt;/b> wpisów (&lt;b>%2$d&lt;/b> na tydzień, ostatni &lt;b>%3$s&lt;/b>)</string>
 </resources>

--- a/core/ui/src/main/res/values-ru/strings.xml
+++ b/core/ui/src/main/res/values-ru/strings.xml
@@ -168,4 +168,9 @@
     <string name="duration_365_days">365 дней</string>
     <string name="action_add_to_tab">Добавить на вкладку</string>
     <string name="action_add_to_tab_success">Добавлено «%1$s» на вкладки</string>
+    <string name="follower_count_fmt">&lt;b>%1$s&lt;/b> подписчиков</string>
+    <string name="follows_count_fmt">&lt;b>%1$s&lt;/b> подписок</string>
+    <string name="statuses_count_fmt">&lt;b>%1$s&lt;/b> записей</string>
+    <string name="statuses_count_per_week_fmt">&lt;b>%1$s&lt;/b> записей (&lt;b>%2$d&lt;/b> в неделю)</string>
+    <string name="statuses_count_per_week_last_fmt">&lt;b>%1$s&lt;/b> записей (&lt;b>%2$d&lt;/b> в неделю, последние &lt;b>%3$s&lt;/b>)</string>
 </resources>

--- a/core/ui/src/main/res/values-sk/strings.xml
+++ b/core/ui/src/main/res/values-sk/strings.xml
@@ -191,4 +191,9 @@
     <string name="action_add_to_tab">Pridať do panelu</string>
     <string name="action_add_to_tab_success">\'%1$s\' pridané do panelov</string>
     <string name="pref_summary_none">Žiadne</string>
+    <string name="follower_count_fmt">&lt;b>%1$s&lt;/b> sledujúcich</string>
+    <string name="follows_count_fmt">&lt;b>%1$s&lt;/b> sledovaných</string>
+    <string name="statuses_count_fmt">&lt;b>%1$s&lt;/b> príspevkov</string>
+    <string name="statuses_count_per_week_fmt">&lt;b>%1$s&lt;/b> príspevkov (&lt;b>%2$d&lt;/b> za týždeň)</string>
+    <string name="statuses_count_per_week_last_fmt">&lt;b>%1$s&lt;/b> príspevkov (&lt;b>%2$d&lt;/b> za týždeň, posledný &lt;b>%3$s&lt;/b>)</string>
 </resources>

--- a/core/ui/src/main/res/values-ta/strings.xml
+++ b/core/ui/src/main/res/values-ta/strings.xml
@@ -179,4 +179,9 @@
     <string name="duration_365_days">365 நாட்கள்</string>
     <string name="action_add_to_tab">தாவலில் சேர்க்கவும்</string>
     <string name="action_add_to_tab_success">தாவல்களில் \'%1$s\' சேர்க்கப்பட்டது</string>
+    <string name="follower_count_fmt">&lt;b&gt;%1$s&lt;/&gt; பின்தொடர்பவர்கள்</string>
+    <string name="follows_count_fmt">&lt;b&gt;%1$s&lt;/&gt; பின்தொடர்கிறது</string>
+    <string name="statuses_count_fmt">&lt;b&gt;%1$s&lt;/&gt; இடுகைகள்</string>
+    <string name="statuses_count_per_week_fmt">&lt;b&gt;%1$s&lt;/&gt; இடுகைகள் (வாரத்திற்கு &lt;b&gt;%2$d&lt;/&gt;)</string>
+    <string name="statuses_count_per_week_last_fmt">&lt;b&gt;%1$s&lt;/&gt; இடுகைகள் (வாரத்திற்கு &lt;b&gt;%2$d&lt;/&gt;, கடந்த &lt;b&gt;%3$s&lt;/&gt;)</string>
 </resources>

--- a/core/ui/src/main/res/values-zh-rCN/strings.xml
+++ b/core/ui/src/main/res/values-zh-rCN/strings.xml
@@ -122,4 +122,8 @@
     <string name="duration_365_days">365 天</string>
     <string name="action_add_to_tab">添加到标签页</string>
     <string name="action_add_to_tab_success">添加“%1$s”到标签页</string>
+    <string name="follower_count_fmt">&lt;b>%1$s&lt;/b>关注者</string>
+    <string name="follows_count_fmt">&lt;b>%1$s&lt;/b>关注</string>
+    <string name="statuses_count_fmt">&lt;b>%1$s&lt;/b> 嘟文</string>
+    <string name="statuses_count_per_week_fmt">&lt;b>%1$s&lt;/b>条嘟文（每周&lt;b>%2$d&lt;/b> 条）</string>
 </resources>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -209,4 +209,14 @@
     <string name="pref_summary_none">None</string>
     <string name="action_add_to_tab">Add to tab</string>
     <string name="action_add_to_tab_success">Added \'%1$s\' to tabs</string>
+
+    <string name="follower_count_fmt">&lt;b>%1$s&lt;/b> followers</string>
+    <string name="follows_count_fmt">&lt;b>%1$s&lt;/b> following</string>
+    <string name="statuses_count_fmt">&lt;b>%1$s&lt;/b> posts</string>
+    <string name="statuses_count_per_week_fmt">&lt;b>%1$s&lt;/b> posts (&lt;b>%2$d&lt;/b> per week)</string>
+    <string name="statuses_count_per_week_last_fmt">&lt;b>%1$s&lt;/b> posts (&lt;b>%2$d&lt;/b> per week, last &lt;b>%3$s&lt;/b>)</string>
+    <string name="account_content_description_fmt" translatable="false">
+        <!-- Display name, follower count, follows count, statuses count, note -->
+        %1$s; %2$s; %3$s; %4$s. %5$s
+    </string>
 </resources>

--- a/feature/suggestions/src/main/kotlin/app/pachli/feature/suggestions/SuggestionsAdapter.kt
+++ b/feature/suggestions/src/main/kotlin/app/pachli/feature/suggestions/SuggestionsAdapter.kt
@@ -228,7 +228,7 @@ internal class SuggestionViewHolder(
 
             // Build an accessible content description.
             root.contentDescription = root.context.getString(
-                R.string.account_content_description_fmt,
+                app.pachli.core.ui.R.string.account_content_description_fmt,
                 account.nameContentDescription(root.context),
                 followerCount.text,
                 followsCount.text,
@@ -320,7 +320,7 @@ internal class SuggestionViewHolder(
 
         followerCount.text = HtmlCompat.fromHtml(
             followerCount.context.getString(
-                R.string.follower_count_fmt,
+                app.pachli.core.ui.R.string.follower_count_fmt,
                 formatNumber(account.followersCount.toLong(), 1000),
             ),
             FROM_HTML_MODE_LEGACY,
@@ -328,7 +328,7 @@ internal class SuggestionViewHolder(
 
         followsCount.text = HtmlCompat.fromHtml(
             followsCount.context.getString(
-                R.string.follows_count_fmt,
+                app.pachli.core.ui.R.string.follows_count_fmt,
                 formatNumber(account.followingCount.toLong(), 1000),
             ),
             FROM_HTML_MODE_LEGACY,
@@ -343,7 +343,7 @@ internal class SuggestionViewHolder(
             if (account.createdAt == null) {
                 text = HtmlCompat.fromHtml(
                     context.getString(
-                        R.string.statuses_count_fmt,
+                        app.pachli.core.ui.R.string.statuses_count_fmt,
                         formatNumber(account.statusesCount.toLong(), 1000),
                     ),
                     FROM_HTML_MODE_LEGACY,
@@ -356,7 +356,7 @@ internal class SuggestionViewHolder(
                 if (account.lastStatusAt == null) {
                     text = HtmlCompat.fromHtml(
                         context.getString(
-                            R.string.statuses_count_per_week_fmt,
+                            app.pachli.core.ui.R.string.statuses_count_per_week_fmt,
                             formatNumber(account.statusesCount.toLong(), 1000),
                             (account.statusesCount / elapsed).roundToInt(),
                         ),
@@ -365,7 +365,7 @@ internal class SuggestionViewHolder(
                 } else {
                     text = HtmlCompat.fromHtml(
                         context.getString(
-                            R.string.statuses_count_per_week_last_fmt,
+                            app.pachli.core.ui.R.string.statuses_count_per_week_last_fmt,
                             formatNumber(account.statusesCount.toLong(), 1000),
                             (account.statusesCount / elapsed).roundToInt(),
                             DateUtils.getRelativeTimeSpanString(

--- a/feature/suggestions/src/main/res/values-de/strings.xml
+++ b/feature/suggestions/src/main/res/values-de/strings.xml
@@ -12,9 +12,4 @@
     <string name="action_dismiss_follow_suggestion">Verwerfen</string>
     <string name="ui_error_delete_suggestion_fmt">Fehler beim Verwerfen des Vorschlags für %1$s : %2$s</string>
     <string name="ui_error_follow_account_fmt">Fehler beim Folgen von %1$s: %2$s</string>
-    <string name="follower_count_fmt">&lt;b>%1$s&lt;/b> Follower</string>
-    <string name="follows_count_fmt">&lt;b>%1$s&lt;/b> folgen</string>
-    <string name="statuses_count_fmt">&lt;b>%1$s&lt;/b> Beiträge</string>
-    <string name="statuses_count_per_week_fmt">&lt;b>%1$s&lt;/b> Beiträge (&lt;b>%2$d&lt;/b> pro Woche)</string>
-    <string name="statuses_count_per_week_last_fmt">&lt;b>%1$s&lt;/b> Beiträge (&lt;b>%2$d&lt;/b> pro Woche, letzter am &lt;b>%3$s&lt;/b>)</string>
 </resources>

--- a/feature/suggestions/src/main/res/values-es/strings.xml
+++ b/feature/suggestions/src/main/res/values-es/strings.xml
@@ -12,9 +12,4 @@
     <string name="action_dismiss_follow_suggestion">Descartar</string>
     <string name="ui_error_delete_suggestion_fmt">Fallo al descartar la sugerencia para %1$s: %2$s</string>
     <string name="ui_error_follow_account_fmt">Fallo al seguir a %1$s: %2$s</string>
-    <string name="follower_count_fmt">&lt;b>%1$s&lt;/b> seguidores</string>
-    <string name="follows_count_fmt">&lt;b>%1$s&lt;/b> siguiendo</string>
-    <string name="statuses_count_fmt">&lt;b>%1$s&lt;/b> publicaciones</string>
-    <string name="statuses_count_per_week_fmt">&lt;b>%1$s&lt;/b> publicaciones (&lt;b>%2$d&lt;/b> por semana)</string>
-    <string name="statuses_count_per_week_last_fmt">&lt;b>%1$s&lt;/b> publicaciones (&lt;b>%2$d&lt;/b> por semana; última: &lt;b>%3$s&lt;/b>)</string>
 </resources>

--- a/feature/suggestions/src/main/res/values-et/strings.xml
+++ b/feature/suggestions/src/main/res/values-et/strings.xml
@@ -12,9 +12,4 @@
     <string name="action_dismiss_follow_suggestion">Loobu</string>
     <string name="ui_error_delete_suggestion_fmt">%1$s soovitusest loobumine ei õnnestunud: %2$s</string>
     <string name="ui_error_follow_account_fmt">%1$s jälgimise alustamine ei õnnestunud: %2$s</string>
-    <string name="follower_count_fmt">&lt;b>%1$s&lt;/b> jälgijat</string>
-    <string name="follows_count_fmt">&lt;b>%1$s&lt;/b> jälgimas</string>
-    <string name="statuses_count_fmt">&lt;b>%1$s&lt;/b> postitust</string>
-    <string name="statuses_count_per_week_fmt">&lt;b>%1$s&lt;/b> postitust (&lt;b>%2$d&lt;/b> nädalas)</string>
-    <string name="statuses_count_per_week_last_fmt">&lt;b>%1$s&lt;/b> postitust (&lt;b>%2$d&lt;/b> nädalas, viimati &lt;b>%3$s&lt;/b>)</string>
 </resources>

--- a/feature/suggestions/src/main/res/values-fi/strings.xml
+++ b/feature/suggestions/src/main/res/values-fi/strings.xml
@@ -7,14 +7,9 @@
     <string name="sources_most_followed">Palvelimesi eniten seurattuja</string>
     <string name="sources_featured">Palvelimesi ylläpitäjien ehdotuksia</string>
     <string name="sources_similar_to_recently_followed">Muistuttaa äskettäin seuraamiasi tilejä</string>
-    <string name="follower_count_fmt">&lt;b>%1$s&lt;/b> seuraajaa</string>
-    <string name="follows_count_fmt">&lt;b>%1$s&lt;/b> seuraa</string>
-    <string name="statuses_count_per_week_last_fmt">&lt;b>%1$s&lt;/b> julkaisua &lt;b>%2$d&lt;/b> viikossa, uusin &lt;b>%3$s&lt;/b>)</string>
     <string name="source_unknown">(palvelimen vastauksessa tunnistamaton lähde)</string>
     <string name="action_follow_account">Seuraa</string>
     <string name="action_dismiss_follow_suggestion">Hylkää</string>
     <string name="ui_error_delete_suggestion_fmt">Ehdotuksen %1$s hylkääminen epäonnistui: %2$s</string>
     <string name="ui_error_follow_account_fmt">Tilin %1$s seuraaminen epäonnistui: %2$s</string>
-    <string name="statuses_count_fmt">&lt;b>%1$s&lt;/b> julkaisua</string>
-    <string name="statuses_count_per_week_fmt">&lt;b>%1$s&lt;/b> julkaisua (&lt;b>%2$d&lt;/b> viikossa)</string>
 </resources>

--- a/feature/suggestions/src/main/res/values-fr/strings.xml
+++ b/feature/suggestions/src/main/res/values-fr/strings.xml
@@ -12,9 +12,4 @@
     <string name="action_dismiss_follow_suggestion">Ignorer</string>
     <string name="ui_error_delete_suggestion_fmt">Ignorer la suggeston de %1$s a échoué : %2$s</string>
     <string name="ui_error_follow_account_fmt">Le suivi de %1$s a échoué : %2$s</string>
-    <string name="follower_count_fmt">&lt;b&gt;%1$s&lt;/b&gt; suivi·e·s</string>
-    <string name="follows_count_fmt">&lt;b&gt;%1$s&lt;/b&gt; abonné·e·s</string>
-    <string name="statuses_count_fmt">&lt;b&gt;%1$s&lt;/b&gt; messages</string>
-    <string name="statuses_count_per_week_fmt">&lt;b&gt;%1$s&lt;/b&gt; messages (&lt;b&gt;%2$d&lt;/b&gt; par semaine)</string>
-    <string name="statuses_count_per_week_last_fmt">&lt;b&gt;%1$s&lt;/b&gt; messages (&lt;b&gt;%2$d&lt;/b&gt; par semaine, depuis &lt;b&gt;%3$s&lt;/b&gt;)</string>
 </resources>

--- a/feature/suggestions/src/main/res/values-ga/strings.xml
+++ b/feature/suggestions/src/main/res/values-ga/strings.xml
@@ -10,11 +10,6 @@
     <string name="action_follow_account">Lean</string>
     <string name="action_dismiss_follow_suggestion">Díbhe</string>
     <string name="ui_error_delete_suggestion_fmt">Theip ar mholadh le haghaidh %1$s a dhíbhe: %2$s</string>
-    <string name="follower_count_fmt">&lt;b>%1$s&lt;/b> leantóir</string>
-    <string name="follows_count_fmt">&lt;b>%1$s&lt;/b> ina dhiaidh</string>
-    <string name="statuses_count_fmt">&lt;b>%1$s&lt;/b> postáil</string>
-    <string name="statuses_count_per_week_fmt">&lt;b>%1$s&lt;/b> postáil (&lt;b>%2$d&lt;/b> in aghaidh na seachtaine)</string>
-    <string name="statuses_count_per_week_last_fmt">&lt;b>%1$s&lt;/b> postáil (&lt;b>%2$d&lt;/b> sa tseachtain, an &lt;b>%3$s&lt;/b> deireanach)</string>
     <string name="sources_similar_to_recently_followed">Cosúil le cuntais a lean tú le déanaí</string>
     <string name="ui_error_follow_account_fmt">Theip ar %1$s a leanúint: %2$s</string>
 </resources>

--- a/feature/suggestions/src/main/res/values-gl/strings.xml
+++ b/feature/suggestions/src/main/res/values-gl/strings.xml
@@ -12,9 +12,4 @@
     <string name="action_dismiss_follow_suggestion">Desbotar</string>
     <string name="ui_error_delete_suggestion_fmt">Fallou o rexeitamento da suxestión %1$s: %2$s</string>
     <string name="ui_error_follow_account_fmt">Fallou o seguimento de %1$s: %2$s</string>
-    <string name="follower_count_fmt">&lt;b>%1$s&lt;/b> seguidoras</string>
-    <string name="follows_count_fmt">&lt;b>%1$s&lt;/b> seguimentos</string>
-    <string name="statuses_count_fmt">&lt;b>%1$s&lt;/b> publicacións</string>
-    <string name="statuses_count_per_week_last_fmt">&lt;b>%1$s&lt;/b> publicacións (&lt;b>%2$d&lt;/b> por semana, última o &lt;b>%3$s&lt;/b>)</string>
-    <string name="statuses_count_per_week_fmt">&lt;b>%1$s&lt;/b> publicacións (&lt;b>%2$d&lt;/b> por semana)</string>
 </resources>

--- a/feature/suggestions/src/main/res/values-in/strings.xml
+++ b/feature/suggestions/src/main/res/values-in/strings.xml
@@ -3,17 +3,12 @@
     <string name="sources_friends_of_friends">Populer di antara orang yang Anda ikuti</string>
     <string name="title_suggestions">Akun yang disarankan</string>
     <string name="sources_featured">Dipetik dengan tangan oleh tim server Anda</string>
-    <string name="statuses_count_fmt">&lt;b>%1$s&lt;/b> postingan</string>
     <string name="sources_unknown">(Server yang dikembalikan sumber yang tidak diakui)</string>
     <string name="sources_most_followed">Salah satu yang paling diikuti di server Anda</string>
     <string name="sources_similar_to_recently_followed">Mirip dengan akun yang baru saja Anda ikuti</string>
     <string name="ui_error_delete_suggestion_fmt">Menyingkirkan saran untuk %1$s gagal: %2$s</string>
     <string name="action_dismiss_follow_suggestion">Menolak</string>
     <string name="ui_error_follow_account_fmt">Mengikuti %1$s failed: %2$s</string>
-    <string name="follower_count_fmt">&lt;b>%1$s&lt;/b> pengikut</string>
-    <string name="follows_count_fmt">&lt;b>%1$s&lt;/b> mengikuti</string>
-    <string name="statuses_count_per_week_fmt">&lt;b>%1$s&lt;/b> postingan (&lt;b>%2$d&lt;/b> per minggu)</string>
-    <string name="statuses_count_per_week_last_fmt">&lt;b>%1$s&lt;/b> postingan (&lt;b>%2$d&lt;/b> per minggu, terakhir &lt;b>%3$s&lt;/b>)</string>
     <string name="source_unknown">(Server yang dikembalikan sumber yang tidak diakui)</string>
     <string name="action_follow_account">Ikuti</string>
     <string name="sources_most_interactions">Mendapatkan banyak perhatian di server Anda</string>

--- a/feature/suggestions/src/main/res/values-it/strings.xml
+++ b/feature/suggestions/src/main/res/values-it/strings.xml
@@ -8,11 +8,6 @@
     <string name="sources_unknown">(il server ha riportato fonti non riconosciute)</string>
     <string name="action_follow_account">Segui</string>
     <string name="action_dismiss_follow_suggestion">Scartare</string>
-    <string name="follower_count_fmt">&lt;b>%1$s&lt;/b> seguaci</string>
-    <string name="follows_count_fmt">&lt;b>%1$s&lt;/b> seguiti</string>
-    <string name="statuses_count_fmt">&lt;b>%1$s&lt;/b> post</string>
     <string name="ui_error_follow_account_fmt">La richiesta di seguire %1$s è fallita: %2$s</string>
     <string name="sources_most_interactions">Il tuo server sta ricevendo molte attenzioni</string>
-    <string name="statuses_count_per_week_fmt">&lt;b>%1$s&lt;/b> posta (&lt;b>%2$d&lt;/b> alla settimana)</string>
-    <string name="statuses_count_per_week_last_fmt">&lt;b>%1$s&lt;/b> post (&lt;b>%2$d&lt;/b> per settimana, ultimo &lt;b>%3$s&lt;/b>)</string>
 </resources>

--- a/feature/suggestions/src/main/res/values-lt/strings.xml
+++ b/feature/suggestions/src/main/res/values-lt/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="sources_most_followed">Vienas iš labiausiai sekamų jūsų serveryje</string>
-    <string name="follower_count_fmt">&lt;b>%1$s&lt;/b> sekėjai</string>
     <string name="action_follow_account">Sekti</string>
     <string name="action_dismiss_follow_suggestion">Atmesti</string>
     <string name="sources_friends_of_friends">Populiarus tarp žmonių, kuriuos sekate</string>
@@ -13,8 +12,4 @@
     <string name="sources_unknown">(serveris grąžino neatpažintus šaltinius)</string>
     <string name="ui_error_delete_suggestion_fmt">Nepavyko atmesti pasiūlymo dėl %1$s: %2$s.</string>
     <string name="ui_error_follow_account_fmt">Nepavyko sekti %1$s: %2$s.</string>
-    <string name="follows_count_fmt">&lt;b>%1$s&lt;/b> sekimai</string>
-    <string name="statuses_count_fmt">&lt;b>%1$s&lt;/b> įrašai</string>
-    <string name="statuses_count_per_week_fmt">&lt;b>%1$s&lt;/b> įrašai (&lt;b>%2$d&lt;/b> per savaitę)</string>
-    <string name="statuses_count_per_week_last_fmt">&lt;b>%1$s&lt;/b> įrašai (&lt;b>%2$d&lt;/b> per savaitę, paskutinis &lt;b>%3$s&lt;/b>)</string>
 </resources>

--- a/feature/suggestions/src/main/res/values-lv/strings.xml
+++ b/feature/suggestions/src/main/res/values-lv/strings.xml
@@ -7,14 +7,9 @@
     <string name="sources_unknown">(serveris atgrieza neatpazītus avotus)</string>
     <string name="ui_error_delete_suggestion_fmt">%1$s ieteikumu noraidīšana neizdevās: %2$s</string>
     <string name="ui_error_follow_account_fmt">Sekošana %1$s neizdevās: %2$s</string>
-    <string name="follower_count_fmt">&lt;b>%1$s&lt;/b> sekotājs/i/u</string>
-    <string name="statuses_count_fmt">&lt;b>%1$s&lt;/b> ieraksts/i/u</string>
-    <string name="statuses_count_per_week_fmt">&lt;b>%1$s&lt;/b> ieraksts/i/u (&lt;b>%2$d&lt;/b> nedēļā)</string>
     <string name="action_follow_account">Sekot</string>
     <string name="sources_similar_to_recently_followed">Līdzīgs kontiem, kuriem nesen sāki sekot</string>
-    <string name="follows_count_fmt">Seko &lt;b>%1$s&lt;/b></string>
     <string name="source_unknown">(serveris atgrieza neatpazītu avotu)</string>
     <string name="sources_most_interactions">Iegūst daudz uzmanības Tavā serverī</string>
-    <string name="statuses_count_per_week_last_fmt">&lt;b>%1$s&lt;/b> ieraksts/i/u (&lt;b>%2$d&lt;/b> nedēļā, pēdējais &lt;b>%3$s&lt;/b>)</string>
     <string name="action_dismiss_follow_suggestion">Noraidīt</string>
 </resources>

--- a/feature/suggestions/src/main/res/values-nb-rNO/strings.xml
+++ b/feature/suggestions/src/main/res/values-nb-rNO/strings.xml
@@ -12,9 +12,4 @@
     <string name="sources_friends_of_friends">Populær blant de du følger</string>
     <string name="sources_unknown">(Serveren ga ukjente kilder)</string>
     <string name="action_dismiss_follow_suggestion">Avvis</string>
-    <string name="follower_count_fmt">&lt;b>%1$s&lt;/b> følgere</string>
-    <string name="follows_count_fmt">Følger &lt;b>%1$s&lt;/b></string>
-    <string name="statuses_count_fmt">&lt;b>%1$s&lt;/b> innlegg</string>
-    <string name="statuses_count_per_week_fmt">&lt;b>%1$s&lt;/b> innlegg (&lt;b>%2$d&lt;/b> om uken)</string>
-    <string name="statuses_count_per_week_last_fmt">&lt;b>%1$s&lt;/b> innlegg (&lt;b>%2$d&lt;/b> om uken, siste uke &lt;b>%3$s&lt;/b>)</string>
 </resources>

--- a/feature/suggestions/src/main/res/values-nn/strings.xml
+++ b/feature/suggestions/src/main/res/values-nn/strings.xml
@@ -12,9 +12,4 @@
     <string name="action_dismiss_follow_suggestion">Avvis</string>
     <string name="ui_error_delete_suggestion_fmt">Mislukkast i å avvise forslag til %1$s: %2$s</string>
     <string name="ui_error_follow_account_fmt">Mislukkast i å fylgje %1$s: %2$s</string>
-    <string name="follower_count_fmt">&lt;b&gt;%1$s&lt;/b&gt; fylgjarar</string>
-    <string name="follows_count_fmt">Fylgjer &lt;b&gt;%1$s&lt;/b&gt;</string>
-    <string name="statuses_count_fmt">&lt;b&gt;%1$s&lt;/b&gt; innlegg</string>
-    <string name="statuses_count_per_week_fmt">&lt;b&gt;%1$s&lt;/b&gt; innlegg (&lt;b&gt;%2$d&lt;/b&gt; om veka)</string>
-    <string name="statuses_count_per_week_last_fmt">&lt;b&gt;%1$s&lt;/b&gt; innlegg (&lt;b&gt;%2$d&lt;/b&gt; om veka, førre veke &lt;b&gt;%3$s&lt;/b&gt;)</string>
 </resources>

--- a/feature/suggestions/src/main/res/values-pl/strings.xml
+++ b/feature/suggestions/src/main/res/values-pl/strings.xml
@@ -10,11 +10,6 @@
     <string name="sources_unknown">(serwer zwrócił nierozpoznawalne źródła)</string>
     <string name="action_follow_account">Obserwuj</string>
     <string name="action_dismiss_follow_suggestion">Odrzuć</string>
-    <string name="follows_count_fmt">&lt;b>%1$s&lt;/b> obserwowanych</string>
-    <string name="statuses_count_fmt">&lt;b>%1$s&lt;/b> wpisów</string>
-    <string name="statuses_count_per_week_fmt">&lt;b>%1$s&lt;/b> wpisów (&lt;b>%2$d&lt;/b> na tydzień)</string>
-    <string name="statuses_count_per_week_last_fmt">&lt;b>%1$s&lt;/b> wpisów (&lt;b>%2$d&lt;/b> na tydzień, ostatni &lt;b>%3$s&lt;/b>)</string>
     <string name="ui_error_follow_account_fmt">Obserwowanie %1$s się nie powiodło: %2$s</string>
     <string name="ui_error_delete_suggestion_fmt">Odrzucanie sugestii %1$s się nie powiodło: %2$s</string>
-    <string name="follower_count_fmt">&lt;b>%1$s&lt;/b> obserwujących</string>
 </resources>

--- a/feature/suggestions/src/main/res/values-ru/strings.xml
+++ b/feature/suggestions/src/main/res/values-ru/strings.xml
@@ -12,9 +12,4 @@
     <string name="action_dismiss_follow_suggestion">Отклонить</string>
     <string name="ui_error_delete_suggestion_fmt">Не удалось отклонить предложение для %1$s: ошибка %2$s</string>
     <string name="ui_error_follow_account_fmt">Не удалось подписаться на %1$s: ошибка %2$s</string>
-    <string name="follower_count_fmt">&lt;b>%1$s&lt;/b> подписчиков</string>
-    <string name="follows_count_fmt">&lt;b>%1$s&lt;/b> подписок</string>
-    <string name="statuses_count_fmt">&lt;b>%1$s&lt;/b> записей</string>
-    <string name="statuses_count_per_week_fmt">&lt;b>%1$s&lt;/b> записей (&lt;b>%2$d&lt;/b> в неделю)</string>
-    <string name="statuses_count_per_week_last_fmt">&lt;b>%1$s&lt;/b> записей (&lt;b>%2$d&lt;/b> в неделю, последние &lt;b>%3$s&lt;/b>)</string>
 </resources>

--- a/feature/suggestions/src/main/res/values-sk/strings.xml
+++ b/feature/suggestions/src/main/res/values-sk/strings.xml
@@ -12,9 +12,4 @@
     <string name="action_dismiss_follow_suggestion">Zavrieť</string>
     <string name="ui_error_delete_suggestion_fmt">Odmietnutie návrhu pre %1$s zlyhalo: %2$s</string>
     <string name="ui_error_follow_account_fmt">Sledovanie účtu %1$s zlyhalo: %2$s</string>
-    <string name="follows_count_fmt">&lt;b>%1$s&lt;/b> sledovaných</string>
-    <string name="follower_count_fmt">&lt;b>%1$s&lt;/b> sledujúcich</string>
-    <string name="statuses_count_fmt">&lt;b>%1$s&lt;/b> príspevkov</string>
-    <string name="statuses_count_per_week_last_fmt">&lt;b>%1$s&lt;/b> príspevkov (&lt;b>%2$d&lt;/b> za týždeň, posledný &lt;b>%3$s&lt;/b>)</string>
-    <string name="statuses_count_per_week_fmt">&lt;b>%1$s&lt;/b> príspevkov (&lt;b>%2$d&lt;/b> za týždeň)</string>
 </resources>

--- a/feature/suggestions/src/main/res/values-ta/strings.xml
+++ b/feature/suggestions/src/main/res/values-ta/strings.xml
@@ -12,9 +12,4 @@
     <string name="action_dismiss_follow_suggestion">நிராகரி</string>
     <string name="ui_error_delete_suggestion_fmt">%1$sக்கான பரிந்துரையை நிராகரிக்க முடியவில்லை: %2$s</string>
     <string name="ui_error_follow_account_fmt">பின்வரும் %1$s தோல்வியடைந்தது: %2$s</string>
-    <string name="follower_count_fmt">&lt;b&gt;%1$s&lt;/&gt; பின்தொடர்பவர்கள்</string>
-    <string name="follows_count_fmt">&lt;b&gt;%1$s&lt;/&gt; பின்தொடர்கிறது</string>
-    <string name="statuses_count_fmt">&lt;b&gt;%1$s&lt;/&gt; இடுகைகள்</string>
-    <string name="statuses_count_per_week_fmt">&lt;b&gt;%1$s&lt;/&gt; இடுகைகள் (வாரத்திற்கு &lt;b&gt;%2$d&lt;/&gt;)</string>
-    <string name="statuses_count_per_week_last_fmt">&lt;b&gt;%1$s&lt;/&gt; இடுகைகள் (வாரத்திற்கு &lt;b&gt;%2$d&lt;/&gt;, கடந்த &lt;b&gt;%3$s&lt;/&gt;)</string>
 </resources>

--- a/feature/suggestions/src/main/res/values-zh-rCN/strings.xml
+++ b/feature/suggestions/src/main/res/values-zh-rCN/strings.xml
@@ -10,10 +10,6 @@
     <string name="action_dismiss_follow_suggestion">取消</string>
     <string name="ui_error_delete_suggestion_fmt">取消对%1$s的建议失败：%2$s</string>
     <string name="ui_error_follow_account_fmt">关注%1$s失败：%2$s</string>
-    <string name="follower_count_fmt">&lt;b>%1$s&lt;/b>关注者</string>
-    <string name="follows_count_fmt">&lt;b>%1$s&lt;/b>关注</string>
-    <string name="statuses_count_per_week_fmt">&lt;b>%1$s&lt;/b>条嘟文（每周&lt;b>%2$d&lt;/b> 条）</string>
-    <string name="statuses_count_fmt">&lt;b>%1$s&lt;/b> 嘟文</string>
     <string name="sources_similar_to_recently_followed">类似于您最近关注的帐户</string>
     <string name="sources_most_interactions">在您的服务器上获得大量关注</string>
 </resources>

--- a/feature/suggestions/src/main/res/values/strings.xml
+++ b/feature/suggestions/src/main/res/values/strings.xml
@@ -31,14 +31,5 @@
     <string name="ui_error_delete_suggestion_fmt">Dismissing suggestion for %1$s failed: %2$s</string>
     <string name="ui_error_follow_account_fmt">Following %1$s failed: %2$s</string>
 
-    <string name="follower_count_fmt">&lt;b>%1$s&lt;/b> followers</string>
-    <string name="follows_count_fmt">&lt;b>%1$s&lt;/b> following</string>
-    <string name="statuses_count_fmt">&lt;b>%1$s&lt;/b> posts</string>
-    <string name="statuses_count_per_week_fmt">&lt;b>%1$s&lt;/b> posts (&lt;b>%2$d&lt;/b> per week)</string>
-    <string name="statuses_count_per_week_last_fmt">&lt;b>%1$s&lt;/b> posts (&lt;b>%2$d&lt;/b> per week, last &lt;b>%3$s&lt;/b>)</string>
 
-    <string name="account_content_description_fmt" translatable="false">
-        <!-- Display name, follower count, follows count, statuses count, note -->
-        %1$s; %2$s; %3$s; %4$s. %5$s
-    </string>
 </resources>


### PR DESCRIPTION
The resources to describe things like the number of follows and following the account has will be re-used when displaying accounts in collections. Move them from `feature.suggestions` to `core.ui`.