### PR TITLE
fix: Remove cached following relationships when blocking a domain

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -121,7 +121,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/components/account/AccountActivity.kt"
-            line="828"
+            line="830"
             column="17"/>
     </issue>
 
@@ -132,7 +132,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/components/account/AccountActivity.kt"
-            line="831"
+            line="833"
             column="17"/>
     </issue>
 
@@ -143,7 +143,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/components/account/AccountActivity.kt"
-            line="836"
+            line="838"
             column="13"/>
     </issue>
 
@@ -497,6 +497,17 @@
             file="src/main/java/app/pachli/components/viewthread/ViewThreadFragment.kt"
             line="268"
             column="21"/>
+    </issue>
+
+    <issue
+        id="NoOp"
+        message="This reference is unused: body"
+        errorLine1="        mastodonApi.blockDomain(domain).map { it.body }"
+        errorLine2="                                                 ~~~~">
+        <location
+            file="src/main/kotlin/app/pachli/core/domain/accounts/BlockDomainUseCase.kt"
+            line="57"
+            column="50"/>
     </issue>
 
     <issue
@@ -2004,7 +2015,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/app/pachli/components/account/AccountActivity.kt"
-            line="570"
+            line="571"
             column="9"/>
     </issue>
 

--- a/app/src/main/java/app/pachli/components/account/AccountActivity.kt
+++ b/app/src/main/java/app/pachli/components/account/AccountActivity.kt
@@ -742,8 +742,8 @@ class AccountActivity :
         binding.accountFollowsYouChip.visible(relation.followedBy && !wellbeingEnabled)
 
         // because subscribing is Pleroma extension, enable it __only__ when we
-        //  have non-null subscribing field. It's also now supported in Mastodon
-        //  3.3.0rc but called notifying and use different API call
+        // have non-null subscribing field. It's also now supported in Mastodon
+        // 3.3.0rc but called notifying and use different API call
         if (!viewModel.isSelf.value &&
             followState == FollowState.FOLLOWING &&
             (relation.subscribing != null || relation.notifying != null)

--- a/app/src/main/java/app/pachli/components/account/AccountActivity.kt
+++ b/app/src/main/java/app/pachli/components/account/AccountActivity.kt
@@ -508,8 +508,9 @@ class AccountActivity :
 
         viewModel.relationshipData.observe(this) {
             val relation = it?.data
-            if (relation != null) {
-                onRelationshipChanged(relation)
+            val account = viewModel.accountData.value.get()?.getOrNull()
+            if (relation != null && account != null) {
+                onRelationshipChanged(account, relation)
             }
 
             if (it is Error) {
@@ -558,15 +559,15 @@ class AccountActivity :
             glide = glide,
             textView = binding.accountNoteTextView,
             content = account.note,
-            emojis = account.emojis.orEmpty(),
+            emojis = account.emojis,
             animateEmojis = viewModel.statusDisplayOptions.value.animateEmojis,
             removeQuoteInline = false,
             linksToUnderline = viewModel.statusDisplayOptions.value.linksToUnderline,
             linkListener = this,
         )
 
-        accountFieldAdapter.fields = account.fields.orEmpty()
-        accountFieldAdapter.emojis = account.emojis.orEmpty()
+        accountFieldAdapter.fields = account.fields
+        accountFieldAdapter.emojis = account.emojis
         accountFieldAdapter.notifyDataSetChanged()
 
         binding.accountLockedImageView.visible(account.locked)
@@ -581,7 +582,7 @@ class AccountActivity :
         invalidateOptionsMenu()
 
         binding.accountMuteButton.setOnClickListener {
-            viewModel.unmuteAccount(accountId)
+            viewModel.unmuteAccount(account)
             updateMuteButton()
         }
     }
@@ -706,21 +707,21 @@ class AccountActivity :
             }
 
             if (blocking) {
-                viewModel.changeBlockState(accountId)
+                viewModel.changeBlockState(account)
                 return@setOnClickListener
             }
 
             when (followState) {
                 FollowState.NOT_FOLLOWING -> {
-                    viewModel.changeFollowState(accountId)
+                    viewModel.changeFollowState(account)
                 }
 
                 FollowState.REQUESTED -> {
-                    showFollowRequestPendingDialog()
+                    showFollowRequestPendingDialog(account)
                 }
 
                 FollowState.FOLLOWING -> {
-                    showUnfollowWarningDialog()
+                    showUnfollowWarningDialog(account)
                 }
             }
             updateFollowButton()
@@ -728,7 +729,7 @@ class AccountActivity :
         }
     }
 
-    private fun onRelationshipChanged(relation: Relationship) {
+    private fun onRelationshipChanged(account: Account, relation: Relationship) {
         followState = relation.followState
         blocking = relation.blocking
         muting = relation.muting
@@ -740,15 +741,16 @@ class AccountActivity :
 
         binding.accountFollowsYouChip.visible(relation.followedBy && !wellbeingEnabled)
 
-        // because subscribing is Pleroma extension, enable it __only__ when we have non-null subscribing field
-        // it's also now supported in Mastodon 3.3.0rc but called notifying and use different API call
+        // because subscribing is Pleroma extension, enable it __only__ when we
+        //  have non-null subscribing field. It's also now supported in Mastodon
+        //  3.3.0rc but called notifying and use different API call
         if (!viewModel.isSelf.value &&
             followState == FollowState.FOLLOWING &&
             (relation.subscribing != null || relation.notifying != null)
         ) {
             binding.accountSubscribeButton.show()
             binding.accountSubscribeButton.setOnClickListener {
-                viewModel.changeSubscribingState(accountId)
+                viewModel.changeSubscribingState(account)
             }
             if (relation.notifying != null) {
                 subscribing = relation.notifying!!
@@ -938,18 +940,18 @@ class AccountActivity :
         }
     }
 
-    private fun showFollowRequestPendingDialog() {
+    private fun showFollowRequestPendingDialog(account: Account) {
         AlertDialog.Builder(this)
             .setMessage(R.string.dialog_message_cancel_follow_request)
-            .setPositiveButton(android.R.string.ok) { _, _ -> viewModel.changeFollowState(accountId) }
+            .setPositiveButton(android.R.string.ok) { _, _ -> viewModel.changeFollowState(account) }
             .setNegativeButton(android.R.string.cancel, null)
             .show()
     }
 
-    private fun showUnfollowWarningDialog() {
+    private fun showUnfollowWarningDialog(account: Account) {
         AlertDialog.Builder(this)
             .setMessage(app.pachli.core.ui.R.string.dialog_unfollow_warning)
-            .setPositiveButton(android.R.string.ok) { _, _ -> viewModel.changeFollowState(accountId) }
+            .setPositiveButton(android.R.string.ok) { _, _ -> viewModel.changeFollowState(account) }
             .setNegativeButton(android.R.string.cancel, null)
             .show()
     }
@@ -970,11 +972,11 @@ class AccountActivity :
         if (viewModel.relationshipData.value?.data?.blocking != true) {
             AlertDialog.Builder(this)
                 .setMessage(getString(R.string.dialog_block_warning, account.username))
-                .setPositiveButton(android.R.string.ok) { _, _ -> viewModel.changeBlockState(accountId) }
+                .setPositiveButton(android.R.string.ok) { _, _ -> viewModel.changeBlockState(account) }
                 .setNegativeButton(android.R.string.cancel, null)
                 .show()
         } else {
-            viewModel.changeBlockState(accountId)
+            viewModel.changeBlockState(account)
         }
     }
 
@@ -984,10 +986,10 @@ class AccountActivity :
                 this,
                 account.username,
             ) { notifications, duration ->
-                viewModel.muteAccount(accountId, notifications, duration)
+                viewModel.muteAccount(account, notifications, duration)
             }
         } else {
-            viewModel.unmuteAccount(accountId)
+            viewModel.unmuteAccount(account)
         }
     }
 
