### PR TITLE
fix: Show the server's emojis when composing posts

### DIFF
--- a/app/src/main/java/app/pachli/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeActivity.kt
@@ -746,7 +746,7 @@ class ComposeActivity :
         }
 
         lifecycleScope.launch {
-            viewModel.emojis.collect(::bindEmojiList)
+            viewModel.serverEmojis.collect(::bindEmojiList)
         }
 
         lifecycleScope.launch {
@@ -1148,7 +1148,7 @@ class ComposeActivity :
     private fun enableButtons(enable: Boolean, editing: Boolean) {
         binding.composeAddAttachmentButton.isClickable = enable
         binding.composeChangeVisibilityButton.isClickable = enable && !editing
-        binding.composeEmojiButton.isClickable = enable && viewModel.emojis.value.isNotEmpty()
+        binding.composeEmojiButton.isClickable = enable && viewModel.serverEmojis.value.isNotEmpty()
         binding.composeMarkSensitiveButton.isClickable = enable
         binding.composeScheduleButton.isClickable = enable && !editing
         binding.composeTootButton.isEnabled = enable

--- a/app/src/main/java/app/pachli/components/compose/ComposeViewModel.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeViewModel.kt
@@ -257,7 +257,8 @@ class ComposeViewModel @AssistedInject constructor(
     val serverLimits = accountFlow.map { it.server.limits }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), ServerLimits())
 
-    val emojis = accountFlow.map { it.emojis }
+    /** Emojis on the server the user can use in their status. */
+    val serverEmojis = accountFlow.map { it.server.emojis }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     private val _markMediaAsSensitive: MutableStateFlow<Boolean?> = MutableStateFlow(composeOptions.draft.sensitive)
@@ -825,7 +826,7 @@ class ComposeViewModel @AssistedInject constructor(
             ':' -> {
                 val incomplete = token.substring(1)
 
-                return emojis.value.filter { emoji ->
+                return serverEmojis.value.filter { emoji ->
                     emoji.shortcode.contains(incomplete, ignoreCase = true)
                 }.sortedBy { emoji ->
                     emoji.shortcode.indexOf(incomplete, ignoreCase = true)

--- a/core/model/src/main/kotlin/app/pachli/core/model/PachliAccount.kt
+++ b/core/model/src/main/kotlin/app/pachli/core/model/PachliAccount.kt
@@ -58,7 +58,7 @@ package app.pachli.core.model
  * is true. This implies that media previews are shown as well as downloaded.
  * @property notificationMarkerId ID of the most recent Mastodon notification
  * that Pachli has fetched to show as an Android notification
- * @property emojis Emojis available for the account to use.
+ * @property emojis Custom emojis used in the account's profile.
  * @property tabPreferences
  * @property notificationsFilter
  * @property oauthScopes


### PR DESCRIPTION
Previous code was using the account's emojis, which are not the same. Clarify with additional comments and a variable rename.