### PR TITLE
fix: Update "following" relationships when following suggested accounts

### DIFF
--- a/app/src/main/java/app/pachli/components/account/AccountViewModel.kt
+++ b/app/src/main/java/app/pachli/components/account/AccountViewModel.kt
@@ -9,6 +9,14 @@ import app.pachli.core.data.repository.AccountRepository
 import app.pachli.core.data.repository.Loadable
 import app.pachli.core.data.repository.StatusDisplayOptionsRepository
 import app.pachli.core.data.repository.getOrNull
+import app.pachli.core.domain.accounts.BlockAccountUseCase
+import app.pachli.core.domain.accounts.FollowAccountUseCase
+import app.pachli.core.domain.accounts.MuteAccountUseCase
+import app.pachli.core.domain.accounts.SubscribeAccountUseCase
+import app.pachli.core.domain.accounts.UnblockAccountUseCase
+import app.pachli.core.domain.accounts.UnfollowAccountUseCase
+import app.pachli.core.domain.accounts.UnmuteAccountUseCase
+import app.pachli.core.domain.accounts.UnsubscribeAccountUseCase
 import app.pachli.core.eventhub.DomainMuteEvent
 import app.pachli.core.eventhub.EventHub
 import app.pachli.core.eventhub.ProfileEditedEvent
@@ -17,7 +25,6 @@ import app.pachli.core.model.Relationship
 import app.pachli.core.network.model.asModel
 import app.pachli.core.network.retrofit.MastodonApi
 import app.pachli.core.ui.getDomain
-import app.pachli.usecase.TimelineCases
 import app.pachli.util.Error
 import app.pachli.util.Loading
 import app.pachli.util.Resource