@@ -1085,7 +1087,9 @@ class AccountActivity :
                 return true
             }
             R.id.action_show_reblogs -> {
-                viewModel.changeShowReblogsState(accountId)
+                viewModel.accountData.value.get()?.getOrNull()?.let {
+                    viewModel.changeShowReblogsState(it)
+                }
                 return true
             }
             R.id.action_refresh_account -> {

--- a/app/src/main/java/app/pachli/components/account/AccountViewModel.kt
+++ b/app/src/main/java/app/pachli/components/account/AccountViewModel.kt
@@ -10,6 +10,7 @@ import app.pachli.core.data.repository.Loadable
 import app.pachli.core.data.repository.StatusDisplayOptionsRepository
 import app.pachli.core.data.repository.getOrNull
 import app.pachli.core.domain.accounts.BlockAccountUseCase
+import app.pachli.core.domain.accounts.BlockDomainUseCase
 import app.pachli.core.domain.accounts.FollowAccountUseCase
 import app.pachli.core.domain.accounts.MuteAccountUseCase
 import app.pachli.core.domain.accounts.SubscribeAccountUseCase
@@ -17,7 +18,6 @@ import app.pachli.core.domain.accounts.UnblockAccountUseCase
 import app.pachli.core.domain.accounts.UnfollowAccountUseCase
 import app.pachli.core.domain.accounts.UnmuteAccountUseCase
 import app.pachli.core.domain.accounts.UnsubscribeAccountUseCase
-import app.pachli.core.eventhub.DomainMuteEvent
 import app.pachli.core.eventhub.EventHub
 import app.pachli.core.eventhub.ProfileEditedEvent
 import app.pachli.core.model.Account
@@ -66,6 +66,7 @@ class AccountViewModel @AssistedInject constructor(
     private val unmuteAccountUseCase: UnmuteAccountUseCase,
     private val subscribeAccountUseCase: SubscribeAccountUseCase,
     private val unsubscribeAccountUseCase: UnsubscribeAccountUseCase,
+    private val blockDomainUseCase: BlockDomainUseCase,
     statusDisplayOptionsRepository: StatusDisplayOptionsRepository,
     private val accountRepository: AccountRepository,
 ) : ViewModel() {
@@ -135,7 +136,7 @@ class AccountViewModel @AssistedInject constructor(
         merge(reload.map { Ok(Loadable.Loading) }, profileUpdates, remoteAccount).flowWhileShared(SharingStarted.WhileSubscribed(5000))
     }
 
-    /** True if the laoded account in [accountData] is the user's account. */
+    /** True if the loaded account in [accountData] is the user's account. */
     val isSelf = combine(accountData, pachliAccount) { accountData, pachliAccount ->
         pachliAccount.accountId == accountData.get()?.getOrNull()?.serverId
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
@@ -158,48 +159,47 @@ class AccountViewModel @AssistedInject constructor(
         }
     }
 
-    fun changeFollowState(accountId: String) {
+    fun changeFollowState(account: Account) {
         val relationship = relationshipData.value?.data
         if (relationship?.following == true || relationship?.requested == true) {
-            changeRelationship(accountId, RelationShipAction.UNFOLLOW)
+            changeRelationship(account, RelationShipAction.UNFOLLOW)
         } else {
-            changeRelationship(accountId, RelationShipAction.FOLLOW)
+            changeRelationship(account, RelationShipAction.FOLLOW)
         }
     }
 
-    fun changeBlockState(accountId: String) {
+    fun changeBlockState(account: Account) {
         if (relationshipData.value?.data?.blocking == true) {
-            changeRelationship(accountId, RelationShipAction.UNBLOCK)
+            changeRelationship(account, RelationShipAction.UNBLOCK)
         } else {
-            changeRelationship(accountId, RelationShipAction.BLOCK)
+            changeRelationship(account, RelationShipAction.BLOCK)
         }
     }
 
-    fun muteAccount(accountId: String, notifications: Boolean, duration: Int?) {
-        changeRelationship(accountId, RelationShipAction.MUTE, notifications, duration)
+    fun muteAccount(account: Account, notifications: Boolean, duration: Int?) {
+        changeRelationship(account, RelationShipAction.MUTE, notifications, duration)
     }
 
-    fun unmuteAccount(accountId: String) {
-        changeRelationship(accountId, RelationShipAction.UNMUTE)
+    fun unmuteAccount(account: Account) {
+        changeRelationship(account, RelationShipAction.UNMUTE)
     }
 
-    fun changeSubscribingState(accountId: String) {
+    fun changeSubscribingState(account: Account) {
         val relationship = relationshipData.value?.data
         if (relationship?.notifying == true ||
             // Mastodon 3.3.0rc1
             relationship?.subscribing == true // Pleroma
         ) {
-            changeRelationship(accountId, RelationShipAction.UNSUBSCRIBE)
+            changeRelationship(account, RelationShipAction.UNSUBSCRIBE)
         } else {
-            changeRelationship(accountId, RelationShipAction.SUBSCRIBE)
+            changeRelationship(account, RelationShipAction.SUBSCRIBE)
         }
     }
 
     fun blockDomain(instance: String) {
         viewModelScope.launch {
-            mastodonApi.blockDomain(instance)
+            blockDomainUseCase(pachliAccountId, instance)
                 .onSuccess {
-                    eventHub.dispatch(DomainMuteEvent(pachliAccountId, instance))
                     val relation = relationshipData.value?.data
                     if (relation != null) {
                         relationshipData.postValue(Success(relation.copy(blockingDomain = true)))
@@ -226,35 +226,35 @@ class AccountViewModel @AssistedInject constructor(
         }
     }
 
-    fun changeShowReblogsState(accountId: String) {
+    fun changeShowReblogsState(account: Account) {
         if (relationshipData.value?.data?.showingReblogs == true) {
-            changeRelationship(accountId, RelationShipAction.HIDE_REBLOGS)
+            changeRelationship(account, RelationShipAction.HIDE_REBLOGS)
         } else {
-            changeRelationship(accountId, RelationShipAction.SHOW_REBLOGS)
+            changeRelationship(account, RelationShipAction.SHOW_REBLOGS)
         }
     }
 
     /**
-     * @param accountId ID of the account that is the target of [relationshipAction].
+     * @param account ID of the account that is the target of [relationshipAction].
      * @param relationshipAction The action to take.
      * @param parameter showReblogs if RelationShipAction.FOLLOW, notifications if MUTE
      */
     private fun changeRelationship(
-        accountId: String,
+        account: Account,
         relationshipAction: RelationShipAction,
         parameter: Boolean? = null,
         duration: Int? = null,
     ) = viewModelScope.launch {
         val relation = relationshipData.value?.data
-        val account = accountData.value.get()?.getOrNull()
+        val cachedAccount = accountData.value.get()?.getOrNull()
         val isMastodon = relationshipData.value?.data?.notifying != null
 
-        if (relation != null && account != null) {
+        if (relation != null && cachedAccount != null) {
             // optimistically post new state for faster response
 
             val newRelation = when (relationshipAction) {
                 RelationShipAction.FOLLOW -> {
-                    if (account.locked) {
+                    if (cachedAccount.locked) {
                         relation.copy(requested = true)
                     } else {
                         relation.copy(following = true)
@@ -287,35 +287,35 @@ class AccountViewModel @AssistedInject constructor(
         }
 
         val response = when (relationshipAction) {
-            RelationShipAction.FOLLOW -> followAccountUseCase(pachliAccountId, accountId, showReblogs = true)
-            RelationShipAction.UNFOLLOW -> unfollowAccountUseCase(pachliAccountId, accountId)
-            RelationShipAction.BLOCK -> blockAccountUseCase(pachliAccountId, accountId)
-            RelationShipAction.UNBLOCK -> unblockAccountUseCase(pachliAccountId, accountId)
+            RelationShipAction.FOLLOW -> followAccountUseCase(pachliAccountId, account, showReblogs = true)
+            RelationShipAction.UNFOLLOW -> unfollowAccountUseCase(pachliAccountId, account.serverId)
+            RelationShipAction.BLOCK -> blockAccountUseCase(pachliAccountId, account.serverId)
+            RelationShipAction.UNBLOCK -> unblockAccountUseCase(pachliAccountId, account.serverId)
             RelationShipAction.MUTE -> muteAccountUseCase(
                 pachliAccountId,
-                accountId,
+                account.serverId,
                 notifications = parameter ?: true,
                 duration,
             )
 
-            RelationShipAction.UNMUTE -> unmuteAccountUseCase(pachliAccountId, accountId)
+            RelationShipAction.UNMUTE -> unmuteAccountUseCase(pachliAccountId, account.serverId)
             RelationShipAction.SUBSCRIBE -> {
                 if (isMastodon) {
-                    followAccountUseCase(pachliAccountId, accountId, notify = true)
+                    followAccountUseCase(pachliAccountId, account, notify = true)
                 } else {
-                    subscribeAccountUseCase(pachliAccountId, accountId)
+                    subscribeAccountUseCase(pachliAccountId, account.serverId)
                 }
             }
             RelationShipAction.UNSUBSCRIBE -> {
                 if (isMastodon) {
-                    followAccountUseCase(pachliAccountId, accountId, notify = false)
+                    followAccountUseCase(pachliAccountId, account, notify = false)
                 } else {
-                    unsubscribeAccountUseCase(pachliAccountId, accountId)
+                    unsubscribeAccountUseCase(pachliAccountId, account.serverId)
                 }
             }
 
-            RelationShipAction.SHOW_REBLOGS -> followAccountUseCase(pachliAccountId, accountId, showReblogs = true)
-            RelationShipAction.HIDE_REBLOGS -> followAccountUseCase(pachliAccountId, accountId, showReblogs = false)
+            RelationShipAction.SHOW_REBLOGS -> followAccountUseCase(pachliAccountId, account, showReblogs = true)
+            RelationShipAction.HIDE_REBLOGS -> followAccountUseCase(pachliAccountId, account, showReblogs = false)
         }
 
         response

--- a/app/src/main/java/app/pachli/components/instancemute/InstanceListActivity.kt
+++ b/app/src/main/java/app/pachli/components/instancemute/InstanceListActivity.kt
@@ -8,6 +8,8 @@ import app.pachli.R
 import app.pachli.components.instancemute.fragment.InstanceListFragment
 import app.pachli.core.activity.BaseActivity
 import app.pachli.core.common.extensions.viewBinding
+import app.pachli.core.common.util.unsafeLazy
+import app.pachli.core.navigation.pachliAccountId
 import app.pachli.core.ui.appbar.FadeChildScrollEffect
 import app.pachli.core.ui.extensions.addScrollEffect
 import app.pachli.core.ui.extensions.applyDefaultWindowInsets
@@ -17,6 +19,8 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class InstanceListActivity : BaseActivity() {
     private val binding by viewBinding(ActivityAccountListBinding::inflate)
+
+    private val pachliAccountId by unsafeLazy { intent.pachliAccountId }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
@@ -35,7 +39,7 @@ class InstanceListActivity : BaseActivity() {
         }
 
         supportFragmentManager.commit {
-            replace(R.id.fragment_container, InstanceListFragment())
+            replace(R.id.fragment_container, InstanceListFragment.newInstance(pachliAccountId))
         }
     }
 }

--- a/app/src/main/java/app/pachli/components/instancemute/fragment/InstanceListFragment.kt
+++ b/app/src/main/java/app/pachli/components/instancemute/fragment/InstanceListFragment.kt
@@ -12,6 +12,8 @@ import app.pachli.components.instancemute.interfaces.InstanceActionListener
 import app.pachli.core.common.extensions.hide
 import app.pachli.core.common.extensions.show
 import app.pachli.core.common.extensions.viewBinding
+import app.pachli.core.common.util.unsafeLazy
+import app.pachli.core.domain.accounts.BlockDomainUseCase
 import app.pachli.core.network.model.HttpHeaderLink
 import app.pachli.core.network.retrofit.MastodonApi
 import app.pachli.core.ui.BackgroundMessage
@@ -35,7 +37,12 @@ class InstanceListFragment :
     @Inject
     lateinit var api: MastodonApi
 
+    @Inject
+    lateinit var blockDomainUseCase: BlockDomainUseCase
+
     private val binding by viewBinding(FragmentInstanceListBinding::bind)
+
+    private val pachliAccountId by unsafeLazy { requireArguments().getLong(ARG_PACHLI_ACCOUNT_ID) }
 
     private var fetching = false
     private var bottomId: String? = null
@@ -72,7 +79,7 @@ class InstanceListFragment :
     override fun mute(mute: Boolean, instance: String, position: Int) {
         viewLifecycleOwner.lifecycleScope.launch {
             if (mute) {
-                api.blockDomain(instance)
+                blockDomainUseCase(pachliAccountId, instance)
                     .onSuccess { adapter.addItem(instance) }
                     .onFailure { Timber.e(it.throwable, "Error muting domain %s", instance) }
             } else {
@@ -139,6 +146,18 @@ class InstanceListFragment :
             binding.messageView.setup(throwable) {
                 binding.messageView.hide()
                 this.fetchInstances(null)
+            }
+        }
+    }
+
+    companion object {
+        private const val ARG_PACHLI_ACCOUNT_ID = "app.pachli.ARG_PACHLI_ACCOUNT_ID"
+
+        fun newInstance(pachliAccountId: Long): InstanceListFragment {
+            return InstanceListFragment().apply {
+                arguments = Bundle(1).apply {
+                    putLong(ARG_PACHLI_ACCOUNT_ID, pachliAccountId)
+                }
             }
         }
     }

--- a/app/src/main/java/app/pachli/components/preference/AccountPreferencesFragment.kt
+++ b/app/src/main/java/app/pachli/components/preference/AccountPreferencesFragment.kt
@@ -220,7 +220,7 @@ class AccountPreferencesFragment : PreferenceFragmentCompat() {
                 setTitle(R.string.title_domain_mutes)
                 setIcon(R.drawable.ic_mute_24dp)
                 setOnPreferenceClickListener {
-                    val intent = InstanceListActivityIntent(context)
+                    val intent = InstanceListActivityIntent(context, pachliAccountId)
                     startActivityWithTransition(intent, TransitionKind.SLIDE_FROM_END)
                     true
                 }

--- a/core/data/src/main/kotlin/app/pachli/core/data/repository/AccountManager.kt
+++ b/core/data/src/main/kotlin/app/pachli/core/data/repository/AccountManager.kt
@@ -751,15 +751,6 @@ class AccountManager @Inject constructor(
         announcementsDao.deleteForAccount(accountId, announcementId)
     }
 
-    // -- Following
-    suspend fun followAccount(pachliAccountId: Long, serverId: String) {
-        followingAccountDao.upsert(FollowingAccountEntity(pachliAccountId, serverId))
-    }
-
-    suspend fun unfollowAccount(pachliAccountId: Long, serverId: String) {
-        followingAccountDao.delete(FollowingAccountEntity(pachliAccountId, serverId))
-    }
-
     // Note: Can't use a Room partial update here because RedactedAccount doesn't
     // contain an ID. And you can't pass an object to a Room query and then
     // reference the object properties in the query.

--- a/core/database/schemas/app.pachli.core.database.AppDatabase/44.json
+++ b/core/database/schemas/app.pachli.core.database.AppDatabase/44.json
@@ -1,0 +1,2083 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 44,
+    "identityHash": "fba8559381a1ebfe55aa956b70c8ee45",
+    "entities": [
+      {
+        "tableName": "AccountEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`pachliAccountId` INTEGER NOT NULL, `serverId` TEXT NOT NULL, `localUsername` TEXT NOT NULL, `username` TEXT NOT NULL, `displayName` TEXT NOT NULL, `createdAt` INTEGER, `url` TEXT NOT NULL, `avatar` TEXT NOT NULL, `note` TEXT NOT NULL, `header` TEXT NOT NULL DEFAULT '', `locked` INTEGER NOT NULL DEFAULT 0, `lastStatusAt` INTEGER, `followersCount` INTEGER NOT NULL DEFAULT 0, `followingCount` INTEGER NOT NULL DEFAULT 0, `statusesCount` INTEGER NOT NULL DEFAULT 0, `bot` INTEGER NOT NULL, `emojis` TEXT NOT NULL, `fields` TEXT NOT NULL DEFAULT '', `movedAccount` TEXT, `limited` INTEGER NOT NULL, `roles` TEXT NOT NULL, `pronouns` TEXT, PRIMARY KEY(`pachliAccountId`, `serverId`), FOREIGN KEY(`pachliAccountId`) REFERENCES `PachliAccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "pachliAccountId",
+            "columnName": "pachliAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUsername",
+            "columnName": "localUsername",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatar",
+            "columnName": "avatar",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "header",
+            "columnName": "header",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "locked",
+            "columnName": "locked",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lastStatusAt",
+            "columnName": "lastStatusAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "followersCount",
+            "columnName": "followersCount",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "followingCount",
+            "columnName": "followingCount",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "statusesCount",
+            "columnName": "statusesCount",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "bot",
+            "columnName": "bot",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "emojis",
+            "columnName": "emojis",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fields",
+            "columnName": "fields",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "movedAccount",
+            "columnName": "movedAccount",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "limited",
+            "columnName": "limited",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "roles",
+            "columnName": "roles",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pronouns",
+            "columnName": "pronouns",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "pachliAccountId",
+            "serverId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "PachliAccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "pachliAccountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "DraftEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `pachliAccountId` INTEGER NOT NULL, `inReplyToId` TEXT, `content` TEXT, `contentWarning` TEXT, `sensitive` INTEGER NOT NULL, `visibility` INTEGER NOT NULL, `attachments` TEXT NOT NULL, `poll` TEXT, `failureMessage` TEXT, `scheduledAt` INTEGER, `language` TEXT, `statusId` TEXT, `quotePolicy` TEXT, `quotedStatusId` TEXT, `cursorPosition` INTEGER NOT NULL DEFAULT 0, `state` TEXT NOT NULL DEFAULT 'DEFAULT', FOREIGN KEY(`pachliAccountId`) REFERENCES `PachliAccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pachliAccountId",
+            "columnName": "pachliAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inReplyToId",
+            "columnName": "inReplyToId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "contentWarning",
+            "columnName": "contentWarning",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sensitive",
+            "columnName": "sensitive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "visibility",
+            "columnName": "visibility",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attachments",
+            "columnName": "attachments",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "poll",
+            "columnName": "poll",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "failureMessage",
+            "columnName": "failureMessage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "scheduledAt",
+            "columnName": "scheduledAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "statusId",
+            "columnName": "statusId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "quotePolicy",
+            "columnName": "quotePolicy",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "quotedStatusId",
+            "columnName": "quotedStatusId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "cursorPosition",
+            "columnName": "cursorPosition",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'DEFAULT'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_DraftEntity_pachliAccountId",
+            "unique": false,
+            "columnNames": [
+              "pachliAccountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_DraftEntity_pachliAccountId` ON `${TABLE_NAME}` (`pachliAccountId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "PachliAccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "pachliAccountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "PachliAccountEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `domain` TEXT NOT NULL, `accessToken` TEXT NOT NULL, `clientId` TEXT NOT NULL, `clientSecret` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `accountId` TEXT NOT NULL, `username` TEXT NOT NULL, `displayName` TEXT NOT NULL, `profilePictureUrl` TEXT NOT NULL, `profileHeaderPictureUrl` TEXT NOT NULL DEFAULT '', `notificationsEnabled` INTEGER NOT NULL, `notificationsMentioned` INTEGER NOT NULL, `notificationsFollowed` INTEGER NOT NULL, `notificationsFollowRequested` INTEGER NOT NULL, `notificationsReblogged` INTEGER NOT NULL, `notificationsFavorited` INTEGER NOT NULL, `notificationsPolls` INTEGER NOT NULL, `notificationsSubscriptions` INTEGER NOT NULL, `notificationsSignUps` INTEGER NOT NULL, `notificationsUpdates` INTEGER NOT NULL, `notificationsReports` INTEGER NOT NULL, `notificationsSeveredRelationships` INTEGER NOT NULL DEFAULT true, `notificationsModerationWarnings` INTEGER NOT NULL DEFAULT true, `notificationsQuotes` INTEGER NOT NULL DEFAULT true, `notificationsQuotedUpdates` INTEGER NOT NULL DEFAULT true, `notificationSound` INTEGER NOT NULL, `notificationVibration` INTEGER NOT NULL, `notificationLight` INTEGER NOT NULL, `defaultPostPrivacy` INTEGER NOT NULL, `defaultMediaSensitivity` INTEGER NOT NULL, `defaultPostLanguage` TEXT NOT NULL, `defaultQuotePolicy` TEXT NOT NULL DEFAULT 'NOBODY', `alwaysShowSensitiveMedia` INTEGER NOT NULL, `alwaysOpenSpoiler` INTEGER NOT NULL, `mediaPreviewEnabled` INTEGER NOT NULL, `notificationMarkerId` TEXT NOT NULL DEFAULT '0', `emojis` TEXT NOT NULL, `tabPreferences` TEXT NOT NULL, `notificationsFilter` TEXT NOT NULL, `oauthScopes` TEXT NOT NULL, `unifiedPushUrl` TEXT NOT NULL, `pushPubKey` TEXT NOT NULL, `pushPrivKey` TEXT NOT NULL, `pushAuth` TEXT NOT NULL, `pushServerKey` TEXT NOT NULL, `locked` INTEGER NOT NULL DEFAULT 0, `notificationAccountFilterNotFollowed` TEXT NOT NULL DEFAULT 'NONE', `notificationAccountFilterYounger30d` TEXT NOT NULL DEFAULT 'NONE', `notificationAccountFilterLimitedByServer` TEXT NOT NULL DEFAULT 'NONE', `conversationAccountFilterNotFollowed` TEXT NOT NULL DEFAULT 'NONE', `conversationAccountFilterYounger30d` TEXT NOT NULL DEFAULT 'NONE', `conversationAccountFilterLimitedByServer` TEXT NOT NULL DEFAULT 'NONE', `isBot` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "domain",
+            "columnName": "domain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessToken",
+            "columnName": "accessToken",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "clientId",
+            "columnName": "clientId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "clientSecret",
+            "columnName": "clientSecret",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profilePictureUrl",
+            "columnName": "profilePictureUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileHeaderPictureUrl",
+            "columnName": "profileHeaderPictureUrl",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "notificationsEnabled",
+            "columnName": "notificationsEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsMentioned",
+            "columnName": "notificationsMentioned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsFollowed",
+            "columnName": "notificationsFollowed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsFollowRequested",
+            "columnName": "notificationsFollowRequested",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsReblogged",
+            "columnName": "notificationsReblogged",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsFavorited",
+            "columnName": "notificationsFavorited",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsPolls",
+            "columnName": "notificationsPolls",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsSubscriptions",
+            "columnName": "notificationsSubscriptions",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsSignUps",
+            "columnName": "notificationsSignUps",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsUpdates",
+            "columnName": "notificationsUpdates",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsReports",
+            "columnName": "notificationsReports",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsSeveredRelationships",
+            "columnName": "notificationsSeveredRelationships",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "true"
+          },
+          {
+            "fieldPath": "notificationsModerationWarnings",
+            "columnName": "notificationsModerationWarnings",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "true"
+          },
+          {
+            "fieldPath": "notificationsQuotes",
+            "columnName": "notificationsQuotes",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "true"
+          },
+          {
+            "fieldPath": "notificationsQuotedUpdates",
+            "columnName": "notificationsQuotedUpdates",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "true"
+          },
+          {
+            "fieldPath": "notificationSound",
+            "columnName": "notificationSound",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationVibration",
+            "columnName": "notificationVibration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationLight",
+            "columnName": "notificationLight",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultPostPrivacy",
+            "columnName": "defaultPostPrivacy",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultMediaSensitivity",
+            "columnName": "defaultMediaSensitivity",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultPostLanguage",
+            "columnName": "defaultPostLanguage",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultQuotePolicy",
+            "columnName": "defaultQuotePolicy",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'NOBODY'"
+          },
+          {
+            "fieldPath": "alwaysShowSensitiveMedia",
+            "columnName": "alwaysShowSensitiveMedia",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alwaysOpenSpoiler",
+            "columnName": "alwaysOpenSpoiler",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaPreviewEnabled",
+            "columnName": "mediaPreviewEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationMarkerId",
+            "columnName": "notificationMarkerId",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'0'"
+          },
+          {
+            "fieldPath": "emojis",
+            "columnName": "emojis",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tabPreferences",
+            "columnName": "tabPreferences",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsFilter",
+            "columnName": "notificationsFilter",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "oauthScopes",
+            "columnName": "oauthScopes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unifiedPushUrl",
+            "columnName": "unifiedPushUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pushPubKey",
+            "columnName": "pushPubKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pushPrivKey",
+            "columnName": "pushPrivKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pushAuth",
+            "columnName": "pushAuth",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pushServerKey",
+            "columnName": "pushServerKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locked",
+            "columnName": "locked",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "notificationAccountFilterNotFollowed",
+            "columnName": "notificationAccountFilterNotFollowed",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'NONE'"
+          },
+          {
+            "fieldPath": "notificationAccountFilterYounger30d",
+            "columnName": "notificationAccountFilterYounger30d",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'NONE'"
+          },
+          {
+            "fieldPath": "notificationAccountFilterLimitedByServer",
+            "columnName": "notificationAccountFilterLimitedByServer",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'NONE'"
+          },
+          {
+            "fieldPath": "conversationAccountFilterNotFollowed",
+            "columnName": "conversationAccountFilterNotFollowed",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'NONE'"
+          },
+          {
+            "fieldPath": "conversationAccountFilterYounger30d",
+            "columnName": "conversationAccountFilterYounger30d",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'NONE'"
+          },
+          {
+            "fieldPath": "conversationAccountFilterLimitedByServer",
+            "columnName": "conversationAccountFilterLimitedByServer",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'NONE'"
+          },
+          {
+            "fieldPath": "isBot",
+            "columnName": "isBot",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_PachliAccountEntity_domain_accountId",
+            "unique": true,
+            "columnNames": [
+              "domain",
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_PachliAccountEntity_domain_accountId` ON `${TABLE_NAME}` (`domain`, `accountId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "StatusEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `url` TEXT, `pachliAccountId` INTEGER NOT NULL, `authorServerId` TEXT NOT NULL, `inReplyToId` TEXT, `inReplyToAccountId` TEXT, `content` TEXT, `createdAt` INTEGER NOT NULL, `editedAt` INTEGER, `emojis` TEXT, `reblogsCount` INTEGER NOT NULL, `favouritesCount` INTEGER NOT NULL, `repliesCount` INTEGER NOT NULL, `quotesCount` INTEGER NOT NULL DEFAULT 0, `reblogged` INTEGER NOT NULL, `bookmarked` INTEGER NOT NULL, `favourited` INTEGER NOT NULL, `sensitive` INTEGER NOT NULL, `spoilerText` TEXT NOT NULL, `visibility` INTEGER NOT NULL, `attachments` TEXT, `mentions` TEXT, `tags` TEXT, `application` TEXT, `reblogServerId` TEXT, `reblogAccountId` TEXT, `poll` TEXT, `muted` INTEGER, `pinned` INTEGER NOT NULL, `card` TEXT, `quoteState` TEXT, `quoteServerId` TEXT, `quoteApproval` TEXT NOT NULL DEFAULT '{\"automatic\":[], \"manual\":[], \"currentUser\":\"UNKNOWN\"}', `language` TEXT, `filtered` TEXT, PRIMARY KEY(`serverId`, `pachliAccountId`), FOREIGN KEY(`pachliAccountId`) REFERENCES `PachliAccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED, FOREIGN KEY(`authorServerId`, `pachliAccountId`) REFERENCES `TimelineAccountEntity`(`serverId`, `pachliAccountId`) ON UPDATE NO ACTION ON DELETE NO ACTION DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pachliAccountId",
+            "columnName": "pachliAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authorServerId",
+            "columnName": "authorServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inReplyToId",
+            "columnName": "inReplyToId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "inReplyToAccountId",
+            "columnName": "inReplyToAccountId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "editedAt",
+            "columnName": "editedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "emojis",
+            "columnName": "emojis",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "reblogsCount",
+            "columnName": "reblogsCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favouritesCount",
+            "columnName": "favouritesCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repliesCount",
+            "columnName": "repliesCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quotesCount",
+            "columnName": "quotesCount",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "reblogged",
+            "columnName": "reblogged",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarked",
+            "columnName": "bookmarked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favourited",
+            "columnName": "favourited",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sensitive",
+            "columnName": "sensitive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spoilerText",
+            "columnName": "spoilerText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "visibility",
+            "columnName": "visibility",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attachments",
+            "columnName": "attachments",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mentions",
+            "columnName": "mentions",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "application",
+            "columnName": "application",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "reblogServerId",
+            "columnName": "reblogServerId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "reblogAccountId",
+            "columnName": "reblogAccountId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "poll",
+            "columnName": "poll",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "muted",
+            "columnName": "muted",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pinned",
+            "columnName": "pinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "card",
+            "columnName": "card",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "quoteState",
+            "columnName": "quoteState",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "quoteServerId",
+            "columnName": "quoteServerId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "quoteApproval",
+            "columnName": "quoteApproval",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'{\"automatic\":[], \"manual\":[], \"currentUser\":\"UNKNOWN\"}'"
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "filtered",
+            "columnName": "filtered",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "pachliAccountId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_StatusEntity_authorServerId_pachliAccountId",
+            "unique": false,
+            "columnNames": [
+              "authorServerId",
+              "pachliAccountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_StatusEntity_authorServerId_pachliAccountId` ON `${TABLE_NAME}` (`authorServerId`, `pachliAccountId`)"
+          },
+          {
+            "name": "index_StatusEntity_pachliAccountId",
+            "unique": false,
+            "columnNames": [
+              "pachliAccountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_StatusEntity_pachliAccountId` ON `${TABLE_NAME}` (`pachliAccountId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "PachliAccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "pachliAccountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "TimelineAccountEntity",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "authorServerId",
+              "pachliAccountId"
+            ],
+            "referencedColumns": [
+              "serverId",
+              "pachliAccountId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "TimelineAccountEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `pachliAccountId` INTEGER NOT NULL, `localUsername` TEXT NOT NULL, `username` TEXT NOT NULL, `displayName` TEXT NOT NULL, `url` TEXT NOT NULL, `avatar` TEXT NOT NULL, `emojis` TEXT NOT NULL, `bot` INTEGER NOT NULL, `createdAt` INTEGER, `limited` INTEGER NOT NULL DEFAULT false, `roles` TEXT DEFAULT '', `pronouns` TEXT DEFAULT '', PRIMARY KEY(`serverId`, `pachliAccountId`), FOREIGN KEY(`pachliAccountId`) REFERENCES `PachliAccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pachliAccountId",
+            "columnName": "pachliAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUsername",
+            "columnName": "localUsername",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatar",
+            "columnName": "avatar",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "emojis",
+            "columnName": "emojis",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bot",
+            "columnName": "bot",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "limited",
+            "columnName": "limited",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "roles",
+            "columnName": "roles",
+            "affinity": "TEXT",
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "pronouns",
+            "columnName": "pronouns",
+            "affinity": "TEXT",
+            "defaultValue": "''"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "pachliAccountId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_TimelineAccountEntity_pachliAccountId",
+            "unique": false,
+            "columnNames": [
+              "pachliAccountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_TimelineAccountEntity_pachliAccountId` ON `${TABLE_NAME}` (`pachliAccountId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "PachliAccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "pachliAccountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "ConversationEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`pachliAccountId` INTEGER NOT NULL, `id` TEXT NOT NULL, `accounts` TEXT NOT NULL, `unread` INTEGER NOT NULL, `lastStatusServerId` TEXT NOT NULL DEFAULT '', `isConversationStarter` INTEGER NOT NULL DEFAULT 1, PRIMARY KEY(`id`, `pachliAccountId`), FOREIGN KEY(`pachliAccountId`) REFERENCES `PachliAccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "pachliAccountId",
+            "columnName": "pachliAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accounts",
+            "columnName": "accounts",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unread",
+            "columnName": "unread",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastStatusServerId",
+            "columnName": "lastStatusServerId",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "isConversationStarter",
+            "columnName": "isConversationStarter",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id",
+            "pachliAccountId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_ConversationEntity_pachliAccountId",
+            "unique": false,
+            "columnNames": [
+              "pachliAccountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ConversationEntity_pachliAccountId` ON `${TABLE_NAME}` (`pachliAccountId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "PachliAccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "pachliAccountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "RemoteKeyEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountId` INTEGER NOT NULL, `timelineId` TEXT NOT NULL, `kind` TEXT NOT NULL, `key` TEXT, PRIMARY KEY(`accountId`, `timelineId`, `kind`), FOREIGN KEY(`accountId`) REFERENCES `PachliAccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timelineId",
+            "columnName": "timelineId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "accountId",
+            "timelineId",
+            "kind"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "PachliAccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "StatusViewDataEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`pachliAccountId` INTEGER NOT NULL, `serverId` TEXT NOT NULL, `expanded` INTEGER, `contentCollapsed` INTEGER, `translationState` TEXT NOT NULL DEFAULT 'SHOW_ORIGINAL', `attachmentDisplayAction` TEXT, PRIMARY KEY(`serverId`, `pachliAccountId`), FOREIGN KEY(`pachliAccountId`) REFERENCES `PachliAccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "pachliAccountId",
+            "columnName": "pachliAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expanded",
+            "columnName": "expanded",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "contentCollapsed",
+            "columnName": "contentCollapsed",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "translationState",
+            "columnName": "translationState",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'SHOW_ORIGINAL'"
+          },
+          {
+            "fieldPath": "attachmentDisplayAction",
+            "columnName": "attachmentDisplayAction",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "pachliAccountId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_StatusViewDataEntity_pachliAccountId",
+            "unique": false,
+            "columnNames": [
+              "pachliAccountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_StatusViewDataEntity_pachliAccountId` ON `${TABLE_NAME}` (`pachliAccountId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "PachliAccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "pachliAccountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "TranslatedStatusEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `pachliAccountId` INTEGER NOT NULL, `content` TEXT NOT NULL, `spoilerText` TEXT NOT NULL, `poll` TEXT, `attachments` TEXT NOT NULL, `provider` TEXT NOT NULL, PRIMARY KEY(`serverId`, `pachliAccountId`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pachliAccountId",
+            "columnName": "pachliAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spoilerText",
+            "columnName": "spoilerText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "poll",
+            "columnName": "poll",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "attachments",
+            "columnName": "attachments",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "pachliAccountId"
+          ]
+        }
+      },
+      {
+        "tableName": "LogEntryEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `instant` INTEGER NOT NULL, `priority` INTEGER, `tag` TEXT, `message` TEXT NOT NULL, `t` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instant",
+            "columnName": "instant",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "t",
+            "columnName": "t",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "MastodonListEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountId` INTEGER NOT NULL, `listId` TEXT NOT NULL, `title` TEXT NOT NULL, `repliesPolicy` TEXT NOT NULL, `exclusive` INTEGER NOT NULL, PRIMARY KEY(`accountId`, `listId`), FOREIGN KEY(`accountId`) REFERENCES `PachliAccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listId",
+            "columnName": "listId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repliesPolicy",
+            "columnName": "repliesPolicy",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exclusive",
+            "columnName": "exclusive",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "accountId",
+            "listId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "PachliAccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "ServerEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountId` INTEGER NOT NULL, `serverKind` TEXT NOT NULL, `version` TEXT NOT NULL, `rawVersion` TEXT NOT NULL DEFAULT '', `capabilities` TEXT NOT NULL, `limits` TEXT NOT NULL DEFAULT '{}', `emojis` TEXT NOT NULL DEFAULT '[]', PRIMARY KEY(`accountId`), FOREIGN KEY(`accountId`) REFERENCES `PachliAccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverKind",
+            "columnName": "serverKind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rawVersion",
+            "columnName": "rawVersion",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "capabilities",
+            "columnName": "capabilities",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "limits",
+            "columnName": "limits",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'{}'"
+          },
+          {
+            "fieldPath": "emojis",
+            "columnName": "emojis",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "accountId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "PachliAccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "ContentFiltersEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountId` INTEGER NOT NULL, `version` TEXT NOT NULL, `contentFilters` TEXT NOT NULL, PRIMARY KEY(`accountId`), FOREIGN KEY(`accountId`) REFERENCES `PachliAccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentFilters",
+            "columnName": "contentFilters",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "accountId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "PachliAccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "AnnouncementEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountId` INTEGER NOT NULL, `announcementId` TEXT NOT NULL, `announcement` TEXT NOT NULL, PRIMARY KEY(`accountId`), FOREIGN KEY(`accountId`) REFERENCES `PachliAccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "announcementId",
+            "columnName": "announcementId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "announcement",
+            "columnName": "announcement",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "accountId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "PachliAccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "FollowingAccountEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`pachliAccountId` INTEGER NOT NULL, `serverId` TEXT NOT NULL, `domain` TEXT NOT NULL DEFAULT '', PRIMARY KEY(`pachliAccountId`, `serverId`), FOREIGN KEY(`pachliAccountId`) REFERENCES `PachliAccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "pachliAccountId",
+            "columnName": "pachliAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "domain",
+            "columnName": "domain",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "pachliAccountId",
+            "serverId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "PachliAccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "pachliAccountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "NotificationEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`pachliAccountId` INTEGER NOT NULL, `serverId` TEXT NOT NULL, `type` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `accountServerId` TEXT NOT NULL, `statusServerId` TEXT, `note` TEXT, `report_reportId` TEXT, `report_actionTaken` INTEGER, `report_actionTakenAt` INTEGER, `report_category` TEXT, `report_comment` TEXT, `report_forwarded` INTEGER, `report_createdAt` INTEGER, `report_statusIds` TEXT, `report_ruleIds` TEXT, `report_target_pachliAccountId` INTEGER, `report_target_serverId` TEXT, `report_target_localUsername` TEXT, `report_target_username` TEXT, `report_target_displayName` TEXT, `report_target_createdAt` INTEGER, `report_target_url` TEXT, `report_target_avatar` TEXT, `report_target_note` TEXT, `report_target_header` TEXT DEFAULT '', `report_target_locked` INTEGER DEFAULT 0, `report_target_lastStatusAt` INTEGER, `report_target_followersCount` INTEGER DEFAULT 0, `report_target_followingCount` INTEGER DEFAULT 0, `report_target_statusesCount` INTEGER DEFAULT 0, `report_target_bot` INTEGER, `report_target_emojis` TEXT, `report_target_fields` TEXT DEFAULT '', `report_target_movedAccount` TEXT, `report_target_limited` INTEGER, `report_target_roles` TEXT, `report_target_pronouns` TEXT, `rse_eventId` TEXT, `rse_type` TEXT, `rse_purged` INTEGER, `rse_targetName` TEXT DEFAULT '', `rse_followersCount` INTEGER, `rse_followingCount` INTEGER, `rse_createdAt` INTEGER, `warn_accountWarningId` TEXT, `warn_text` TEXT, `warn_action` TEXT, `warn_createdAt` INTEGER, PRIMARY KEY(`pachliAccountId`, `serverId`), FOREIGN KEY(`pachliAccountId`) REFERENCES `PachliAccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED, FOREIGN KEY(`pachliAccountId`, `accountServerId`) REFERENCES `TimelineAccountEntity`(`pachliAccountId`, `serverId`) ON UPDATE NO ACTION ON DELETE NO ACTION DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "pachliAccountId",
+            "columnName": "pachliAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountServerId",
+            "columnName": "accountServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "statusServerId",
+            "columnName": "statusServerId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "report.reportId",
+            "columnName": "report_reportId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "report.actionTaken",
+            "columnName": "report_actionTaken",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "report.actionTakenAt",
+            "columnName": "report_actionTakenAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "report.category",
+            "columnName": "report_category",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "report.comment",
+            "columnName": "report_comment",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "report.forwarded",
+            "columnName": "report_forwarded",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "report.createdAt",
+            "columnName": "report_createdAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "report.statusIds",
+            "columnName": "report_statusIds",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "report.ruleIds",
+            "columnName": "report_ruleIds",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "report.targetAccount.pachliAccountId",
+            "columnName": "report_target_pachliAccountId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "report.targetAccount.serverId",
+            "columnName": "report_target_serverId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "report.targetAccount.localUsername",
+            "columnName": "report_target_localUsername",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "report.targetAccount.username",
+            "columnName": "report_target_username",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "report.targetAccount.displayName",
+            "columnName": "report_target_displayName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "report.targetAccount.createdAt",
+            "columnName": "report_target_createdAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "report.targetAccount.url",
+            "columnName": "report_target_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "report.targetAccount.avatar",
+            "columnName": "report_target_avatar",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "report.targetAccount.note",
+            "columnName": "report_target_note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "report.targetAccount.header",
+            "columnName": "report_target_header",
+            "affinity": "TEXT",
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "report.targetAccount.locked",
+            "columnName": "report_target_locked",
+            "affinity": "INTEGER",
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "report.targetAccount.lastStatusAt",
+            "columnName": "report_target_lastStatusAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "report.targetAccount.followersCount",
+            "columnName": "report_target_followersCount",
+            "affinity": "INTEGER",
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "report.targetAccount.followingCount",
+            "columnName": "report_target_followingCount",
+            "affinity": "INTEGER",
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "report.targetAccount.statusesCount",
+            "columnName": "report_target_statusesCount",
+            "affinity": "INTEGER",
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "report.targetAccount.bot",
+            "columnName": "report_target_bot",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "report.targetAccount.emojis",
+            "columnName": "report_target_emojis",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "report.targetAccount.fields",
+            "columnName": "report_target_fields",
+            "affinity": "TEXT",
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "report.targetAccount.movedAccount",
+            "columnName": "report_target_movedAccount",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "report.targetAccount.limited",
+            "columnName": "report_target_limited",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "report.targetAccount.roles",
+            "columnName": "report_target_roles",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "report.targetAccount.pronouns",
+            "columnName": "report_target_pronouns",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "relationshipSeveranceEvent.eventId",
+            "columnName": "rse_eventId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "relationshipSeveranceEvent.type",
+            "columnName": "rse_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "relationshipSeveranceEvent.purged",
+            "columnName": "rse_purged",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "relationshipSeveranceEvent.targetName",
+            "columnName": "rse_targetName",
+            "affinity": "TEXT",
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "relationshipSeveranceEvent.followersCount",
+            "columnName": "rse_followersCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "relationshipSeveranceEvent.followingCount",
+            "columnName": "rse_followingCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "relationshipSeveranceEvent.createdAt",
+            "columnName": "rse_createdAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "accountWarning.accountWarningId",
+            "columnName": "warn_accountWarningId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountWarning.text",
+            "columnName": "warn_text",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountWarning.action",
+            "columnName": "warn_action",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountWarning.createdAt",
+            "columnName": "warn_createdAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "pachliAccountId",
+            "serverId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_NotificationEntity_accountServerId_pachliAccountId",
+            "unique": false,
+            "columnNames": [
+              "accountServerId",
+              "pachliAccountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_NotificationEntity_accountServerId_pachliAccountId` ON `${TABLE_NAME}` (`accountServerId`, `pachliAccountId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "PachliAccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "pachliAccountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "TimelineAccountEntity",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "pachliAccountId",
+              "accountServerId"
+            ],
+            "referencedColumns": [
+              "pachliAccountId",
+              "serverId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "NotificationViewDataEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`pachliAccountId` INTEGER NOT NULL, `serverId` TEXT NOT NULL, `accountFilterDecision` TEXT, PRIMARY KEY(`pachliAccountId`, `serverId`), FOREIGN KEY(`pachliAccountId`) REFERENCES `PachliAccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "pachliAccountId",
+            "columnName": "pachliAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountFilterDecision",
+            "columnName": "accountFilterDecision",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "pachliAccountId",
+            "serverId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "PachliAccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "pachliAccountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "TimelineStatusEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`kind` TEXT NOT NULL, `pachliAccountId` INTEGER NOT NULL, `statusId` TEXT NOT NULL, PRIMARY KEY(`kind`, `pachliAccountId`, `statusId`))",
+        "fields": [
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pachliAccountId",
+            "columnName": "pachliAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "statusId",
+            "columnName": "statusId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "kind",
+            "pachliAccountId",
+            "statusId"
+          ]
+        }
+      },
+      {
+        "tableName": "ConversationViewDataEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`pachliAccountId` INTEGER NOT NULL, `serverId` TEXT NOT NULL, `contentFilterAction` TEXT, `accountFilterDecision` TEXT, PRIMARY KEY(`pachliAccountId`, `serverId`), FOREIGN KEY(`pachliAccountId`) REFERENCES `PachliAccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "pachliAccountId",
+            "columnName": "pachliAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentFilterAction",
+            "columnName": "contentFilterAction",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accountFilterDecision",
+            "columnName": "accountFilterDecision",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "pachliAccountId",
+            "serverId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "PachliAccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "pachliAccountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "HashtagEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`pachliAccountId` INTEGER NOT NULL, `name` TEXT NOT NULL, `url` TEXT NOT NULL, `history` TEXT NOT NULL, `following` INTEGER NOT NULL, PRIMARY KEY(`pachliAccountId`, `name`), FOREIGN KEY(`pachliAccountId`) REFERENCES `PachliAccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "pachliAccountId",
+            "columnName": "pachliAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "history",
+            "columnName": "history",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "following",
+            "columnName": "following",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "pachliAccountId",
+            "name"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "PachliAccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "pachliAccountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "views": [
+      {
+        "viewName": "TimelineStatusWithAccount",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS SELECT\n    s.serverId,\n    s.url,\n    s.pachliAccountId,\n    s.authorServerId,\n    s.inReplyToId,\n    s.inReplyToAccountId,\n    s.createdAt,\n    s.editedAt,\n    s.emojis,\n    s.reblogsCount,\n    s.favouritesCount,\n    s.repliesCount,\n    s.quotesCount,\n    s.reblogged,\n    s.favourited,\n    s.bookmarked,\n    s.sensitive,\n    s.spoilerText,\n    s.visibility,\n    s.mentions,\n    s.tags,\n    s.application,\n    s.reblogServerId,\n    s.reblogAccountId,\n    s.content,\n    s.attachments,\n    s.poll,\n    s.card,\n    s.muted,\n    s.pinned,\n    s.language,\n    s.filtered,\n    s.quoteState,\n    s.quoteServerId,\n    s.quoteApproval,\n    a.serverId AS 'a_serverId',\n    a.pachliAccountId AS 'a_pachliAccountId',\n    a.localUsername AS 'a_localUsername',\n    a.username AS 'a_username',\n    a.displayName AS 'a_displayName',\n    a.url AS 'a_url',\n    a.avatar AS 'a_avatar',\n    a.emojis AS 'a_emojis',\n    a.bot AS 'a_bot',\n    a.createdAt AS 'a_createdAt',\n    a.limited AS 'a_limited',\n    a.roles AS 'a_roles',\n    a.pronouns AS 'a_pronouns',\n    rb.serverId AS 'rb_serverId',\n    rb.pachliAccountId AS 'rb_pachliAccountId',\n    rb.localUsername AS 'rb_localUsername',\n    rb.username AS 'rb_username',\n    rb.displayName AS 'rb_displayName',\n    rb.url AS 'rb_url',\n    rb.avatar AS 'rb_avatar',\n    rb.emojis AS 'rb_emojis',\n    rb.bot AS 'rb_bot',\n    rb.createdAt AS 'rb_createdAt',\n    rb.limited AS 'rb_limited',\n    rb.roles AS 'rb_roles',\n    rb.pronouns AS 'rb_pronouns',\n    svd.serverId AS 'svd_serverId',\n    svd.pachliAccountId AS 'svd_pachliAccountId',\n    svd.expanded AS 'svd_expanded',\n    svd.contentCollapsed AS 'svd_contentCollapsed',\n    svd.translationState AS 'svd_translationState',\n    svd.attachmentDisplayAction AS 'svd_attachmentDisplayAction',\n    tr.serverId AS 't_serverId',\n    tr.pachliAccountId AS 't_pachliAccountId',\n    tr.content AS 't_content',\n    tr.spoilerText AS 't_spoilerText',\n    tr.poll AS 't_poll',\n    tr.attachments AS 't_attachments',\n    tr.provider AS 't_provider',\n    reply.serverId AS 'reply_serverId',\n    reply.pachliAccountId AS 'reply_pachliAccountId',\n    reply.localUsername AS 'reply_localUsername',\n    reply.username AS 'reply_username',\n    reply.displayName AS 'reply_displayName',\n    reply.url AS 'reply_url',\n    reply.avatar AS 'reply_avatar',\n    reply.emojis AS 'reply_emojis',\n    reply.bot AS 'reply_bot',\n    reply.createdAt AS 'reply_createdAt',\n    reply.limited AS 'reply_limited',\n    reply.roles AS 'reply_roles',\n    reply.pronouns AS 'reply_pronouns'\nFROM StatusEntity AS s\nLEFT JOIN TimelineAccountEntity AS a ON (s.pachliAccountId = a.pachliAccountId AND s.authorServerId = a.serverId)\nLEFT JOIN TimelineAccountEntity AS rb ON (s.pachliAccountId = rb.pachliAccountId AND s.reblogAccountId = rb.serverId)\nLEFT JOIN\n    StatusViewDataEntity AS svd\n    ON (s.pachliAccountId = svd.pachliAccountId AND (s.serverId = svd.serverId OR s.reblogServerId = svd.serverId))\nLEFT JOIN\n    TranslatedStatusEntity AS tr\n    ON (s.pachliAccountId = tr.pachliAccountId AND (s.serverId = tr.serverId OR s.reblogServerId = tr.serverId))\nLEFT JOIN TimelineAccountEntity AS reply ON (s.pachliAccountId = reply.pachliAccountId AND s.inReplyToAccountId = reply.serverId)"
+      },
+      {
+        "viewName": "ReferencedStatusId",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS WITH RECURSIVE\n-- CTEs to normalise the column names and restrict to just rows with\n-- non-null references to status IDs, for use in the refId CTE.\ntimelineStatusId(pachliAccountId, statusId) AS (\n    SELECT\n        pachliAccountId,\n        statusId\n    FROM TimelineStatusEntity\n),\n\nnotificationStatusId(pachliAccountId, statusId) AS (\n    SELECT\n        pachliAccountId,\n        statusServerId AS statusId\n    FROM NotificationEntity\n    WHERE statusServerId IS NOT NULL\n),\n\nconversationStatusId(pachliAccountId, statusId) AS (\n    SELECT\n        pachliAccountId,\n        lastStatusServerId AS statusId\n    FROM ConversationEntity\n    WHERE lastStatusServerId IS NOT NULL\n),\n\ndraftStatusId(pachliAccountId, statusId) AS (\n    SELECT\n        pachliAccountId AS pachliAccountId,\n        inReplyToId AS statusId\n    FROM DraftEntity\n    WHERE inReplyToId IS NOT NULL\n),\n\n--\n-- refId is a table of all referenced statusIds. A statusId is referenced\n-- if it is either (a) directly referenced by one of the CTEs above, or\n-- (b) referenced by a reply, reblog, or quote in any of the statuses\n-- from \"a\".\n--\nrefId(pachliAccountId, statusId) AS (\n    --\n    -- Find all the \"root\" statusId. These are the IDs that\n    -- are referenced by tables containing \"live\" data.\n    --\n    SELECT\n        pachliAccountId,\n        statusId\n    FROM timelineStatusId\n    UNION\n    SELECT\n        pachliAccountId,\n        statusId\n    FROM notificationStatusId\n    UNION\n    SELECT\n        pachliAccountId,\n        statusId\n    FROM conversationStatusId\n    UNION\n    SELECT\n        pachliAccountId,\n        statusId\n    FROM draftStatusId\n\n    -- Recursively chase down all the references to replies, reblogs, and\n    -- quotes, emitting the `inReblogId`, `inReplyToId`, or `quoteServerId`\n    -- columns renamed to `statusId` as extra rows.\n    UNION\n    SELECT\n        s.pachliAccountId AS pachliAccountId,\n        s.reblogServerId AS statusId\n    FROM StatusEntity AS s, refId AS r\n    WHERE\n        s.reblogServerId IS NOT NULL\n        AND s.pachliAccountId = r.pachliAccountId\n        AND s.serverId = r.statusID\n\n    UNION\n    SELECT\n        s.pachliAccountId AS pachliAccountId,\n        s.inReplyToId AS statusId\n    FROM StatusEntity AS s, refId AS r\n    WHERE\n        s.inReplyToId IS NOT NULL\n        AND s.pachliAccountId = r.pachliAccountId\n        AND s.serverId = r.statusID\n\n    UNION\n    SELECT\n        s.pachliAccountId AS pachliAccountId,\n        s.quoteServerId AS statusId\n    FROM StatusEntity AS s, refId AS r\n    WHERE\n        s.quoteServerId IS NOT NULL\n        AND s.pachliAccountId = r.pachliAccountId\n        AND s.serverId = r.statusID\n)\n\nSELECT\n    pachliAccountId,\n    statusId\nFROM refId"
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'fba8559381a1ebfe55aa956b70c8ee45')"
+    ]
+  }
+}

--- a/core/database/src/main/kotlin/app/pachli/core/database/AppDatabase.kt
+++ b/core/database/src/main/kotlin/app/pachli/core/database/AppDatabase.kt
@@ -101,7 +101,7 @@ import java.util.TimeZone
         TimelineStatusWithAccount::class,
         ReferencedStatusId::class,
     ],
-    version = 43,
+    version = 44,
     autoMigrations = [
         AutoMigration(from = 1, to = 2, spec = AppDatabase.MIGRATE_1_2::class),
         AutoMigration(from = 2, to = 3),
@@ -164,6 +164,8 @@ import java.util.TimeZone
         AutoMigration(from = 41, to = 42, spec = AppDatabase.MIGRATE_41_42::class),
         // Renames, removal of NotificationReportEntity, etc.
         AutoMigration(from = 42, to = 43, spec = AppDatabase.MIGRATE_42_43::class),
+        // Add .domain to FollowingAccountEntity
+        AutoMigration(from = 43, to = 44),
     ],
 )
 abstract class AppDatabase : RoomDatabase() {

--- a/core/database/src/main/kotlin/app/pachli/core/database/dao/FollowingAccountDao.kt
+++ b/core/database/src/main/kotlin/app/pachli/core/database/dao/FollowingAccountDao.kt
@@ -48,10 +48,31 @@ WHERE pachliAccountId = :accountId
 
     @Query(
         """
+DELETE
+FROM FollowingAccountEntity
+WHERE pachliAccountId = :pachliAccountId AND serverId = :accountId
+    """,
+    )
+    suspend fun delete(pachliAccountId: Long, accountId: String)
+
+    @Query(
+        """
 SELECT *
 FROM FollowingAccountEntity
 WHERE pachliAccountId = :pachliAccountId
 """,
     )
     suspend fun loadAllForAccount(pachliAccountId: Long): List<FollowingAccountEntity>
+
+    /**
+     * Delete cached following relationships with [domain].
+     */
+    @Query(
+        """
+DELETE
+FROM FollowingAccountEntity
+WHERE pachliAccountId = :pachliAccountId AND domain = :domain
+    """,
+    )
+    suspend fun deleteAllByDomain(pachliAccountId: Long, domain: String)
 }

--- a/core/database/src/main/kotlin/app/pachli/core/database/model/FollowingAccountEntity.kt
+++ b/core/database/src/main/kotlin/app/pachli/core/database/model/FollowingAccountEntity.kt
@@ -17,6 +17,7 @@
 
 package app.pachli.core.database.model
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.ForeignKey
 import app.pachli.core.model.ITimelineAccount
@@ -27,6 +28,8 @@ import app.pachli.core.model.ITimelineAccount
  * @property pachliAccountId ID of the local account that is following this account.
  * @property serverId Server's identifier for the account. Unique within a single server,
  * but not unique across the federated network.
+ * @property domain The domain of the account identified by [serverId]. Allows for bulk
+ * delete of all relationships on a particular domain, if the user blocks the domain.
  */
 @Entity(
     primaryKeys = ["pachliAccountId", "serverId"],
@@ -43,11 +46,14 @@ import app.pachli.core.model.ITimelineAccount
 data class FollowingAccountEntity(
     val pachliAccountId: Long,
     val serverId: String,
+    @ColumnInfo(defaultValue = "")
+    val domain: String,
 ) {
     companion object {
         fun from(pachliAccountId: Long, account: ITimelineAccount) = FollowingAccountEntity(
             pachliAccountId = pachliAccountId,
             serverId = account.serverId,
+            domain = account.domain,
         )
     }
 }

--- a/core/database/src/test/kotlin/app/pachli/core/database/dao/PachliAccountEntityForeignKeyTest.kt
+++ b/core/database/src/test/kotlin/app/pachli/core/database/dao/PachliAccountEntityForeignKeyTest.kt
@@ -274,6 +274,7 @@ class PachliAccountEntityForeignKeyTest {
         val followingAccount = FollowingAccountEntity(
             pachliAccountId = pachliAccountId,
             serverId = "2",
+            domain = "example.com",
         )
         followingAccountDao.upsert(followingAccount)
 

--- a/core/domain/src/main/kotlin/app/pachli/core/domain/accounts/BlockDomainUseCase.kt
+++ b/core/domain/src/main/kotlin/app/pachli/core/domain/accounts/BlockDomainUseCase.kt
@@ -19,9 +19,8 @@ package app.pachli.core.domain.accounts
 
 import app.pachli.core.common.di.ApplicationScope
 import app.pachli.core.database.dao.FollowingAccountDao
-import app.pachli.core.eventhub.BlockEvent
+import app.pachli.core.eventhub.DomainMuteEvent
 import app.pachli.core.eventhub.EventHub
-import app.pachli.core.model.Relationship
 import app.pachli.core.network.retrofit.MastodonApi
 import app.pachli.core.network.retrofit.UseCaseOnly
 import app.pachli.core.network.retrofit.apiresult.ApiError
@@ -34,29 +33,31 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 
 /**
- * Block [accountId].
+ * Block [domain].
  *
  * On success:
  *
- * - [BlockEvent] is dispatched.
+ * - [DomainMuteEvent] is dispatched.
+ * - Local cached following relationships in [FollowingAccountDao]
+ * are cleared.
  */
 @Singleton
-class BlockAccountUseCase @Inject constructor(
+class BlockDomainUseCase @Inject constructor(
     @ApplicationScope private val externalScope: CoroutineScope,
     private val mastodonApi: MastodonApi,
-    private val followingAccountDao: FollowingAccountDao,
     private val eventHub: EventHub,
+    private val followingAccountDao: FollowingAccountDao,
 ) {
     /**
      * @param pachliAccountId
-     * @param accountId ID of the account to block.
+     * @param domain Domain of the account to block.
      */
     @OptIn(UseCaseOnly::class)
-    suspend operator fun invoke(pachliAccountId: Long, accountId: String): Result<Relationship, ApiError> = externalScope.async {
-        mastodonApi.blockAccount(accountId).map { it.body.asModel() }
+    suspend operator fun invoke(pachliAccountId: Long, domain: String): Result<Unit, ApiError> = externalScope.async {
+        mastodonApi.blockDomain(domain).map { it.body }
             .onSuccess {
-                followingAccountDao.delete(pachliAccountId, accountId)
-                eventHub.dispatch(BlockEvent(pachliAccountId, accountId))
+                eventHub.dispatch(DomainMuteEvent(pachliAccountId, domain))
+                followingAccountDao.deleteAllByDomain(pachliAccountId, domain)
             }
     }.await()
 }

--- a/core/domain/src/main/kotlin/app/pachli/core/domain/accounts/FollowAccountUseCase.kt
+++ b/core/domain/src/main/kotlin/app/pachli/core/domain/accounts/FollowAccountUseCase.kt
@@ -19,6 +19,9 @@ package app.pachli.core.domain.accounts
 
 import app.pachli.core.common.di.ApplicationScope
 import app.pachli.core.data.repository.AccountManager
+import app.pachli.core.database.dao.FollowingAccountDao
+import app.pachli.core.database.model.FollowingAccountEntity
+import app.pachli.core.model.ITimelineAccount
 import app.pachli.core.model.Relationship
 import app.pachli.core.network.retrofit.MastodonApi
 import app.pachli.core.network.retrofit.UseCaseOnly
@@ -42,7 +45,7 @@ import kotlinx.coroutines.async
 class FollowAccountUseCase @Inject constructor(
     @ApplicationScope private val externalScope: CoroutineScope,
     private val mastodonApi: MastodonApi,
-    private val accountManager: AccountManager,
+    private val followingAccountDao: FollowingAccountDao,
 ) {
     /**
      * @param pachliAccountId
@@ -53,8 +56,10 @@ class FollowAccountUseCase @Inject constructor(
      * posts.
      */
     @OptIn(UseCaseOnly::class)
-    suspend operator fun invoke(pachliAccountId: Long, accountId: String, showReblogs: Boolean? = null, notify: Boolean? = null): Result<Relationship, ApiError> = externalScope.async {
-        mastodonApi.followAccount(accountId, showReblogs, notify).map { it.body.asModel() }
-            .onSuccess { accountManager.followAccount(pachliAccountId, accountId) }
+    suspend operator fun invoke(pachliAccountId: Long, account: ITimelineAccount, showReblogs: Boolean? = null, notify: Boolean? = null): Result<Relationship, ApiError> = externalScope.async {
+        mastodonApi.followAccount(account.serverId, showReblogs, notify).map { it.body.asModel() }
+            .onSuccess {
+                followingAccountDao.upsert(FollowingAccountEntity(pachliAccountId, account.serverId, account.domain))
+            }
     }.await()
 }

--- a/core/domain/src/main/kotlin/app/pachli/core/domain/accounts/UnfollowAccountUseCase.kt
+++ b/core/domain/src/main/kotlin/app/pachli/core/domain/accounts/UnfollowAccountUseCase.kt
@@ -19,6 +19,7 @@ package app.pachli.core.domain.accounts
 
 import app.pachli.core.common.di.ApplicationScope
 import app.pachli.core.data.repository.AccountManager
+import app.pachli.core.database.dao.FollowingAccountDao
 import app.pachli.core.eventhub.EventHub
 import app.pachli.core.eventhub.UnfollowEvent
 import app.pachli.core.model.Relationship
@@ -46,6 +47,7 @@ class UnfollowAccountUseCase @Inject constructor(
     @ApplicationScope private val externalScope: CoroutineScope,
     private val mastodonApi: MastodonApi,
     private val accountManager: AccountManager,
+    private val followingAccountDao: FollowingAccountDao,
     private val eventHub: EventHub,
 ) {
     /**
@@ -56,7 +58,7 @@ class UnfollowAccountUseCase @Inject constructor(
     suspend operator fun invoke(pachliAccountId: Long, accountId: String): Result<Relationship, ApiError> = externalScope.async {
         mastodonApi.unfollowAccount(accountId).map { it.body.asModel() }
             .onSuccess {
-                accountManager.unfollowAccount(pachliAccountId, accountId)
+                followingAccountDao.delete(pachliAccountId, accountId)
                 eventHub.dispatch(UnfollowEvent(pachliAccountId, accountId))
             }
     }.await()

--- a/core/navigation/src/main/kotlin/app/pachli/core/navigation/Navigation.kt
+++ b/core/navigation/src/main/kotlin/app/pachli/core/navigation/Navigation.kt
@@ -1007,9 +1007,10 @@ class FollowedTagsActivityIntent(context: Context, pachliAccountId: Long) : Inte
     }
 }
 
-class InstanceListActivityIntent(context: Context) : Intent() {
+class InstanceListActivityIntent(context: Context, pachliAccountId: Long) : Intent() {
     init {
         setClassName(context, QuadrantConstants.INSTANCE_LIST_ACTIVITY)
+        this.pachliAccountId = pachliAccountId
     }
 }
 

--- a/core/network/src/main/kotlin/app/pachli/core/network/retrofit/MastodonApi.kt
+++ b/core/network/src/main/kotlin/app/pachli/core/network/retrofit/MastodonApi.kt
@@ -534,6 +534,7 @@ interface MastodonApi {
         @Query("limit") limit: Int? = null,
     ): ApiResult<List<String>>
 
+    @UseCaseOnly
     @FormUrlEncoded
     @POST("api/v1/domain_blocks")
     suspend fun blockDomain(

--- a/feature/suggestions/src/main/kotlin/app/pachli/feature/suggestions/SuggestionsViewModel.kt
+++ b/feature/suggestions/src/main/kotlin/app/pachli/feature/suggestions/SuggestionsViewModel.kt
@@ -255,7 +255,7 @@ internal class SuggestionsViewModel @Inject constructor(
      * @return Result with the new relationship, or an error.
      */
     private suspend fun acceptSuggestion(action: AcceptSuggestion): Result<Relationship, FollowAccountError> = operationCounter {
-        followAccountUseCase(action.pachliAccountId, action.suggestion.account.serverId)
+        followAccountUseCase(action.pachliAccountId, action.suggestion.account)
             .mapError { FollowAccountError(it) }
     }
 }


### PR DESCRIPTION
Previous code allowed users to block a domain, but didn't delete the locally cached following relationships. So until the next cold start the abuse filters would act as though the user was still following the accounts.

Fix this with a new UseCase that blocks the domain and deletes the local copy of the following relationships. For this to work the account's domain must be stored as part of the following relationship, and passed when following the account, which necessitated changes to the code that called the use case.

Update callers of the `MastodonApi.blockDomain` method to use the new use case. For `InstanceListFragment` this meant also passing `pachliAccountId` when creating the fragment.

While I'm here, remove the follow/unfollow account functionality from `AccountManager` and put the equivalent code in the use case classes, so the domain logic sits in a single place.