### PR TITLE
fix: Don't crash if quote policy is missing

### DIFF
--- a/app/src/main/java/app/pachli/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/app/pachli/components/compose/ComposeActivity.kt
@@ -473,7 +473,7 @@ class ComposeActivity :
                         setStatusVisibility(this)
                     }
 
-                    (it.getSerializable(KEY_QUOTE_POLICY) as AccountSource.QuotePolicy).apply {
+                    (it.getSerializable(KEY_QUOTE_POLICY) as AccountSource.QuotePolicy?)?.apply {
                         bindQuotePolicy(this)
                     }
 


### PR DESCRIPTION
Previous code was treating the value saved at `KEY_QUOTE_POLICY` as  non-nullable, which was incorrect and could crash with an NPE.

Fix by treating as nullable, and only calling `bindQuotePolicy` when a  non-null value is returned.