@@ -51,7 +58,14 @@ class AccountViewModel @AssistedInject constructor(
     private val mastodonApi: MastodonApi,
     private val eventHub: EventHub,
     accountManager: AccountManager,
-    private val timelineCases: TimelineCases,
+    private val followAccountUseCase: FollowAccountUseCase,
+    private val unfollowAccountUseCase: UnfollowAccountUseCase,
+    private val blockAccountUseCase: BlockAccountUseCase,
+    private val unblockAccountUseCase: UnblockAccountUseCase,
+    private val muteAccountUseCase: MuteAccountUseCase,
+    private val unmuteAccountUseCase: UnmuteAccountUseCase,
+    private val subscribeAccountUseCase: SubscribeAccountUseCase,
+    private val unsubscribeAccountUseCase: UnsubscribeAccountUseCase,
     statusDisplayOptionsRepository: StatusDisplayOptionsRepository,
     private val accountRepository: AccountRepository,
 ) : ViewModel() {
@@ -273,39 +287,38 @@ class AccountViewModel @AssistedInject constructor(
         }
 
         val response = when (relationshipAction) {
-            RelationShipAction.FOLLOW -> timelineCases.followAccount(pachliAccountId, accountId, showReblogs = true)
-            RelationShipAction.UNFOLLOW -> timelineCases.unfollowAccount(pachliAccountId, accountId)
-            RelationShipAction.BLOCK -> timelineCases.blockAccount(pachliAccountId, accountId)
-            RelationShipAction.UNBLOCK -> timelineCases.unblockAccount(pachliAccountId, accountId)
-            RelationShipAction.MUTE -> timelineCases.muteAccount(
+            RelationShipAction.FOLLOW -> followAccountUseCase(pachliAccountId, accountId, showReblogs = true)
+            RelationShipAction.UNFOLLOW -> unfollowAccountUseCase(pachliAccountId, accountId)
+            RelationShipAction.BLOCK -> blockAccountUseCase(pachliAccountId, accountId)
+            RelationShipAction.UNBLOCK -> unblockAccountUseCase(pachliAccountId, accountId)
+            RelationShipAction.MUTE -> muteAccountUseCase(
                 pachliAccountId,
                 accountId,
                 notifications = parameter ?: true,
                 duration,
             )
 
-            RelationShipAction.UNMUTE -> timelineCases.unmuteAccount(pachliAccountId, accountId)
+            RelationShipAction.UNMUTE -> unmuteAccountUseCase(pachliAccountId, accountId)
             RelationShipAction.SUBSCRIBE -> {
                 if (isMastodon) {
-                    timelineCases.followAccount(pachliAccountId, accountId, notify = true)
+                    followAccountUseCase(pachliAccountId, accountId, notify = true)
                 } else {
-                    timelineCases.subscribeAccount(pachliAccountId, accountId)
+                    subscribeAccountUseCase(pachliAccountId, accountId)
                 }
             }
             RelationShipAction.UNSUBSCRIBE -> {
                 if (isMastodon) {
-                    timelineCases.followAccount(pachliAccountId, accountId, notify = false)
+                    followAccountUseCase(pachliAccountId, accountId, notify = false)
                 } else {
-                    timelineCases.unsubscribeAccount(pachliAccountId, accountId)
+                    unsubscribeAccountUseCase(pachliAccountId, accountId)
                 }
             }
 
-            RelationShipAction.SHOW_REBLOGS -> timelineCases.followAccount(pachliAccountId, accountId, showReblogs = true)
-            RelationShipAction.HIDE_REBLOGS -> timelineCases.followAccount(pachliAccountId, accountId, showReblogs = false)
+            RelationShipAction.SHOW_REBLOGS -> followAccountUseCase(pachliAccountId, accountId, showReblogs = true)
+            RelationShipAction.HIDE_REBLOGS -> followAccountUseCase(pachliAccountId, accountId, showReblogs = false)
         }
 
         response
-            .map { it.body.asModel() }
             .onSuccess { relationshipData.postValue(Success(it)) }
             .onFailure { e ->
                 Timber.w("failed loading relationship: %s", e)

--- a/app/src/main/java/app/pachli/components/accountlist/AccountListFragment.kt
+++ b/app/src/main/java/app/pachli/components/accountlist/AccountListFragment.kt
@@ -39,6 +39,10 @@ import app.pachli.core.common.extensions.viewBinding
 import app.pachli.core.common.util.unsafeLazy
 import app.pachli.core.data.repository.AccountManager
 import app.pachli.core.data.repository.StatusDisplayOptionsRepository
+import app.pachli.core.domain.accounts.BlockAccountUseCase
+import app.pachli.core.domain.accounts.MuteAccountUseCase
+import app.pachli.core.domain.accounts.UnblockAccountUseCase
+import app.pachli.core.domain.accounts.UnmuteAccountUseCase
 import app.pachli.core.model.Relationship
 import app.pachli.core.navigation.AccountActivityIntent
 import app.pachli.core.navigation.AccountListActivityIntent.Kind
@@ -64,7 +68,6 @@ import app.pachli.core.ui.SetContentAsMastodonHtml
 import app.pachli.core.ui.extensions.applyDefaultWindowInsets
 import app.pachli.databinding.FragmentAccountListBinding
 import app.pachli.interfaces.AccountActionListener
-import app.pachli.usecase.TimelineCases
 import app.pachli.view.EndlessOnScrollListener
 import com.bumptech.glide.Glide
 import com.github.michaelbull.result.getOrElse
@@ -98,7 +101,16 @@ class AccountListFragment :
     lateinit var statusDisplayOptionsRepository: StatusDisplayOptionsRepository
 
     @Inject
-    lateinit var timelineCases: TimelineCases
+    lateinit var blockAccountUseCase: BlockAccountUseCase
+
+    @Inject
+    lateinit var unblockAccountUseCase: UnblockAccountUseCase
+
+    @Inject
+    lateinit var muteAccountUseCase: MuteAccountUseCase
+
+    @Inject
+    lateinit var unmuteAccountUseCase: UnmuteAccountUseCase
 
     private val binding by viewBinding(FragmentAccountListBinding::bind)
 
@@ -229,9 +241,9 @@ class AccountListFragment :
     override fun onMute(mute: Boolean, id: String, position: Int, notifications: Boolean) {
         viewLifecycleOwner.lifecycleScope.launch {
             if (!mute) {
-                timelineCases.unmuteAccount(pachliAccountId, id)
+                unmuteAccountUseCase(pachliAccountId, id)
             } else {
-                timelineCases.muteAccount(pachliAccountId, id, notifications)
+                muteAccountUseCase(pachliAccountId, id, notifications)
             }
                 .onSuccess { onMuteSuccess(mute, id, position, notifications) }
                 .onFailure { onMuteFailure(mute, id, notifications) }
@@ -272,9 +284,9 @@ class AccountListFragment :
     override fun onBlock(block: Boolean, id: String, position: Int) {
         viewLifecycleOwner.lifecycleScope.launch {
             if (block) {
-                timelineCases.blockAccount(pachliAccountId, id)
+                blockAccountUseCase(pachliAccountId, id)
             } else {
-                timelineCases.unblockAccount(pachliAccountId, id)
+                unblockAccountUseCase(pachliAccountId, id)
             }
                 .onSuccess { onBlockSuccess(block, id, position) }
                 .onFailure { onBlockFailure(block, id, it.throwable) }

--- a/app/src/main/java/app/pachli/components/report/ReportViewModel.kt
+++ b/app/src/main/java/app/pachli/components/report/ReportViewModel.kt
@@ -24,6 +24,10 @@ import app.pachli.core.data.repository.AccountManager
 import app.pachli.core.data.repository.Loadable
 import app.pachli.core.data.repository.StatusDisplayOptionsRepository
 import app.pachli.core.data.repository.getOrNull
+import app.pachli.core.domain.accounts.BlockAccountUseCase
+import app.pachli.core.domain.accounts.MuteAccountUseCase
+import app.pachli.core.domain.accounts.UnblockAccountUseCase
+import app.pachli.core.domain.accounts.UnmuteAccountUseCase
 import app.pachli.core.eventhub.EventHub
 import app.pachli.core.model.Relationship
 import app.pachli.core.model.Status
@@ -85,6 +89,10 @@ class ReportViewModel @AssistedInject constructor(
     eventHub: EventHub,
     repository: NetworkTimelineRepository,
     timelineCases: TimelineCases,
+    private val blockAccountUseCase: BlockAccountUseCase,
+    private val unblockAccountUseCase: UnblockAccountUseCase,
+    private val muteAccountUseCase: MuteAccountUseCase,
+    private val unmuteAccountUseCase: UnmuteAccountUseCase,
     accountManager: AccountManager,
     sharedPreferencesRepository: SharedPreferencesRepository,
 ) : NetworkTimelineViewModel(
@@ -224,12 +232,11 @@ class ReportViewModel @AssistedInject constructor(
 
         viewModelScope.launch {
             if (alreadyMuted) {
-                timelineCases.unmuteAccount(pachliAccountId, this@ReportViewModel.reportedAccountId)
+                unmuteAccountUseCase(pachliAccountId, this@ReportViewModel.reportedAccountId)
             } else {
-                timelineCases.muteAccount(pachliAccountId, this@ReportViewModel.reportedAccountId)
+                muteAccountUseCase(pachliAccountId, this@ReportViewModel.reportedAccountId)
             }
-                .map { it.body.muting }
-                .onSuccess { _muting.emit(Ok(Loadable.Loaded(it))) }
+                .onSuccess { _muting.emit(Ok(Loadable.Loaded(it.muting))) }
                 .onFailure { _muting.emit(Err(it)) }
         }
     }
@@ -241,12 +248,11 @@ class ReportViewModel @AssistedInject constructor(
 
         viewModelScope.launch {
             if (alreadyBlocked) {
-                timelineCases.unblockAccount(pachliAccountId, this@ReportViewModel.reportedAccountId)
+                unblockAccountUseCase(pachliAccountId, this@ReportViewModel.reportedAccountId)
             } else {
-                timelineCases.blockAccount(pachliAccountId, this@ReportViewModel.reportedAccountId)
+                blockAccountUseCase(pachliAccountId, this@ReportViewModel.reportedAccountId)
             }
-                .map { it.body.blocking }
-                .onSuccess { _blocking.emit(Ok(Loadable.Loaded(it))) }
+                .onSuccess { _blocking.emit(Ok(Loadable.Loaded(it.blocking))) }
                 .onFailure { _blocking.emit(Err(it)) }
         }
     }

--- a/app/src/main/java/app/pachli/components/search/SearchViewModel.kt
+++ b/app/src/main/java/app/pachli/components/search/SearchViewModel.kt
@@ -44,6 +44,8 @@ import app.pachli.core.data.repository.StatusDisplayOptionsRepository
 import app.pachli.core.database.dao.TimelineStatusWithAccount
 import app.pachli.core.database.model.TimelineStatusWithQuote
 import app.pachli.core.database.model.asEntity
+import app.pachli.core.domain.accounts.BlockAccountUseCase
+import app.pachli.core.domain.accounts.MuteAccountUseCase
 import app.pachli.core.model.AttachmentDisplayAction
 import app.pachli.core.model.ContentFilterVersion
 import app.pachli.core.model.DeletedStatus
@@ -98,6 +100,8 @@ import timber.log.Timber
 class SearchViewModel @Inject constructor(
     private val mastodonApi: MastodonApi,
     private val timelineCases: TimelineCases,
+    private val blockAccountUseCase: BlockAccountUseCase,
+    private val muteAccountUseCase: MuteAccountUseCase,
     accountManager: AccountManager,
     private val statusRepository: OfflineFirstStatusRepository,
     statusDisplayOptionsRepository: StatusDisplayOptionsRepository,
@@ -394,7 +398,7 @@ class SearchViewModel @Inject constructor(
 
     fun muteAccount(pachliAccountId: Long, accountId: String, notifications: Boolean, duration: Int?) {
         viewModelScope.launch {
-            timelineCases.muteAccount(pachliAccountId, accountId, notifications, duration)
+            muteAccountUseCase(pachliAccountId, accountId, notifications, duration)
         }
     }
 
@@ -406,7 +410,7 @@ class SearchViewModel @Inject constructor(
 
     fun blockAccount(pachliAccountId: Long, accountId: String) {
         viewModelScope.launch {
-            timelineCases.blockAccount(pachliAccountId, accountId)
+            blockAccountUseCase(pachliAccountId, accountId)
         }
     }
 

--- a/app/src/main/java/app/pachli/fragment/SFragment.kt
+++ b/app/src/main/java/app/pachli/fragment/SFragment.kt
@@ -48,6 +48,8 @@ import app.pachli.core.data.repository.createDraftReply
 import app.pachli.core.database.model.PachliAccountEntity
 import app.pachli.core.database.model.TranslationState
 import app.pachli.core.domain.DownloadUrlUseCase
+import app.pachli.core.domain.accounts.BlockAccountUseCase
+import app.pachli.core.domain.accounts.MuteAccountUseCase
 import app.pachli.core.model.Attachment
 import app.pachli.core.model.Draft
 import app.pachli.core.model.IStatus
@@ -89,6 +91,12 @@ abstract class SFragment<T : IStatusViewData> : Fragment(), StatusActionListener
 
     @Inject
     lateinit var timelineCases: TimelineCases
+
+    @Inject
+    lateinit var blockAccountUseCase: BlockAccountUseCase
+
+    @Inject
+    lateinit var muteAccountUseCase: MuteAccountUseCase
 
     @Inject
     lateinit var downloadUrlUseCase: DownloadUrlUseCase
@@ -412,7 +420,7 @@ abstract class SFragment<T : IStatusViewData> : Fragment(), StatusActionListener
     private fun onMute(accountId: String, accountUsername: String) {
         showMuteAccountDialog(this.requireActivity(), accountUsername) { notifications: Boolean?, duration: Int? ->
             lifecycleScope.launch {
-                timelineCases.muteAccount(pachliAccountId, accountId, notifications == true, duration)
+                muteAccountUseCase(pachliAccountId, accountId, notifications == true, duration)
             }
         }
     }
@@ -422,7 +430,7 @@ abstract class SFragment<T : IStatusViewData> : Fragment(), StatusActionListener
             .setMessage(getString(R.string.dialog_block_warning, accountUsername))
             .setPositiveButton(android.R.string.ok) { _: DialogInterface?, _: Int ->
                 lifecycleScope.launch {
-                    timelineCases.blockAccount(pachliAccountId, accountId)
+                    blockAccountUseCase(pachliAccountId, accountId)
                 }
             }
             .setNegativeButton(android.R.string.cancel, null)

--- a/app/src/main/java/app/pachli/usecase/TimelineCases.kt
+++ b/app/src/main/java/app/pachli/usecase/TimelineCases.kt
@@ -18,7 +18,6 @@ package app.pachli.usecase
 
 import app.pachli.core.common.di.ApplicationScope
 import app.pachli.core.data.model.IStatusViewData
-import app.pachli.core.data.repository.AccountManager
 import app.pachli.core.data.repository.OfflineFirstStatusRepository
 import app.pachli.core.data.repository.StatusActionError
 import app.pachli.core.database.dao.RemoteKeyDao
@@ -27,18 +26,13 @@ import app.pachli.core.database.model.RemoteKeyEntity
 import app.pachli.core.database.model.RemoteKeyEntity.RemoteKeyKind
 import app.pachli.core.database.model.TranslationState
 import app.pachli.core.database.model.toEntity
-import app.pachli.core.eventhub.BlockEvent
 import app.pachli.core.eventhub.EventHub
-import app.pachli.core.eventhub.MuteEvent
 import app.pachli.core.eventhub.StatusDeletedEvent
-import app.pachli.core.eventhub.UnfollowEvent
 import app.pachli.core.model.Status
 import app.pachli.core.model.translation.TranslatedStatus
 import app.pachli.core.network.model.DeletedStatus
 import app.pachli.core.network.model.Relationship
 import app.pachli.core.network.retrofit.MastodonApi
-import app.pachli.core.network.retrofit.apiresult.ApiError
-import app.pachli.core.network.retrofit.apiresult.ApiResponse
 import app.pachli.core.network.retrofit.apiresult.ApiResult
 import app.pachli.translation.TranslationService
 import app.pachli.translation.TranslatorError
@@ -60,117 +54,10 @@ class TimelineCases @Inject constructor(
     private val translatedStatusDao: TranslatedStatusDao,
     private val translationService: TranslationService,
     private val remoteKeyDao: RemoteKeyDao,
-    private val accountManager: AccountManager,
     @ApplicationScope private val externalScope: CoroutineScope,
 ) {
     suspend fun muteConversation(pachliAccountId: Long, statusId: String, mute: Boolean): Result<Status, StatusActionError.Mute> {
         return statusRepository.mute(pachliAccountId, statusId, mute)
-    }
-
-    /**
-     * Sends a follow request for [accountId] to the server for [pachliAccountId].
-     *
-     * On success:
-     *
-     * - The following relationship is added to [AccountManager].
-     *
-     * @param pachliAccountId
-     * @param accountId ID of account to follow.
-     * @param showReblogs If true, show reblogs from this account. Null uses server default.
-     * @param notify If true, receive notifications when this account posts. Null uses server default.
-     */
-    suspend fun followAccount(pachliAccountId: Long, accountId: String, showReblogs: Boolean? = null, notify: Boolean? = null): ApiResult<Relationship> {
-        return mastodonApi.followAccount(accountId, showReblogs, notify)
-            .onSuccess { accountManager.followAccount(pachliAccountId, accountId) }
-    }
-
-    /**
-     * Unfollow [accountId].
-     *
-     * On success:
-     *
-     * - The following relationship is removed from [AccountManager].
-     * - [UnfollowEvent] is dispatched.
-     *
-     * @param pachliAccountId
-     * @param accountID ID of the account to unfollow.
-     */
-    suspend fun unfollowAccount(pachliAccountId: Long, accountId: String): ApiResult<Relationship> {
-        return mastodonApi.unfollowAccount(accountId)
-            .onSuccess {
-                accountManager.unfollowAccount(pachliAccountId, accountId)
-                eventHub.dispatch(UnfollowEvent(pachliAccountId, accountId))
-            }
-    }
-
-    /**
-     * Subscribe to [accountId].
-     *
-     * @param pachliAccountId
-     * @param accountId ID of the account to subscribe to.
-     */
-    suspend fun subscribeAccount(pachliAccountId: Long, accountId: String): ApiResult<Relationship> {
-        return mastodonApi.subscribeAccount(accountId)
-    }
-
-    /**
-     * Unsubscribe from [accountId].
-     *
-     * @param pachliAccountId
-     * @param accountId ID of the account to unsubscribe from.
-     */
-    suspend fun unsubscribeAccount(pachliAccountId: Long, accountId: String): ApiResult<Relationship> {
-        return mastodonApi.unsubscribeAccount(accountId)
-    }
-
-    /**
-     * Mute [accountId].
-     *
-     * On success:
-     *
-     * - [MuteEvent] is dispatched.
-     *
-     * @param pachliAccountId
-     * @param accountId ID of the account to mute.
-     */
-    suspend fun muteAccount(pachliAccountId: Long, accountId: String, notifications: Boolean? = null, duration: Int? = null): Result<ApiResponse<Relationship>, ApiError> {
-        return mastodonApi.muteAccount(accountId, notifications, duration)
-            .onSuccess { eventHub.dispatch(MuteEvent(pachliAccountId, accountId)) }
-    }
-
-    /**
-     * Unmute [accountId].
-     *
-     * @param pachliAccountId
-     * @param accountId ID of the account to unmute.
-     */
-    suspend fun unmuteAccount(pachliAccountId: Long, accountId: String): ApiResult<Relationship> {
-        return mastodonApi.unmuteAccount(accountId)
-    }
-
-    /**
-     * Block [accountId].
-     *
-     * On success:
-     *
-     * - [BlockEvent] is dispatched.
-     *
-     * @param pachliAccountId
-     * @param accountId ID of the account to block.
-     */
-    suspend fun blockAccount(pachliAccountId: Long, accountId: String): Result<ApiResponse<Relationship>, ApiError> {
-        return mastodonApi.blockAccount(accountId)
-            .onSuccess { eventHub.dispatch(BlockEvent(pachliAccountId, accountId)) }
-    }
-
-    /**
-     * Unblock [accountId].
-     *
-     * @param pachliAccountId
-     * @param accountId ID of the account to unblock.
-     */
-    suspend fun unblockAccount(pachliAccountId: Long, accountId: String): ApiResult<Relationship> {
-        return mastodonApi.unblockAccount(accountId)
     }
 
     suspend fun delete(statusId: String): ApiResult<DeletedStatus> {

--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/Loadable.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/Loadable.kt
@@ -20,6 +20,7 @@ package app.pachli.core.data.repository
 import app.pachli.core.data.repository.Loadable.Loaded
 import app.pachli.core.data.repository.Loadable.Loading
 import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
 /**
@@ -51,5 +52,22 @@ fun <T> Loadable<T>.getOrNull(): T? {
     return when (this) {
         is Loaded<T> -> this.data
         is Loading -> null
+    }
+}
+
+/**
+ * Maps this [Loadable&lt;T>][Loadable] to [Loadable&lt;R>][Loadable] by
+ * applying the [transform] function if this [Loadable] is
+ * [Loadable.Loading], or returning [this] unchanged.
+ */
+@OptIn(ExperimentalContracts::class)
+fun <T, R> Loadable<T>.mapLoaded(transform: (T) -> R): Loadable<R> {
+    contract {
+        callsInPlace(transform, InvocationKind.AT_MOST_ONCE)
+    }
+
+    return when (this) {
+        is Loading -> this
+        is Loaded -> Loaded(transform(data))
     }
 }

--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/NetworkSuggestionsRepository.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/NetworkSuggestionsRepository.kt
@@ -19,7 +19,6 @@ package app.pachli.core.data.repository
 
 import app.pachli.core.common.di.ApplicationScope
 import app.pachli.core.data.repository.SuggestionsError.DeleteSuggestionError
-import app.pachli.core.data.repository.SuggestionsError.FollowAccountError
 import app.pachli.core.data.repository.SuggestionsError.GetSuggestionsError
 import app.pachli.core.model.Suggestion
 import app.pachli.core.network.retrofit.MastodonApi
@@ -59,12 +58,6 @@ class NetworkSuggestionsRepository @Inject constructor(
     override suspend fun deleteSuggestion(accountId: String): Result<Unit, DeleteSuggestionError> = binding {
         externalScope.async {
             api.deleteSuggestion(accountId).mapError { DeleteSuggestionError(it) }.bind()
-        }.await()
-    }
-
-    override suspend fun followAccount(accountId: String): Result<Unit, FollowAccountError> = binding {
-        externalScope.async {
-            api.followAccount(accountId).mapError { FollowAccountError(it) }.bind()
         }.await()
     }
 

--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/SuggestionsRepository.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/SuggestionsRepository.kt
@@ -19,7 +19,6 @@ package app.pachli.core.data.repository
 
 import app.pachli.core.common.PachliError
 import app.pachli.core.data.repository.SuggestionsError.DeleteSuggestionError
-import app.pachli.core.data.repository.SuggestionsError.FollowAccountError
 import app.pachli.core.data.repository.SuggestionsError.GetSuggestionsError
 import app.pachli.core.model.Suggestion
 import app.pachli.core.network.retrofit.apiresult.ApiError
@@ -57,12 +56,4 @@ interface SuggestionsRepository {
      * @return Unit, or an error
      */
     suspend fun deleteSuggestion(accountId: String): Result<Unit, DeleteSuggestionError>
-
-    /**
-     * Follow an account from a suggestion
-     *
-     * @param accountId ID of the account to follow
-     * @return Unit, or an error
-     */
-    suspend fun followAccount(accountId: String): Result<Unit, FollowAccountError>
 }

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -31,6 +31,8 @@ android {
 dependencies {
     implementation(projects.core.common)
     implementation(projects.core.data)
+    implementation(projects.core.eventhub)
+        ?.because("Some usecases send events")
     implementation(projects.core.model)
     implementation(projects.core.network)
         ?.because("Depends on UserListRepliesPolicy type")

--- a/core/domain/src/main/kotlin/app/pachli/core/domain/accounts/BlockAccountUseCase.kt
+++ b/core/domain/src/main/kotlin/app/pachli/core/domain/accounts/BlockAccountUseCase.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.core.domain.accounts
+
+import app.pachli.core.common.di.ApplicationScope
+import app.pachli.core.data.repository.AccountManager
+import app.pachli.core.eventhub.BlockEvent
+import app.pachli.core.eventhub.EventHub
+import app.pachli.core.model.Relationship
+import app.pachli.core.network.retrofit.MastodonApi
+import app.pachli.core.network.retrofit.UseCaseOnly
+import app.pachli.core.network.retrofit.apiresult.ApiError
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.map
+import com.github.michaelbull.result.onSuccess
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+
+/**
+ * Block [accountId].
+ *
+ * On success:
+ *
+ * - [BlockEvent] is dispatched.
+ */
+@Singleton
+class BlockAccountUseCase @Inject constructor(
+    @ApplicationScope private val externalScope: CoroutineScope,
+    private val mastodonApi: MastodonApi,
+    private val accountManager: AccountManager,
+    private val eventHub: EventHub,
+) {
+    /**
+     * @param pachliAccountId
+     * @param accountId ID of the account to block.
+     */
+    @OptIn(UseCaseOnly::class)
+    suspend operator fun invoke(pachliAccountId: Long, accountId: String): Result<Relationship, ApiError> = externalScope.async {
+        mastodonApi.blockAccount(accountId).map { it.body.asModel() }
+            .onSuccess {
+                accountManager.unfollowAccount(pachliAccountId, accountId)
+                eventHub.dispatch(BlockEvent(pachliAccountId, accountId))
+            }
+    }.await()
+}

--- a/core/domain/src/main/kotlin/app/pachli/core/domain/accounts/FollowAccountUseCase.kt
+++ b/core/domain/src/main/kotlin/app/pachli/core/domain/accounts/FollowAccountUseCase.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.core.domain.accounts
+
+import app.pachli.core.common.di.ApplicationScope
+import app.pachli.core.data.repository.AccountManager
+import app.pachli.core.model.Relationship
+import app.pachli.core.network.retrofit.MastodonApi
+import app.pachli.core.network.retrofit.UseCaseOnly
+import app.pachli.core.network.retrofit.apiresult.ApiError
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.map
+import com.github.michaelbull.result.onSuccess
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+
+/**
+ * Sends a follow request for [accountId] to the server for [pachliAccountId].
+ *
+ * On success:
+ *
+ * - The following relationship is added to [AccountManager].
+ */
+@Singleton
+class FollowAccountUseCase @Inject constructor(
+    @ApplicationScope private val externalScope: CoroutineScope,
+    private val mastodonApi: MastodonApi,
+    private val accountManager: AccountManager,
+) {
+    /**
+     * @param pachliAccountId
+     * @param accountId
+     * @param showReblogs True if the boosts of posts made by the account
+     * should be shown.
+     * @param notify True if the user should be notified when this account
+     * posts.
+     */
+    @OptIn(UseCaseOnly::class)
+    suspend operator fun invoke(pachliAccountId: Long, accountId: String, showReblogs: Boolean? = null, notify: Boolean? = null): Result<Relationship, ApiError> = externalScope.async {
+        mastodonApi.followAccount(accountId, showReblogs, notify).map { it.body.asModel() }
+            .onSuccess { accountManager.followAccount(pachliAccountId, accountId) }
+    }.await()
+}

--- a/core/domain/src/main/kotlin/app/pachli/core/domain/accounts/MuteAccountUseCase.kt
+++ b/core/domain/src/main/kotlin/app/pachli/core/domain/accounts/MuteAccountUseCase.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.core.domain.accounts
+
+import app.pachli.core.common.di.ApplicationScope
+import app.pachli.core.eventhub.EventHub
+import app.pachli.core.eventhub.MuteEvent
+import app.pachli.core.model.Relationship
+import app.pachli.core.network.retrofit.MastodonApi
+import app.pachli.core.network.retrofit.UseCaseOnly
+import app.pachli.core.network.retrofit.apiresult.ApiError
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.map
+import com.github.michaelbull.result.onSuccess
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+
+/**
+ * Mute [accountId].
+ *
+ * On success:
+ *
+ * - [MuteEvent] is dispatched.
+*/
+@Singleton
+class MuteAccountUseCase @Inject constructor(
+    @ApplicationScope private val externalScope: CoroutineScope,
+    private val mastodonApi: MastodonApi,
+    private val eventHub: EventHub,
+) {
+    /**
+     * @param pachliAccountId
+     * @param accountId ID of the account to mute.
+     */
+    @OptIn(UseCaseOnly::class)
+    suspend operator fun invoke(pachliAccountId: Long, accountId: String, notifications: Boolean? = null, duration: Int? = null): Result<Relationship, ApiError> = externalScope.async {
+        mastodonApi.muteAccount(accountId, notifications, duration).map { it.body.asModel() }
+            .onSuccess { eventHub.dispatch(MuteEvent(pachliAccountId, accountId)) }
+    }.await()
+}

--- a/core/domain/src/main/kotlin/app/pachli/core/domain/accounts/SubscribeAccountUseCase.kt
+++ b/core/domain/src/main/kotlin/app/pachli/core/domain/accounts/SubscribeAccountUseCase.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.core.domain.accounts
+
+import app.pachli.core.common.di.ApplicationScope
+import app.pachli.core.model.Relationship
+import app.pachli.core.network.retrofit.MastodonApi
+import app.pachli.core.network.retrofit.UseCaseOnly
+import app.pachli.core.network.retrofit.apiresult.ApiError
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.map
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+
+/**
+ * Subscribe to [accountId].
+ */
+@Singleton
+class SubscribeAccountUseCase @Inject constructor(
+    @ApplicationScope private val externalScope: CoroutineScope,
+    private val mastodonApi: MastodonApi,
+) {
+    /**
+     * @param pachliAccountId
+     * @param accountId ID of the account to subscribe to.
+     */
+    @OptIn(UseCaseOnly::class)
+    suspend operator fun invoke(pachliAccountId: Long, accountId: String, showReblogs: Boolean? = null, notify: Boolean? = null): Result<Relationship, ApiError> = externalScope.async {
+        mastodonApi.subscribeAccount(accountId).map { it.body.asModel() }
+    }.await()
+}

--- a/core/domain/src/main/kotlin/app/pachli/core/domain/accounts/UnblockAccountUseCase.kt
+++ b/core/domain/src/main/kotlin/app/pachli/core/domain/accounts/UnblockAccountUseCase.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.core.domain.accounts
+
+import app.pachli.core.common.di.ApplicationScope
+import app.pachli.core.model.Relationship
+import app.pachli.core.network.retrofit.MastodonApi
+import app.pachli.core.network.retrofit.UseCaseOnly
+import app.pachli.core.network.retrofit.apiresult.ApiError
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.map
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+
+/**
+ * Unblock [accountId].
+ */
+@Singleton
+class UnblockAccountUseCase @Inject constructor(
+    @ApplicationScope private val externalScope: CoroutineScope,
+    private val mastodonApi: MastodonApi,
+) {
+    /**
+     * @param pachliAccountId
+     * @param accountId ID of the account to unblock.
+     */
+    @OptIn(UseCaseOnly::class)
+    suspend operator fun invoke(pachliAccountId: Long, accountId: String): Result<Relationship, ApiError> = externalScope.async {
+        mastodonApi.unblockAccount(accountId).map { it.body.asModel() }
+    }.await()
+}

--- a/core/domain/src/main/kotlin/app/pachli/core/domain/accounts/UnfollowAccountUseCase.kt
+++ b/core/domain/src/main/kotlin/app/pachli/core/domain/accounts/UnfollowAccountUseCase.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.core.domain.accounts
+
+import app.pachli.core.common.di.ApplicationScope
+import app.pachli.core.data.repository.AccountManager
+import app.pachli.core.eventhub.EventHub
+import app.pachli.core.eventhub.UnfollowEvent
+import app.pachli.core.model.Relationship
+import app.pachli.core.network.retrofit.MastodonApi
+import app.pachli.core.network.retrofit.UseCaseOnly
+import app.pachli.core.network.retrofit.apiresult.ApiError
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.map
+import com.github.michaelbull.result.onSuccess
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+
+/**
+ * Unfollow [accountId].
+ *
+ * On success:
+ *
+ * - The following relationship is removed from [AccountManager].
+ * - [UnfollowEvent] is dispatched.
+ */
+@Singleton
+class UnfollowAccountUseCase @Inject constructor(
+    @ApplicationScope private val externalScope: CoroutineScope,
+    private val mastodonApi: MastodonApi,
+    private val accountManager: AccountManager,
+    private val eventHub: EventHub,
+) {
+    /**
+     * @param pachliAccountId
+     * @param accountId ID of the account to unfollow.
+     */
+    @OptIn(UseCaseOnly::class)
+    suspend operator fun invoke(pachliAccountId: Long, accountId: String): Result<Relationship, ApiError> = externalScope.async {
+        mastodonApi.unfollowAccount(accountId).map { it.body.asModel() }
+            .onSuccess {
+                accountManager.unfollowAccount(pachliAccountId, accountId)
+                eventHub.dispatch(UnfollowEvent(pachliAccountId, accountId))
+            }
+    }.await()
+}

--- a/core/domain/src/main/kotlin/app/pachli/core/domain/accounts/UnmuteAccountUseCase.kt
+++ b/core/domain/src/main/kotlin/app/pachli/core/domain/accounts/UnmuteAccountUseCase.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.core.domain.accounts
+
+import app.pachli.core.common.di.ApplicationScope
+import app.pachli.core.model.Relationship
+import app.pachli.core.network.retrofit.MastodonApi
+import app.pachli.core.network.retrofit.UseCaseOnly
+import app.pachli.core.network.retrofit.apiresult.ApiError
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.map
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+
+/**
+ * Unmute [accountId].
+*/
+@Singleton
+class UnmuteAccountUseCase @Inject constructor(
+    @ApplicationScope private val externalScope: CoroutineScope,
+    private val mastodonApi: MastodonApi,
+) {
+    /**
+     * @param pachliAccountId
+     * @param accountId ID of the account to unmute.
+     */
+    @OptIn(UseCaseOnly::class)
+    suspend operator fun invoke(pachliAccountId: Long, accountId: String, notifications: Boolean? = null, duration: Int? = null): Result<Relationship, ApiError> = externalScope.async {
+        mastodonApi.unmuteAccount(accountId).map { it.body.asModel() }
+    }.await()
+}

--- a/core/domain/src/main/kotlin/app/pachli/core/domain/accounts/UnsubscribeAccountUseCase.kt
+++ b/core/domain/src/main/kotlin/app/pachli/core/domain/accounts/UnsubscribeAccountUseCase.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.core.domain.accounts
+
+import app.pachli.core.common.di.ApplicationScope
+import app.pachli.core.model.Relationship
+import app.pachli.core.network.retrofit.MastodonApi
+import app.pachli.core.network.retrofit.UseCaseOnly
+import app.pachli.core.network.retrofit.apiresult.ApiError
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.map
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+
+/**
+ * Unsubscribe from [accountId].
+ */
+@Singleton
+class UnsubscribeAccountUseCase @Inject constructor(
+    @ApplicationScope private val externalScope: CoroutineScope,
+    private val mastodonApi: MastodonApi,
+) {
+    /**
+     * @param pachliAccountId
+     * @param accountId ID of the account to unsubscribe from.
+     */
+    @OptIn(UseCaseOnly::class)
+    suspend operator fun invoke(pachliAccountId: Long, accountId: String, showReblogs: Boolean? = null, notify: Boolean? = null): Result<Relationship, ApiError> = externalScope.async {
+        mastodonApi.unsubscribeAccount(accountId).map { it.body.asModel() }
+    }.await()
+}

--- a/core/network/src/main/kotlin/app/pachli/core/network/retrofit/MastodonApi.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/retrofit/MastodonApi.kt
@@ -77,9 +77,19 @@ import retrofit2.http.Path
 import retrofit2.http.Query
 
 /**
+ * Annotation that marks a network method as only callable through a
+ * UseCase class, as the UseCase is expected to contain additional
+ * business logic that must be applied whenever the network method
+ * is called.
+ */
+@RequiresOptIn(message = "This API should only be called through or by the appropriate UseCase class.")
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+annotation class UseCaseOnly
+
+/**
  * for documentation of the Mastodon REST API see https://docs.joinmastodon.org/api/
  */
-
 @JvmSuppressWildcards
 interface MastodonApi {
 
@@ -448,6 +458,7 @@ interface MastodonApi {
         @Query("limit") limit: Int = 80,
     ): ApiResult<List<TimelineAccount>>
 
+    @UseCaseOnly
     @FormUrlEncoded
     @POST("api/v1/accounts/{id}/follow")
     suspend fun followAccount(
@@ -456,21 +467,25 @@ interface MastodonApi {
         @Field("notify") notify: Boolean? = null,
     ): ApiResult<Relationship>
 
+    @UseCaseOnly
     @POST("api/v1/accounts/{id}/unfollow")
     suspend fun unfollowAccount(
         @Path("id") accountId: String,
     ): ApiResult<Relationship>
 
+    @UseCaseOnly
     @POST("api/v1/accounts/{id}/block")
     suspend fun blockAccount(
         @Path("id") accountId: String,
     ): ApiResult<Relationship>
 
+    @UseCaseOnly
     @POST("api/v1/accounts/{id}/unblock")
     suspend fun unblockAccount(
         @Path("id") accountId: String,
     ): ApiResult<Relationship>
 
+    @UseCaseOnly
     @FormUrlEncoded
     @POST("api/v1/accounts/{id}/mute")
     suspend fun muteAccount(
@@ -479,6 +494,7 @@ interface MastodonApi {
         @Field("duration") duration: Int? = null,
     ): ApiResult<Relationship>
 
+    @UseCaseOnly
     @POST("api/v1/accounts/{id}/unmute")
     suspend fun unmuteAccount(
         @Path("id") accountId: String,
@@ -489,11 +505,13 @@ interface MastodonApi {
         @Query("id[]") accountIds: List<String>,
     ): ApiResult<List<Relationship>>
 
+    @UseCaseOnly
     @POST("api/v1/pleroma/accounts/{id}/subscribe")
     suspend fun subscribeAccount(
         @Path("id") accountId: String,
     ): ApiResult<Relationship>
 
+    @UseCaseOnly
     @POST("api/v1/pleroma/accounts/{id}/unsubscribe")
     suspend fun unsubscribeAccount(
         @Path("id") accountId: String,

--- a/feature/suggestions/build.gradle.kts
+++ b/feature/suggestions/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     implementation(projects.core.common)
     implementation(projects.core.data)
     implementation(projects.core.designsystem)
+    implementation(projects.core.domain)
     implementation(projects.core.model)
     implementation(projects.core.navigation)
     implementation(projects.core.network)

--- a/feature/suggestions/src/main/kotlin/app/pachli/feature/suggestions/SuggestionAccessibilityDelegate.kt
+++ b/feature/suggestions/src/main/kotlin/app/pachli/feature/suggestions/SuggestionAccessibilityDelegate.kt
@@ -111,13 +111,13 @@ internal class SuggestionAccessibilityDelegate(
 
                 app.pachli.core.ui.R.id.action_dismiss_follow_suggestion -> {
                     interrupt()
-                    accept(UiAction.SuggestionAction.DeleteSuggestion(viewData.suggestion))
+                    accept(UiAction.SuggestionAction.DeleteSuggestion(viewData.pachliAccountId, viewData.suggestion))
                     true
                 }
 
                 app.pachli.core.ui.R.id.action_follow_account -> {
                     interrupt()
-                    accept(UiAction.SuggestionAction.AcceptSuggestion(viewData.suggestion))
+                    accept(UiAction.SuggestionAction.AcceptSuggestion(viewData.pachliAccountId, viewData.suggestion))
                     true
                 }
 

--- a/feature/suggestions/src/main/kotlin/app/pachli/feature/suggestions/SuggestionsAdapter.kt
+++ b/feature/suggestions/src/main/kotlin/app/pachli/feature/suggestions/SuggestionsAdapter.kt
@@ -187,8 +187,8 @@ internal class SuggestionViewHolder(
 
     init {
         with(binding) {
-            followAccount.setOnClickListener { accept(SuggestionAction.AcceptSuggestion(suggestion)) }
-            deleteSuggestion.setOnClickListener { accept(SuggestionAction.DeleteSuggestion(suggestion)) }
+            followAccount.setOnClickListener { accept(SuggestionAction.AcceptSuggestion(viewData.pachliAccountId, viewData.suggestion)) }
+            deleteSuggestion.setOnClickListener { accept(SuggestionAction.DeleteSuggestion(viewData.pachliAccountId, viewData.suggestion)) }
             accountNote.setOnClickListener { accept(NavigationAction.ViewAccount(suggestion.account.id)) }
             root.setOnClickListener { accept(NavigationAction.ViewAccount(suggestion.account.id)) }
 

--- a/feature/suggestions/src/main/kotlin/app/pachli/feature/suggestions/SuggestionsFragment.kt
+++ b/feature/suggestions/src/main/kotlin/app/pachli/feature/suggestions/SuggestionsFragment.kt
@@ -71,7 +71,6 @@ import com.google.android.material.divider.MaterialDividerItemDecoration
 import com.google.android.material.snackbar.Snackbar
 import com.mikepenz.iconics.typeface.library.googlematerial.GoogleMaterial
 import dagger.hilt.android.AndroidEntryPoint
-import kotlin.properties.Delegates
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -106,16 +105,11 @@ class SuggestionsFragment :
     /** The active snackbar */
     private var snackbar: Snackbar? = null
 
-    private var pachliAccountId by Delegates.notNull<Long>()
+    private val pachliAccountId by unsafeLazy { requireArguments().getLong(ARG_PACHLI_ACCOUNT_ID) }
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
         (context as? ViewUrlActivity) ?: throw IllegalStateException("Fragment must be attached to a BottomSheetActivity")
-    }
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        pachliAccountId = requireArguments().getLong(ARG_PACHLI_ACCOUNT_ID)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -157,6 +151,8 @@ class SuggestionsFragment :
         }
 
         bind()
+
+        viewModel.accept(GetSuggestions(pachliAccountId))
     }
 
     /** Binds data to the UI */
@@ -228,7 +224,7 @@ class SuggestionsFragment :
             binding.messageView.show()
             binding.recyclerView.hide()
 
-            binding.messageView.setup(it) { viewModel.accept(GetSuggestions) }
+            binding.messageView.setup(it) { viewModel.accept(GetSuggestions(pachliAccountId)) }
         }
 
         result.onSuccess {
@@ -289,7 +285,7 @@ class SuggestionsFragment :
 
     override fun onRefresh() {
         snackbar?.dismiss()
-        viewModel.accept(GetSuggestions)
+        viewModel.accept(GetSuggestions(pachliAccountId))
     }
 
     override fun onReselect() {

--- a/feature/suggestions/src/main/kotlin/app/pachli/feature/suggestions/SuggestionsViewModel.kt
+++ b/feature/suggestions/src/main/kotlin/app/pachli/feature/suggestions/SuggestionsViewModel.kt
@@ -19,7 +19,6 @@ package app.pachli.feature.suggestions
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import app.pachli.core.common.extensions.mapIfInstance
 import app.pachli.core.common.extensions.stateFlow
 import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.data.repository.Loadable
@@ -27,6 +26,9 @@ import app.pachli.core.data.repository.StatusDisplayOptionsRepository
 import app.pachli.core.data.repository.SuggestionsError.DeleteSuggestionError
 import app.pachli.core.data.repository.SuggestionsError.FollowAccountError
 import app.pachli.core.data.repository.SuggestionsRepository
+import app.pachli.core.data.repository.mapLoaded
+import app.pachli.core.domain.accounts.FollowAccountUseCase
+import app.pachli.core.model.Relationship
 import app.pachli.core.model.Suggestion
 import app.pachli.core.preferences.LinksToUnderline
 import app.pachli.core.preferences.PronounDisplay
@@ -37,7 +39,10 @@ import app.pachli.feature.suggestions.UiAction.SuggestionAction.AcceptSuggestion
 import app.pachli.feature.suggestions.UiAction.SuggestionAction.DeleteSuggestion
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.map
 import com.github.michaelbull.result.mapEither
+import com.github.michaelbull.result.mapError
+import com.github.michaelbull.result.onSuccess
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.channels.Channel
@@ -80,11 +85,17 @@ internal data class UiState(
     }
 }
 
-/** Data to show a [Suggestion]. */
+/**
+ * Data to show a [Suggestion].
+ *
+ * @property pachliAccountId
+ * @property isEnabled If false the user should not be able to interact
+ * with the suggestion.
+ * @property suggestion The [Suggestion].
+ */
 internal data class SuggestionViewData(
-    /** If false the user should not be able to interact with the suggestion. */
+    val pachliAccountId: Long,
     val isEnabled: Boolean = true,
-    /** The suggestion. */
     val suggestion: Suggestion,
 )
 
@@ -122,6 +133,7 @@ internal interface ISuggestionsViewModel {
 internal class SuggestionsViewModel @Inject constructor(
     private val suggestionsRepository: SuggestionsRepository,
     statusDisplayOptionsRepository: StatusDisplayOptionsRepository,
+    private val followAccountUseCase: FollowAccountUseCase,
 ) : ViewModel(),
     ISuggestionsViewModel {
     private val uiAction = MutableSharedFlow<UiAction>()
@@ -133,20 +145,33 @@ internal class SuggestionsViewModel @Inject constructor(
     private val operationCounter = OperationCounter()
     override val operationCount = operationCounter.count
 
-    private val reload = MutableSharedFlow<Unit>(replay = 1)
+    private val pachliAccountId = MutableSharedFlow<Long>(replay = 1)
 
-    private var disabledSuggestions = MutableStateFlow<Set<String>>(setOf()) // mutableSetOf<String>()
+    /**
+     * Account IDs of suggestions that should be disabled in the UI.
+     * E.g., because there is an active operation involving the account.
+     */
+    private var disabledSuggestions = MutableStateFlow<Set<String>>(setOf())
 
-    private var _suggestions = MutableStateFlow<Result<Suggestions, GetSuggestionsError>>(Ok(Loadable.Loading))
+    /** Cache of suggestions fetched from the network. */
+    // Modified depending on the user's actions (e.g., rejecting or accepting)
+    // a suggestion, as refreshing on each network operation could return a
+    // completely different list of suggestions, losing the user's place in
+    // the list.
+    private var _suggestions = MutableStateFlow<Result<Loadable<List<Suggestion>>, GetSuggestionsError>>(Ok(Loadable.Loading))
+
     override val suggestions = stateFlow(viewModelScope, Ok(Loadable.Loading)) {
-        disabledSuggestions.combine(_suggestions) { disabled, suggestions ->
-            // Mark any disabled suggestions.
-            suggestions.mapIfInstance<_, _, Loadable.Loaded<List<SuggestionViewData>>> {
-                it.copy(
-                    data = it.data.map {
-                        it.copy(isEnabled = !disabled.contains(it.suggestion.account.id))
-                    },
-                )
+        combine(pachliAccountId, _suggestions, disabledSuggestions) { pachliAccountId, suggestionsResult, disabled ->
+            suggestionsResult.map {
+                it.mapLoaded { suggestions ->
+                    suggestions.map {
+                        SuggestionViewData(
+                            pachliAccountId = pachliAccountId,
+                            suggestion = it,
+                            isEnabled = !disabled.contains(it.account.id),
+                        )
+                    }
+                }
             }
         }.flowWhileShared(SharingStarted.WhileSubscribed(5000))
     }
@@ -164,15 +189,21 @@ internal class SuggestionsViewModel @Inject constructor(
         }
 
         viewModelScope.launch {
-            reload.collect {
-                _suggestions.emit(Ok(Loadable.Loading))
-                _suggestions.emit(getSuggestions())
+            uiAction.filterIsInstance<GetSuggestions>().collect {
+                pachliAccountId.emit(it.pachliAccountId)
             }
         }
 
         viewModelScope.launch {
-            reload.emit(Unit)
-            uiAction.filterIsInstance<GetSuggestions>().collect { reload.emit(Unit) }
+            pachliAccountId.collect {
+                operationCounter {
+                    _suggestions.value = Ok(Loadable.Loading)
+                    _suggestions.value = suggestionsRepository.getSuggestions().mapEither(
+                        { Loadable.Loaded(it) },
+                        { GetSuggestionsError(it) },
+                    )
+                }
+            }
         }
     }
 
@@ -189,22 +220,21 @@ internal class SuggestionsViewModel @Inject constructor(
 
         // Process the suggestion, and handle the success/failure
         val result = when (suggestionAction) {
-            is DeleteSuggestion -> deleteSuggestion(suggestionAction.suggestion)
-            is AcceptSuggestion -> acceptSuggestion(suggestionAction.suggestion)
-        }.mapEither(
-            {
-                // Remove this suggestion from the list.
-                _suggestions.update { suggestions ->
-                    suggestions.mapIfInstance<_, _, Loadable.Loaded<List<SuggestionViewData>>> {
-                        it.copy(
-                            data = it.data.filterNot {
-                                it.suggestion.account.id == suggestionAction.suggestion.account.id
-                            },
-                        )
+            is DeleteSuggestion -> deleteSuggestion(suggestionAction)
+            is AcceptSuggestion -> acceptSuggestion(suggestionAction)
+        }.onSuccess {
+            // Remove this suggestion from _suggestions, updates the UI.
+            _suggestions.update { suggestions ->
+                suggestions.map { loadable ->
+                    loadable.mapLoaded { suggestions ->
+                        suggestions.filterNot { suggestion ->
+                            suggestion.account.id == suggestionAction.suggestion.account.id
+                        }
                     }
                 }
-                UiSuccess.from(suggestionAction)
-            },
+            }
+        }.mapEither(
+            { UiSuccess.from(suggestionAction) },
             { UiError.make(it, suggestionAction) },
         )
 
@@ -213,26 +243,19 @@ internal class SuggestionsViewModel @Inject constructor(
         _uiResult.send(result)
     }
 
-    /** Get fresh suggestions from the repository. */
-    private suspend fun getSuggestions(): Result<Loadable.Loaded<List<SuggestionViewData>>, GetSuggestionsError> = operationCounter {
-        // Note: disabledSuggestions is *not* cleared here. Suppose the user has
-        // dismissed a suggestion and the network operation has not completed yet.
-        // They reload, and get a list of suggestions that includes the suggestion
-        // they have just dismissed. In that case the suggestion should still be
-        // disabled.
-        suggestionsRepository.getSuggestions().mapEither(
-            { Loadable.Loaded(it.map { SuggestionViewData(suggestion = it) }) },
-            { GetSuggestionsError(it) },
-        )
-    }
-
     /** Delete a suggestion from the repository. */
-    private suspend fun deleteSuggestion(suggestion: Suggestion): Result<Unit, DeleteSuggestionError> = operationCounter {
-        suggestionsRepository.deleteSuggestion(suggestion.account.id)
+    private suspend fun deleteSuggestion(action: DeleteSuggestion): Result<Unit, DeleteSuggestionError> = operationCounter {
+        suggestionsRepository.deleteSuggestion(action.suggestion.account.id)
     }
 
-    /** Accept the suggestion and follow the account. */
-    private suspend fun acceptSuggestion(suggestion: Suggestion): Result<Unit, FollowAccountError> = operationCounter {
-        suggestionsRepository.followAccount(suggestion.account.id)
+    /**
+     * Follow an account from a suggestion
+     *
+     * @param action [AcceptSuggestion] containing the account to follow.
+     * @return Result with the new relationship, or an error.
+     */
+    private suspend fun acceptSuggestion(action: AcceptSuggestion): Result<Relationship, FollowAccountError> = operationCounter {
+        followAccountUseCase(action.pachliAccountId, action.suggestion.account.id)
+            .mapError { FollowAccountError(it) }
     }
 }

--- a/feature/suggestions/src/main/kotlin/app/pachli/feature/suggestions/UiAction.kt
+++ b/feature/suggestions/src/main/kotlin/app/pachli/feature/suggestions/UiAction.kt
@@ -28,7 +28,7 @@ import app.pachli.feature.suggestions.UiAction.SuggestionAction
 /** Actions the user can take from the UI. */
 internal sealed interface UiAction {
     /** Get fresh suggestions. */
-    data object GetSuggestions : UiAction
+    data class GetSuggestions(val pachliAccountId: Long) : UiAction
 
     /** Actions that navigate the user to another part of the app. */
     sealed interface NavigationAction : UiAction {
@@ -39,13 +39,20 @@ internal sealed interface UiAction {
 
     /** Actions that operate on a suggestion. */
     sealed interface SuggestionAction : UiAction {
+        val pachliAccountId: Long
         val suggestion: Suggestion
 
         /** Delete the suggestion. */
-        data class DeleteSuggestion(override val suggestion: Suggestion) : SuggestionAction
+        data class DeleteSuggestion(
+            override val pachliAccountId: Long,
+            override val suggestion: Suggestion,
+        ) : SuggestionAction
 
         /** Accept the suggestion and follow the user. */
-        data class AcceptSuggestion(override val suggestion: Suggestion) : SuggestionAction
+        data class AcceptSuggestion(
+            override val pachliAccountId: Long,
+            override val suggestion: Suggestion,
+        ) : SuggestionAction
     }
 }
 


### PR DESCRIPTION
With the previous code, if you followed an account from the "Suggested Accounts" screen the local cache of followed accounts wasn't updated. This meant the features that use that cache, like the anti-harassment controls, weren't updated until Pachli was restarted.

Fix this by always using the "use case" classes to perform account operations (follow, block, mute, etc).

To do this:

- Move the existing functions in TimelineCases to new `...UseCase` classes in `core.domain.accounts`.
- Mark all the used network methods in MastodonApi as `@OptIn`, to get a warning if anything tries to use those classes. Opt the new `...UseCase` classes in.
- Update callers to use the new `...UseCase` classes.
- Remove "follow account" functionality from `SuggestionsRepository`.
- The `...UseCase` classes need the `pachliAccountId` to operate, modify `SuggestionsViewModel` to receive and store this from `SuggestionsFragment` so it can be included in the operations.