### PR TITLE
refactor: Compose LinkListener interface from smaller fun interfaces

### DIFF
--- a/app/src/main/java/app/pachli/components/account/AccountActivity.kt
+++ b/app/src/main/java/app/pachli/components/account/AccountActivity.kt
@@ -1007,8 +1007,8 @@ class AccountActivity :
         startActivityWithDefaultTransition(intent)
     }
 
-    override fun onViewAccount(id: String) {
-        val intent = AccountActivityIntent(this, intent.pachliAccountId, id)
+    override fun onViewAccount(accountId: String) {
+        val intent = AccountActivityIntent(this, intent.pachliAccountId, accountId)
         startActivityWithDefaultTransition(intent)
     }
 

--- a/app/src/main/java/app/pachli/components/accountlist/AccountListFragment.kt
+++ b/app/src/main/java/app/pachli/components/accountlist/AccountListFragment.kt
@@ -228,9 +228,9 @@ class AccountListFragment :
         )
     }
 
-    override fun onViewAccount(id: String) {
+    override fun onViewAccount(accountId: String) {
         startActivityWithDefaultTransition(
-            AccountActivityIntent(requireContext(), pachliAccountId, id),
+            AccountActivityIntent(requireContext(), pachliAccountId, accountId),
         )
     }
 

--- a/app/src/main/java/app/pachli/components/announcements/AnnouncementsActivity.kt
+++ b/app/src/main/java/app/pachli/components/announcements/AnnouncementsActivity.kt
@@ -207,8 +207,8 @@ class AnnouncementsActivity :
         startActivityWithDefaultTransition(intent)
     }
 
