### PR TITLE
fix: Show data about the account being replied to in more cases

### DIFF
--- a/core/database/src/main/kotlin/app/pachli/core/database/dao/ConversationsDao.kt
+++ b/core/database/src/main/kotlin/app/pachli/core/database/dao/ConversationsDao.kt
@@ -152,6 +152,22 @@ SELECT
     s.t_attachments AS 's_s_t_attachments',
     s.t_provider AS 's_s_t_provider',
 
+    -- Reply account
+    s.reply_serverId AS 's_s_reply_serverId',
+    s.reply_timelineUserId AS 's_s_reply_timelineUserId',
+    s.reply_localUsername AS 's_s_reply_localUsername',
+    s.reply_username AS 's_s_reply_username',
+    s.reply_displayName AS 's_s_reply_displayName',
+    s.reply_url AS 's_s_reply_url',
+    s.reply_avatar AS 's_s_reply_avatar',
+    s.reply_emojis AS 's_s_reply_emojis',
+    s.reply_bot AS 's_s_reply_bot',
+    s.reply_createdAt AS 's_s_reply_createdAt',
+    s.reply_limited AS 's_s_reply_limited',
+    s.reply_note AS 's_s_reply_note',
+    s.reply_roles AS 's_s_reply_roles',
+    s.reply_pronouns AS 's_s_reply_pronouns',
+
     -- Quoted status (if any)
     -- TimelineStatusWithAccount
     q.serverId AS 's_q_serverId',
@@ -238,6 +254,22 @@ SELECT
     q.t_poll AS 's_q_t_poll',
     q.t_attachments AS 's_q_t_attachments',
     q.t_provider AS 's_q_t_provider',
+
+    -- Reply account
+    q.reply_serverId AS 's_q_reply_serverId',
+    q.reply_timelineUserId AS 's_q_reply_timelineUserId',
+    q.reply_localUsername AS 's_q_reply_localUsername',
+    q.reply_username AS 's_q_reply_username',
+    q.reply_displayName AS 's_q_reply_displayName',
+    q.reply_url AS 's_q_reply_url',
+    q.reply_avatar AS 's_q_reply_avatar',
+    q.reply_emojis AS 's_q_reply_emojis',
+    q.reply_bot AS 's_q_reply_bot',
+    q.reply_createdAt AS 's_q_reply_createdAt',
+    q.reply_limited AS 's_q_reply_limited',
+    q.reply_note AS 's_q_reply_note',
+    q.reply_roles AS 's_q_reply_roles',
+    q.reply_pronouns AS 's_q_reply_pronouns',
 
     -- ConversationViewDataEntity
     cvd.pachliAccountId AS 'cvd_pachliAccountId',
@@ -379,6 +411,22 @@ SELECT
     s.t_attachments AS 's_s_t_attachments',
     s.t_provider AS 's_s_t_provider',
 
+    -- Reply account
+    s.reply_serverId AS 's_s_reply_serverId',
+    s.reply_timelineUserId AS 's_s_reply_timelineUserId',
+    s.reply_localUsername AS 's_s_reply_localUsername',
+    s.reply_username AS 's_s_reply_username',
+    s.reply_displayName AS 's_s_reply_displayName',
+    s.reply_url AS 's_s_reply_url',
+    s.reply_avatar AS 's_s_reply_avatar',
+    s.reply_emojis AS 's_s_reply_emojis',
+    s.reply_bot AS 's_s_reply_bot',
+    s.reply_createdAt AS 's_s_reply_createdAt',
+    s.reply_limited AS 's_s_reply_limited',
+    s.reply_note AS 's_s_reply_note',
+    s.reply_roles AS 's_s_reply_roles',
+    s.reply_pronouns AS 's_s_reply_pronouns',
+
     -- Quoted status (if any)
     -- TimelineStatusWithAccount
     q.serverId AS 's_q_serverId',
@@ -465,6 +513,22 @@ SELECT
     q.t_poll AS 's_q_t_poll',
     q.t_attachments AS 's_q_t_attachments',
     q.t_provider AS 's_q_t_provider',
