### PR TITLE
chore: Remove MastodonApi.followSuggestedAccount

### DIFF
--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/NetworkSuggestionsRepository.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/NetworkSuggestionsRepository.kt
@@ -64,7 +64,7 @@ class NetworkSuggestionsRepository @Inject constructor(
 
     override suspend fun followAccount(accountId: String): Result<Unit, FollowAccountError> = binding {
         externalScope.async {
-            api.followSuggestedAccount(accountId).mapError { FollowAccountError(it) }.bind()
+            api.followAccount(accountId).mapError { FollowAccountError(it) }.bind()
         }.await()
     }
 

--- a/core/network/src/main/kotlin/app/pachli/core/network/retrofit/MastodonApi.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/retrofit/MastodonApi.kt
@@ -837,11 +837,6 @@ interface MastodonApi {
 
     @DELETE("api/v1/suggestions/{accountId}")
     suspend fun deleteSuggestion(@Path("accountId") accountId: String): ApiResult<Unit>
-
-    // Copy of followAccount, except it returns an ApiResult. Temporary, until followAccount
-    // is converted to also return ApiResult.
-    @POST("api/v1/accounts/{id}/follow")
-    suspend fun followSuggestedAccount(@Path("id") accountId: String): ApiResult<Relationship>
 }
 
 /**


### PR DESCRIPTION
It was temporary until MastodonApi.followAccount was converted to return an ApiResult, and that's happened.