### PR TITLE
ci: Exclude OrangeFdroid... build variants from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,9 @@ jobs:
         color: ["orange"]
         store: [ "Fdroid", "Github", "Google" ]
         type: [ "Debug", "Release" ]
+        exclude:
+          - color: "orange"
+            store: "Fdroid"
     name: Android Lint
     runs-on: ubuntu-latest
 
@@ -113,6 +116,9 @@ jobs:
         color: ["orange"]
         store: [ "Fdroid", "Github", "Google" ]
         type: [ "Debug", "Release" ]
+        exclude:
+          - color: "orange"
+            store: "Fdroid"
     name: Android Unit Test
     runs-on: ubuntu-latest
 
@@ -134,6 +140,9 @@ jobs:
         color: ["orange"]
         store: [ "Fdroid", "Github", "Google" ]
         type: [ "Debug", "Release" ]
+        exclude:
+          - color: "orange"
+            store: "Fdroid"
     name: Android Assemble
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,16 @@ jobs:
         run: ./gradlew validateOrangeGoogleDebugScreenshotTest
 
   # Connected tests are per-store-variant, debug builds only.
+  #
+  # Currently disabled because of
+  # https://github.com/ReactiveCircus/android-emulator-runner/issues/478
+  #
+  # To locally verify a PR works run:
+  #
+  # gh pr checkout [pr]
+  # ./gradlew pixel9api31Check
   connected:
+    if: false
     strategy:
       matrix:
         color: [ "blue", "orange" ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,11 +178,14 @@ jobs:
   connected:
     strategy:
       matrix:
-        color: ["Orange"]
+        color: [ "blue", "orange" ]
         store: ["Fdroid", "Github", "Google"]
         type: ["Debug"]
         api-level: [31]
         target: [default]
+        exclude:
+          - color: "orange"
+            store: "Fdroid"
     name: Android Emulator Tests
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
There is no OrangeFdroid... variant that is released, so there is no need to build or test it.