+
+    -- Reply account
+    q.reply_serverId AS 's_q_reply_serverId',
+    q.reply_timelineUserId AS 's_q_reply_timelineUserId',
+    q.reply_localUsername AS 's_q_reply_localUsername',
+    q.reply_username AS 's_q_reply_username',
+    q.reply_displayName AS 's_q_reply_displayName',
+    q.reply_url AS 's_q_reply_url',
+    q.reply_avatar AS 's_q_reply_avatar',
+    q.reply_emojis AS 's_q_reply_emojis',
+    q.reply_bot AS 's_q_reply_bot',
+    q.reply_createdAt AS 's_q_reply_createdAt',
+    q.reply_limited AS 's_q_reply_limited',
+    q.reply_note AS 's_q_reply_note',
+    q.reply_roles AS 's_q_reply_roles',
+    q.reply_pronouns AS 's_q_reply_pronouns',
 
     -- ConversationViewDataEntity
     cvd.pachliAccountId AS 'cvd_pachliAccountId',

--- a/core/database/src/main/kotlin/app/pachli/core/database/dao/NotificationDao.kt
+++ b/core/database/src/main/kotlin/app/pachli/core/database/dao/NotificationDao.kt
@@ -151,6 +151,22 @@ SELECT
     s.t_attachments AS 's_s_t_attachments',
     s.t_provider AS 's_s_t_provider',
 
+    -- Reply account
+    s.reply_serverId AS 's_s_reply_serverId',
+    s.reply_timelineUserId AS 's_s_reply_timelineUserId',
+    s.reply_localUsername AS 's_s_reply_localUsername',
+    s.reply_username AS 's_s_reply_username',
+    s.reply_displayName AS 's_s_reply_displayName',
+    s.reply_url AS 's_s_reply_url',
+    s.reply_avatar AS 's_s_reply_avatar',
+    s.reply_emojis AS 's_s_reply_emojis',
+    s.reply_bot AS 's_s_reply_bot',
+    s.reply_createdAt AS 's_s_reply_createdAt',
+    s.reply_limited AS 's_s_reply_limited',
+    s.reply_note AS 's_s_reply_note',
+    s.reply_roles AS 's_s_reply_roles',
+    s.reply_pronouns AS 's_s_reply_pronouns',
+
     -- Quoted status (if any)
     -- TimelineStatusWithAccount
     q.serverId AS 's_q_serverId',
@@ -238,6 +254,22 @@ SELECT
     q.t_attachments AS 's_q_t_attachments',
     q.t_provider AS 's_q_t_provider',
 
+    -- Reply account
+    q.reply_serverId AS 's_q_reply_serverId',
+    q.reply_timelineUserId AS 's_q_reply_timelineUserId',
+    q.reply_localUsername AS 's_q_reply_localUsername',
+    q.reply_username AS 's_q_reply_username',
+    q.reply_displayName AS 's_q_reply_displayName',
+    q.reply_url AS 's_q_reply_url',
+    q.reply_avatar AS 's_q_reply_avatar',
+    q.reply_emojis AS 's_q_reply_emojis',
+    q.reply_bot AS 's_q_reply_bot',
+    q.reply_createdAt AS 's_q_reply_createdAt',
+    q.reply_limited AS 's_q_reply_limited',
+    q.reply_note AS 's_q_reply_note',
+    q.reply_roles AS 's_q_reply_roles',
+    q.reply_pronouns AS 's_q_reply_pronouns',
+
     -- NotificationViewData
     nvd.pachliAccountId AS 'nvd_pachliAccountId',
     nvd.serverId AS 'nvd_serverId',
@@ -267,6 +299,8 @@ SELECT
     report.target_createdAt AS 'report_target_createdAt',
     report.target_limited AS 'report_target_limited',
     report.target_note AS 'report_target_note',
+    report.target_roles AS 'report_target_roles',
+    report.target_pronouns AS 'report_target_pronouns',
 
     -- NotificationRelationshipSeveranceEvent
     rse.pachliAccountId AS 'rse_pachliAccountId',
@@ -288,18 +322,16 @@ SELECT
     warn.createdAt AS 'warn_createdAt'
 FROM NotificationEntity AS n
 LEFT JOIN TimelineAccountEntity AS a ON (n.pachliAccountId = a.timelineUserId AND n.accountServerId = a.serverId)
