### PR TITLE
refactor: Flatten adapter change payloads (List<Any?>) properly

### DIFF
--- a/app/src/main/java/app/pachli/adapter/FilterableStatusViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/FilterableStatusViewHolder.kt
@@ -41,7 +41,7 @@ open class FilterableStatusViewHolder<T : IStatusViewData>(
         viewData: T,
         listener: StatusActionListener,
         statusDisplayOptions: StatusDisplayOptions,
-        payloads: List<List<Any?>>?,
+        payloads: List<Any?>,
     ) {
         super.setupWithStatus(viewData, listener, statusDisplayOptions, payloads)
         setupFilterPlaceholder(viewData, listener)

--- a/app/src/main/java/app/pachli/adapter/FollowRequestViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/FollowRequestViewHolder.kt
@@ -53,12 +53,12 @@ class FollowRequestViewHolder(
 
     override fun bind(
         viewData: FollowRequestNotificationViewData,
-        payloads: List<List<Any?>>?,
+        payloads: List<Any?>,
         statusDisplayOptions: StatusDisplayOptions,
     ) {
         // Skip updates with payloads. That indicates a timestamp update, and
         // this view does not have timestamps.
-        if (!payloads.isNullOrEmpty()) return
+        if (payloads.isNotEmpty()) return
 
         setupWithAccount(
             viewData.account,

--- a/app/src/main/java/app/pachli/adapter/ReportNotificationViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/ReportNotificationViewHolder.kt
@@ -47,12 +47,12 @@ class ReportNotificationViewHolder(
 
     override fun bind(
         viewData: ReportNotificationViewData,
-        payloads: List<List<Any?>>?,
+        payloads: List<Any?>,
         statusDisplayOptions: StatusDisplayOptions,
     ) {
         // Skip updates with payloads. That indicates a timestamp update, and
         // this view does not have timestamps.
-        if (!payloads.isNullOrEmpty()) return
+        if (payloads.isNotEmpty()) return
 
         setupWithReport(
             viewData.account,

--- a/app/src/main/java/app/pachli/adapter/StatusBaseViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/StatusBaseViewHolder.kt
@@ -23,6 +23,7 @@ import android.widget.TextView
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import app.pachli.R
+import app.pachli.core.common.extensions.flatten
 import app.pachli.core.data.model.IStatusViewData
 import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.data.model.StatusItemViewData
@@ -52,9 +53,9 @@ abstract class StatusBaseViewHolder<T : IStatusViewData> protected constructor(
         viewData: T,
         listener: StatusActionListener,
         statusDisplayOptions: StatusDisplayOptions,
-        payloads: List<List<Any?>>?,
+        payloads: List<Any?>,
     ) {
-        if (payloads.isNullOrEmpty()) {
+        if (payloads.isEmpty()) {
             val actionable = viewData.actionable
 
             // Set the status

--- a/app/src/main/java/app/pachli/adapter/StatusDetailedViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/StatusDetailedViewHolder.kt
@@ -34,7 +34,7 @@ class StatusDetailedViewHolder(
         viewData: StatusItemViewData,
         listener: StatusActionListener,
         statusDisplayOptions: StatusDisplayOptions,
-        payloads: List<List<Any?>>?,
+        payloads: List<Any?>,
     ) {
         // Hide statistics on the controls in detailed view, statistics are (optionally) shown
         // elsewhere in the UI.

--- a/app/src/main/java/app/pachli/adapter/StatusViewHolder.kt
+++ b/app/src/main/java/app/pachli/adapter/StatusViewHolder.kt
@@ -75,9 +75,9 @@ open class StatusViewHolder<T : IStatusViewData>(
         viewData: T,
         listener: StatusActionListener,
         statusDisplayOptions: StatusDisplayOptions,
-        payloads: List<List<Any?>>?,
+        payloads: List<Any?>,
     ) {
-        if (payloads.isNullOrEmpty()) {
+        if (payloads.isEmpty()) {
             setStatusInfo(binding.statusInfo, viewData, statusDisplayOptions, listener)
         }
         super.setupWithStatus(viewData, listener, statusDisplayOptions, payloads)

--- a/app/src/main/java/app/pachli/components/compose/MediaPreviewAdapter.kt
+++ b/app/src/main/java/app/pachli/components/compose/MediaPreviewAdapter.kt
@@ -40,6 +40,7 @@ import app.pachli.components.compose.MediaPreviewAdapter.MediaAction.EDIT_IMAGE
 import app.pachli.components.compose.MediaPreviewAdapter.MediaAction.MOVE_DOWN
 import app.pachli.components.compose.MediaPreviewAdapter.MediaAction.MOVE_UP
 import app.pachli.components.compose.MediaPreviewAdapter.MediaAction.REMOVE
+import app.pachli.core.common.extensions.flatten
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
 import app.pachli.core.common.extensions.visible
@@ -348,15 +349,15 @@ class AttachmentViewHolder(
         )
     }
 
-    fun bind(item: QueuedMedia, payloads: List<Any?>? = null) {
+    fun bind(item: QueuedMedia, payloads: List<Any?> = emptyList()) {
         this.item = item
 
-        if (payloads.isNullOrEmpty()) {
+        if (payloads.isEmpty()) {
             bindAll(item)
             return
         }
 
-        payloads.forEach { payload ->
+        payloads.flatten().forEach { payload ->
             when (payload) {
                 Payload.URI -> bindUri(item)
                 Payload.DESCRIPTION -> {

--- a/app/src/main/java/app/pachli/components/conversation/ConversationAdapter.kt
+++ b/app/src/main/java/app/pachli/components/conversation/ConversationAdapter.kt
@@ -49,7 +49,7 @@ internal class ConversationAdapter(
         /** Bind the data from the notification and payloads to the view. */
         fun bind(
             viewData: ConversationViewData,
-            payloads: List<List<Any?>>?,
+            payloads: List<Any?>,
             statusDisplayOptions: StatusDisplayOptions,
         )
     }
@@ -112,7 +112,7 @@ internal class ConversationAdapter(
         payloads: List<Any?>,
     ) {
         getItem(position)?.let { conversationViewData ->
-            (holder as ViewHolder).bind(conversationViewData, payloads as? List<List<Any?>>, statusDisplayOptions)
+            (holder as ViewHolder).bind(conversationViewData, payloads, statusDisplayOptions)
         }
     }
 
@@ -166,8 +166,8 @@ class FilterableConversationStatusViewHolder internal constructor(
     setContent: SetContent,
     private val listener: StatusActionListener,
 ) : ConversationAdapter.ViewHolder, FilterableStatusViewHolder<ConversationViewData>(binding, glide, setContent) {
-    override fun bind(viewData: ConversationViewData, payloads: List<List<Any?>>?, statusDisplayOptions: StatusDisplayOptions) {
-        if (payloads.isNullOrEmpty()) {
+    override fun bind(viewData: ConversationViewData, payloads: List<Any?>, statusDisplayOptions: StatusDisplayOptions) {
+        if (payloads.isEmpty()) {
             showStatusContent(true)
         }
         setupWithStatus(
@@ -222,7 +222,7 @@ class FilterableConversationViewHolder internal constructor(
         }
     }
 
-    override fun bind(viewData: ConversationViewData, payloads: List<List<Any?>>?, statusDisplayOptions: StatusDisplayOptions) {
+    override fun bind(viewData: ConversationViewData, payloads: List<Any?>, statusDisplayOptions: StatusDisplayOptions) {
         this.viewData = viewData
         binding.accountFilterDomain.text = HtmlCompat.fromHtml(
             context.getString(

--- a/app/src/main/java/app/pachli/components/conversation/ConversationViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/conversation/ConversationViewHolder.kt
@@ -20,6 +20,7 @@ package app.pachli.components.conversation
 import app.pachli.R
 import app.pachli.adapter.StatusBaseViewHolder
 import app.pachli.adapter.StatusViewDataDiffCallback
+import app.pachli.core.common.extensions.flatten
 import app.pachli.core.data.model.ConversationViewData
 import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.model.ConversationAccount
@@ -35,8 +36,8 @@ class ConversationViewHolder internal constructor(
     private val listener: StatusActionListener,
 ) : ConversationAdapter.ViewHolder, StatusBaseViewHolder<ConversationViewData>(binding.root, glide, setContent) {
 
-    override fun bind(viewData: ConversationViewData, payloads: List<List<Any?>>?, statusDisplayOptions: StatusDisplayOptions) {
-        if (payloads.isNullOrEmpty()) {
+    override fun bind(viewData: ConversationViewData, payloads: List<Any?>, statusDisplayOptions: StatusDisplayOptions) {
+        if (payloads.isEmpty()) {
             val actionable = viewData.actionable
 
             binding.statusView.setupWithStatus(setContent, glide, viewData, listener, statusDisplayOptions)

--- a/app/src/main/java/app/pachli/components/notifications/FilterableNotificationViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/notifications/FilterableNotificationViewHolder.kt
@@ -74,7 +74,7 @@ class FilterableNotificationViewHolder(
         }
     }
 
-    override fun bind(viewData: NotificationViewData, payloads: List<List<Any?>>?, statusDisplayOptions: StatusDisplayOptions) {
+    override fun bind(viewData: NotificationViewData, payloads: List<Any?>, statusDisplayOptions: StatusDisplayOptions) {
         this.viewData = viewData
 
         val icon = viewData.icon(context)

--- a/app/src/main/java/app/pachli/components/notifications/FilterableStatusNotificationViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/notifications/FilterableStatusNotificationViewHolder.kt
@@ -34,10 +34,10 @@ class FilterableStatusNotificationViewHolder(
     // Note: Identical to bind() in StatusViewHolder above
     override fun bind(
         viewData: WithStatus,
-        payloads: List<List<Any?>>?,
+        payloads: List<Any?>,
         statusDisplayOptions: StatusDisplayOptions,
     ) {
-        if (payloads.isNullOrEmpty()) {
+        if (payloads.isEmpty()) {
             showStatusContent(true)
         }
         setupWithStatus(

--- a/app/src/main/java/app/pachli/components/notifications/FollowViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/notifications/FollowViewHolder.kt
@@ -50,12 +50,12 @@ class FollowViewHolder(
 
     override fun bind(
         viewData: NotificationViewData,
-        payloads: List<List<Any?>>?,
+        payloads: List<Any?>,
         statusDisplayOptions: StatusDisplayOptions,
     ) {
         // Skip updates with payloads. That indicates a timestamp update, and
         // this view does not have timestamps.
-        if (!payloads.isNullOrEmpty()) return
+        if (payloads.isNotEmpty()) return
 
         setMessage(
             viewData.account,

--- a/app/src/main/java/app/pachli/components/notifications/ModerationWarningViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/notifications/ModerationWarningViewHolder.kt
@@ -40,7 +40,7 @@ class ModerationWarningViewHolder(
         }
     }
 
-    override fun bind(viewData: ModerationWarningNotificationViewData, payloads: List<List<Any?>>?, statusDisplayOptions: StatusDisplayOptions) {
+    override fun bind(viewData: ModerationWarningNotificationViewData, payloads: List<Any?>, statusDisplayOptions: StatusDisplayOptions) {
         this.viewData = viewData
         val context = itemView.context
         val warning = viewData.accountWarning

--- a/app/src/main/java/app/pachli/components/notifications/NotificationsPagingAdapter.kt
+++ b/app/src/main/java/app/pachli/components/notifications/NotificationsPagingAdapter.kt
@@ -163,7 +163,7 @@ class NotificationsPagingAdapter(
         /** Bind the data from the notification and payloads to the view. */
         fun bind(
             viewData: T,
-            payloads: List<List<Any?>>?,
+            payloads: List<Any?>,
             statusDisplayOptions: StatusDisplayOptions,
         )
     }
@@ -265,7 +265,7 @@ class NotificationsPagingAdapter(
     }
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
-        bindViewHolder(holder, position, null)
+        bindViewHolder(holder, position, emptyList())
     }
 
     override fun onBindViewHolder(
@@ -273,10 +273,10 @@ class NotificationsPagingAdapter(
         position: Int,
         payloads: List<Any?>,
     ) {
-        bindViewHolder(holder, position, payloads as? List<List<Any?>>?)
+        bindViewHolder(holder, position, payloads)
     }
 
-    private fun bindViewHolder(holder: RecyclerView.ViewHolder, position: Int, payloads: List<List<Any?>>?) {
+    private fun bindViewHolder(holder: RecyclerView.ViewHolder, position: Int, payloads: List<Any?>) {
         getItem(position)?.let {
             (holder as ViewHolder<NotificationViewData>).bind(it, payloads, statusDisplayOptions)
         }
@@ -291,7 +291,7 @@ class NotificationsPagingAdapter(
     ) : ViewHolder<UnknownNotificationViewData>, RecyclerView.ViewHolder(binding.root) {
         override fun bind(
             viewData: UnknownNotificationViewData,
-            payloads: List<List<Any?>>?,
+            payloads: List<Any?>,
             statusDisplayOptions: StatusDisplayOptions,
         ) {
             binding.text1.text = binding.root.context.getString(R.string.notification_unknown)

--- a/app/src/main/java/app/pachli/components/notifications/SeveredRelationshipsViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/notifications/SeveredRelationshipsViewHolder.kt
@@ -21,6 +21,7 @@ import androidx.core.text.HtmlCompat
 import androidx.recyclerview.widget.RecyclerView
 import app.pachli.R
 import app.pachli.adapter.StatusViewDataDiffCallback
+import app.pachli.core.common.extensions.flatten
 import app.pachli.core.data.model.NotificationViewData.SeveredRelationshipsNotificationViewData
 import app.pachli.core.data.model.StatusDisplayOptions
 import app.pachli.core.model.RelationshipSeveranceEvent.Type.ACCOUNT_SUSPENSION
@@ -35,13 +36,13 @@ class SeveredRelationshipsViewHolder(
 ) : NotificationsPagingAdapter.ViewHolder<SeveredRelationshipsNotificationViewData>, RecyclerView.ViewHolder(binding.root) {
     override fun bind(
         viewData: SeveredRelationshipsNotificationViewData,
-        payloads: List<List<Any?>>?,
+        payloads: List<Any?>,
         statusDisplayOptions: StatusDisplayOptions,
     ) {
         val context = itemView.context
         val event = viewData.relationshipSeveranceEvent
 
-        if (payloads.isNullOrEmpty()) {
+        if (payloads.isEmpty()) {
             val topTextHtml = when (event.type) {
                 DOMAIN_BLOCK -> context.getString(
                     R.string.notification_severed_relationships_domain_block_fmt,

--- a/app/src/main/java/app/pachli/components/notifications/StatusNotificationViewHolder.kt
+++ b/app/src/main/java/app/pachli/components/notifications/StatusNotificationViewHolder.kt
@@ -23,6 +23,7 @@ import androidx.core.text.htmlEncode
 import app.pachli.R
 import app.pachli.adapter.StatusViewDataDiffCallback
 import app.pachli.adapter.StatusViewHolder
+import app.pachli.core.common.extensions.flatten
 import app.pachli.core.common.string.unicodeWrap
 import app.pachli.core.data.model.NotificationViewData.WithStatus
 import app.pachli.core.data.model.NotificationViewData.WithStatus.FavouriteNotificationViewData
@@ -57,10 +58,10 @@ internal class StatusNotificationViewHolder(
 ) : NotificationsPagingAdapter.ViewHolder<WithStatus>, StatusViewHolder<WithStatus>(binding, glide, setContent) {
     override fun bind(
         viewData: WithStatus,
-        payloads: List<List<Any?>>?,
+        payloads: List<Any?>,
         statusDisplayOptions: StatusDisplayOptions,
     ) {
-        if (payloads.isNullOrEmpty()) {
+        if (payloads.isEmpty()) {
             binding.statusInfo.setOnClickListener {
                 notificationActionListener.onViewAccount(viewData.account.id)
             }

--- a/app/src/main/java/app/pachli/components/search/adapter/SearchStatusesAdapter.kt
+++ b/app/src/main/java/app/pachli/components/search/adapter/SearchStatusesAdapter.kt
@@ -46,13 +46,13 @@ class SearchStatusesAdapter(
 
     override fun onBindViewHolder(holder: StatusViewHolder<StatusItemViewData>, position: Int) {
         getItem(position)?.let { item ->
-            holder.setupWithStatus(item, statusListener, statusDisplayOptions, null)
+            holder.setupWithStatus(item, statusListener, statusDisplayOptions, emptyList())
         }
     }
 
     override fun onBindViewHolder(holder: StatusViewHolder<StatusItemViewData>, position: Int, payloads: List<Any?>) {
         getItem(position)?.let { item ->
-            holder.setupWithStatus(item, statusListener, statusDisplayOptions, payloads as? List<List<Any?>>?)
+            holder.setupWithStatus(item, statusListener, statusDisplayOptions, payloads)
         }
     }
 

--- a/app/src/main/java/app/pachli/components/timeline/TimelinePagingAdapter.kt
+++ b/app/src/main/java/app/pachli/components/timeline/TimelinePagingAdapter.kt
@@ -61,14 +61,14 @@ class TimelinePagingAdapter(
     }
 
     override fun onBindViewHolder(viewHolder: RecyclerView.ViewHolder, position: Int) {
-        bindViewHolder(viewHolder, position, null)
+        bindViewHolder(viewHolder, position, emptyList())
     }
 
     override fun onBindViewHolder(viewHolder: RecyclerView.ViewHolder, position: Int, payloads: List<Any?>) {
-        bindViewHolder(viewHolder, position, payloads as? List<List<Any?>>)
+        bindViewHolder(viewHolder, position, payloads)
     }
 
-    private fun bindViewHolder(viewHolder: RecyclerView.ViewHolder, position: Int, payloads: List<List<Any?>>?) {
+    private fun bindViewHolder(viewHolder: RecyclerView.ViewHolder, position: Int, payloads: List<Any?>) {
         try {
             getItem(position)
         } catch (_: IndexOutOfBoundsException) {

--- a/app/src/main/java/app/pachli/components/viewthread/ThreadAdapter.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/ThreadAdapter.kt
@@ -71,12 +71,12 @@ class ThreadAdapter(
 
     override fun onBindViewHolder(viewHolder: StatusBaseViewHolder<StatusItemViewData>, position: Int) {
         val status = getItem(position)
-        viewHolder.setupWithStatus(status, statusActionListener, statusDisplayOptions, null)
+        viewHolder.setupWithStatus(status, statusActionListener, statusDisplayOptions, emptyList())
     }
 
     override fun onBindViewHolder(holder: StatusBaseViewHolder<StatusItemViewData>, position: Int, payloads: List<Any?>) {
         val status = getItem(position)
-        holder.setupWithStatus(status, statusActionListener, statusDisplayOptions, payloads as? List<List<Any?>>)
+        holder.setupWithStatus(status, statusActionListener, statusDisplayOptions, payloads)
     }
 
     override fun getItemViewType(position: Int): Int {

--- a/core/common/src/main/kotlin/app/pachli/core/common/extensions/ListExtensions.kt
+++ b/core/common/src/main/kotlin/app/pachli/core/common/extensions/ListExtensions.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.core.common.extensions
+
+/**
+ * Returns a single list of all elements from all iterables
+ * in the given iterable.
+ */
+// kotlin.collections.flatten() doesn't work on a List<Any?>
+// (e.g., as used in Adapter.onBindViewHolder) as it requires
+// all members of the collection to have the same type T.
+//
+// This implementation flattens everything.
+fun Iterable<*>.flatten(): List<*> {
+    return buildList {
+        fun innerFlatten(element: Any?) {
+            when (element) {
+                is Iterable<*> -> element.forEach { innerFlatten(it) }
+                else -> add(element)
+            }
+        }
+
+        this@flatten.forEach { innerFlatten(it) }
+    }
+}

--- a/core/common/src/test/kotlin/app/pachli/core/common/extensions/ListExtensionsTest.kt
+++ b/core/common/src/test/kotlin/app/pachli/core/common/extensions/ListExtensionsTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Pachli Association
+ *
+ * This file is a part of Pachli.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Pachli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Pachli; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package app.pachli.core.common.extensions
+
+import com.google.common.truth.Truth.assertThat
+import kotlin.test.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+data class TestData(
+    val got: Iterable<*>,
+    val want: Iterable<*>,
+)
+
+@RunWith(Parameterized::class)
+class ListExtensionsTest(private val testData: TestData) {
+    companion object {
+        @Parameterized.Parameters()
+        @JvmStatic
+        fun data(): Iterable<Any> {
+            return listOf(
+                TestData(emptyList<Unit>(), emptyList<Unit>()),
+                TestData(listOf(1), listOf(1)),
+                TestData(listOf(1, 2, 3), listOf(1, 2, 3)),
+                TestData(listOf(1, null, 2), listOf(1, null, 2)),
+                // 1-level flattening
+                TestData(listOf(listOf(1), listOf(2)), listOf(1, 2)),
+                // 1-level flattening with null
+                TestData(listOf(listOf(1), null, listOf(2)), listOf(1, null, 2)),
+                // 1-level flattening, different types
+                TestData(listOf(listOf(1), listOf("hello")), listOf(1, "hello")),
+                // 1-level flattening, different types, with null
+                TestData(listOf(listOf(1), listOf(null), listOf("hello")), listOf(1, null, "hello")),
+                // 2-level flattening, different types, with null
+                TestData(
+                    got = listOf(
+                        listOf(
+                            1,
+                            listOf(2, 3, null),
+                        ),
+                        listOf(null),
+                        "hello",
+                        listOf("world"),
+                    ),
+                    want = listOf(1, 2, 3, null, null, "hello", "world"),
+                ),
+                // Works on Sets
+                TestData(setOf(1, 2, 3), listOf(1, 2, 3)),
+                TestData(
+                    got = setOf(
+                        setOf(
+                            1,
+                            listOf(2, 3, null),
+                        ),
+                        setOf(null),
+                        "hello",
+                        listOf("world"),
+                    ),
+                    want = listOf(1, 2, 3, null, null, "hello", "world"),
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun test() {
+        assertThat(testData.got.flatten()).isEqualTo(testData.want)
+    }
+}

--- a/feature/manageaccounts/src/main/kotlin/app/pachli/feature/manageaccounts/PachliAccountAdapter.kt
+++ b/feature/manageaccounts/src/main/kotlin/app/pachli/feature/manageaccounts/PachliAccountAdapter.kt
@@ -25,6 +25,7 @@ import androidx.core.view.isVisible
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import app.pachli.core.common.extensions.flatten
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
 import app.pachli.core.common.extensions.visible
@@ -173,7 +174,7 @@ internal class PachliAccountViewHolder(
         animateEmojis: Boolean,
         animateAvatars: Boolean,
         showBotOverlay: Boolean,
-        payloads: List<Any?>? = null,
+        payloads: List<Any?> = emptyList(),
     ) = with(binding) {
         this@PachliAccountViewHolder.account = account
 
@@ -182,7 +183,7 @@ internal class PachliAccountViewHolder(
             return@with
         }
 
-        payloads.forEach { payload ->
+        payloads.flatten().forEach { payload ->
             when (payload) {
                 is ChangePayload.AnimateAvatars -> bindAvatar(account, animateAvatars)
                 is ChangePayload.AnimateEmojis -> bindAnimateEmojis(account, animateEmojis)

--- a/feature/suggestions/src/main/kotlin/app/pachli/feature/suggestions/SuggestionsAdapter.kt
+++ b/feature/suggestions/src/main/kotlin/app/pachli/feature/suggestions/SuggestionsAdapter.kt
@@ -27,6 +27,7 @@ import androidx.core.view.children
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import app.pachli.core.common.extensions.flatten
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
 import app.pachli.core.common.extensions.visible
@@ -108,7 +109,7 @@ internal class SuggestionsAdapter(
         if (payloads.isEmpty()) {
             onBindViewHolder(holder, position)
         } else {
-            payloads.filterIsInstance<ChangePayload>().forEach { payload ->
+            payloads.flatten().filterIsInstance<ChangePayload>().forEach { payload ->
                 when (payload) {
                     is ChangePayload.IsEnabled -> holder.bindIsEnabled(payload.isEnabled)
                     is ChangePayload.AnimateAvatars -> holder.bindAvatar(viewData, payload.animateAvatars)


### PR DESCRIPTION
Previous code either wasn't doing this, or was relying on hacks like casting the value to `List<List<Any?>>`, which worked, with ominous warnings.

Fix this by implementing `Iterable<*>.flatten()` which flattens all items in the `Iterable` to a single list, and use this everywhere it makes sense.