### PR TITLE
ci: Run tests and lint on debug variant only, both colours

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,12 +70,9 @@ jobs:
       security-events: write
     strategy:
       matrix:
-        color: ["orange"]
+        color: [ "blue", "orange" ]
         store: [ "Fdroid", "Github", "Google" ]
-        type: [ "Debug", "Release" ]
-        exclude:
-          - color: "orange"
-            store: "Fdroid"
+        type: [ "Debug" ]
     name: Android Lint
     runs-on: ubuntu-latest
 
@@ -113,12 +110,9 @@ jobs:
   test:
     strategy:
       matrix:
-        color: ["orange"]
+        color: [ "blue", "orange" ]
         store: [ "Fdroid", "Github", "Google" ]
-        type: [ "Debug", "Release" ]
-        exclude:
-          - color: "orange"
-            store: "Fdroid"
+        type: [ "Debug" ]
     name: Android Unit Test
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
No need to run tests or lint release builds, but do need to check both colours.