-LEFT JOIN TimelineStatusWithAccount AS s ON (n.pachliAccountId = s.timelineUserId AND n.statusServerId = s.serverId)
- LEFT JOIN TimelineStatusWithAccount AS q
+LEFT JOIN TimelineStatusWithAccount AS s
+    ON (n.pachliAccountId = s.timelineUserId AND n.statusServerId = s.serverId)
+LEFT JOIN TimelineStatusWithAccount AS q
     ON (n.pachliAccountId = :pachliAccountId AND (q.timelineUserId = :pachliAccountId AND s.quoteServerId = q.serverId))
 LEFT JOIN NotificationViewDataEntity AS nvd ON (n.pachliAccountId = nvd.pachliAccountId AND n.serverId = nvd.serverId)
-LEFT JOIN
-    NotificationReportEntity AS report
+LEFT JOIN NotificationReportEntity AS report
     ON (n.pachliAccountId = report.pachliAccountId AND n.serverId = report.serverId)
-LEFT JOIN
-    NotificationRelationshipSeveranceEventEntity AS rse
+LEFT JOIN NotificationRelationshipSeveranceEventEntity AS rse
     ON (n.pachliAccountId = rse.pachliAccountId AND n.serverId = rse.serverId)
-LEFT JOIN
-    NotificationAccountWarningEntity AS warn
+LEFT JOIN NotificationAccountWarningEntity AS warn
     ON (n.pachliAccountId = warn.pachliAccountId AND n.serverId = warn.serverId)
 WHERE n.pachliAccountId = :pachliAccountId
 ORDER BY LENGTH(n.serverId) DESC, n.serverId DESC
@@ -531,6 +563,22 @@ SELECT
     s.t_attachments AS 's_s_t_attachments',
     s.t_provider AS 's_s_t_provider',
 
+    -- Reply account
+    s.reply_serverId AS 's_s_reply_serverId',
+    s.reply_timelineUserId AS 's_s_reply_timelineUserId',
+    s.reply_localUsername AS 's_s_reply_localUsername',
+    s.reply_username AS 's_s_reply_username',
+    s.reply_displayName AS 's_s_reply_displayName',
+    s.reply_url AS 's_s_reply_url',
+    s.reply_avatar AS 's_s_reply_avatar',
+    s.reply_emojis AS 's_s_reply_emojis',
+    s.reply_bot AS 's_s_reply_bot',
+    s.reply_createdAt AS 's_s_reply_createdAt',
+    s.reply_limited AS 's_s_reply_limited',
+    s.reply_note AS 's_s_reply_note',
+    s.reply_roles AS 's_s_reply_roles',
+    s.reply_pronouns AS 's_s_reply_pronouns',
+
     -- Quoted status (if any)
     -- TimelineStatusWithAccount
     q.serverId AS 's_q_serverId',
@@ -618,6 +666,22 @@ SELECT
     q.t_attachments AS 's_q_t_attachments',
     q.t_provider AS 's_q_t_provider',
 
+    -- Reply account
+    q.reply_serverId AS 's_q_reply_serverId',
+    q.reply_timelineUserId AS 's_q_reply_timelineUserId',
+    q.reply_localUsername AS 's_q_reply_localUsername',
+    q.reply_username AS 's_q_reply_username',
+    q.reply_displayName AS 's_q_reply_displayName',
+    q.reply_url AS 's_q_reply_url',
+    q.reply_avatar AS 's_q_reply_avatar',
+    q.reply_emojis AS 's_q_reply_emojis',
+    q.reply_bot AS 's_q_reply_bot',
+    q.reply_createdAt AS 's_q_reply_createdAt',
+    q.reply_limited AS 's_q_reply_limited',
+    q.reply_note AS 's_q_reply_note',
+    q.reply_roles AS 's_q_reply_roles',
+    q.reply_pronouns AS 's_q_reply_pronouns',
+
     -- NotificationViewData
     nvd.pachliAccountId AS 'nvd_pachliAccountId',
     nvd.serverId AS 'nvd_serverId',
@@ -647,6 +711,8 @@ SELECT
     report.target_createdAt AS 'report_target_createdAt',
     report.target_limited AS 'report_target_limited',
     report.target_note AS 'report_target_note',