-    override fun onViewAccount(id: String) {
-        viewAccount(intent.pachliAccountId, id)
+    override fun onViewAccount(accountId: String) {
+        viewAccount(intent.pachliAccountId, accountId)
     }
 
     override fun onViewUrl(url: String) {

--- a/app/src/main/java/app/pachli/components/conversation/ConversationsFragment.kt
+++ b/app/src/main/java/app/pachli/components/conversation/ConversationsFragment.kt
@@ -427,8 +427,8 @@ class ConversationsFragment :
         viewModel.collapseLongStatus(viewData.pachliAccountId, isCollapsed, viewData.actionableId)
     }
 
-    override fun onViewAccount(id: String) {
-        val intent = AccountActivityIntent(requireContext(), pachliAccountId, id)
+    override fun onViewAccount(accountId: String) {
+        val intent = AccountActivityIntent(requireContext(), pachliAccountId, accountId)
         startActivityWithDefaultTransition(intent)
     }
 

--- a/app/src/main/java/app/pachli/components/notifications/NotificationsFragment.kt
+++ b/app/src/main/java/app/pachli/components/notifications/NotificationsFragment.kt
@@ -641,8 +641,8 @@ class NotificationsFragment :
         super.viewTag(tag)
     }
 
-    override fun onViewAccount(id: String) {
-        super.viewAccount(id)
+    override fun onViewAccount(accountId: String) {
+        super.viewAccount(accountId)
     }
 
     override fun onMute(mute: Boolean, id: String, position: Int, notifications: Boolean) {

--- a/app/src/main/java/app/pachli/components/report/fragments/ReportStatusesFragment.kt
+++ b/app/src/main/java/app/pachli/components/report/fragments/ReportStatusesFragment.kt
@@ -285,8 +285,8 @@ class ReportStatusesFragment :
         )
     }
 
-    override fun onViewAccount(id: String) = startActivityWithDefaultTransition(
-        AccountActivityIntent(requireContext(), pachliAccountId, id),
+    override fun onViewAccount(accountId: String) = startActivityWithDefaultTransition(
+        AccountActivityIntent(requireContext(), pachliAccountId, accountId),
     )
 
     override fun onViewTag(tag: String) = startActivityWithDefaultTransition(

--- a/app/src/main/java/app/pachli/components/search/fragments/SearchFragment.kt
+++ b/app/src/main/java/app/pachli/components/search/fragments/SearchFragment.kt
@@ -149,9 +149,9 @@ abstract class SearchFragment<T : Any> :
         }
     }
 
-    override fun onViewAccount(id: String) {
+    override fun onViewAccount(accountId: String) {
         startActivityWithDefaultTransition(
-            AccountActivityIntent(requireContext(), pachliAccountId, id),
+            AccountActivityIntent(requireContext(), pachliAccountId, accountId),
         )
     }
 

--- a/app/src/main/java/app/pachli/components/timeline/TimelineFragment.kt
+++ b/app/src/main/java/app/pachli/components/timeline/TimelineFragment.kt
@@ -710,11 +710,11 @@ class TimelineFragment :
         super.viewTag(tag)
     }
 
-    override fun onViewAccount(id: String) {
+    override fun onViewAccount(accountId: String) {
         // Ignore request to view the account page we're currently viewing
-        (timeline as? Timeline.User)?.let { if (it.id == id) return }
+        (timeline as? Timeline.User)?.let { if (it.id == accountId) return }
 
-        super.viewAccount(id)
+        super.viewAccount(accountId)
     }
 
     /**

--- a/app/src/main/java/app/pachli/components/viewthread/ViewThreadFragment.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/ViewThreadFragment.kt
@@ -435,8 +435,8 @@ class ViewThreadFragment :
         super.viewTag(tag)
     }
 
-    override fun onViewAccount(id: String) {
-        super.viewAccount(id)
+    override fun onViewAccount(accountId: String) {
+        super.viewAccount(accountId)
     }
 
     public override fun removeItem(viewData: IStatusViewData) {

--- a/app/src/main/java/app/pachli/components/viewthread/edits/ViewEditsFragment.kt
+++ b/app/src/main/java/app/pachli/components/viewthread/edits/ViewEditsFragment.kt
@@ -205,9 +205,9 @@ class ViewEditsFragment :
         viewModel.loadEdits(statusId, force = true, refreshing = true)
     }
 
-    override fun onViewAccount(id: String) {
+    override fun onViewAccount(accountId: String) {
         startActivityWithDefaultTransition(
-            AccountActivityIntent(requireContext(), pachliAccountId, id),
+            AccountActivityIntent(requireContext(), pachliAccountId, accountId),
         )
     }
 

--- a/core/ui/src/main/kotlin/app/pachli/core/ui/LinkHelper.kt
+++ b/core/ui/src/main/kotlin/app/pachli/core/ui/LinkHelper.kt
@@ -34,9 +34,40 @@ import com.mikepenz.iconics.typeface.library.googlematerial.GoogleMaterial
 import com.mikepenz.iconics.utils.color
 import com.mikepenz.iconics.utils.size
 
-interface LinkListener {
+/**
+ * Collect common interfaces for viewing links to things typically
+ * found in statuses.
+ */
+interface LinkListener : OnViewTag, OnViewAccount, OnViewUrl
+
+/** See [onViewTag]. */
+fun interface OnViewTag {
+    /**
+     * User wants to view the timeline for [tag].
+     *
+     * @param tag Name of the hashtag, without the leading `#`.
+     */
     fun onViewTag(tag: String)
-    fun onViewAccount(id: String)
+}
+
+/** See [onViewAccount]. */
+fun interface OnViewAccount {
+    /**
+     * User wants to view details for the account identified
+     * by [accountId].
+     *
+     * @param accountId Server ID of the account to view.
+     */
+    fun onViewAccount(accountId: String)
+}
+
+/** See [onViewUrl]. */
+fun interface OnViewUrl {
+    /**
+     * User wants to open [url].
+     *
+     * @param url URL to open.
+     */
     fun onViewUrl(url: String)
 }
 

--- a/core/ui/src/test/kotlin/app/pachli/core/ui/LinkHelperTest.kt
+++ b/core/ui/src/test/kotlin/app/pachli/core/ui/LinkHelperTest.kt
@@ -34,7 +34,7 @@ import org.junit.runner.RunWith
 class LinkHelperTest {
     private val listener = object : LinkListener {
         override fun onViewTag(tag: String) { }
-        override fun onViewAccount(id: String) { }
+        override fun onViewAccount(accountId: String) {}
         override fun onViewUrl(url: String) { }
     }
 

--- a/feature/suggestions/src/main/kotlin/app/pachli/feature/suggestions/SuggestionsAdapter.kt
+++ b/feature/suggestions/src/main/kotlin/app/pachli/feature/suggestions/SuggestionsAdapter.kt
@@ -182,7 +182,7 @@ internal class SuggestionViewHolder(
      */
     private val linkListener = object : LinkListener {
         override fun onViewTag(tag: String) = accept(NavigationAction.ViewHashtag(tag))
-        override fun onViewAccount(id: String) = accept(NavigationAction.ViewAccount(id))
+        override fun onViewAccount(accountId: String) = accept(NavigationAction.ViewAccount(accountId))
         override fun onViewUrl(url: String) = accept(NavigationAction.ViewUrl(url))
     }
 


### PR DESCRIPTION
This will allow other interfaces that require some of the same `fun interface` declarations to share common functionality.