+    report.target_roles AS 'report_target_roles',
+    report.target_pronouns AS 'report_target_pronouns',
 
     -- NotificationRelationshipSeveranceEvent
     rse.pachliAccountId AS 'rse_pachliAccountId',
@@ -669,17 +735,14 @@ SELECT
 FROM NotificationEntity AS n
 LEFT JOIN TimelineAccountEntity AS a ON (n.pachliAccountId = a.timelineUserId AND n.accountServerId = a.serverId)
 LEFT JOIN TimelineStatusWithAccount AS s ON (n.pachliAccountId = s.timelineUserId AND n.statusServerId = s.serverId)
- LEFT JOIN TimelineStatusWithAccount AS q
+LEFT JOIN TimelineStatusWithAccount AS q
     ON (n.pachliAccountId = :pachliAccountId AND (q.timelineUserId = :pachliAccountId AND s.quoteServerId = q.serverId))
 LEFT JOIN NotificationViewDataEntity AS nvd ON (n.pachliAccountId = nvd.pachliAccountId AND n.serverId = nvd.serverId)
-LEFT JOIN
-    NotificationReportEntity AS report
+LEFT JOIN NotificationReportEntity AS report
     ON (n.pachliAccountId = report.pachliAccountId AND n.serverId = report.serverId)
-LEFT JOIN
-    NotificationRelationshipSeveranceEventEntity AS rse
+LEFT JOIN NotificationRelationshipSeveranceEventEntity AS rse
     ON (n.pachliAccountId = rse.pachliAccountId AND n.serverId = rse.serverId)
-LEFT JOIN
-    NotificationAccountWarningEntity AS warn
+LEFT JOIN NotificationAccountWarningEntity AS warn
     ON (n.pachliAccountId = warn.pachliAccountId AND n.serverId = warn.serverId)
 WHERE n.pachliAccountId = :pachliAccountId
 ORDER BY LENGTH(n.serverId) DESC, n.serverId DESC

--- a/core/database/src/main/kotlin/app/pachli/core/database/dao/TimelineDao.kt
+++ b/core/database/src/main/kotlin/app/pachli/core/database/dao/TimelineDao.kt
@@ -154,6 +154,22 @@ ORDER BY LENGTH(s.serverId) DESC, s.serverId DESC
     s.t_attachments AS 's_t_attachments',
     s.t_provider AS 's_t_provider',
 
+    -- Reply account
+    s.reply_serverId AS 's_reply_serverId',
+    s.reply_timelineUserId AS 's_reply_timelineUserId',
+    s.reply_localUsername AS 's_reply_localUsername',
+    s.reply_username AS 's_reply_username',
+    s.reply_displayName AS 's_reply_displayName',
+    s.reply_url AS 's_reply_url',
+    s.reply_avatar AS 's_reply_avatar',
+    s.reply_emojis AS 's_reply_emojis',
+    s.reply_bot AS 's_reply_bot',
+    s.reply_createdAt AS 's_reply_createdAt',
+    s.reply_limited AS 's_reply_limited',
+    s.reply_note AS 's_reply_note',
+    s.reply_roles AS 's_reply_roles',
+    s.reply_pronouns AS 's_reply_pronouns',
+
     -- Quoted status (if any)
     -- TimelineStatusWithAccount
     q.serverId AS 'q_serverId',
@@ -239,7 +255,23 @@ ORDER BY LENGTH(s.serverId) DESC, s.serverId DESC
     q.t_spoilerText AS 'q_t_spoilerText',
     q.t_poll AS 'q_t_poll',
     q.t_attachments AS 'q_t_attachments',
-    q.t_provider AS 'q_t_provider'
+    q.t_provider AS 'q_t_provider',
+
+    -- Reply account
+    q.reply_serverId AS 'q_reply_serverId',
+    q.reply_timelineUserId AS 'q_reply_timelineUserId',
+    q.reply_localUsername AS 'q_reply_localUsername',
+    q.reply_username AS 'q_reply_username',
+    q.reply_displayName AS 'q_reply_displayName',
+    q.reply_url AS 'q_reply_url',
+    q.reply_avatar AS 'q_reply_avatar',
+    q.reply_emojis AS 'q_reply_emojis',
+    q.reply_bot AS 'q_reply_bot',
+    q.reply_createdAt AS 'q_reply_createdAt',
+    q.reply_limited AS 'q_reply_limited',
+    q.reply_note AS 'q_reply_note',
+    q.reply_roles AS 'q_reply_roles',
+    q.reply_pronouns AS 'q_reply_pronouns'
   FROM TimelineStatusEntity AS t
  LEFT JOIN TimelineStatusWithAccount AS s
     ON (t.pachliAccountId = :account AND (s.timelineUserId = :account AND t.statusId = s.serverId))
@@ -386,6 +418,22 @@ SELECT
     s.t_attachments AS 's_t_attachments',
     s.t_provider AS 's_t_provider',
 
+    -- Reply account
+    s.reply_serverId AS 's_reply_serverId',
+    s.reply_timelineUserId AS 's_reply_timelineUserId',
+    s.reply_localUsername AS 's_reply_localUsername',
+    s.reply_username AS 's_reply_username',
+    s.reply_displayName AS 's_reply_displayName',
+    s.reply_url AS 's_reply_url',
+    s.reply_avatar AS 's_reply_avatar',
+    s.reply_emojis AS 's_reply_emojis',
+    s.reply_bot AS 's_reply_bot',
+    s.reply_createdAt AS 's_reply_createdAt',
+    s.reply_limited AS 's_reply_limited',
+    s.reply_note AS 's_reply_note',
+    s.reply_roles AS 's_reply_roles',
+    s.reply_pronouns AS 's_reply_pronouns',
+
     -- Quoted status (if any)
     -- TimelineStatusWithAccount
     q.serverId AS 'q_serverId',
@@ -471,7 +519,23 @@ SELECT
     q.t_spoilerText AS 'q_t_spoilerText',
     q.t_poll AS 'q_t_poll',
     q.t_attachments AS 'q_t_attachments',
-    q.t_provider AS 'q_t_provider'
+    q.t_provider AS 'q_t_provider',
+
+    -- Reply account
+    q.reply_serverId AS 'q_reply_serverId',
+    q.reply_timelineUserId AS 'q_reply_timelineUserId',
+    q.reply_localUsername AS 'q_reply_localUsername',
+    q.reply_username AS 'q_reply_username',
+    q.reply_displayName AS 'q_reply_displayName',
+    q.reply_url AS 'q_reply_url',
+    q.reply_avatar AS 'q_reply_avatar',
+    q.reply_emojis AS 'q_reply_emojis',
+    q.reply_bot AS 'q_reply_bot',
+    q.reply_createdAt AS 'q_reply_createdAt',
+    q.reply_limited AS 'q_reply_limited',
+    q.reply_note AS 'q_reply_note',
+    q.reply_roles AS 'q_reply_roles',
+    q.reply_pronouns AS 'q_reply_pronouns'
 FROM TimelineStatusWithAccount AS s
  LEFT JOIN TimelineStatusWithAccount AS q
     ON (s.timelineUserId = q.timelineUserId AND s.quoteServerId = q.serverId)
@@ -576,6 +640,22 @@ SELECT
     s.t_attachments AS 's_t_attachments',
     s.t_provider AS 's_t_provider',
 
+    -- Reply account
+    s.reply_serverId AS 's_reply_serverId',
+    s.reply_timelineUserId AS 's_reply_timelineUserId',
+    s.reply_localUsername AS 's_reply_localUsername',
+    s.reply_username AS 's_reply_username',
+    s.reply_displayName AS 's_reply_displayName',
+    s.reply_url AS 's_reply_url',
+    s.reply_avatar AS 's_reply_avatar',
+    s.reply_emojis AS 's_reply_emojis',
+    s.reply_bot AS 's_reply_bot',
+    s.reply_createdAt AS 's_reply_createdAt',
+    s.reply_limited AS 's_reply_limited',
+    s.reply_note AS 's_reply_note',
+    s.reply_roles AS 's_reply_roles',
+    s.reply_pronouns AS 's_reply_pronouns',
+
     -- Quoted status (if any)
     -- TimelineStatusWithAccount
     q.serverId AS 'q_serverId',
@@ -661,7 +741,23 @@ SELECT
     q.t_spoilerText AS 'q_t_spoilerText',
     q.t_poll AS 'q_t_poll',
     q.t_attachments AS 'q_t_attachments',
-    q.t_provider AS 'q_t_provider'
+    q.t_provider AS 'q_t_provider',
+
+    -- Reply account
+    q.reply_serverId AS 'q_reply_serverId',
+    q.reply_timelineUserId AS 'q_reply_timelineUserId',
+    q.reply_localUsername AS 'q_reply_localUsername',
+    q.reply_username AS 'q_reply_username',
+    q.reply_displayName AS 'q_reply_displayName',
+    q.reply_url AS 'q_reply_url',
+    q.reply_avatar AS 'q_reply_avatar',
+    q.reply_emojis AS 'q_reply_emojis',
+    q.reply_bot AS 'q_reply_bot',
+    q.reply_createdAt AS 'q_reply_createdAt',
+    q.reply_limited AS 'q_reply_limited',
+    q.reply_note AS 'q_reply_note',
+    q.reply_roles AS 'q_reply_roles',
+    q.reply_pronouns AS 'q_reply_pronouns'
 FROM TimelineStatusWithAccount AS s
  LEFT JOIN TimelineStatusWithAccount AS q
     ON (s.timelineUserId = q.timelineUserId AND s.quoteServerId = q.serverId)
@@ -1005,6 +1101,22 @@ WHERE timelineUserId = :pachliAccountId
     s.t_attachments AS 's_t_attachments',
     s.t_provider AS 's_t_provider',
 
+    -- Reply account
+    s.reply_serverId AS 's_reply_serverId',
+    s.reply_timelineUserId AS 's_reply_timelineUserId',
+    s.reply_localUsername AS 's_reply_localUsername',
+    s.reply_username AS 's_reply_username',
+    s.reply_displayName AS 's_reply_displayName',
+    s.reply_url AS 's_reply_url',
+    s.reply_avatar AS 's_reply_avatar',
+    s.reply_emojis AS 's_reply_emojis',
+    s.reply_bot AS 's_reply_bot',
+    s.reply_createdAt AS 's_reply_createdAt',
+    s.reply_limited AS 's_reply_limited',
+    s.reply_note AS 's_reply_note',
+    s.reply_roles AS 's_reply_roles',
+    s.reply_pronouns AS 's_reply_pronouns',
+
     -- Quoted status (if any)
     -- TimelineStatusWithAccount
     q.serverId AS 'q_serverId',
@@ -1090,7 +1202,23 @@ WHERE timelineUserId = :pachliAccountId
     q.t_spoilerText AS 'q_t_spoilerText',
     q.t_poll AS 'q_t_poll',
     q.t_attachments AS 'q_t_attachments',
-    q.t_provider AS 'q_t_provider'
+    q.t_provider AS 'q_t_provider',
+
+    -- Reply account
+    q.reply_serverId AS 'q_reply_serverId',
+    q.reply_timelineUserId AS 'q_reply_timelineUserId',
+    q.reply_localUsername AS 'q_reply_localUsername',
+    q.reply_username AS 'q_reply_username',
+    q.reply_displayName AS 'q_reply_displayName',
+    q.reply_url AS 'q_reply_url',
+    q.reply_avatar AS 'q_reply_avatar',
+    q.reply_emojis AS 'q_reply_emojis',
+    q.reply_bot AS 'q_reply_bot',
+    q.reply_createdAt AS 'q_reply_createdAt',
+    q.reply_limited AS 'q_reply_limited',
+    q.reply_note AS 'q_reply_note',
+    q.reply_roles AS 'q_reply_roles',
+    q.reply_pronouns AS 'q_reply_pronouns'
   FROM TimelineStatusEntity AS t
  LEFT JOIN TimelineStatusWithAccount AS s
     ON (t.pachliAccountId = :account AND (s.timelineUserId = :account AND t.statusId = s.serverId))


### PR DESCRIPTION
DAO queries were missing the columns from the "reply account" relationship (i.e., the account that authored the status being replied to, if the status is a reply). Include them in the queries.

Practically, this meant that the "Replied to" header that could show above some posts always showed "Replied to" and never "Replied to <some account name>" as intended.